### PR TITLE
Fix jgrapht-core pom

### DIFF
--- a/jgrapht-core/pom.xml
+++ b/jgrapht-core/pom.xml
@@ -13,6 +13,21 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-		</dependency>
-	</dependencies>
+                        <scope>test</scope>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
There is a manifest in resources, however it was overwritten by maven. This patch add instructions in order to copy the right manifest in final jar. This fix also the incomplete dependency to JUnit, test scope must be provided to not depend on junit on runtime.
- Embed manifest in jar
- Junit dependency is only is test scope
