### PR TITLE
Add missing Override annotations in org.jgrapht.alg

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/AbstractPathElementList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/AbstractPathElementList.java
@@ -168,6 +168,7 @@ abstract class AbstractPathElementList<V,
      * Returns path <code>AbstractPathElement</code> stored at the specified
      * index.
      */
+    @Override
     public T get(int index)
     {
         return this.pathElements.get(index);
@@ -184,6 +185,7 @@ abstract class AbstractPathElementList<V,
     /**
      * Returns the number of paths stored in the list.
      */
+    @Override
     public int size()
     {
         return this.pathElements.size();

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/BellmanFordIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/BellmanFordIterator.java
@@ -126,6 +126,7 @@ class BellmanFordIterator<V, E>
      * @return <code>true</code> if at least one path has been improved during
      * the previous pass, <code>false</code> otherwise.
      */
+    @Override
     public boolean hasNext()
     {
         if (!this.startVertexEncountered) {
@@ -141,6 +142,7 @@ class BellmanFordIterator<V, E>
      *
      * @see java.util.Iterator#next()
      */
+    @Override
     public List<V> next()
     {
         if (!this.startVertexEncountered) {
@@ -187,6 +189,7 @@ class BellmanFordIterator<V, E>
      *
      * @see java.util.Iterator#remove()
      */
+    @Override
     public void remove()
     {
         throw new UnsupportedOperationException();

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/BlockCutpointGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/BlockCutpointGraph.java
@@ -321,11 +321,13 @@ public class BlockCutpointGraph<V, E>
             this.target = target;
         }
 
+        @Override
         public V getSource()
         {
             return this.source;
         }
 
+        @Override
         public V getTarget()
         {
             return this.target;
@@ -342,11 +344,13 @@ public class BlockCutpointGraph<V, E>
             this.vertexComponent = vertexComponent;
         }
 
+        @Override
         public boolean isEdgeMasked(E edge)
         {
             return false;
         }
 
+        @Override
         public boolean isVertexMasked(V vertex)
         {
             if (this.vertexComponent.contains(vertex)) {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/ConnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/ConnectivityInspector.java
@@ -167,6 +167,7 @@ public class ConnectivityInspector<V, E>
     /**
      * @see GraphListener#edgeAdded(GraphEdgeChangeEvent)
      */
+    @Override
     public void edgeAdded(GraphEdgeChangeEvent<V, E> e)
     {
         init(); // for now invalidate cached results, in the future need to
@@ -176,6 +177,7 @@ public class ConnectivityInspector<V, E>
     /**
      * @see GraphListener#edgeRemoved(GraphEdgeChangeEvent)
      */
+    @Override
     public void edgeRemoved(GraphEdgeChangeEvent<V, E> e)
     {
         init(); // for now invalidate cached results, in the future need to
@@ -210,6 +212,7 @@ public class ConnectivityInspector<V, E>
     /**
      * @see VertexSetListener#vertexAdded(GraphVertexChangeEvent)
      */
+    @Override
     public void vertexAdded(GraphVertexChangeEvent<V> e)
     {
         init(); // for now invalidate cached results, in the future need to
@@ -219,6 +222,7 @@ public class ConnectivityInspector<V, E>
     /**
      * @see VertexSetListener#vertexRemoved(GraphVertexChangeEvent)
      */
+    @Override
     public void vertexRemoved(GraphVertexChangeEvent<V> e)
     {
         init(); // for now invalidate cached results, in the future need to
@@ -269,6 +273,7 @@ public class ConnectivityInspector<V, E>
         /**
          * @see TraversalListenerAdapter#connectedComponentFinished(ConnectedComponentTraversalEvent)
          */
+        @Override
         public void connectedComponentFinished(
             ConnectedComponentTraversalEvent e)
         {
@@ -278,6 +283,7 @@ public class ConnectivityInspector<V, E>
         /**
          * @see TraversalListenerAdapter#connectedComponentStarted(ConnectedComponentTraversalEvent)
          */
+        @Override
         public void connectedComponentStarted(
             ConnectedComponentTraversalEvent e)
         {
@@ -287,6 +293,7 @@ public class ConnectivityInspector<V, E>
         /**
          * @see TraversalListenerAdapter#vertexTraversed(VertexTraversalEvent)
          */
+        @Override
         public void vertexTraversed(VertexTraversalEvent<V> e)
         {
             V v = e.getVertex();

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/CycleDetector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/CycleDetector.java
@@ -209,6 +209,7 @@ public class CycleDetector<V, E>
         /**
          * {@inheritDoc}
          */
+        @Override
         protected void encounterVertexAgain(V vertex, E edge)
         {
             super.encounterVertexAgain(vertex, edge);
@@ -245,6 +246,7 @@ public class CycleDetector<V, E>
         /**
          * {@inheritDoc}
          */
+        @Override
         protected V provideNextVertex()
         {
             V v = super.provideNextVertex();

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/DirectedNeighborIndex.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/DirectedNeighborIndex.java
@@ -146,6 +146,7 @@ public class DirectedNeighborIndex<V, E>
     /**
      * @see GraphListener#edgeAdded(GraphEdgeChangeEvent)
      */
+    @Override
     public void edgeAdded(GraphEdgeChangeEvent<V, E> e)
     {
         E edge = e.getEdge();
@@ -172,6 +173,7 @@ public class DirectedNeighborIndex<V, E>
     /**
      * @see GraphListener#edgeRemoved(GraphEdgeChangeEvent)
      */
+    @Override
     public void edgeRemoved(GraphEdgeChangeEvent<V, E> e)
     {
         E edge = e.getEdge();
@@ -188,6 +190,7 @@ public class DirectedNeighborIndex<V, E>
     /**
      * @see VertexSetListener#vertexAdded(GraphVertexChangeEvent)
      */
+    @Override
     public void vertexAdded(GraphVertexChangeEvent<V> e)
     {
         // nothing to cache until there are edges
@@ -196,6 +199,7 @@ public class DirectedNeighborIndex<V, E>
     /**
      * @see VertexSetListener#vertexRemoved(GraphVertexChangeEvent)
      */
+    @Override
     public void vertexRemoved(GraphVertexChangeEvent<V> e)
     {
         predecessorMap.remove(e.getVertex());

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/KShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/KShortestPaths.java
@@ -212,24 +212,28 @@ public class KShortestPaths<V, E>
         }
 
         // implement GraphPath
+        @Override
         public Graph<V, E> getGraph()
         {
             return graph;
         }
 
         // implement GraphPath
+        @Override
         public V getStartVertex()
         {
             return startVertex;
         }
 
         // implement GraphPath
+        @Override
         public V getEndVertex()
         {
             return rankingPathElement.getVertex();
         }
 
         // implement GraphPath
+        @Override
         public List<E> getEdgeList()
         {
             if (edgeList == null) {
@@ -239,12 +243,14 @@ public class KShortestPaths<V, E>
         }
 
         // implement GraphPath
+        @Override
         public double getWeight()
         {
             return rankingPathElement.getWeight();
         }
 
         // override Object
+        @Override
         public String toString()
         {
             return getEdgeList().toString();

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/KShortestPathsIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/KShortestPathsIterator.java
@@ -134,6 +134,7 @@ class KShortestPathsIterator<V, E>
      * @return <code>true</code> if at least one path has been improved during
      * the previous pass, <code>false</code> otherwise.
      */
+    @Override
     public boolean hasNext()
     {
         if (!this.startVertexEncountered) {
@@ -155,6 +156,7 @@ class KShortestPathsIterator<V, E>
      *
      * @see java.util.Iterator#next()
      */
+    @Override
     public Set<V> next()
     {
         if (!this.startVertexEncountered) {
@@ -188,6 +190,7 @@ class KShortestPathsIterator<V, E>
      *
      * @see java.util.Iterator#remove()
      */
+    @Override
     public void remove()
     {
         throw new UnsupportedOperationException();

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/KruskalMinimumSpanningTree.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/KruskalMinimumSpanningTree.java
@@ -76,6 +76,7 @@ public class KruskalMinimumSpanningTree<V, E>
         Collections.sort(
             allEdges,
             new Comparator<E>() {
+                @Override
                 public int compare(E edge1, E edge2)
                 {
                     return Double.valueOf(graph.getEdgeWeight(edge1)).compareTo(

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/NeighborIndex.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/NeighborIndex.java
@@ -117,6 +117,7 @@ public class NeighborIndex<V, E>
     /**
      * @see GraphListener#edgeAdded(GraphEdgeChangeEvent)
      */
+    @Override
     public void edgeAdded(GraphEdgeChangeEvent<V, E> e)
     {
         E edge = e.getEdge();
@@ -143,6 +144,7 @@ public class NeighborIndex<V, E>
     /**
      * @see GraphListener#edgeRemoved(GraphEdgeChangeEvent)
      */
+    @Override
     public void edgeRemoved(GraphEdgeChangeEvent<V, E> e)
     {
         E edge = e.getEdge();
@@ -159,6 +161,7 @@ public class NeighborIndex<V, E>
     /**
      * @see VertexSetListener#vertexAdded(GraphVertexChangeEvent)
      */
+    @Override
     public void vertexAdded(GraphVertexChangeEvent<V> e)
     {
         // nothing to cache until there are edges
@@ -167,6 +170,7 @@ public class NeighborIndex<V, E>
     /**
      * @see VertexSetListener#vertexRemoved(GraphVertexChangeEvent)
      */
+    @Override
     public void vertexRemoved(GraphVertexChangeEvent<V> e)
     {
         neighborMap.remove(e.getVertex());

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElement.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElement.java
@@ -103,6 +103,7 @@ final class RankingPathElement<V, E>
      *
      * @return <code>null</code> is the path is empty.
      */
+    @Override
     public RankingPathElement<V, E> getPrevPathElement()
     {
         return (RankingPathElement<V, E>) super.getPrevPathElement();

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElementList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElementList.java
@@ -423,12 +423,14 @@ final class RankingPathElementList<V, E>
         }
 
         // implement MaskFunctor
+        @Override
         public boolean isEdgeMasked(E edge)
         {
             return this.maskedEdges.contains(edge);
         }
 
         // implement MaskFunctor
+        @Override
         public boolean isVertexMasked(V vertex)
         {
             return this.maskedVertices.contains(vertex);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/StrongConnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/StrongConnectivityInspector.java
@@ -350,11 +350,13 @@ public class StrongConnectivityInspector<V, E>
             this.finishedData = finishedData;
         }
 
+        @Override
         VertexData<V> getFinishedData()
         {
             return finishedData;
         }
 
+        @Override
         V getVertex()
         {
             return null;
@@ -375,11 +377,13 @@ public class StrongConnectivityInspector<V, E>
             this.vertex = vertex;
         }
 
+        @Override
         VertexData<V> getFinishedData()
         {
             return null;
         }
 
+        @Override
         V getVertex()
         {
             return vertex;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
@@ -108,6 +108,7 @@ public class VertexDegreeComparator<V, E>
      * @return -1 if <code>v1</code> comes before <code>v2</code>, +1 if <code>
      * v1</code> comes after <code>v2</code>, 0 if equal.
      */
+    @Override
     public int compare(V v1, V v2)
     {
         int degree1 = graph.degreeOf(v1);


### PR DESCRIPTION
As discussed in #102, this pull request adds Override annotations for classes in the org.jgrapht.alg package hierarchy. I have created a new branch instead of splitting up #9, because that seemed easier to me.
