### PR TITLE
Configure maven to use src/main/resources/META-INF/MANIFEST.MF

### DIFF
--- a/jgrapht-core/pom.xml
+++ b/jgrapht-core/pom.xml
@@ -15,4 +15,17 @@
 			<artifactId>junit</artifactId>
 		</dependency>
 	</dependencies>
+	<build>
+	<plugins>
+	<plugin>
+		<groupId>org.apache.maven.plugins</groupId>
+		<artifactId>maven-jar-plugin</artifactId>
+		<configuration>
+			<archive>
+				<manifestFile>src/main/resources/META-INF/MANIFEST.MF</manifestFile>
+			</archive>
+		</configuration>
+      </plugin>
+     </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Fixes MANIFEST.MF  not being included in generated jgrapht-core jar file. 
