### PR TITLE
fix for Floyd-Warshall algorithm for non-default weighted edges 

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/FloydWarshallShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/FloydWarshallShortestPaths.java
@@ -232,9 +232,14 @@ public class FloydWarshallShortestPaths<V, E>
         if (edges.size() < 1) {
             return null;
         }
-
+        
+        double weight = 0.;
+        for (E e : edges) {
+        	weight += graph.getEdgeWeight(e);
+        }
+        
         GraphPathImpl<V, E> path =
-            new GraphPathImpl<V, E>(graph, a, b, edges, edges.size());
+            new GraphPathImpl<V, E>(graph, a, b, edges, weight);
 
         return path;
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/FloydWarshallShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/FloydWarshallShortestPathsTest.java
@@ -181,6 +181,18 @@ public class FloydWarshallShortestPathsTest
         double diameter = fw.getDiameter();
         assertEquals(0.0, diameter);
     }
+    
+    public void testWeightedEdges() {
+    	SimpleGraph<String, DefaultWeightedEdge> weighted = 
+    		new SimpleGraph<String, DefaultWeightedEdge>(DefaultWeightedEdge.class);
+    	weighted.addVertex("a");
+    	weighted.addVertex("b");
+    	weighted.setEdgeWeight(weighted.addEdge("a", "b"), 5.0);
+    	FloydWarshallShortestPaths<String, DefaultWeightedEdge> fw =
+                new FloydWarshallShortestPaths<String, DefaultWeightedEdge>(weighted);
+    	double sD = fw.shortestDistance("a", "b");
+        assertEquals(5.0, sD, 0.1);
+    }
 }
 
 // End FloydWarshallShortestPathsTest.java


### PR DESCRIPTION
hello,

Algorithm has incorrectly assumed that all edges are weighted with 1.0. That is not always true, so I fixed this in code. I've also written a new test to show that this works. 
My change does not fail any existing UnitTests.

please apply this fix to main code branch.

thank you for excellent job you're doing with jgrapht library!
yours,
Mike
