### PR TITLE
Add missing Override and Deprecated annotations in org.jgrapht.event

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/event/GraphEdgeChangeEvent.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/event/GraphEdgeChangeEvent.java
@@ -105,6 +105,7 @@ public class GraphEdgeChangeEvent<V, E>
      *
      * @deprecated Use new constructor which takes vertex parameters.
      */
+    @Deprecated
     public GraphEdgeChangeEvent(
         Object eventSource,
         int type,

--- a/jgrapht-core/src/main/java/org/jgrapht/event/TraversalListenerAdapter.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/event/TraversalListenerAdapter.java
@@ -53,6 +53,7 @@ public class TraversalListenerAdapter<V, E>
     /**
      * @see TraversalListener#connectedComponentFinished(ConnectedComponentTraversalEvent)
      */
+    @Override
     public void connectedComponentFinished(
         ConnectedComponentTraversalEvent e)
     {
@@ -61,6 +62,7 @@ public class TraversalListenerAdapter<V, E>
     /**
      * @see TraversalListener#connectedComponentStarted(ConnectedComponentTraversalEvent)
      */
+    @Override
     public void connectedComponentStarted(ConnectedComponentTraversalEvent e)
     {
     }
@@ -68,6 +70,7 @@ public class TraversalListenerAdapter<V, E>
     /**
      * @see TraversalListener#edgeTraversed(EdgeTraversalEvent)
      */
+    @Override
     public void edgeTraversed(EdgeTraversalEvent<V, E> e)
     {
     }
@@ -75,6 +78,7 @@ public class TraversalListenerAdapter<V, E>
     /**
      * @see TraversalListener#vertexTraversed(VertexTraversalEvent)
      */
+    @Override
     public void vertexTraversed(VertexTraversalEvent<V> e)
     {
     }
@@ -82,6 +86,7 @@ public class TraversalListenerAdapter<V, E>
     /**
      * @see TraversalListener#vertexFinished(VertexTraversalEvent)
      */
+    @Override
     public void vertexFinished(VertexTraversalEvent<V> e)
     {
     }


### PR DESCRIPTION
This pull request adds Override and Deprecated annotations for classes in the org.jgrapht.event package hierarchy.
