### PR TITLE
Use Travis CI for Continuous Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: java
+jdk:
+  - openjdk7
+  - oraclejdk7
+  - openjdk6


### PR DESCRIPTION
One of the projects on the roadmap was to set up a Jenkins server for CI.  An easier option would be to use Travis CI (http://www.travis-ci.org).  I've added a basic .travis.yml file that will run the tests against a number of JVMs, and it runs green with all tests.

After merging in this pull request the jgrapht owner then need to carry out steps 1 and 2 as described here - http://about.travis-ci.org/docs/user/getting-started/ .  Once that's done Travis-CI will run against all updates to the repo, ensuring tests are run on every change.

I think this is a really good CI solution for JGraphT.  Travis CI has very widespread adoption and it's free for open source projects.
