### PR TITLE
Add missing Override annotations in org.jgrapht.ext

### DIFF
--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerEdgeNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerEdgeNameProvider.java
@@ -64,6 +64,7 @@ public class IntegerEdgeNameProvider<E>
      *
      * @param edge the edge to be named
      */
+    @Override
     public String getEdgeName(E edge)
     {
         Integer id = idMap.get(edge);

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerNameProvider.java
@@ -77,6 +77,7 @@ public class IntegerNameProvider<V>
      *
      * @see GraphListener#edgeAdded(GraphEdgeChangeEvent)
      */
+    @Override
     public String getVertexName(V vertex)
     {
         Integer id = idMap.get(vertex);

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/JGraphModelAdapter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/JGraphModelAdapter.java
@@ -825,6 +825,7 @@ public class JGraphModelAdapter<V, E>
         /**
          * @see JGraphModelAdapter.CellFactory#createEdgeCell(Object)
          */
+        @Override
         public DefaultEdge createEdgeCell(EE jGraphTEdge)
         {
             return new DefaultEdge(jGraphTEdge);
@@ -833,6 +834,7 @@ public class JGraphModelAdapter<V, E>
         /**
          * @see JGraphModelAdapter.CellFactory#createVertexCell(Object)
          */
+        @Override
         public DefaultGraphCell createVertexCell(VV jGraphTVertex)
         {
             return new DefaultGraphCell(jGraphTVertex);
@@ -859,6 +861,7 @@ public class JGraphModelAdapter<V, E>
          *
          * @param e
          */
+        @Override
         public void graphChanged(GraphModelEvent e)
         {
             // We first remove edges that have to be removed, then we
@@ -1025,6 +1028,7 @@ public class JGraphModelAdapter<V, E>
         /**
          * @see GraphListener#edgeAdded(GraphEdgeChangeEvent)
          */
+        @Override
         public void edgeAdded(GraphEdgeChangeEvent<V, E> e)
         {
             E jtEdge = e.getEdge();
@@ -1037,6 +1041,7 @@ public class JGraphModelAdapter<V, E>
         /**
          * @see GraphListener#edgeRemoved(GraphEdgeChangeEvent)
          */
+        @Override
         public void edgeRemoved(GraphEdgeChangeEvent<V, E> e)
         {
             E jtEdge = e.getEdge();
@@ -1049,6 +1054,7 @@ public class JGraphModelAdapter<V, E>
         /**
          * @see VertexSetListener#vertexAdded(GraphVertexChangeEvent)
          */
+        @Override
         public void vertexAdded(GraphVertexChangeEvent<V> e)
         {
             V jtVertex = e.getVertex();
@@ -1061,6 +1067,7 @@ public class JGraphModelAdapter<V, E>
         /**
          * @see VertexSetListener#vertexRemoved(GraphVertexChangeEvent)
          */
+        @Override
         public void vertexRemoved(GraphVertexChangeEvent<V> e)
         {
             V jtVertex = e.getVertex();

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/StringEdgeNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/StringEdgeNameProvider.java
@@ -52,6 +52,7 @@ public class StringEdgeNameProvider<E>
      *
      * @param edge the edge to be named
      */
+    @Override
     public String getEdgeName(E edge)
     {
         return edge.toString();

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/StringNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/StringNameProvider.java
@@ -66,6 +66,7 @@ public class StringNameProvider<V>
      *
      * @see GraphListener#edgeAdded(GraphEdgeChangeEvent)
      */
+    @Override
     public String getVertexName(V vertex)
     {
         return vertex.toString();

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
@@ -81,6 +81,7 @@ public class DOTExporterTest
         StringWriter w = new StringWriter();
         ComponentAttributeProvider<String> vertexAttributeProvider =
             new ComponentAttributeProvider<String>() {
+                @Override
                 public Map<String, String> getComponentAttributes(String v)
                 {
                     Map<String, String> map =


### PR DESCRIPTION
This pull request adds Override annotations for classes in the org.jgrapht.ext package hierarchy.
