### PR TITLE
Add missing Override annotations in org.jgrapht.traverse

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/AbstractGraphIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/AbstractGraphIterator.java
@@ -86,6 +86,7 @@ public abstract class AbstractGraphIterator<V, E>
      * @return <code>true</code> if traverses across connected components,
      * otherwise <code>false</code>.
      */
+    @Override
     public boolean isCrossComponentTraversal()
     {
         return crossComponentTraversal;
@@ -94,6 +95,7 @@ public abstract class AbstractGraphIterator<V, E>
     /**
      * @see GraphIterator#setReuseEvents(boolean)
      */
+    @Override
     public void setReuseEvents(boolean reuseEvents)
     {
         this.reuseEvents = reuseEvents;
@@ -102,6 +104,7 @@ public abstract class AbstractGraphIterator<V, E>
     /**
      * @see GraphIterator#isReuseEvents()
      */
+    @Override
     public boolean isReuseEvents()
     {
         return reuseEvents;
@@ -112,6 +115,7 @@ public abstract class AbstractGraphIterator<V, E>
      *
      * @param l the traversal listener to be added.
      */
+    @Override
     public void addTraversalListener(TraversalListener<V, E> l)
     {
         if (!traversalListeners.contains(l)) {
@@ -125,6 +129,7 @@ public abstract class AbstractGraphIterator<V, E>
      *
      * @throws UnsupportedOperationException
      */
+    @Override
     public void remove()
     {
         throw new UnsupportedOperationException();
@@ -135,6 +140,7 @@ public abstract class AbstractGraphIterator<V, E>
      *
      * @param l the traversal listener to be removed.
      */
+    @Override
     public void removeTraversalListener(TraversalListener<V, E> l)
     {
         traversalListeners.remove(l);

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
@@ -94,6 +94,7 @@ public class BreadthFirstIterator<V, E>
     /**
      * @see CrossComponentIterator#isConnectedComponentExhausted()
      */
+    @Override
     protected boolean isConnectedComponentExhausted()
     {
         return queue.isEmpty();
@@ -102,6 +103,7 @@ public class BreadthFirstIterator<V, E>
     /**
      * @see CrossComponentIterator#encounterVertex(Object, Object)
      */
+    @Override
     protected void encounterVertex(V vertex, E edge)
     {
         putSeenData(vertex, null);
@@ -111,6 +113,7 @@ public class BreadthFirstIterator<V, E>
     /**
      * @see CrossComponentIterator#encounterVertexAgain(Object, Object)
      */
+    @Override
     protected void encounterVertexAgain(V vertex, E edge)
     {
     }
@@ -118,6 +121,7 @@ public class BreadthFirstIterator<V, E>
     /**
      * @see CrossComponentIterator#provideNextVertex()
      */
+    @Override
     protected V provideNextVertex()
     {
         return queue.removeFirst();

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/ClosestFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/ClosestFirstIterator.java
@@ -128,6 +128,7 @@ public class ClosestFirstIterator<V, E>
     
 
     // override AbstractGraphIterator
+    @Override
     public void setCrossComponentTraversal(boolean crossComponentTraversal)
     {
         if (initialized) {
@@ -183,6 +184,7 @@ public class ClosestFirstIterator<V, E>
     /**
      * @see CrossComponentIterator#isConnectedComponentExhausted()
      */
+    @Override
     protected boolean isConnectedComponentExhausted()
     {
         if (heap.size() == 0) {
@@ -201,6 +203,7 @@ public class ClosestFirstIterator<V, E>
     /**
      * @see CrossComponentIterator#encounterVertex(Object, Object)
      */
+    @Override
     protected void encounterVertex(V vertex, E edge)
     {
         double shortestPathLength;
@@ -221,6 +224,7 @@ public class ClosestFirstIterator<V, E>
      * @param vertex the vertex re-encountered
      * @param edge the edge via which the vertex was re-encountered
      */
+    @Override
     protected void encounterVertexAgain(V vertex, E edge)
     {
         FibonacciHeapNode<QueueEntry<V, E>> node = getSeenData(vertex);
@@ -241,6 +245,7 @@ public class ClosestFirstIterator<V, E>
     /**
      * @see CrossComponentIterator#provideNextVertex()
      */
+    @Override
     protected V provideNextVertex()
     {
         FibonacciHeapNode<QueueEntry<V, E>> node = heap.removeMin();

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
@@ -182,6 +182,7 @@ public abstract class CrossComponentIterator<V, E, D>
     /**
      * @see java.util.Iterator#hasNext()
      */
+    @Override
     public boolean hasNext()
     {
         if (startVertex != null) {
@@ -220,6 +221,7 @@ public abstract class CrossComponentIterator<V, E, D>
     /**
      * @see java.util.Iterator#next()
      */
+    @Override
     public V next()
     {
         if (startVertex != null) {
@@ -529,6 +531,7 @@ public abstract class CrossComponentIterator<V, E, D>
         /**
          * @see CrossComponentIterator.Specifics#edgesOf(Object)
          */
+        @Override
         public Set<? extends EE> edgesOf(VV vertex)
         {
             return graph.outgoingEdgesOf(vertex);
@@ -557,6 +560,7 @@ public abstract class CrossComponentIterator<V, E, D>
         /**
          * @see CrossComponentIterator.Specifics#edgesOf(Object)
          */
+        @Override
         public Set<EE> edgesOf(VV vertex)
         {
             return graph.edgesOf(vertex);

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/DepthFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/DepthFirstIterator.java
@@ -114,6 +114,7 @@ public class DepthFirstIterator<V, E>
     /**
      * @see CrossComponentIterator#isConnectedComponentExhausted()
      */
+    @Override
     protected boolean isConnectedComponentExhausted()
     {
         for (;;) {
@@ -139,6 +140,7 @@ public class DepthFirstIterator<V, E>
     /**
      * @see CrossComponentIterator#encounterVertex(Object, Object)
      */
+    @Override
     protected void encounterVertex(V vertex, E edge)
     {
         putSeenData(vertex, VisitColor.WHITE);
@@ -148,6 +150,7 @@ public class DepthFirstIterator<V, E>
     /**
      * @see CrossComponentIterator#encounterVertexAgain(Object, Object)
      */
+    @Override
     protected void encounterVertexAgain(V vertex, E edge)
     {
         VisitColor color = getSeenData(vertex);
@@ -171,6 +174,7 @@ public class DepthFirstIterator<V, E>
     /**
      * @see CrossComponentIterator#provideNextVertex()
      */
+    @Override
     protected V provideNextVertex()
     {
         V v;

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/GraphIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/GraphIterator.java
@@ -98,6 +98,7 @@ public interface GraphIterator<V, E>
      *
      * @throws UnsupportedOperationException
      */
+    @Override
     public void remove();
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/TopologicalOrderIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/TopologicalOrderIterator.java
@@ -140,6 +140,7 @@ public class TopologicalOrderIterator<V, E>
     /**
      * @see CrossComponentIterator#isConnectedComponentExhausted()
      */
+    @Override
     protected boolean isConnectedComponentExhausted()
     {
         // FIXME jvs 25-Apr-2005: This isn't correct for a graph with more than
@@ -152,6 +153,7 @@ public class TopologicalOrderIterator<V, E>
     /**
      * @see CrossComponentIterator#encounterVertex(Object, Object)
      */
+    @Override
     protected void encounterVertex(V vertex, E edge)
     {
         putSeenData(vertex, null);
@@ -161,6 +163,7 @@ public class TopologicalOrderIterator<V, E>
     /**
      * @see CrossComponentIterator#encounterVertexAgain(Object, Object)
      */
+    @Override
     protected void encounterVertexAgain(V vertex, E edge)
     {
         decrementInDegree(vertex);
@@ -169,6 +172,7 @@ public class TopologicalOrderIterator<V, E>
     /**
      * @see CrossComponentIterator#provideNextVertex()
      */
+    @Override
     protected V provideNextVertex()
     {
         return queue.remove();
@@ -238,16 +242,19 @@ public class TopologicalOrderIterator<V, E>
     {
         private static final long serialVersionUID = 4217659843476891334L;
 
+        @Override
         public T element()
         {
             return getFirst();
         }
 
+        @Override
         public boolean offer(T o)
         {
             return add(o);
         }
 
+        @Override
         public T peek()
         {
             if (isEmpty()) {
@@ -256,6 +263,7 @@ public class TopologicalOrderIterator<V, E>
             return getFirst();
         }
 
+        @Override
         public T poll()
         {
             if (isEmpty()) {
@@ -264,6 +272,7 @@ public class TopologicalOrderIterator<V, E>
             return removeFirst();
         }
 
+        @Override
         public T remove()
         {
             return removeFirst();


### PR DESCRIPTION
This pull request adds Override annotations for classes in the org.jgrapht.traverse package hierarchy.
