### PR TITLE
Update the maven-compiler-plugin version to get full compiler error messages.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-compiler-plugin</artifactId>
-					<version>2.3.2</version>
+					<version>3.1</version>
 					<configuration>
 						<source>1.6</source>
 						<target>1.6</target>


### PR DESCRIPTION
Update the maven-compiler-plugin version to 3.1, where a bug causing error messages to be truncated is fixed.

See
---
http://jira.codehaus.org/browse/MCOMPILER-158
http://stackoverflow.com/questions/14164386/maven-cannot-find-symbol-message-unhelpful