### PR TITLE
Quick Fix (one line)

### DIFF
--- a/jgrapht-core/src/test/java/org/jgrapht/alg/MinSourceSinkCutTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/MinSourceSinkCutTest.java
@@ -111,7 +111,7 @@ public class MinSourceSinkCutTest extends TestCase{
 	    double weight=0;
 	    for(DefaultWeightedEdge e: cutEdges)
 	    	weight+=graph.getEdgeWeight(e);
-	    assertEquals(7.0, weight);
+	    assertEquals(7.0, weight, 0.0);
 	}
 	
 	/**


### PR DESCRIPTION
To compare floating-point numbers, we need to provide a delta.

Before this change, I was not able to compile using javac 1.7.0_13.
