### PR TITLE
Ensure that SimpleDirectedGraph equality works.

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultEdge.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultEdge.java
@@ -96,8 +96,20 @@ public class DefaultEdge
         }
 
         DefaultEdge other = (DefaultEdge) obj;
-        boolean sourceE = this.source.equals(other.source);
-        boolean targetE = this.target.equals(other.target);
+
+        boolean sourceE = false;
+        if(null == source) {
+            sourceE = (null == other.source);
+        } else {
+            sourceE = source.equals(other.source);
+        }
+
+        boolean targetE = false;
+        if(null == target) {
+            targetE = (null == other.target);
+        } else {
+            targetE = target.equals(other.target);
+        }
         return sourceE && targetE;
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultEdge.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultEdge.java
@@ -83,6 +83,30 @@ public class DefaultEdge
     {
         return "(" + source + " : " + target + ")";
     }
+
+    @Override public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof DefaultEdge)) {
+            return false;
+        }
+
+        DefaultEdge other = (DefaultEdge) obj;
+        boolean sourceE = this.source.equals(other.source);
+        boolean targetE = this.target.equals(other.target);
+        return sourceE && targetE;
+    }
+
+    @Override public int hashCode() {
+        int hash = 1;
+        hash = hash *  17 + (null == source ? 0: source.hashCode());
+        hash = hash * 31 + (null == target ? 0 : target.hashCode());
+        return hash;
+    }
 }
 
 // End DefaultEdge.java

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleDirectedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleDirectedGraphTest.java
@@ -403,6 +403,35 @@ public class SimpleDirectedGraphTest
         init(); // TODO Implement vertexSet().
     }
 
+    /**
+     *
+     */
+    public void testEquals(){
+        DirectedGraph<String, DefaultEdge> g1 =
+            new SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge.class);
+        DirectedGraph<String, DefaultEdge> g2 =
+            new SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge.class);
+
+        g1.addVertex("A");
+        g2.addVertex("A");
+
+        assertEquals(g1, g2);
+
+        g1.addVertex("B");
+        g2.addVertex("B");
+
+        assertEquals(g1, g2);
+
+        g1.addEdge("A", "B");
+        g2.addEdge("A", "B");
+
+        assertTrue(g1.containsEdge("A", "B"));
+        assertTrue(g2.containsEdge("A", "B"));
+        assertTrue(g1.vertexSet().equals(g2.vertexSet()));
+        assertTrue(g1.edgeSet().equals(g2.edgeSet()));
+        assertTrue(g1.equals(g2));
+    }
+
     public void testReversedView()
     {
         init();


### PR DESCRIPTION
The equality test for two SimpleDirectedGraphs doesn't work as DefaultEdge doesn't have a deterministic hashCode.  Added hashCode and equals to DefaultEdge and a unit test that fails without the patch and passes with the patch.