### PR TITLE
Include vertex #toString value in exception message

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
@@ -54,7 +54,7 @@ import org.jgrapht.graph.*;
  */
 public abstract class Graphs
 {
-    
+
 
     /**
      * Creates a new edge and adds it to the specified graph similarly to the
@@ -411,7 +411,7 @@ public abstract class Graphs
         } else if (v.equals(target)) {
             return source;
         } else {
-            throw new IllegalArgumentException("no such vertex");
+            throw new IllegalArgumentException("no such vertex: " + v.toString());
         }
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractGraph.java
@@ -60,7 +60,7 @@ import org.jgrapht.util.*;
 public abstract class AbstractGraph<V, E>
     implements Graph<V, E>
 {
-    
+
 
     /**
      * Construct a new empty graph object.
@@ -69,7 +69,7 @@ public abstract class AbstractGraph<V, E>
     {
     }
 
-    
+
 
     /**
      * @see Graph#containsEdge(Object, Object)
@@ -160,7 +160,7 @@ public abstract class AbstractGraph<V, E>
         } else if (v == null) {
             throw new NullPointerException();
         } else {
-            throw new IllegalArgumentException("no such vertex in graph");
+            throw new IllegalArgumentException("no such vertex in graph: " + v.toString());
         }
     }
 


### PR DESCRIPTION
This has been somewhat plaguing me for years. 

When a vertex in a graph mistakenly changes its #hashCode() value, any graph operations throw a ‘no such vertex’ exception, not stating which vertex is the culprit.

Would be nice to see this included. I didn’t not do a comprehensive sweep to add the vertex #toString() but this should hit the major cases.
