### PR TITLE
Use 'ó' instead of 'o' in "López"

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -65,7 +65,7 @@ JGraphT wouldn't be the library it is today without the source contributions and
 - Javier Gutierrez (javierj)
 - Nicolas Fortin
 - Peter Goldstein
-- Rodrigo Lopez Dato
+- Rodrigo López Dato
 
 (if we have missed your name on this list, please email us to get it fixed).
 


### PR DESCRIPTION
Minor typo :)
