### PR TITLE
Add missing Override annotations in org.jgrapht.graph (part 1).

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -127,6 +127,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#getAllEdges(Object, Object)
      */
+    @Override
     public Set<E> getAllEdges(V sourceVertex, V targetVertex)
     {
         return specifics.getAllEdges(sourceVertex, targetVertex);
@@ -159,6 +160,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#getEdge(Object, Object)
      */
+    @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
         return specifics.getEdge(sourceVertex, targetVertex);
@@ -167,6 +169,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#getEdgeFactory()
      */
+    @Override
     public EdgeFactory<V, E> getEdgeFactory()
     {
         return edgeFactory;
@@ -188,6 +191,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object)
      */
+    @Override
     public E addEdge(V sourceVertex, V targetVertex)
     {
         assertVertexExist(sourceVertex);
@@ -222,6 +226,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object, Object)
      */
+    @Override
     public boolean addEdge(V sourceVertex, V targetVertex, E e)
     {
         if (e == null) {
@@ -271,6 +276,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#addVertex(Object)
      */
+    @Override
     public boolean addVertex(V v)
     {
         if (v == null) {
@@ -287,6 +293,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#getEdgeSource(Object)
      */
+    @Override
     public V getEdgeSource(E e)
     {
         return TypeUtil.uncheckedCast(
@@ -297,6 +304,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#getEdgeTarget(Object)
      */
+    @Override
     public V getEdgeTarget(E e)
     {
         return TypeUtil.uncheckedCast(
@@ -323,6 +331,7 @@ public abstract class AbstractBaseGraph<V, E>
      *
      * @see java.lang.Object#clone()
      */
+    @Override
     public Object clone()
     {
         try {
@@ -354,6 +363,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#containsEdge(Object)
      */
+    @Override
     public boolean containsEdge(E e)
     {
         return edgeMap.containsKey(e);
@@ -362,6 +372,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#containsVertex(Object)
      */
+    @Override
     public boolean containsVertex(V v)
     {
         return specifics.getVertexSet().contains(v);
@@ -378,6 +389,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#edgeSet()
      */
+    @Override
     public Set<E> edgeSet()
     {
         if (unmodifiableEdgeSet == null) {
@@ -390,6 +402,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#edgesOf(Object)
      */
+    @Override
     public Set<E> edgesOf(V vertex)
     {
         return specifics.edgesOf(vertex);
@@ -430,6 +443,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#removeEdge(Object, Object)
      */
+    @Override
     public E removeEdge(V sourceVertex, V targetVertex)
     {
         E e = getEdge(sourceVertex, targetVertex);
@@ -445,6 +459,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#removeEdge(Object)
      */
+    @Override
     public boolean removeEdge(E e)
     {
         if (containsEdge(e)) {
@@ -460,6 +475,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#removeVertex(Object)
      */
+    @Override
     public boolean removeVertex(V v)
     {
         if (containsVertex(v)) {
@@ -480,6 +496,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#vertexSet()
      */
+    @Override
     public Set<V> vertexSet()
     {
         if (unmodifiableVertexSet == null) {
@@ -493,6 +510,7 @@ public abstract class AbstractBaseGraph<V, E>
     /**
      * @see Graph#getEdgeWeight(Object)
      */
+    @Override
     public double getEdgeWeight(E e)
     {
         if (e instanceof DefaultWeightedEdge) {
@@ -642,6 +660,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see EdgeSetFactory.createEdgeSet
          */
+        @Override
         public Set<EE> createEdgeSet(VV vertex)
         {
             // NOTE:  use size 1 to keep memory usage under control
@@ -760,12 +779,14 @@ public abstract class AbstractBaseGraph<V, E>
         private Map<V, DirectedEdgeContainer<V, E>> vertexMapDirected =
             new LinkedHashMap<V, DirectedEdgeContainer<V, E>>();
 
+        @Override
         public void addVertex(V v)
         {
             // add with a lazy edge container entry
             vertexMapDirected.put(v, null);
         }
 
+        @Override
         public Set<V> getVertexSet()
         {
             return vertexMapDirected.keySet();
@@ -774,6 +795,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see Graph#getAllEdges(Object, Object)
          */
+        @Override
         public Set<E> getAllEdges(V sourceVertex, V targetVertex)
         {
             Set<E> edges = null;
@@ -802,6 +824,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see Graph#getEdge(Object, Object)
          */
+        @Override
         public E getEdge(V sourceVertex, V targetVertex)
         {
             if (containsVertex(sourceVertex)
@@ -826,6 +849,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see AbstractBaseGraph#addEdgeToTouchingVertices(Edge)
          */
+        @Override
         public void addEdgeToTouchingVertices(E e)
         {
             V source = getEdgeSource(e);
@@ -838,6 +862,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see UndirectedGraph#degreeOf(Object)
          */
+        @Override
         public int degreeOf(V vertex)
         {
             throw new UnsupportedOperationException(NOT_IN_DIRECTED_GRAPH);
@@ -846,6 +871,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see Graph#edgesOf(Object)
          */
+        @Override
         public Set<E> edgesOf(V vertex)
         {
             ArrayUnenforcedSet<E> inAndOut =
@@ -874,6 +900,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see DirectedGraph#inDegree(Object)
          */
+        @Override
         public int inDegreeOf(V vertex)
         {
             return getEdgeContainer(vertex).incoming.size();
@@ -882,6 +909,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see DirectedGraph#incomingEdges(Object)
          */
+        @Override
         public Set<E> incomingEdgesOf(V vertex)
         {
             return getEdgeContainer(vertex).getUnmodifiableIncomingEdges();
@@ -890,6 +918,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see DirectedGraph#outDegree(Object)
          */
+        @Override
         public int outDegreeOf(V vertex)
         {
             return getEdgeContainer(vertex).outgoing.size();
@@ -898,6 +927,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see DirectedGraph#outgoingEdges(Object)
          */
+        @Override
         public Set<E> outgoingEdgesOf(V vertex)
         {
             return getEdgeContainer(vertex).getUnmodifiableOutgoingEdges();
@@ -906,6 +936,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see AbstractBaseGraph#removeEdgeFromTouchingVertices(Edge)
          */
+        @Override
         public void removeEdgeFromTouchingVertices(E e)
         {
             V source = getEdgeSource(e);
@@ -1022,12 +1053,14 @@ public abstract class AbstractBaseGraph<V, E>
         private Map<V, UndirectedEdgeContainer<V, E>> vertexMapUndirected =
             new LinkedHashMap<V, UndirectedEdgeContainer<V, E>>();
 
+        @Override
         public void addVertex(V v)
         {
             // add with a lazy edge container entry
             vertexMapUndirected.put(v, null);
         }
 
+        @Override
         public Set<V> getVertexSet()
         {
             return vertexMapUndirected.keySet();
@@ -1036,6 +1069,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see Graph#getAllEdges(Object, Object)
          */
+        @Override
         public Set<E> getAllEdges(V sourceVertex, V targetVertex)
         {
             Set<E> edges = null;
@@ -1069,6 +1103,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see Graph#getEdge(Object, Object)
          */
+        @Override
         public E getEdge(V sourceVertex, V targetVertex)
         {
             if (containsVertex(sourceVertex)
@@ -1113,6 +1148,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see AbstractBaseGraph#addEdgeToTouchingVertices(Edge)
          */
+        @Override
         public void addEdgeToTouchingVertices(E e)
         {
             V source = getEdgeSource(e);
@@ -1128,6 +1164,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see UndirectedGraph#degreeOf(V)
          */
+        @Override
         public int degreeOf(V vertex)
         {
             if (allowingLoops) { // then we must count, and add loops twice
@@ -1152,6 +1189,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see Graph#edgesOf(V)
          */
+        @Override
         public Set<E> edgesOf(V vertex)
         {
             return getEdgeContainer(vertex).getUnmodifiableVertexEdges();
@@ -1160,6 +1198,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see DirectedGraph#inDegreeOf(Object)
          */
+        @Override
         public int inDegreeOf(V vertex)
         {
             throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
@@ -1168,6 +1207,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see DirectedGraph#incomingEdgesOf(Object)
          */
+        @Override
         public Set<E> incomingEdgesOf(V vertex)
         {
             throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
@@ -1176,6 +1216,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see DirectedGraph#outDegreeOf(Object)
          */
+        @Override
         public int outDegreeOf(V vertex)
         {
             throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
@@ -1184,6 +1225,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see DirectedGraph#outgoingEdgesOf(Object)
          */
+        @Override
         public Set<E> outgoingEdgesOf(V vertex)
         {
             throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
@@ -1192,6 +1234,7 @@ public abstract class AbstractBaseGraph<V, E>
         /**
          * @see AbstractBaseGraph#removeEdgeFromTouchingVertices(Edge)
          */
+        @Override
         public void removeEdgeFromTouchingVertices(E e)
         {
             V source = getEdgeSource(e);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractGraph.java
@@ -74,6 +74,7 @@ public abstract class AbstractGraph<V, E>
     /**
      * @see Graph#containsEdge(Object, Object)
      */
+    @Override
     public boolean containsEdge(V sourceVertex, V targetVertex)
     {
         return getEdge(sourceVertex, targetVertex) != null;
@@ -82,6 +83,7 @@ public abstract class AbstractGraph<V, E>
     /**
      * @see Graph#removeAllEdges(Collection)
      */
+    @Override
     public boolean removeAllEdges(Collection<? extends E> edges)
     {
         boolean modified = false;
@@ -96,6 +98,7 @@ public abstract class AbstractGraph<V, E>
     /**
      * @see Graph#removeAllEdges(Object, Object)
      */
+    @Override
     public Set<E> removeAllEdges(V sourceVertex, V targetVertex)
     {
         Set<E> removed = getAllEdges(sourceVertex, targetVertex);
@@ -110,6 +113,7 @@ public abstract class AbstractGraph<V, E>
     /**
      * @see Graph#removeAllVertices(Collection)
      */
+    @Override
     public boolean removeAllVertices(Collection<? extends V> vertices)
     {
         boolean modified = false;
@@ -128,6 +132,7 @@ public abstract class AbstractGraph<V, E>
      *
      * @return a string representation of this graph.
      */
+    @Override
     public String toString()
     {
         return toStringFromSets(
@@ -239,6 +244,7 @@ public abstract class AbstractGraph<V, E>
      *
      * @see Object#hashCode()
      */
+    @Override
     public int hashCode()
     {
         int hash = vertexSet().hashCode();
@@ -276,6 +282,7 @@ public abstract class AbstractGraph<V, E>
      *
      * @see Object#equals(Object)
      */
+    @Override
     public boolean equals(Object obj)
     {
         if (this == obj) {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUndirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUndirectedGraph.java
@@ -103,6 +103,7 @@ public class AsUndirectedGraph<V, E>
     /**
      * @see Graph#getAllEdges(Object, Object)
      */
+    @Override
     public Set<E> getAllEdges(V sourceVertex, V targetVertex)
     {
         Set<E> forwardList = super.getAllEdges(sourceVertex, targetVertex);
@@ -125,6 +126,7 @@ public class AsUndirectedGraph<V, E>
     /**
      * @see Graph#getEdge(Object, Object)
      */
+    @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
         E edge = super.getEdge(sourceVertex, targetVertex);
@@ -140,6 +142,7 @@ public class AsUndirectedGraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object)
      */
+    @Override
     public E addEdge(V sourceVertex, V targetVertex)
     {
         throw new UnsupportedOperationException(NO_EDGE_ADD);
@@ -148,6 +151,7 @@ public class AsUndirectedGraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object, Object)
      */
+    @Override
     public boolean addEdge(V sourceVertex, V targetVertex, E e)
     {
         throw new UnsupportedOperationException(NO_EDGE_ADD);
@@ -156,6 +160,7 @@ public class AsUndirectedGraph<V, E>
     /**
      * @see UndirectedGraph#degreeOf(Object)
      */
+    @Override
     public int degreeOf(V vertex)
     {
         // this counts loops twice, which is consistent with AbstractBaseGraph
@@ -165,6 +170,7 @@ public class AsUndirectedGraph<V, E>
     /**
      * @see DirectedGraph#inDegreeOf(Object)
      */
+    @Override
     public int inDegreeOf(V vertex)
     {
         throw new UnsupportedOperationException(UNDIRECTED);
@@ -173,6 +179,7 @@ public class AsUndirectedGraph<V, E>
     /**
      * @see DirectedGraph#incomingEdgesOf(Object)
      */
+    @Override
     public Set<E> incomingEdgesOf(V vertex)
     {
         throw new UnsupportedOperationException(UNDIRECTED);
@@ -181,6 +188,7 @@ public class AsUndirectedGraph<V, E>
     /**
      * @see DirectedGraph#outDegreeOf(Object)
      */
+    @Override
     public int outDegreeOf(V vertex)
     {
         throw new UnsupportedOperationException(UNDIRECTED);
@@ -189,6 +197,7 @@ public class AsUndirectedGraph<V, E>
     /**
      * @see DirectedGraph#outgoingEdgesOf(Object)
      */
+    @Override
     public Set<E> outgoingEdgesOf(V vertex)
     {
         throw new UnsupportedOperationException(UNDIRECTED);
@@ -197,6 +206,7 @@ public class AsUndirectedGraph<V, E>
     /**
      * @see AbstractBaseGraph#toString()
      */
+    @Override
     public String toString()
     {
         return super.toStringFromSets(vertexSet(), edgeSet(), false);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedDirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedDirectedGraph.java
@@ -89,6 +89,7 @@ public class AsUnweightedDirectedGraph<V, E>
     /**
      * @see Graph#getEdgeWeight
      */
+    @Override
     public double getEdgeWeight(E e)
     {
         if (e == null) {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedGraph.java
@@ -89,6 +89,7 @@ public class AsUnweightedGraph<V, E>
     /**
      * @see Graph#getEdgeWeight
      */
+    @Override
     public double getEdgeWeight(E e)
     {
         return WeightedGraph.DEFAULT_EDGE_WEIGHT;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
@@ -112,6 +112,7 @@ public class AsWeightedGraph<V, E>
     /**
      * @see WeightedGraph#setEdgeWeight
      */
+    @Override
     public void setEdgeWeight(E e, double weight)
     {
         if (isWeightedGraph) {
@@ -126,6 +127,7 @@ public class AsWeightedGraph<V, E>
     /**
      * @see Graph#getEdgeWeight
      */
+    @Override
     public double getEdgeWeight(E e)
     {
         double weight;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/ClassBasedEdgeFactory.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/ClassBasedEdgeFactory.java
@@ -75,6 +75,7 @@ public class ClassBasedEdgeFactory<V, E>
     /**
      * @see EdgeFactory#createEdge(Object, Object)
      */
+    @Override
     public E createEdge(V source, V target)
     {
         try {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/ClassBasedVertexFactory.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/ClassBasedVertexFactory.java
@@ -63,6 +63,7 @@ public class ClassBasedVertexFactory<V>
     /**
      * @see VertexFactory#createVertex()
      */
+    @Override
     public V createVertex()
     {
         try {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultEdge.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultEdge.java
@@ -79,6 +79,7 @@ public class DefaultEdge
         return target;
     }
 
+    @Override
     public String toString()
     {
         return "(" + source + " : " + target + ")";

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphMapping.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphMapping.java
@@ -85,6 +85,7 @@ public class DefaultGraphMapping<V, E>
 
     
 
+    @Override
     public E getEdgeCorrespondence(E currEdge, boolean forward)
     {
         Graph<V, E> sourceGraph, targetGraph;
@@ -114,6 +115,7 @@ public class DefaultGraphMapping<V, E>
         }
     }
 
+    @Override
     public V getVertexCorrespondence(
         V keyVertex,
         boolean forward)

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultListenableGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultListenableGraph.java
@@ -157,6 +157,7 @@ public class DefaultListenableGraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object)
      */
+    @Override
     public E addEdge(V sourceVertex, V targetVertex)
     {
         E e = super.addEdge(sourceVertex, targetVertex);
@@ -171,6 +172,7 @@ public class DefaultListenableGraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object, Object)
      */
+    @Override
     public boolean addEdge(V sourceVertex, V targetVertex, E e)
     {
         boolean added = super.addEdge(sourceVertex, targetVertex, e);
@@ -185,6 +187,7 @@ public class DefaultListenableGraph<V, E>
     /**
      * @see ListenableGraph#addGraphListener(GraphListener)
      */
+    @Override
     public void addGraphListener(GraphListener<V, E> l)
     {
         addToListenerList(graphListeners, l);
@@ -193,6 +196,7 @@ public class DefaultListenableGraph<V, E>
     /**
      * @see Graph#addVertex(Object)
      */
+    @Override
     public boolean addVertex(V v)
     {
         boolean modified = super.addVertex(v);
@@ -207,6 +211,7 @@ public class DefaultListenableGraph<V, E>
     /**
      * @see ListenableGraph#addVertexSetListener(VertexSetListener)
      */
+    @Override
     public void addVertexSetListener(VertexSetListener<V> l)
     {
         addToListenerList(vertexSetListeners, l);
@@ -215,6 +220,7 @@ public class DefaultListenableGraph<V, E>
     /**
      * @see java.lang.Object#clone()
      */
+    @Override
     public Object clone()
     {
         try {
@@ -236,6 +242,7 @@ public class DefaultListenableGraph<V, E>
     /**
      * @see Graph#removeEdge(Object, Object)
      */
+    @Override
     public E removeEdge(V sourceVertex, V targetVertex)
     {
         E e = super.removeEdge(sourceVertex, targetVertex);
@@ -250,6 +257,7 @@ public class DefaultListenableGraph<V, E>
     /**
      * @see Graph#removeEdge(Object)
      */
+    @Override
     public boolean removeEdge(E e)
     {
         V sourceVertex = getEdgeSource(e);
@@ -267,6 +275,7 @@ public class DefaultListenableGraph<V, E>
     /**
      * @see ListenableGraph#removeGraphListener(GraphListener)
      */
+    @Override
     public void removeGraphListener(GraphListener<V, E> l)
     {
         graphListeners.remove(l);
@@ -275,6 +284,7 @@ public class DefaultListenableGraph<V, E>
     /**
      * @see Graph#removeVertex(Object)
      */
+    @Override
     public boolean removeVertex(V v)
     {
         if (containsVertex(v)) {
@@ -296,6 +306,7 @@ public class DefaultListenableGraph<V, E>
     /**
      * @see ListenableGraph#removeVertexSetListener(VertexSetListener)
      */
+    @Override
     public void removeVertexSetListener(VertexSetListener<V> l)
     {
         vertexSetListeners.remove(l);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedGraphUnion.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedGraphUnion.java
@@ -66,12 +66,14 @@ public class DirectedGraphUnion<V, E>
 
     
 
+    @Override
     public int inDegreeOf(V vertex)
     {
         Set<E> res = incomingEdgesOf(vertex);
         return res.size();
     }
 
+    @Override
     public Set<E> incomingEdgesOf(V vertex)
     {
         Set<E> res = new HashSet<E>();
@@ -84,12 +86,14 @@ public class DirectedGraphUnion<V, E>
         return Collections.unmodifiableSet(res);
     }
 
+    @Override
     public int outDegreeOf(V vertex)
     {
         Set<E> res = outgoingEdgesOf(vertex);
         return res.size();
     }
 
+    @Override
     public Set<E> outgoingEdgesOf(V vertex)
     {
         Set<E> res = new HashSet<E>();

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedSubgraph.java
@@ -82,6 +82,7 @@ public class DirectedSubgraph<V, E>
     /**
      * @see DirectedGraph#inDegreeOf(Object)
      */
+    @Override
     public int inDegreeOf(V vertex)
     {
         assertVertexExist(vertex);
@@ -100,6 +101,7 @@ public class DirectedSubgraph<V, E>
     /**
      * @see DirectedGraph#incomingEdgesOf(Object)
      */
+    @Override
     public Set<E> incomingEdgesOf(V vertex)
     {
         assertVertexExist(vertex);
@@ -118,6 +120,7 @@ public class DirectedSubgraph<V, E>
     /**
      * @see DirectedGraph#outDegreeOf(Object)
      */
+    @Override
     public int outDegreeOf(V vertex)
     {
         assertVertexExist(vertex);
@@ -136,6 +139,7 @@ public class DirectedSubgraph<V, E>
     /**
      * @see DirectedGraph#outgoingEdgesOf(Object)
      */
+    @Override
     public Set<E> outgoingEdgesOf(V vertex)
     {
         assertVertexExist(vertex);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/EdgeReversedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/EdgeReversedGraph.java
@@ -84,6 +84,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see Graph#getEdge(Object, Object)
      */
+    @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
         return super.getEdge(targetVertex, sourceVertex);
@@ -92,6 +93,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see Graph#getAllEdges(Object, Object)
      */
+    @Override
     public Set<E> getAllEdges(V sourceVertex, V targetVertex)
     {
         return super.getAllEdges(targetVertex, sourceVertex);
@@ -100,6 +102,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object)
      */
+    @Override
     public E addEdge(V sourceVertex, V targetVertex)
     {
         return super.addEdge(targetVertex, sourceVertex);
@@ -108,6 +111,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object, Object)
      */
+    @Override
     public boolean addEdge(V sourceVertex, V targetVertex, E e)
     {
         return super.addEdge(targetVertex, sourceVertex, e);
@@ -116,6 +120,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see DirectedGraph#inDegreeOf(Object)
      */
+    @Override
     public int inDegreeOf(V vertex)
     {
         return super.outDegreeOf(vertex);
@@ -124,6 +129,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see DirectedGraph#outDegreeOf(Object)
      */
+    @Override
     public int outDegreeOf(V vertex)
     {
         return super.inDegreeOf(vertex);
@@ -132,6 +138,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see DirectedGraph#incomingEdgesOf(Object)
      */
+    @Override
     public Set<E> incomingEdgesOf(V vertex)
     {
         return super.outgoingEdgesOf(vertex);
@@ -140,6 +147,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see DirectedGraph#outgoingEdgesOf(Object)
      */
+    @Override
     public Set<E> outgoingEdgesOf(V vertex)
     {
         return super.incomingEdgesOf(vertex);
@@ -148,6 +156,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see Graph#removeEdge(Object, Object)
      */
+    @Override
     public E removeEdge(V sourceVertex, V targetVertex)
     {
         return super.removeEdge(targetVertex, sourceVertex);
@@ -156,6 +165,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see Graph#getEdgeSource(Object)
      */
+    @Override
     public V getEdgeSource(E e)
     {
         return super.getEdgeTarget(e);
@@ -164,6 +174,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see Graph#getEdgeTarget(Object)
      */
+    @Override
     public V getEdgeTarget(E e)
     {
         return super.getEdgeSource(e);
@@ -172,6 +183,7 @@ public class EdgeReversedGraph<V, E>
     /**
      * @see java.lang.Object#toString()
      */
+    @Override
     public String toString()
     {
         return toStringFromSets(


### PR DESCRIPTION
This pull request adds Override annotations for some classes in the org.jgrapht.graph package hierarchy.

I have split this up into two pull requests, because there were over 200 missing annotations.
