### PR TITLE
Feature/builder

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleGraph.java
@@ -43,9 +43,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.jgrapht.EdgeFactory;
-import org.jgrapht.UndirectedGraph;
+import org.jgrapht.*;
 import org.jgrapht.util.VertexPair;
+
 
 /**
  * A simple graph. A simple graph is an undirected graph for which at most one
@@ -54,32 +54,37 @@ import org.jgrapht.util.VertexPair;
  * href="http://mathworld.wolfram.com/SimpleGraph.html">
  * http://mathworld.wolfram.com/SimpleGraph.html</a>.
  */
-public class SimpleGraph<V, E> extends AbstractBaseGraph<V, E> implements
-		UndirectedGraph<V, E> {
+public class SimpleGraph<V, E>
+    extends AbstractBaseGraph<V, E>
+    implements UndirectedGraph<V, E>
+{
+    
 
-	private static final long serialVersionUID = 3545796589454112304L;
+    private static final long serialVersionUID = 3545796589454112304L;
 
-	/**
-	 * Creates a new simple graph with the specified edge factory.
-	 *
-	 * @param ef
-	 *            the edge factory of the new graph.
-	 */
-	public SimpleGraph(EdgeFactory<V, E> ef) {
-		super(ef, false, false);
-	}
+    
 
-	/**
-	 * Creates a new simple graph.
-	 *
-	 * @param edgeClass
-	 *            class on which to base factory for edges
-	 */
-	public SimpleGraph(Class<? extends E> edgeClass) {
-		this(new ClassBasedEdgeFactory<V, E>(edgeClass));
-	}
+    /**
+     * Creates a new simple graph with the specified edge factory.
+     *
+     * @param ef the edge factory of the new graph.
+     */
+    public SimpleGraph(EdgeFactory<V, E> ef)
+    {
+        super(ef, false, false);
+    }
 
-	/**
+    /**
+     * Creates a new simple graph.
+     *
+     * @param edgeClass class on which to base factory for edges
+     */
+    public SimpleGraph(Class<? extends E> edgeClass)
+    {
+        this(new ClassBasedEdgeFactory<V, E>(edgeClass));
+    }
+    
+    /**
 	 * Builder for {@link SimpleGraph}.
 	 * 
 	 * @author Thomas Feichtinger (t.feichtinger[at]gmail[dot]com)

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleGraph.java
@@ -38,8 +38,14 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
+import org.jgrapht.EdgeFactory;
+import org.jgrapht.UndirectedGraph;
+import org.jgrapht.util.VertexPair;
 
 /**
  * A simple graph. A simple graph is an undirected graph for which at most one
@@ -48,35 +54,106 @@ import org.jgrapht.*;
  * href="http://mathworld.wolfram.com/SimpleGraph.html">
  * http://mathworld.wolfram.com/SimpleGraph.html</a>.
  */
-public class SimpleGraph<V, E>
-    extends AbstractBaseGraph<V, E>
-    implements UndirectedGraph<V, E>
-{
-    
+public class SimpleGraph<V, E> extends AbstractBaseGraph<V, E> implements
+		UndirectedGraph<V, E> {
 
-    private static final long serialVersionUID = 3545796589454112304L;
+	private static final long serialVersionUID = 3545796589454112304L;
 
-    
+	/**
+	 * Creates a new simple graph with the specified edge factory.
+	 *
+	 * @param ef
+	 *            the edge factory of the new graph.
+	 */
+	public SimpleGraph(EdgeFactory<V, E> ef) {
+		super(ef, false, false);
+	}
 
-    /**
-     * Creates a new simple graph with the specified edge factory.
-     *
-     * @param ef the edge factory of the new graph.
-     */
-    public SimpleGraph(EdgeFactory<V, E> ef)
-    {
-        super(ef, false, false);
-    }
+	/**
+	 * Creates a new simple graph.
+	 *
+	 * @param edgeClass
+	 *            class on which to base factory for edges
+	 */
+	public SimpleGraph(Class<? extends E> edgeClass) {
+		this(new ClassBasedEdgeFactory<V, E>(edgeClass));
+	}
 
-    /**
-     * Creates a new simple graph.
-     *
-     * @param edgeClass class on which to base factory for edges
-     */
-    public SimpleGraph(Class<? extends E> edgeClass)
-    {
-        this(new ClassBasedEdgeFactory<V, E>(edgeClass));
-    }
+	/**
+	 * Builder for {@link SimpleGraph}.
+	 * 
+	 * @author Thomas Feichtinger (t.feichtinger[at]gmail[dot]com)
+	 */
+	public static class Builder<V, E> {
+
+		private final Class<? extends E> edgeclass;
+		private final Set<V> vertices;
+		private final List<VertexPair<V>> edges;
+
+		public Builder(final Class<? extends E> edgeClass) {
+			this.edgeclass = edgeClass;
+			this.vertices = new HashSet<V>();
+			this.edges = new ArrayList<VertexPair<V>>();
+		}
+
+		public Builder(final Class<? extends E> edgeClass, V... vertices) {
+			this(edgeClass);
+			vertices(vertices);
+		}
+
+		/**
+		 * Adds the specified vertices to the graph. Vertices already contained
+		 * in the graph will be ignored.
+		 * 
+		 * @param vertices
+		 *            the vertices to add
+		 * @return the builder
+		 */
+		public Builder<V, E> vertices(final V... vertices) {
+			for (final V vertex : vertices) {
+				this.vertices.add(vertex);
+			}
+			return this;
+		}
+
+		/**
+		 * Adds an edge between two vertices to the graph.
+		 * 
+		 * If the vertex is not yet contained in the graph it will be added.
+		 * 
+		 * @param source
+		 *            the source vertex
+		 * @param target
+		 *            the target vertex
+		 * @return the builder
+		 */
+		public Builder<V, E> edge(final V source, final V target) {
+			if (!vertices.contains(source)) {
+				vertices.add(source);
+			}
+			if (!vertices.contains(target)) {
+				vertices.add(target);
+			}
+			edges.add(new VertexPair<V>(source, target));
+			return this;
+		}
+
+		/**
+		 * Builds the actual graph from the state of this builder.
+		 * 
+		 * @return the graph
+		 */
+		public SimpleGraph<V, E> build() {
+			final SimpleGraph<V, E> g = new SimpleGraph<V, E>(edgeclass);
+			for (final V v : vertices) {
+				g.addVertex(v);
+			}
+			for (final VertexPair<V> edge : edges) {
+				g.addEdge(edge.getFirst(), edge.getSecond());
+			}
+			return g;
+		}
+	}
 }
 
 // End SimpleGraph.java

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleWeightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleWeightedGraph.java
@@ -43,40 +43,45 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.jgrapht.EdgeFactory;
-import org.jgrapht.WeightedGraph;
+import org.jgrapht.*;
 import org.jgrapht.util.VertexPair;
+
 
 /**
  * A simple weighted graph. A simple weighted graph is a simple graph for which
  * edges are assigned weights.
  */
-public class SimpleWeightedGraph<V, E> extends SimpleGraph<V, E> implements
-		WeightedGraph<V, E> {
+public class SimpleWeightedGraph<V, E>
+    extends SimpleGraph<V, E>
+    implements WeightedGraph<V, E>
+{
+    
 
-	private static final long serialVersionUID = 3906088949100655922L;
+    private static final long serialVersionUID = 3906088949100655922L;
 
-	/**
-	 * Creates a new simple weighted graph with the specified edge factory.
-	 *
-	 * @param ef
-	 *            the edge factory of the new graph.
-	 */
-	public SimpleWeightedGraph(EdgeFactory<V, E> ef) {
-		super(ef);
-	}
+    
 
-	/**
-	 * Creates a new simple weighted graph.
-	 *
-	 * @param edgeClass
-	 *            class on which to base factory for edges
-	 */
-	public SimpleWeightedGraph(Class<? extends E> edgeClass) {
-		this(new ClassBasedEdgeFactory<V, E>(edgeClass));
-	}
+    /**
+     * Creates a new simple weighted graph with the specified edge factory.
+     *
+     * @param ef the edge factory of the new graph.
+     */
+    public SimpleWeightedGraph(EdgeFactory<V, E> ef)
+    {
+        super(ef);
+    }
 
-	/**
+    /**
+     * Creates a new simple weighted graph.
+     *
+     * @param edgeClass class on which to base factory for edges
+     */
+    public SimpleWeightedGraph(Class<? extends E> edgeClass)
+    {
+        this(new ClassBasedEdgeFactory<V, E>(edgeClass));
+    }
+    
+    /**
 	 * Builder for {@SimpleWeightedGraph}.
 	 * 
 	 * @author Thomas Feichtinger (t.feichtinger[at]gmail[dot]com)

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleWeightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleWeightedGraph.java
@@ -38,42 +38,128 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
+import org.jgrapht.EdgeFactory;
+import org.jgrapht.WeightedGraph;
+import org.jgrapht.util.VertexPair;
 
 /**
  * A simple weighted graph. A simple weighted graph is a simple graph for which
  * edges are assigned weights.
  */
-public class SimpleWeightedGraph<V, E>
-    extends SimpleGraph<V, E>
-    implements WeightedGraph<V, E>
-{
-    
+public class SimpleWeightedGraph<V, E> extends SimpleGraph<V, E> implements
+		WeightedGraph<V, E> {
 
-    private static final long serialVersionUID = 3906088949100655922L;
+	private static final long serialVersionUID = 3906088949100655922L;
 
-    
+	/**
+	 * Creates a new simple weighted graph with the specified edge factory.
+	 *
+	 * @param ef
+	 *            the edge factory of the new graph.
+	 */
+	public SimpleWeightedGraph(EdgeFactory<V, E> ef) {
+		super(ef);
+	}
 
-    /**
-     * Creates a new simple weighted graph with the specified edge factory.
-     *
-     * @param ef the edge factory of the new graph.
-     */
-    public SimpleWeightedGraph(EdgeFactory<V, E> ef)
-    {
-        super(ef);
-    }
+	/**
+	 * Creates a new simple weighted graph.
+	 *
+	 * @param edgeClass
+	 *            class on which to base factory for edges
+	 */
+	public SimpleWeightedGraph(Class<? extends E> edgeClass) {
+		this(new ClassBasedEdgeFactory<V, E>(edgeClass));
+	}
 
-    /**
-     * Creates a new simple weighted graph.
-     *
-     * @param edgeClass class on which to base factory for edges
-     */
-    public SimpleWeightedGraph(Class<? extends E> edgeClass)
-    {
-        this(new ClassBasedEdgeFactory<V, E>(edgeClass));
-    }
+	/**
+	 * Builder for {@SimpleWeightedGraph}.
+	 * 
+	 * @author Thomas Feichtinger (t.feichtinger[at]gmail[dot]com)
+	 */
+	public static class Builder<V, E> {
+
+		private final Class<? extends E> edgeclass;
+		private final Set<V> vertices;
+		private final List<VertexPair<V>> edges;
+		private final List<Double> weights;
+
+		public Builder(final Class<? extends E> edgeClass) {
+			this.edgeclass = edgeClass;
+			this.vertices = new HashSet<V>();
+			this.edges = new ArrayList<VertexPair<V>>();
+			this.weights = new ArrayList<Double>();
+		}
+
+		public Builder(final Class<? extends E> edgeClass, V... vertices) {
+			this(edgeClass);
+			vertices(vertices);
+		}
+
+		/**
+		 * Adds the specified vertices to the graph. Vertices already contained
+		 * in the graph will be ignored.
+		 * 
+		 * @param vertices
+		 *            the vertices to add
+		 * @return the builder
+		 */
+		public Builder<V, E> vertices(final V... vertices) {
+			for (final V vertex : vertices) {
+				this.vertices.add(vertex);
+			}
+			return this;
+		}
+
+		/**
+		 * Adds an edge between two vertices to the graph.
+		 * 
+		 * If the vertex is not yet contained in the graph it will be added.
+		 * 
+		 * @param source
+		 *            the source vertex
+		 * @param target
+		 *            the target vertex
+		 * @param weight
+		 *            the weight of the edge
+		 * @return the builder
+		 */
+		public Builder<V, E> edge(final V source, final V target,
+				final double weight) {
+			vertices.add(source);
+			vertices.add(target);
+			edges.add(new VertexPair<V>(source, target));
+			weights.add(weight);
+			return this;
+		}
+
+		/**
+		 * Builds the actual graph from the state of this builder.
+		 * 
+		 * @return the graph
+		 */
+		public SimpleWeightedGraph<V, E> build() {
+			final SimpleWeightedGraph<V, E> g = new SimpleWeightedGraph<V, E>(
+					edgeclass);
+
+			for (final V v : vertices) {
+				g.addVertex(v);
+			}
+
+			for (int i = 0; i < edges.size(); ++i) {
+				E edge = g.addEdge(edges.get(i).getFirst(), edges.get(i)
+						.getSecond());
+				if (edge != null) {
+					g.setEdgeWeight(edge, weights.get(i));
+				}
+			}
+			return g;
+		}
+	}
 }
 
 // End SimpleWeightedGraph.java

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleGraphBuilderTests.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleGraphBuilderTests.java
@@ -1,0 +1,57 @@
+package org.jgrapht.graph;
+
+import java.util.Arrays;
+
+import org.jgrapht.EnhancedTestCase;
+import org.jgrapht.Graph;
+
+/**
+ * Tests for the SimpleGraphBuilder.
+ * 
+ * @author Thomas Feichtinger
+ *
+ */
+public class SimpleGraphBuilderTests extends EnhancedTestCase {
+	private static final String V1 = "v1";
+	private static final String V2 = "v2";
+	private static final String V3 = "v3";
+	private static final String V4 = "v4";
+
+	private Graph<String, DefaultEdge> simpleGraph;
+	private Graph<String, DefaultEdge> regularSimpleGraph;
+
+	@Override
+	public void setUp() {
+		simpleGraph = new SimpleGraph.Builder<String, DefaultEdge>(
+				DefaultEdge.class).edge(V1, V2).edge(V1, V3).edge(V3, V4)
+				.edge(V2, V4).build();
+
+		regularSimpleGraph = new SimpleGraph<String, DefaultEdge>(
+				DefaultEdge.class);
+		regularSimpleGraph.addVertex(V1);
+		regularSimpleGraph.addVertex(V2);
+		regularSimpleGraph.addVertex(V3);
+		regularSimpleGraph.addVertex(V4);
+		regularSimpleGraph.addEdge(V1, V2);
+		regularSimpleGraph.addEdge(V1, V3);
+		regularSimpleGraph.addEdge(V3, V4);
+		regularSimpleGraph.addEdge(V2, V4);
+	}
+
+	public void testVertices() {
+		assertTrue(simpleGraph.vertexSet().containsAll(
+				Arrays.asList(V1, V2, V3, V4)));
+	}
+
+	public void testEdges() {
+		assert simpleGraph.edgeSet().size() == 4;
+		assert simpleGraph.containsEdge(V1, V2);
+		assert simpleGraph.containsEdge(V1, V3);
+		assert simpleGraph.containsEdge(V3, V4);
+		assert simpleGraph.containsEdge(V2, V4);
+	}
+
+	public void testCompareGraphs() {
+		assert simpleGraph.equals(regularSimpleGraph);
+	}
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleWeightedGraphBuilderTests.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleWeightedGraphBuilderTests.java
@@ -1,0 +1,63 @@
+package org.jgrapht.graph;
+
+import java.util.Arrays;
+
+import org.jgrapht.EnhancedTestCase;
+
+/**
+ * Tests for the SimpleWeightedGraphBuilder.
+ * @author Thomas Feichtinger
+ *
+ */
+public class SimpleWeightedGraphBuilderTests extends EnhancedTestCase {
+	private static final String V1 = "v1";
+	private static final String V2 = "v2";
+	private static final String V3 = "v3";
+	private static final String V4 = "v4";
+
+	private SimpleWeightedGraph<String, DefaultWeightedEdge> weightedGraph;
+	private SimpleWeightedGraph<String, DefaultWeightedEdge> regularWeightedGraph;
+
+	@Override
+	public void setUp() {
+		weightedGraph = new SimpleWeightedGraph.Builder<String, DefaultWeightedEdge>(
+				DefaultWeightedEdge.class).edge(V1, V2, 1.0).edge(V1, V3, 2.0)
+				.edge(V3, V4, 3.0).edge(V2, V4, 4.0).build();
+
+		regularWeightedGraph = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
+				DefaultWeightedEdge.class);
+
+		regularWeightedGraph.addVertex(V1);
+		regularWeightedGraph.addVertex(V2);
+		regularWeightedGraph.addVertex(V3);
+		regularWeightedGraph.addVertex(V4);
+
+		DefaultWeightedEdge e;
+		e = regularWeightedGraph.addEdge(V1, V2);
+		regularWeightedGraph.setEdgeWeight(e, 1.0);
+		e = regularWeightedGraph.addEdge(V1, V3);
+		regularWeightedGraph.setEdgeWeight(e, 2.0);
+		e = regularWeightedGraph.addEdge(V3, V4);
+		regularWeightedGraph.setEdgeWeight(e, 3.0);
+		e = regularWeightedGraph.addEdge(V2, V4);
+		regularWeightedGraph.setEdgeWeight(e, 4.0);
+
+	}
+
+	public void testVertices() {
+		assertTrue(weightedGraph.vertexSet().containsAll(
+				Arrays.asList(V1, V2, V3, V4)));
+	}
+
+	public void testEdges() {
+		assert weightedGraph.edgeSet().size() == 4;
+		assert weightedGraph.containsEdge(V1, V2);
+		assert weightedGraph.containsEdge(V1, V3);
+		assert weightedGraph.containsEdge(V3, V4);
+		assert weightedGraph.containsEdge(V2, V4);
+	}
+
+	public void testCompareGraphs() {
+		assert weightedGraph.equals(regularWeightedGraph);
+	}
+}


### PR DESCRIPTION
followup on MR#81: I moved the builder into the respective graph classes as a static class. now it is possible to create a new graph like this:

```java
new SimpleGraph.Builder<String, DefaultEdge>(DefaultEdge.class) ...
```

What
-----
Builders for SimpleGraph and SimpleWeightedGraph.

Why
-----
Right now initializing graphs is very verbose: 
* create an empty graph
* add vertices one by one
* add edges
* possibly set weights

With the builder object this can be done in a much more concise way.

Example:

```java
g =  new SimpleWeightedGraph.Builder<String, DefaultWeightedEdge>(DefaultWeightedEdge.class)
    .edge(V1, V2, 1.0).edge(V1, V3, 2.0).edge(V3, V4, 3.0).edge(V2, V4, 4.0).build();
```
vs.

```java
g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(DefaultWeightedEdge.class);

regularWeightedGraph.addVertex(V1);
regularWeightedGraph.addVertex(V2);
regularWeightedGraph.addVertex(V3);
regularWeightedGraph.addVertex(V4);

regularWeightedGraph.setEdgeWeight(regularWeightedGraph.addEdge(V1, V2), 1.0);
regularWeightedGraph.setEdgeWeight(regularWeightedGraph.addEdge(V1, V3), 2.0);
regularWeightedGraph.setEdgeWeight(regularWeightedGraph.addEdge(V3, V4), 3.0);
regularWeightedGraph.setEdgeWeight(regularWeightedGraph.addEdge(V2, V4), 4.0);
```

If you think this is useful I will be open to implement builders for the other graph types.