### PR TITLE
Add missing Override annotations in org.jgrapht.graph (part 2).

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphDelegator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphDelegator.java
@@ -102,6 +102,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#getAllEdges(Object, Object)
      */
+    @Override
     public Set<E> getAllEdges(V sourceVertex, V targetVertex)
     {
         return delegate.getAllEdges(sourceVertex, targetVertex);
@@ -110,6 +111,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#getEdge(Object, Object)
      */
+    @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
         return delegate.getEdge(sourceVertex, targetVertex);
@@ -118,6 +120,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#getEdgeFactory()
      */
+    @Override
     public EdgeFactory<V, E> getEdgeFactory()
     {
         return delegate.getEdgeFactory();
@@ -126,6 +129,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#addEdge(Object, Object)
      */
+    @Override
     public E addEdge(V sourceVertex, V targetVertex)
     {
         return delegate.addEdge(sourceVertex, targetVertex);
@@ -134,6 +138,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#addEdge(Object, Object, Object)
      */
+    @Override
     public boolean addEdge(V sourceVertex, V targetVertex, E e)
     {
         return delegate.addEdge(sourceVertex, targetVertex, e);
@@ -142,6 +147,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#addVertex(Object)
      */
+    @Override
     public boolean addVertex(V v)
     {
         return delegate.addVertex(v);
@@ -150,6 +156,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#containsEdge(Object)
      */
+    @Override
     public boolean containsEdge(E e)
     {
         return delegate.containsEdge(e);
@@ -158,6 +165,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#containsVertex(Object)
      */
+    @Override
     public boolean containsVertex(V v)
     {
         return delegate.containsVertex(v);
@@ -174,6 +182,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#edgeSet()
      */
+    @Override
     public Set<E> edgeSet()
     {
         return delegate.edgeSet();
@@ -182,6 +191,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#edgesOf(Object)
      */
+    @Override
     public Set<E> edgesOf(V vertex)
     {
         return delegate.edgesOf(vertex);
@@ -222,6 +232,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#removeEdge(Object)
      */
+    @Override
     public boolean removeEdge(E e)
     {
         return delegate.removeEdge(e);
@@ -230,6 +241,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#removeEdge(Object, Object)
      */
+    @Override
     public E removeEdge(V sourceVertex, V targetVertex)
     {
         return delegate.removeEdge(sourceVertex, targetVertex);
@@ -238,6 +250,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#removeVertex(Object)
      */
+    @Override
     public boolean removeVertex(V v)
     {
         return delegate.removeVertex(v);
@@ -246,6 +259,7 @@ public class GraphDelegator<V, E>
     /**
      * @see java.lang.Object#toString()
      */
+    @Override
     public String toString()
     {
         return delegate.toString();
@@ -254,6 +268,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#vertexSet()
      */
+    @Override
     public Set<V> vertexSet()
     {
         return delegate.vertexSet();
@@ -262,6 +277,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#getEdgeSource(Object)
      */
+    @Override
     public V getEdgeSource(E e)
     {
         return delegate.getEdgeSource(e);
@@ -270,6 +286,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#getEdgeTarget(Object)
      */
+    @Override
     public V getEdgeTarget(E e)
     {
         return delegate.getEdgeTarget(e);
@@ -278,6 +295,7 @@ public class GraphDelegator<V, E>
     /**
      * @see Graph#getEdgeWeight(Object)
      */
+    @Override
     public double getEdgeWeight(E e)
     {
         return delegate.getEdgeWeight(e);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphPathImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphPathImpl.java
@@ -80,36 +80,42 @@ public class GraphPathImpl<V, E>
     
 
     // implement GraphPath
+    @Override
     public Graph<V, E> getGraph()
     {
         return graph;
     }
 
     // implement GraphPath
+    @Override
     public V getStartVertex()
     {
         return startVertex;
     }
 
     // implement GraphPath
+    @Override
     public V getEndVertex()
     {
         return endVertex;
     }
 
     // implement GraphPath
+    @Override
     public List<E> getEdgeList()
     {
         return edgeList;
     }
 
     // implement GraphPath
+    @Override
     public double getWeight()
     {
         return weight;
     }
 
     // override Object
+    @Override
     public String toString()
     {
         return edgeList.toString();

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphUnion.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphUnion.java
@@ -95,6 +95,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
 
     
 
+    @Override
     public Set<E> getAllEdges(V sourceVertex, V targetVertex)
     {
         Set<E> res = new HashSet<E>();
@@ -111,6 +112,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
         return Collections.unmodifiableSet(res);
     }
 
+    @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
         E res = null;
@@ -132,6 +134,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
      * Throws <tt>UnsupportedOperationException</tt>, because <tt>
      * GraphUnion</tt> is read-only.
      */
+    @Override
     public EdgeFactory<V, E> getEdgeFactory()
     {
         throw new UnsupportedOperationException(READ_ONLY);
@@ -141,6 +144,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
      * Throws <tt>UnsupportedOperationException</tt>, because <tt>
      * GraphUnion</tt> is read-only.
      */
+    @Override
     public E addEdge(V sourceVertex, V targetVertex)
     {
         throw new UnsupportedOperationException(READ_ONLY);
@@ -150,6 +154,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
      * Throws <tt>UnsupportedOperationException</tt>, because <tt>
      * GraphUnion</tt> is read-only.
      */
+    @Override
     public boolean addEdge(V sourceVertex, V targetVertex, E e)
     {
         throw new UnsupportedOperationException(READ_ONLY);
@@ -159,21 +164,25 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
      * Throws <tt>UnsupportedOperationException</tt>, because <tt>
      * GraphUnion</tt> is read-only.
      */
+    @Override
     public boolean addVertex(V v)
     {
         throw new UnsupportedOperationException(READ_ONLY);
     }
 
+    @Override
     public boolean containsEdge(E e)
     {
         return g1.containsEdge(e) || g2.containsEdge(e);
     }
 
+    @Override
     public boolean containsVertex(V v)
     {
         return g1.containsVertex(v) || g2.containsVertex(v);
     }
 
+    @Override
     public Set<E> edgeSet()
     {
         Set<E> res = new HashSet<E>();
@@ -182,6 +191,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
         return Collections.unmodifiableSet(res);
     }
 
+    @Override
     public Set<E> edgesOf(V vertex)
     {
         Set<E> res = new HashSet<E>();
@@ -198,6 +208,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
      * Throws <tt>UnsupportedOperationException</tt>, because <tt>
      * GraphUnion</tt> is read-only.
      */
+    @Override
     public E removeEdge(V sourceVertex, V targetVertex)
     {
         throw new UnsupportedOperationException(READ_ONLY);
@@ -207,6 +218,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
      * Throws <tt>UnsupportedOperationException</tt>, because <tt>
      * GraphUnion</tt> is read-only.
      */
+    @Override
     public boolean removeEdge(E e)
     {
         throw new UnsupportedOperationException(READ_ONLY);
@@ -216,11 +228,13 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
      * Throws <tt>UnsupportedOperationException</tt>, because <tt>
      * GraphUnion</tt> is read-only.
      */
+    @Override
     public boolean removeVertex(V v)
     {
         throw new UnsupportedOperationException(READ_ONLY);
     }
 
+    @Override
     public Set<V> vertexSet()
     {
         Set<V> res = new HashSet<V>();
@@ -229,6 +243,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
         return Collections.unmodifiableSet(res);
     }
 
+    @Override
     public V getEdgeSource(E e)
     {
         if (g1.containsEdge(e)) {
@@ -240,6 +255,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
         return null;
     }
 
+    @Override
     public V getEdgeTarget(E e)
     {
         if (g1.containsEdge(e)) {
@@ -251,6 +267,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
         return null;
     }
 
+    @Override
     public double getEdgeWeight(E e)
     {
         if (g1.containsEdge(e) && g2.containsEdge(e)) {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/IntrusiveEdge.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/IntrusiveEdge.java
@@ -65,6 +65,7 @@ class IntrusiveEdge
     /**
      * @see Object#clone()
      */
+    @Override
     public Object clone()
     {
         try {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/MaskEdgeSet.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/MaskEdgeSet.java
@@ -81,6 +81,7 @@ class MaskEdgeSet<V, E>
     /**
      * @see java.util.Collection#contains(java.lang.Object)
      */
+    @Override
     public boolean contains(Object o)
     {
         return this.edgeSet.contains(o)
@@ -90,6 +91,7 @@ class MaskEdgeSet<V, E>
     /**
      * @see java.util.Set#iterator()
      */
+    @Override
     public Iterator<E> iterator()
     {
         return new PrefetchIterator<E>(new MaskEdgeSetNextElementFunctor());
@@ -98,6 +100,7 @@ class MaskEdgeSet<V, E>
     /**
      * @see java.util.Set#size()
      */
+    @Override
     public int size()
     {
         if (this.size == -1) {
@@ -122,6 +125,7 @@ class MaskEdgeSet<V, E>
             this.iter = MaskEdgeSet.this.edgeSet.iterator();
         }
 
+        @Override
         public E nextElement()
             throws NoSuchElementException
         {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/MaskSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/MaskSubgraph.java
@@ -92,11 +92,13 @@ public class MaskSubgraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object)
      */
+    @Override
     public E addEdge(V sourceVertex, V targetVertex)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
     }
 
+    @Override
     public boolean addEdge(V sourceVertex, V targetVertex, E edge)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -105,16 +107,19 @@ public class MaskSubgraph<V, E>
     /**
      * @see Graph#addVertex(Object)
      */
+    @Override
     public boolean addVertex(V v)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
     }
 
+    @Override
     public boolean containsEdge(E e)
     {
         return edgeSet().contains(e);
     }
 
+    @Override
     public boolean containsVertex(V v)
     {
         return !this.mask.isVertexMasked(v) && this.base.containsVertex(v);
@@ -128,11 +133,13 @@ public class MaskSubgraph<V, E>
         return edgesOf(vertex).size();
     }
 
+    @Override
     public Set<E> edgeSet()
     {
         return this.edges;
     }
 
+    @Override
     public Set<E> edgesOf(V vertex)
     {
         assertVertexExist(vertex);
@@ -143,6 +150,7 @@ public class MaskSubgraph<V, E>
             this.mask);
     }
 
+    @Override
     public Set<E> getAllEdges(V sourceVertex, V targetVertex)
     {
         Set<E> edges = null;
@@ -159,6 +167,7 @@ public class MaskSubgraph<V, E>
         return edges;
     }
 
+    @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
         Set<E> edges = getAllEdges(sourceVertex, targetVertex);
@@ -170,11 +179,13 @@ public class MaskSubgraph<V, E>
         }
     }
 
+    @Override
     public EdgeFactory<V, E> getEdgeFactory()
     {
         return this.base.getEdgeFactory();
     }
 
+    @Override
     public V getEdgeSource(E edge)
     {
         assert (edgeSet().contains(edge));
@@ -182,6 +193,7 @@ public class MaskSubgraph<V, E>
         return this.base.getEdgeSource(edge);
     }
 
+    @Override
     public V getEdgeTarget(E edge)
     {
         assert (edgeSet().contains(edge));
@@ -189,6 +201,7 @@ public class MaskSubgraph<V, E>
         return this.base.getEdgeTarget(edge);
     }
 
+    @Override
     public double getEdgeWeight(E edge)
     {
         assert (edgeSet().contains(edge));
@@ -241,6 +254,7 @@ public class MaskSubgraph<V, E>
     /**
      * @see Graph#removeAllEdges(Collection)
      */
+    @Override
     public boolean removeAllEdges(Collection<? extends E> edges)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -249,6 +263,7 @@ public class MaskSubgraph<V, E>
     /**
      * @see Graph#removeAllEdges(Object, Object)
      */
+    @Override
     public Set<E> removeAllEdges(V sourceVertex, V targetVertex)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -257,6 +272,7 @@ public class MaskSubgraph<V, E>
     /**
      * @see Graph#removeAllVertices(Collection)
      */
+    @Override
     public boolean removeAllVertices(Collection<? extends V> vertices)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -265,6 +281,7 @@ public class MaskSubgraph<V, E>
     /**
      * @see Graph#removeEdge(Object)
      */
+    @Override
     public boolean removeEdge(E e)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -273,6 +290,7 @@ public class MaskSubgraph<V, E>
     /**
      * @see Graph#removeEdge(Object, Object)
      */
+    @Override
     public E removeEdge(V sourceVertex, V targetVertex)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -281,11 +299,13 @@ public class MaskSubgraph<V, E>
     /**
      * @see Graph#removeVertex(Object)
      */
+    @Override
     public boolean removeVertex(V v)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
     }
 
+    @Override
     public Set<V> vertexSet()
     {
         return this.vertices;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/MaskVertexSet.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/MaskVertexSet.java
@@ -74,6 +74,7 @@ class MaskVertexSet<V, E>
     /**
      * @see java.util.Collection#contains(java.lang.Object)
      */
+    @Override
     public boolean contains(Object o)
     {
         return
@@ -84,6 +85,7 @@ class MaskVertexSet<V, E>
     /**
      * @see java.util.Set#iterator()
      */
+    @Override
     public Iterator<V> iterator()
     {
         return new PrefetchIterator<V>(new MaskVertexSetNextElementFunctor());
@@ -92,6 +94,7 @@ class MaskVertexSet<V, E>
     /**
      * @see java.util.Set#size()
      */
+    @Override
     public int size()
     {
         if (this.size == -1) {
@@ -116,6 +119,7 @@ class MaskVertexSet<V, E>
             this.iter = MaskVertexSet.this.vertexSet.iterator();
         }
 
+        @Override
         public V nextElement()
             throws NoSuchElementException
         {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/ParanoidGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/ParanoidGraph.java
@@ -71,6 +71,7 @@ public class ParanoidGraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object, Object)
      */
+    @Override
     public boolean addEdge(V sourceVertex, V targetVertex, E e)
     {
         verifyAdd(edgeSet(), e);
@@ -80,6 +81,7 @@ public class ParanoidGraph<V, E>
     /**
      * @see Graph#addVertex(Object)
      */
+    @Override
     public boolean addVertex(V v)
     {
         verifyAdd(vertexSet(), v);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/Subgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/Subgraph.java
@@ -179,6 +179,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#getAllEdges(Object, Object)
      */
+    @Override
     public Set<E> getAllEdges(V sourceVertex, V targetVertex)
     {
         Set<E> edges = null;
@@ -204,6 +205,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#getEdge(Object, Object)
      */
+    @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
         Set<E> edges = getAllEdges(sourceVertex, targetVertex);
@@ -218,6 +220,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#getEdgeFactory()
      */
+    @Override
     public EdgeFactory<V, E> getEdgeFactory()
     {
         return base.getEdgeFactory();
@@ -226,6 +229,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#addEdge(Object, Object)
      */
+    @Override
     public E addEdge(V sourceVertex, V targetVertex)
     {
         assertVertexExist(sourceVertex);
@@ -253,6 +257,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#addEdge(Object, Object, Object)
      */
+    @Override
     public boolean addEdge(V sourceVertex, V targetVertex, E e)
     {
         if (e == null) {
@@ -292,6 +297,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
      * @see Subgraph
      * @see Graph#addVertex(Object)
      */
+    @Override
     public boolean addVertex(V v)
     {
         if (v == null) {
@@ -314,6 +320,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#containsEdge(Object)
      */
+    @Override
     public boolean containsEdge(E e)
     {
         return edgeSet.contains(e);
@@ -322,6 +329,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#containsVertex(Object)
      */
+    @Override
     public boolean containsVertex(V v)
     {
         return vertexSet.contains(v);
@@ -330,6 +338,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#edgeSet()
      */
+    @Override
     public Set<E> edgeSet()
     {
         if (unmodifiableEdgeSet == null) {
@@ -342,6 +351,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#edgesOf(Object)
      */
+    @Override
     public Set<E> edgesOf(V vertex)
     {
         assertVertexExist(vertex);
@@ -361,6 +371,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#removeEdge(Object)
      */
+    @Override
     public boolean removeEdge(E e)
     {
         return edgeSet.remove(e);
@@ -369,6 +380,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#removeEdge(Object, Object)
      */
+    @Override
     public E removeEdge(V sourceVertex, V targetVertex)
     {
         E e = getEdge(sourceVertex, targetVertex);
@@ -379,6 +391,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#removeVertex(Object)
      */
+    @Override
     public boolean removeVertex(V v)
     {
         // If the base graph does NOT contain v it means we are here in
@@ -394,6 +407,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#vertexSet()
      */
+    @Override
     public Set<V> vertexSet()
     {
         if (unmodifiableVertexSet == null) {
@@ -406,6 +420,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#getEdgeSource(Object)
      */
+    @Override
     public V getEdgeSource(E e)
     {
         return base.getEdgeSource(e);
@@ -414,6 +429,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#getEdgeTarget(Object)
      */
+    @Override
     public V getEdgeTarget(E e)
     {
         return base.getEdgeTarget(e);
@@ -465,6 +481,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
     /**
      * @see Graph#getEdgeWeight(Object)
      */
+    @Override
     public double getEdgeWeight(E e)
     {
         return base.getEdgeWeight(e);
@@ -495,6 +512,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
         /**
          * @see GraphListener#edgeAdded(GraphEdgeChangeEvent)
          */
+        @Override
         public void edgeAdded(GraphEdgeChangeEvent<V, E> e)
         {
             if (isInduced) {
@@ -513,6 +531,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
         /**
          * @see GraphListener#edgeRemoved(GraphEdgeChangeEvent)
          */
+        @Override
         public void edgeRemoved(GraphEdgeChangeEvent<V, E> e)
         {
             E edge = e.getEdge();
@@ -523,6 +542,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
         /**
          * @see VertexSetListener#vertexAdded(GraphVertexChangeEvent)
          */
+        @Override
         public void vertexAdded(GraphVertexChangeEvent<V> e)
         {
             // we don't care
@@ -531,6 +551,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
         /**
          * @see VertexSetListener#vertexRemoved(GraphVertexChangeEvent)
          */
+        @Override
         public void vertexRemoved(GraphVertexChangeEvent<V> e)
         {
             V vertex = e.getVertex();

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedGraphUnion.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedGraphUnion.java
@@ -68,6 +68,7 @@ public class UndirectedGraphUnion<V, E>
 
     
 
+    @Override
     public int degreeOf(V vertex)
     {
         Set<E> res = edgesOf(vertex);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedSubgraph.java
@@ -80,6 +80,7 @@ public class UndirectedSubgraph<V, E>
     /**
      * @see UndirectedGraph#degreeOf(Object)
      */
+    @Override
     public int degreeOf(V vertex)
     {
         assertVertexExist(vertex);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/UnmodifiableGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/UnmodifiableGraph.java
@@ -88,6 +88,7 @@ public class UnmodifiableGraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object)
      */
+    @Override
     public E addEdge(V sourceVertex, V targetVertex)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -96,6 +97,7 @@ public class UnmodifiableGraph<V, E>
     /**
      * @see Graph#addEdge(Object, Object, Object)
      */
+    @Override
     public boolean addEdge(V sourceVertex, V targetVertex, E e)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -104,6 +106,7 @@ public class UnmodifiableGraph<V, E>
     /**
      * @see Graph#addVertex(Object)
      */
+    @Override
     public boolean addVertex(V v)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -112,6 +115,7 @@ public class UnmodifiableGraph<V, E>
     /**
      * @see Graph#removeAllEdges(Collection)
      */
+    @Override
     public boolean removeAllEdges(Collection<? extends E> edges)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -120,6 +124,7 @@ public class UnmodifiableGraph<V, E>
     /**
      * @see Graph#removeAllEdges(Object, Object)
      */
+    @Override
     public Set<E> removeAllEdges(V sourceVertex, V targetVertex)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -128,6 +133,7 @@ public class UnmodifiableGraph<V, E>
     /**
      * @see Graph#removeAllVertices(Collection)
      */
+    @Override
     public boolean removeAllVertices(Collection<? extends V> vertices)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -136,6 +142,7 @@ public class UnmodifiableGraph<V, E>
     /**
      * @see Graph#removeEdge(Object)
      */
+    @Override
     public boolean removeEdge(E e)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -144,6 +151,7 @@ public class UnmodifiableGraph<V, E>
     /**
      * @see Graph#removeEdge(Object, Object)
      */
+    @Override
     public E removeEdge(V sourceVertex, V targetVertex)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);
@@ -152,6 +160,7 @@ public class UnmodifiableGraph<V, E>
     /**
      * @see Graph#removeVertex(Object)
      */
+    @Override
     public boolean removeVertex(V v)
     {
         throw new UnsupportedOperationException(UNMODIFIABLE);


### PR DESCRIPTION
This pull request adds Override annotations for some classes in the org.jgrapht.graph package hierarchy.
