### PR TITLE
Use JUnit4's RunWith and Suite annotations to simplify test suites.

### DIFF
--- a/jgrapht-core/src/test/java/org/jgrapht/AllTests.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/AllTests.java
@@ -36,87 +36,30 @@
  */
 package org.jgrapht;
 
-import java.util.*;
-
-import junit.framework.*;
-
 import org.jgrapht.alg.*;
 import org.jgrapht.alg.util.*;
 import org.jgrapht.generate.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.traverse.*;
 import org.jgrapht.util.*;
-
+import org.junit.runner.*;
+import org.junit.runners.*;
 
 /**
  * Runs all unit tests of the JGraphT library.
  *
  * @author Barak Naveh
  */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    AllAlgTests.class,
+    AllAlgUtilTests.class,
+    AllGenerateTests.class,
+    AllGraphTests.class,
+    AllTraverseTests.class,
+    AllUtilTests.class
+})
 public final class AllTests
 {
-    //~ Constructors -----------------------------------------------------------
-
-    private AllTests()
-    {
-    } // ensure non-instantiability.
-
-    //~ Methods ----------------------------------------------------------------
-
-    /**
-     * Creates a test suite that includes all JGraphT tests.
-     *
-     * @return a test suite that includes all JGraphT tests.
-     */
-    public static Test suite()
-    {
-        ExpandableTestSuite suite =
-            new ExpandableTestSuite("All tests of JGraphT");
-
-        suite.addTestSuit((TestSuite) AllAlgTests.suite());
-        suite.addTestSuit((TestSuite) AllAlgUtilTests.suite());
-        suite.addTestSuit((TestSuite) AllGenerateTests.suite());
-        suite.addTestSuit((TestSuite) AllGraphTests.suite());
-        suite.addTestSuit((TestSuite) AllTraverseTests.suite());
-        suite.addTestSuit((TestSuite) AllUtilTests.suite());
-
-        return suite;
-    }
-
-    //~ Inner Classes ----------------------------------------------------------
-
-    private static class ExpandableTestSuite
-        extends TestSuite
-    {
-        /**
-         * @see TestSuite#TestSuite()
-         */
-        public ExpandableTestSuite()
-        {
-            super();
-        }
-
-        /**
-         * @see TestSuite#TestSuite(java.lang.String)
-         */
-        public ExpandableTestSuite(String name)
-        {
-            super(name);
-        }
-
-        /**
-         * Adds all the test from the specified suite into this suite.
-         *
-         * @param suite
-         */
-        public void addTestSuit(TestSuite suite)
-        {
-            for (Enumeration e = suite.tests(); e.hasMoreElements();) {
-                Test t = (Test) e.nextElement();
-                this.addTest(t);
-            }
-        }
-    }
 }
-
 // End AllTests.java

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/AllAlgTests.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/AllAlgTests.java
@@ -36,66 +36,47 @@
  */
 package org.jgrapht.alg;
 
-import junit.framework.Test;
-import junit.framework.TestSuite;
-import org.jgrapht.experimental.isomorphism.IsomorphismInspectorTest;
-
+import org.jgrapht.experimental.isomorphism.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
 
 /**
  * A TestSuite for all tests in this package.
  *
  * @author Barak Naveh
  */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    BellmanFordShortestPathTest.class,
+    BiconnectivityInspectorTest.class,
+    BlockCutpointGraphTest.class,
+    BronKerboschCliqueFinderTest.class,
+    ChromaticNumberTest.class,
+    ConnectivityInspectorTest.class,
+    CycleDetectorTest.class,
+    DijkstraShortestPathTest.class,
+    EdmondsBlossomShrinkingTest.class,
+    EdmondsKarpMaximumFlowTest.class,
+    EulerianCircuitTest.class,
+    FloydWarshallShortestPathsTest.class,
+    HamiltonianCycleTest.class,
+    HopcroftKarpBipartiteMatchingTest.class,
+    IsomorphismInspectorTest.class,
+    KShortestPathCostTest.class,
+    KShortestPathKValuesTest.class,
+    KSPDiscardsValidPathsTest.class,
+    KSPExampleTest.class,
+    KuhnMunkresMinimalWeightBipartitePerfectMatchingTest.class,
+    MinimumSpanningTreeTest.class,
+    MinSourceSinkCutTest.class,
+    NaiveLcaFinderTest.class,
+    NeighborIndexTest.class,
+    StoerWagnerMinimumCutTest.class,
+    TarjanLowestCommonAncestorTest.class,
+    TransitiveClosureTest.class,
+    VertexCoversTest.class
+})
 public final class AllAlgTests
 {
-    //~ Constructors -----------------------------------------------------------
-
-    private AllAlgTests()
-    {
-    } // ensure non-instantiability.
-
-    //~ Methods ----------------------------------------------------------------
-
-    /**
-     * Creates a test suite for all tests in this package.
-     *
-     * @return a test suite for all tests in this package.
-     */
-    public static Test suite()
-    {
-        TestSuite suite = new TestSuite();
-
-        // $JUnit-BEGIN$
-        suite.addTest(new TestSuite(ConnectivityInspectorTest.class));
-        suite.addTest(new TestSuite(DijkstraShortestPathTest.class));
-        suite.addTest(new TestSuite(BellmanFordShortestPathTest.class));
-        suite.addTest(new TestSuite(FloydWarshallShortestPathsTest.class));
-        suite.addTest(new TestSuite(VertexCoversTest.class));
-        suite.addTest(new TestSuite(CycleDetectorTest.class));
-        suite.addTest(new TestSuite(BronKerboschCliqueFinderTest.class));
-        suite.addTest(new TestSuite(TransitiveClosureTest.class));
-        suite.addTest(new TestSuite(BiconnectivityInspectorTest.class));
-        suite.addTest(new TestSuite(BlockCutpointGraphTest.class));
-        suite.addTest(new TestSuite(KShortestPathCostTest.class));
-        suite.addTest(new TestSuite(KShortestPathKValuesTest.class));
-        suite.addTest(new TestSuite(KSPExampleTest.class));
-        suite.addTest(new TestSuite(KSPDiscardsValidPathsTest.class));
-        suite.addTestSuite(IsomorphismInspectorTest.class);
-        suite.addTest(new TestSuite(EdmondsKarpMaximumFlowTest.class));
-        suite.addTest(new TestSuite(ChromaticNumberTest.class));
-        suite.addTest(new TestSuite(EulerianCircuitTest.class));
-        suite.addTest(new TestSuite(HamiltonianCycleTest.class));
-        suite.addTest(new TestSuite(MinimumSpanningTreeTest.class));
-        suite.addTest(new TestSuite(StoerWagnerMinimumCutTest.class));
-        suite.addTest(new TestSuite(EdmondsBlossomShrinkingTest.class));
-        suite.addTest(new TestSuite(MinSourceSinkCutTest.class));
-        suite.addTest(new TestSuite(HopcroftKarpBipartiteMatchingTest.class));
-        suite.addTest(new TestSuite(KuhnMunkresMinimalWeightBipartitePerfectMatchingTest.class));
-        suite.addTest(new TestSuite(TarjanLowestCommonAncestorTest.class));
-        
-        // $JUnit-END$
-        return suite;
-    }
 }
-
 // End AllAlgTests.java

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/util/AllAlgUtilTests.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/util/AllAlgUtilTests.java
@@ -34,39 +34,19 @@
  */
 package org.jgrapht.alg.util;
 
-import junit.framework.*;
-
+import org.junit.runner.*;
+import org.junit.runners.*;
 
 /**
  * A TestSuite for all tests in this package.
  *
  * @author Tom Conerly
  */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    UnionFindTest.class
+})
 public final class AllAlgUtilTests
 {
-    //~ Constructors -----------------------------------------------------------
-
-    private AllAlgUtilTests()
-    {
-    } // ensure non-instantiability.
-
-    //~ Methods ----------------------------------------------------------------
-
-    /**
-     * Creates a test suite for all tests in this package.
-     *
-     * @return a test suite for all tests in this package.
-     */
-    public static Test suite()
-    {
-        TestSuite suite = new TestSuite();
-
-        // $JUnit-BEGIN$
-        suite.addTest(new TestSuite(UnionFindTest.class));
-
-        // $JUnit-END$
-        return suite;
-    }
 }
-
 // End AllAlgUtilTests.java

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/AllGenerateTests.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/AllGenerateTests.java
@@ -36,40 +36,20 @@
  */
 package org.jgrapht.generate;
 
-import junit.framework.*;
-
+import org.junit.runner.*;
+import org.junit.runners.*;
 
 /**
  * A TestSuite for all tests in this package.
  *
  * @author Barak Naveh
  */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    GraphGeneratorTest.class,
+    RandomGraphGeneratorTest.class
+})
 public final class AllGenerateTests
 {
-    //~ Constructors -----------------------------------------------------------
-
-    private AllGenerateTests()
-    {
-    } // ensure non-instantiability.
-
-    //~ Methods ----------------------------------------------------------------
-
-    /**
-     * Creates a test suite for all tests in this package.
-     *
-     * @return a test suite for all tests in this package.
-     */
-    public static Test suite()
-    {
-        TestSuite suite = new TestSuite();
-
-        // $JUnit-BEGIN$
-        suite.addTest(new TestSuite(GraphGeneratorTest.class));
-        suite.addTestSuite(RandomGraphGeneratorTest.class);
-
-        // $JUnit-END$
-        return suite;
-    }
 }
-
 // End AllGenerateTests.java

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/AllGraphTests.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/AllGraphTests.java
@@ -36,8 +36,8 @@
  */
 package org.jgrapht.graph;
 
-import junit.framework.*;
-
+import org.junit.runner.*;
+import org.junit.runners.*;
 
 /**
  * A TestSuite for all tests in this package.
@@ -45,39 +45,22 @@ import junit.framework.*;
  * @author Barak Naveh
  * @since Aug 3, 2003
  */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    AsUndirectedGraphTest.class,
+    AsUnweightedGraphTest.class,
+    AsWeightedGraphTest.class,
+    CloneTest.class,
+    DefaultDirectedGraphTest.class,
+    EqualsAndHashCodeTest.class,
+    GenericGraphsTest.class,
+    ListenableGraphTest.class,
+    SerializationTest.class,
+    SimpleDirectedGraphTest.class,
+    SimpleGraphPathTest.class,
+    SubgraphTest.class
+})
 public final class AllGraphTests
 {
-    //~ Constructors -----------------------------------------------------------
-
-    private AllGraphTests()
-    {
-    } // ensure non-instantiability.
-
-    //~ Methods ----------------------------------------------------------------
-
-    /**
-     * Creates a test suite for all tests in this package.
-     *
-     * @return a test suite for all tests in this package.
-     */
-    public static Test suite()
-    {
-        TestSuite suite = new TestSuite();
-
-        // $JUnit-BEGIN$
-        suite.addTest(new TestSuite(DefaultDirectedGraphTest.class));
-        suite.addTest(new TestSuite(ListenableGraphTest.class));
-        suite.addTest(new TestSuite(SimpleDirectedGraphTest.class));
-        suite.addTest(new TestSuite(AsUndirectedGraphTest.class));
-        suite.addTest(new TestSuite(AsUnweightedGraphTest.class));
-        suite.addTest(new TestSuite(CloneTest.class));
-        suite.addTest(new TestSuite(SerializationTest.class));
-        suite.addTest(new TestSuite(GenericGraphsTest.class));
-        suite.addTest(new TestSuite(EqualsAndHashCodeTest.class));
-        suite.addTest(new TestSuite(SimpleGraphPathTest.class));
-        // $JUnit-END$
-        return suite;
-    }
 }
-
 // End AllGraphTests.java

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/AllTraverseTests.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/AllTraverseTests.java
@@ -36,43 +36,23 @@
  */
 package org.jgrapht.traverse;
 
-import junit.framework.*;
-
+import org.junit.runner.*;
+import org.junit.runners.*;
 
 /**
  * A TestSuite for all tests in this package.
  *
  * @author Barak Naveh
  */
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    BreadthFirstIteratorTest.class,
+    ClosestFirstIteratorTest.class,
+    DepthFirstIteratorTest.class,
+    IgnoreDirectionTest.class,
+    TopologicalOrderIteratorTest.class
+})
 public final class AllTraverseTests
 {
-    //~ Constructors -----------------------------------------------------------
-
-    private AllTraverseTests()
-    {
-    } // ensure non-instantiability.
-
-    //~ Methods ----------------------------------------------------------------
-
-    /**
-     * Creates a test suite for all tests in this package.
-     *
-     * @return a test suite for all tests in this package.
-     */
-    public static Test suite()
-    {
-        TestSuite suite = new TestSuite();
-
-        // $JUnit-BEGIN$
-        suite.addTest(new TestSuite(BreadthFirstIteratorTest.class));
-        suite.addTest(new TestSuite(DepthFirstIteratorTest.class));
-        suite.addTest(new TestSuite(ClosestFirstIteratorTest.class));
-        suite.addTest(new TestSuite(IgnoreDirectionTest.class));
-        suite.addTest(new TestSuite(TopologicalOrderIteratorTest.class));
-
-        // $JUnit-END$
-        return suite;
-    }
 }
-
 // End AllTraverseTests.java

--- a/jgrapht-core/src/test/java/org/jgrapht/util/AllUtilTests.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/AllUtilTests.java
@@ -34,29 +34,19 @@
  */
 package org.jgrapht.util;
 
-import junit.framework.*;
-
 import org.jgrapht.experimental.equivalence.*;
 import org.jgrapht.experimental.permutation.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
 
-
+@RunWith(Suite.class)
+@Suite.SuiteClasses({
+    FibonacciHeapTest.class,
+    PrefetchIteratorTest.class,
+    CompoundPermutationIterTest.class,
+    EquivalenceGroupCreatorTest.class
+})
 public class AllUtilTests
 {
-    //~ Methods ----------------------------------------------------------------
-
-    public static Test suite()
-    {
-        TestSuite suite = new TestSuite("Test for org.jgrapht.util");
-
-        // $JUnit-BEGIN$
-        suite.addTestSuite(FibonacciHeapTest.class);
-        suite.addTestSuite(PrefetchIteratorTest.class);
-        suite.addTestSuite(CompoundPermutationIterTest.class);
-        suite.addTestSuite(EquivalenceGroupCreatorTest.class);
-
-        // $JUnit-END$
-        return suite;
-    }
 }
-
 // End AllUtilTests.java


### PR DESCRIPTION
Just a minor change: JUnit4 offers the annotations @RunWith and @Suite, which allow to
group test classes in suites in a simpler and more legible way.
