### PR TITLE
Reworked FloydWarshallShortestPaths code, updated As(Un)Weighted(Directed)Graph classes, added a Mixed-Graph Implementation.

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/FloydWarshallShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/FloydWarshallShortestPaths.java
@@ -25,7 +25,7 @@
  * (C) Copyright 2009-2009, by Tom Larkworthy and Contributors
  *
  * Original Author:  Tom Larkworthy
- * Contributor(s):   Soren Davidsen
+ * Contributor(s):   Soren Davidsen, Joris Kinable
  *
  * $Id: FloydWarshallShortestPaths.java 755 2012-01-18 23:50:37Z perfecthash $
  *
@@ -33,6 +33,7 @@
  * -------
  * 29-Jun-2009 : Initial revision (TL);
  * 03-Dec-2009 : Optimized and enhanced version (SD);
+ * Aug 2015: Algorithm now works with Mixed-Graphs. Included some performance tweaks.
  *
  */
 package org.jgrapht.alg;
@@ -41,7 +42,6 @@ import java.util.*;
 
 import org.jgrapht.*;
 import org.jgrapht.graph.*;
-import org.jgrapht.util.*;
 
 
 /**
@@ -142,8 +142,8 @@ public class FloydWarshallShortestPaths<V, E>
         }else{ //This works for both Directed and Mixed graphs! Iterating over the arcs and querying source/sink does not suffice for graphs which contain both edges and arcs
             DirectedGraph<V,E> directedGraph=(DirectedGraph<V,E>)graph;
             for(V v1 : directedGraph.vertexSet()){
+                int v_1 = vertexIndices.get(v1);
                 for(V v2 : Graphs.successorListOf(directedGraph, v1)){
-                    int v_1 = vertexIndices.get(v1);
                     int v_2 = vertexIndices.get(v2);
                     d[v_1][v_2] =directedGraph.getEdgeWeight(directedGraph.getEdge(v1, v2));
                 }
@@ -183,8 +183,7 @@ public class FloydWarshallShortestPaths<V, E>
      * @return the diameter (longest of all the shortest paths) computed for the
      * graph. If the graph is vertexless, return 0.0.
      */
-    public double getDiameter()
-    {
+    public double getDiameter() {
         lazyCalculateMatrix();
 
         if (Double.isNaN(diameter)) {
@@ -202,17 +201,14 @@ public class FloydWarshallShortestPaths<V, E>
     }
 
     /**
-     * Get the shortest path between two vertices. Note: The paths are
-     * calculated using a recursive algorithm. It *will* give problems on paths
-     * longer than the stack allows.
+     * Get the shortest path between two vertices.
      *
      * @param a From vertice
      * @param b To vertice
      *
      * @return the path, or null if none found
      */
-    public GraphPath<V, E> getShortestPath(V a, V b)
-    {
+    public GraphPath<V, E> getShortestPath(V a, V b) {
         lazyCalculateMatrix();
 
         int v_a = vertexIndices.get(a);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/FloydWarshallShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/FloydWarshallShortestPaths.java
@@ -47,23 +47,28 @@ import org.jgrapht.util.*;
 /**
  * The <a href="http://en.wikipedia.org/wiki/Floyd-Warshall_algorithm">
  * Floyd-Warshall algorithm</a> finds all shortest paths (all n^2 of them) in
- * O(n^3) time. It can also calculate the graph diameter.
+ * O(n^3) time. It can also calculate the graph diameter. Note that during construction time,
+ * no computations are performed! All computations are performed the first time one of the member methods
+ * of this class is invoked. The results are stored, so all subsequent calls to the same method are computationally
+ * efficient.
+ *
+ * Warning: This code has not been tested (and probably doesn't work) on multi-graphs. Code should be updated to work properly on multi-graphs.
  *
  * @author Tom Larkworthy
  * @author Soren Davidsen (soren@tanesha.net)
+ * @author Joris Kinable
  */
 public class FloydWarshallShortestPaths<V, E>
 {
-    
+    private final Graph<V, E> graph;
+    private final List<V> vertices;
+    private final Map<V, Integer> vertexIndices;
 
-    private Graph<V, E> graph;
-    private List<V> vertices;
-    private Map<V, Integer> vertexIndices;
     private int nShortestPaths = 0;
     private double diameter = Double.NaN;
     private double [][] d = null;
     private int [][] backtrace = null;
-    private Map<VertexPair<V>, GraphPath<V, E>> paths = null;
+    private Map<V, List<GraphPath<V, E>>> paths = null;
 
     
 
@@ -128,18 +133,20 @@ public class FloydWarshallShortestPaths<V, E>
         }
 
         // initialize matrix, 2
-        boolean directed = graph instanceof DirectedGraph<?, ?>;
-        Set<E> edges = graph.edgeSet();
-        for (E edge : edges) {
-            V v1 = graph.getEdgeSource(edge);
-            V v2 = graph.getEdgeTarget(edge);
-
-            int v_1 = vertexIndices.get(v1);
-            int v_2 = vertexIndices.get(v2);
-
-            d[v_1][v_2] = graph.getEdgeWeight(edge);
-            if (!directed) {
-                d[v_2][v_1] = graph.getEdgeWeight(edge);
+        if(graph instanceof  UndirectedGraph<?, ?>){
+            for (E edge : graph.edgeSet()) {
+                int v_1 = vertexIndices.get(graph.getEdgeSource(edge));
+                int v_2 = vertexIndices.get(graph.getEdgeTarget(edge));
+                d[v_1][v_2] =d[v_2][v_1] =graph.getEdgeWeight(edge);
+            }
+        }else{ //This works for both Directed and Mixed graphs! Iterating over the arcs and querying source/sink does not suffice for graphs which contain both edges and arcs
+            DirectedGraph<V,E> directedGraph=(DirectedGraph<V,E>)graph;
+            for(V v1 : directedGraph.vertexSet()){
+                for(V v2 : Graphs.successorListOf(directedGraph, v1)){
+                    int v_1 = vertexIndices.get(v1);
+                    int v_2 = vertexIndices.get(v2);
+                    d[v_1][v_2] =directedGraph.getEdgeWeight(directedGraph.getEdge(v1, v2));
+                }
             }
         }
 
@@ -194,20 +201,6 @@ public class FloydWarshallShortestPaths<V, E>
         return diameter;
     }
 
-    private void shortestPathRecur(List<E> edges, int v_a, int v_b)
-    {
-        int k = backtrace[v_a][v_b];
-        if (k == -1) {
-            E edge = graph.getEdge(vertices.get(v_a), vertices.get(v_b));
-            if (edge != null) {
-                edges.add(edge);
-            }
-        } else {
-            shortestPathRecur(edges, v_a, k);
-            shortestPathRecur(edges, k, v_b);
-        }
-    }
-
     /**
      * Get the shortest path between two vertices. Note: The paths are
      * calculated using a recursive algorithm. It *will* give problems on paths
@@ -220,72 +213,23 @@ public class FloydWarshallShortestPaths<V, E>
      */
     public GraphPath<V, E> getShortestPath(V a, V b)
     {
-        lazyCalculatePaths();
-        return getShortestPathImpl(a, b);
-    }
+        lazyCalculateMatrix();
 
-    private GraphPath<V, E> getShortestPathImpl(V a, V b)
-    {
         int v_a = vertexIndices.get(a);
         int v_b = vertexIndices.get(b);
 
-        List<E> edges = new ArrayList<E>();
-        shortestPathRecur(edges, v_a, v_b);
-
-        // no path, return null
-        if (edges.size() < 1) {
+        if(backtrace[v_a][v_b]==-1) //No path exists
             return null;
+
+        //Reconstruct the path
+        List<E> edges = new ArrayList<E>();
+        int u=v_a;
+        while(u != v_b){
+            int v=backtrace[u][v_b];
+            edges.add(graph.getEdge(vertices.get(u), vertices.get(v)));
+            u=v;
         }
-
-        double weight = 0.;
-        for (E e : edges) {
-            weight += graph.getEdgeWeight(e);
-        }
-
-        GraphPathImpl<V, E> path =
-            new GraphPathImpl<V, E>(graph, a, b, edges, weight);
-
-        return path;
-    }
-
-    /**
-     * Calculate the shortest paths (not done per default)
-     */
-    private void lazyCalculatePaths()
-    {
-        // already we have calculated it once.
-        if (paths != null) {
-            return;
-        }
-
-        lazyCalculateMatrix();
-
-        Map<VertexPair<V>, GraphPath<V, E>> sps =
-            new HashMap<VertexPair<V>, GraphPath<V, E>>();
-        int n = vertices.size();
-
-        nShortestPaths = 0;
-        for (int i = 0; i < n; i++) {
-            V v_i = vertices.get(i);
-            for (int j = 0; j < n; j++) {
-                // don't count this.
-                if (i == j) {
-                    continue;
-                }
-
-                V v_j = vertices.get(j);
-
-                GraphPath<V, E> path = getShortestPathImpl(v_i, v_j);
-
-                // we got a path
-                if (path != null) {
-                    sps.put(new VertexPair<V>(v_i, v_j), path);
-                    nShortestPaths++;
-                }
-            }
-        }
-
-        this.paths = sps;
+        return new GraphPathImpl<V, E>(graph, a, b, edges, d[v_a][v_b]);
     }
 
     /**
@@ -298,17 +242,7 @@ public class FloydWarshallShortestPaths<V, E>
     public List<GraphPath<V, E>> getShortestPaths(V v)
     {
         lazyCalculatePaths();
-        List<GraphPath<V, E>> found = new ArrayList<GraphPath<V, E>>();
-
-        // TODO:  two-level map for paths so that we don't have to
-        // iterate over all paths here!
-        for (VertexPair<V> pair : paths.keySet()) {
-            if (pair.getFirst().equals(v)) {
-                found.add(paths.get(pair));
-            }
-        }
-
-        return found;
+        return Collections.unmodifiableList(paths.get(v));
     }
 
     /**
@@ -316,10 +250,49 @@ public class FloydWarshallShortestPaths<V, E>
      *
      * @return List of paths
      */
-    public Collection<GraphPath<V, E>> getShortestPaths()
+    public List<GraphPath<V, E>> getShortestPaths()
     {
         lazyCalculatePaths();
-        return paths.values();
+        List<GraphPath<V, E>> allPaths=new ArrayList<GraphPath<V, E>>();
+        for(List<GraphPath<V, E>> pathSubset : paths.values())
+            allPaths.addAll(pathSubset);
+
+        return allPaths;
+    }
+
+    /**
+     * Calculate the shortest paths (not done per default)
+     * TODO: This method can be optimized. Instead of calculating each path individidually, use a constructive method.
+     * TODO: I.e. if we have a shortest path from i to j: [i,....j] and we know that the shortest path from j to k, we can simply glue the paths together to obtain the shortest path from i to k
+     *
+     */
+    private void lazyCalculatePaths()
+    {
+        // already we have calculated it once.
+        if (paths != null)
+            return;
+
+        lazyCalculateMatrix();
+
+        paths=new LinkedHashMap<V, List<GraphPath<V, E>>>();
+        int n = vertices.size();
+        for (int i = 0; i < n; i++) {
+            V v_i = vertices.get(i);
+            paths.put(v_i, new ArrayList<GraphPath<V, E>>());
+            for (int j = 0; j < n; j++) {
+                if (i == j)
+                    continue;
+
+                V v_j = vertices.get(j);
+
+                GraphPath<V, E> path = getShortestPath(v_i, v_j);
+
+                if (path != null) {
+                    paths.get(v_i).add(path);
+                    nShortestPaths++;
+                }
+            }
+        }
     }
 }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedDirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedDirectedGraph.java
@@ -58,21 +58,13 @@ import org.jgrapht.*;
  * graph is serializable.</p>
  *
  * @author Lucas J. Scharenbroich
+ * @author Joris Kinable
  * @since Sep 7, 2007
  */
 public class AsUnweightedDirectedGraph<V, E>
-    extends GraphDelegator<V, E>
-    implements Serializable,
-        DirectedGraph<V, E>
+    extends AsUnweightedGraph<V, E>
+    implements DirectedGraph<V, E>
 {
-    
-
-    /**
-     */
-    private static final long serialVersionUID = -4320818446777715312L;
-
-    
-
     /**
      * Constructor for AsUnweightedGraph.
      *
@@ -84,19 +76,6 @@ public class AsUnweightedDirectedGraph<V, E>
         super(g);
     }
 
-    
-
-    /**
-     * @see Graph#getEdgeWeight
-     */
-    @Override public double getEdgeWeight(E e)
-    {
-        if (e == null) {
-            throw new NullPointerException();
-        } else {
-            return WeightedGraph.DEFAULT_EDGE_WEIGHT;
-        }
-    }
 }
 
 // End AsUnweightedDirectedGraph.java

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedGraph.java
@@ -91,7 +91,10 @@ public class AsUnweightedGraph<V, E>
      */
     @Override public double getEdgeWeight(E e)
     {
-        return WeightedGraph.DEFAULT_EDGE_WEIGHT;
+        if (e == null)
+            throw new NullPointerException();
+        else
+            return WeightedGraph.DEFAULT_EDGE_WEIGHT;
     }
 }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedDirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedDirectedGraph.java
@@ -1,3 +1,39 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/*  ----------------------
+ * AsWeightedDirectedGraph.java
+ * ----------------------
+ * (C) Copyright 2015-2015, by Joris Kinable and Contributors.
+ *
+ * Original Author:  Joris Kinable
+ * Contributor(s):
+*
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 20-Aug-2015 : Initial revision;
+ *
+ */
 package org.jgrapht.graph;
 
 import org.jgrapht.DirectedGraph;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedDirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedDirectedGraph.java
@@ -1,0 +1,49 @@
+package org.jgrapht.graph;
+
+import org.jgrapht.DirectedGraph;
+
+import java.util.Map;
+
+/**
+ * <p>A weighted view of the backing graph specified in the constructor. This
+ * allows you to apply algorithms designed for weighted graphs to an
+ * unweighted graph by providing an explicit edge weight mapping. The
+ * implementation also allows for "masking" weights for a subset of the edges in
+ * an existing weighted graph.</p>
+ *
+ * <p>Query operations on this graph "read through" to the backing graph. Vertex
+ * addition/removal and edge addition/removal are all supported (and immediately
+ * reflected in the backing graph). Setting an edge weight will pass the
+ * operation to the backing graph as well if the backing graph implements the
+ * WeightedGraph interface. Setting an edge weight will modify the weight map in
+ * order to maintain a consistent graph.</p>
+ *
+ * <p>Note that edges returned by this graph's accessors are really just the
+ * edges of the underlying directed graph.</p>
+ *
+ * <p>This graph does <i>not</i> pass the hashCode and equals operations through
+ * to the backing graph, but relies on <tt>Object</tt>'s <tt>equals</tt> and
+ * <tt>hashCode</tt> methods. This graph will be serializable if the backing
+ * graph is serializable.</p>
+ *
+ * @author Joris Kinable
+ * @since Aug 20, 2015
+ */
+public class AsWeightedDirectedGraph<V, E>
+        extends AsWeightedGraph<V, E>
+        implements DirectedGraph<V, E> {
+
+
+    /**
+     * Constructor for AsWeightedGraph.
+     *
+     * @param g         the backing graph over which a weighted view is to be created.
+     * @param weightMap A mapping of edges to weights. If an edge is not present
+     *                  in the weight map, the edge weight for the underlying graph is returned.
+     *                  Note that a live reference to this map is retained, so if the caller
+     *                  changes the map after construction, the changes will affect the
+     */
+    public AsWeightedDirectedGraph(DirectedGraph<V, E> g, Map<E, Double> weightMap) {
+        super(g, weightMap);
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphUnion.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphUnion.java
@@ -97,7 +97,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
 
     @Override public Set<E> getAllEdges(V sourceVertex, V targetVertex)
     {
-        Set<E> res = new HashSet<E>();
+        Set<E> res = new LinkedHashSet<E>();
         if (g1.containsVertex(sourceVertex)
             && g1.containsVertex(targetVertex))
         {
@@ -176,7 +176,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
 
     @Override public Set<E> edgeSet()
     {
-        Set<E> res = new HashSet<E>();
+        Set<E> res = new LinkedHashSet<E>();
         res.addAll(g1.edgeSet());
         res.addAll(g2.edgeSet());
         return Collections.unmodifiableSet(res);
@@ -184,7 +184,7 @@ public class GraphUnion<V, E, G extends Graph<V, E>>
 
     @Override public Set<E> edgesOf(V vertex)
     {
-        Set<E> res = new HashSet<E>();
+        Set<E> res = new LinkedHashSet<E>();
         if (g1.containsVertex(vertex)) {
             res.addAll(g1.edgesOf(vertex));
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/MixedGraphUnion.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/MixedGraphUnion.java
@@ -1,0 +1,122 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2009, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -------------------------
+ * MixedGraphUnion.java
+ * -------------------------
+ *
+ * This class implements a <a href="https://en.wikipedia.org/wiki/Mixed_graph">Mixed-Graph</a>. A Mixed-Graph consists of
+ * both undirected edges, and directed arcs. The mixed graph is obtained by taking the union of a undirected and a directed graph.
+ * Be careful: NOT all algorithm implementations in the JgraphT handle Mixed Graphs correctly, so thoroughly check the results! From the outside, a Mixed-Graph is a
+ * DirectedGraph. However, the undirected edges should obviously be treated as undirected. Many algorithms have a switch checking whether the graph is Directed or Undirected, and behave
+ * differently uppon the result; these algorithms do not necessarily handle hybrid cases like this correctly. An example algorithm which *does* handle the Mixed-Graphs correctly
+ * is the FloydWarshallShortestPath implementation.
+ *
+ * Often, a Mixed-Graph is unnecessary: every undirected edge (i,j) can be replaced by two directed arcs: <i,j>,<j,i>, thereby obtaining a Directed Graph. This is the
+ * preferred approach since all algorithm implementations work well for Directed Graphs. However, there are use-cases where a pair of directed arcs <i,j>,<j,i> have a different
+ * meaning than a single undirected edge (i,j). In the latter case, this class is applicable.
+ *
+ * Original Author:  Joris Kinable.
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 20-Aug-2015 : Initial revision (IR);
+ *
+ */
+package org.jgrapht.graph;
+
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.Graph;
+import org.jgrapht.UndirectedGraph;
+import org.jgrapht.util.WeightCombiner;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+
+public class MixedGraphUnion<V, E>
+    extends GraphUnion<V, E, Graph<V, E>>
+    implements DirectedGraph<V, E>
+{
+
+    private final UndirectedGraph<V, E> undirectedGraph;
+    private final DirectedGraph<V, E> directedGraph;
+
+    public MixedGraphUnion(
+            UndirectedGraph<V, E> g1,
+            DirectedGraph<V, E> g2,
+            WeightCombiner operator)
+    {
+        super(g1, g2, operator);
+        this.undirectedGraph=g1;
+        this.directedGraph=g2;
+    }
+
+    public MixedGraphUnion(UndirectedGraph<V, E> g1, DirectedGraph<V, E> g2)
+    {
+        super(g1, g2);
+        this.undirectedGraph=g1;
+        this.directedGraph=g2;
+    }
+
+    
+
+    @Override public int inDegreeOf(V vertex)
+    {
+        Set<E> res = incomingEdgesOf(vertex);
+        return res.size();
+    }
+
+    @Override public Set<E> incomingEdgesOf(V vertex)
+    {
+        Set<E> res = new LinkedHashSet<E>();
+        if (directedGraph.containsVertex(vertex)) {
+            res.addAll(directedGraph.incomingEdgesOf(vertex));
+        }
+        if (undirectedGraph.containsVertex(vertex)) {
+            res.addAll(undirectedGraph.edgesOf(vertex));
+        }
+        return Collections.unmodifiableSet(res);
+    }
+
+    @Override public int outDegreeOf(V vertex)
+    {
+        Set<E> res = outgoingEdgesOf(vertex);
+        return res.size();
+    }
+
+    @Override public Set<E> outgoingEdgesOf(V vertex)
+    {
+        Set<E> res = new LinkedHashSet<E>();
+        if (directedGraph.containsVertex(vertex)) {
+            res.addAll(directedGraph.outgoingEdgesOf(vertex));
+        }
+        if (undirectedGraph.containsVertex(vertex)) {
+            res.addAll(undirectedGraph.edgesOf(vertex));
+        }
+        return Collections.unmodifiableSet(res);
+    }
+}
+
+// End MixedGraphUnion.java

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedGraphUnion.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedGraphUnion.java
@@ -49,7 +49,21 @@ public class UndirectedGraphUnion<V, E>
 
     private static final long serialVersionUID = -740199233080172450L;
 
-    
+
+    UndirectedGraphUnion(
+            UndirectedGraph<V, E> g1,
+            UndirectedGraph<V, E> g2,
+            WeightCombiner operator)
+    {
+        super(g1, g2, operator);
+    }
+
+    UndirectedGraphUnion(
+            UndirectedGraph<V, E> g1,
+            UndirectedGraph<V, E> g2)
+    {
+        super(g1, g2);
+    }
 
     UndirectedGraphUnion(
         UndirectedGraph<V, E> g1,

--- a/jgrapht-core/src/main/java/org/jgrapht/util/WeightCombiner.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/WeightCombiner.java
@@ -54,6 +54,17 @@ public interface WeightCombiner
         };
 
     /**
+     * Multiplication of weights.
+     */
+    public WeightCombiner MULT =
+        new WeightCombiner() {
+            @Override public double combine(double a, double b)
+            {
+                return a * b;
+            }
+        };
+
+    /**
      * Minimum weight.
      */
     public WeightCombiner MIN =

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/AllGraphTests.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/AllGraphTests.java
@@ -59,7 +59,8 @@ import org.junit.runners.*;
     SimpleDirectedGraphTest.class,
     SimpleGraphPathTest.class,
     SubgraphTest.class,
-    SimpleIdentityDirectedGraphTest.class
+    SimpleIdentityDirectedGraphTest.class, 
+    UnionGraphTest.class
 })
 public final class AllGraphTests
 {

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/AsWeightedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/AsWeightedGraphTest.java
@@ -25,13 +25,14 @@
  * (C) Copyright 2007, by Lucas J. Scharenbroich and Contributors.
  *
  * Original Author:  Lucas J. Scharenbroich
- * Contributor(s):   John V. Sichi
+ * Contributor(s):   John V. Sichi, Joris Kinable
  *
  * $Id$
  *
  * Changes
  * -------
  * 22-Sep-2007 : Initial revision (JVS);
+ * 24-Aug-2015: Added tests for AsWeightedDirectedGraphTest
  *
  */
 package org.jgrapht.graph;
@@ -42,106 +43,128 @@ import org.jgrapht.*;
 
 
 /**
- * A unit test for the AsWeightedGraph view.
+ * A unit test for the AsWeightedGraph view and the AsDirectedWeightedGraph view.
  *
  * @author Lucas J. Scharenbroich
+ * @author Joris Kinable
  */
 public class AsWeightedGraphTest
     extends EnhancedTestCase
 {
     //~ Instance fields --------------------------------------------------------
 
-    public SimpleWeightedGraph<String, DefaultWeightedEdge> weightedGraph;
-    public SimpleGraph<String, DefaultEdge> unweightedGraph;
+    public WeightedGraph<String, DefaultWeightedEdge> weightedGraph;
+    public Graph<String, DefaultEdge> unweightedGraph;
+
+    public SimpleDirectedWeightedGraph<String, DefaultWeightedEdge> directedWeightedGraph;
+    public DirectedGraph<String, DefaultEdge> directedUnweightedGraph;
 
     //~ Methods ----------------------------------------------------------------
 
     @Override
     public void setUp()
     {
-        weightedGraph =
-            new SimpleWeightedGraph<String, DefaultWeightedEdge>(
-                DefaultWeightedEdge.class);
-        unweightedGraph =
-            new SimpleGraph<String, DefaultEdge>(DefaultEdge.class);
+        // Create a weighted, undirected graph
+        weightedGraph = new SimpleWeightedGraph<String, DefaultWeightedEdge>(DefaultWeightedEdge.class);
+        this.createdWeightedGraph(weightedGraph);
 
-        // Create a very simple graph
-        weightedGraph.addVertex("v1");
-        weightedGraph.addVertex("v2");
-        weightedGraph.addVertex("v3");
+        //Create an undirected graph without weights
+        unweightedGraph = new SimpleGraph<String, DefaultEdge>(DefaultEdge.class);
+        this.createdUnweightedGraph(unweightedGraph);
 
-        unweightedGraph.addVertex("v1");
-        unweightedGraph.addVertex("v2");
-        unweightedGraph.addVertex("v3");
+        //Create a weighted, directed graph
+        directedWeightedGraph=new SimpleDirectedWeightedGraph<String, DefaultWeightedEdge>(DefaultWeightedEdge.class);
+        this.createdWeightedGraph(directedWeightedGraph);
 
-        weightedGraph.setEdgeWeight(weightedGraph.addEdge("v1", "v2"), 1.);
-        weightedGraph.setEdgeWeight(weightedGraph.addEdge("v2", "v3"), 2.);
-        weightedGraph.setEdgeWeight(weightedGraph.addEdge("v3", "v1"), 3.);
-
-        unweightedGraph.addEdge("v1", "v2");
-        unweightedGraph.addEdge("v2", "v3");
-        unweightedGraph.addEdge("v3", "v1");
+        //Create a directed graph without weights
+        directedUnweightedGraph =new SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge.class);
+        this.createdUnweightedGraph(directedUnweightedGraph);
     }
 
-    @Override
-    public void tearDown()
-    {
+    private void createdWeightedGraph(WeightedGraph<String, DefaultWeightedEdge> graph){
+        graph.addVertex("v1");
+        graph.addVertex("v2");
+        graph.addVertex("v3");
+
+        graph.setEdgeWeight(graph.addEdge("v1", "v2"), 1.);
+        graph.setEdgeWeight(graph.addEdge("v2", "v3"), 2.);
+        graph.setEdgeWeight(graph.addEdge("v3", "v1"), 3.);
     }
 
-    public void test1()
-    {
-        Map<DefaultEdge, Double> weightMap1 =
-            new HashMap<DefaultEdge, Double>();
-        Map<DefaultWeightedEdge, Double> weightMap2 =
-            new HashMap<DefaultWeightedEdge, Double>();
+    private void createdUnweightedGraph(Graph<String, DefaultEdge> graph){
+        graph.addVertex("v1");
+        graph.addVertex("v2");
+        graph.addVertex("v3");
 
-        DefaultEdge e1 = unweightedGraph.getEdge("v1", "v2");
-        DefaultEdge e2 = unweightedGraph.getEdge("v2", "v3");
-        DefaultEdge e3 = unweightedGraph.getEdge("v3", "v1");
+        graph.addEdge("v1", "v2");
+        graph.addEdge("v2", "v3");
+        graph.addEdge("v3", "v1");
+    }
 
-        DefaultWeightedEdge e4 = weightedGraph.getEdge("v1", "v2");
-        DefaultWeightedEdge e5 = weightedGraph.getEdge("v2", "v3");
-        DefaultWeightedEdge e6 = weightedGraph.getEdge("v3", "v1");
+    /*** Unweighted graphs ***/
 
-        weightMap1.put(e1, 9.0);
+    public void testUnweightedGraphs(){
+        this.testUnweightedGraph(unweightedGraph);
+        this.testUnweightedGraph(directedUnweightedGraph);
+    }
 
-        weightMap2.put(e4, 9.0);
-        weightMap2.put(e6, 8.0);
+    public void testUnweightedGraph(Graph<String, DefaultEdge> graph){
+        DefaultEdge e1 = graph.getEdge("v1", "v2");
+        DefaultEdge e2 = graph.getEdge("v2", "v3");
+        DefaultEdge e3 = graph.getEdge("v3", "v1");
 
-        assertEquals(
-            unweightedGraph.getEdgeWeight(e1),
-            WeightedGraph.DEFAULT_EDGE_WEIGHT);
+        Map<DefaultEdge, Double> weightMap = new HashMap<DefaultEdge, Double>();
+        weightMap.put(e1, 9.0);
 
-        WeightedGraph<String, DefaultEdge> g1 =
-            new AsWeightedGraph<String, DefaultEdge>(
-                unweightedGraph,
-                weightMap1);
-        WeightedGraph<String, DefaultWeightedEdge> g2 =
-            new AsWeightedGraph<String, DefaultWeightedEdge>(
-                weightedGraph,
-                weightMap2);
+        assertEquals( graph.getEdgeWeight(e1), WeightedGraph.DEFAULT_EDGE_WEIGHT);
 
-        assertEquals(g1.getEdgeWeight(e1), 9.0);
-        assertEquals(g1.getEdgeWeight(e2), WeightedGraph.DEFAULT_EDGE_WEIGHT);
-        assertEquals(g1.getEdgeWeight(e3), WeightedGraph.DEFAULT_EDGE_WEIGHT);
+        WeightedGraph<String, DefaultEdge> graphView;
+        if(graph instanceof DirectedGraph)
+            graphView= new AsWeightedDirectedGraph<String, DefaultEdge>((DirectedGraph<String, DefaultEdge>)graph, weightMap);
+        else
+            graphView=new AsWeightedGraph<String, DefaultEdge>( graph, weightMap);
 
-        assertEquals(g2.getEdgeWeight(e4), 9.0);
-        assertEquals(g2.getEdgeWeight(e5), 2.0);
-        assertEquals(g2.getEdgeWeight(e6), 8.0);
+        assertEquals(graphView.getEdgeWeight(e1), 9.0);
+        assertEquals(graphView.getEdgeWeight(e2), WeightedGraph.DEFAULT_EDGE_WEIGHT);
+        assertEquals(graphView.getEdgeWeight(e3), WeightedGraph.DEFAULT_EDGE_WEIGHT);
 
-        g1.setEdgeWeight(e2, 5.0);
-        g2.setEdgeWeight(e5, 5.0);
+        graphView.setEdgeWeight(e2, 5.0);
+        assertEquals(graphView.getEdgeWeight(e2), 5.0);
+        assertEquals(graph.getEdgeWeight(e2), WeightedGraph.DEFAULT_EDGE_WEIGHT);
+    }
 
-        assertEquals(g1.getEdgeWeight(e2), 5.0);
-        assertEquals(
-            unweightedGraph.getEdgeWeight(e2),
-            WeightedGraph.DEFAULT_EDGE_WEIGHT);
+    /*** Weighted graphs ***/
 
-        assertEquals(g2.getEdgeWeight(e5), 5.0);
-        assertEquals(weightedGraph.getEdgeWeight(e5), 5.0);
+    public void testWeightedGraphs(){
+        this.testWeightedGraph(weightedGraph);
+        this.testWeightedGraph(directedWeightedGraph);
+    }
+
+    public void testWeightedGraph(Graph<String, DefaultWeightedEdge> graph){
+        DefaultWeightedEdge e1 = graph.getEdge("v1", "v2");
+        DefaultWeightedEdge e2 = graph.getEdge("v2", "v3");
+        DefaultWeightedEdge e3 = graph.getEdge("v3", "v1");
+
+        Map<DefaultWeightedEdge, Double> weightMap = new HashMap<DefaultWeightedEdge, Double>();
+        weightMap.put(e1, 9.0);
+        weightMap.put(e3, 8.0);
+
+        WeightedGraph<String, DefaultWeightedEdge> graphView;
+        if(graph instanceof DirectedGraph)
+            graphView= new AsWeightedDirectedGraph<String, DefaultWeightedEdge>((DirectedGraph<String, DefaultWeightedEdge>)graph, weightMap);
+        else
+            graphView=new AsWeightedGraph<String, DefaultWeightedEdge>(graph,weightMap);
+
+        assertEquals(graphView.getEdgeWeight(e1), 9.0);
+        assertEquals(graphView.getEdgeWeight(e2), 2.0);
+        assertEquals(graphView.getEdgeWeight(e3), 8.0);
+
+        graphView.setEdgeWeight(e2, 5.0);
+        assertEquals(graphView.getEdgeWeight(e2), 5.0);
+        assertEquals(graph.getEdgeWeight(e2), 5.0);
 
         try {
-            double d = weightedGraph.getEdgeWeight(null);
+            double d = graphView.getEdgeWeight(null);
             // should not get here
             assertFalse();
         } catch (NullPointerException ex) {

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/UnionGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/UnionGraphTest.java
@@ -38,9 +38,12 @@ package org.jgrapht.graph;
 
 import junit.framework.TestCase;
 import org.jgrapht.*;
+import org.jgrapht.util.WeightCombiner;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 
 /**
  * Unit test for the {@link DirectedGraphUnion} class, {@link UndirectedGraphUnion} class, {@link MixedGraphUnion} class.
@@ -174,4 +177,41 @@ public class UnionGraphTest extends TestCase {
         assertEquals(3, graphUnion.inDegreeOf(v4));
 
     }
+
+    /**
+     * Test the weight combiner for graphs having an edge in common.
+     */
+    public void testWeightCombiner(){
+        //Create two graphs, both having the same vertices {0,1} and the same weighted edge (0,1)
+        SimpleWeightedGraph<Integer, DefaultWeightedEdge> g1=new SimpleWeightedGraph<Integer, DefaultWeightedEdge>(DefaultWeightedEdge.class);
+        Graphs.addAllVertices(g1, Arrays.asList(0,1));
+        DefaultWeightedEdge edge=g1.addEdge(0,1);
+        g1.setEdgeWeight(edge, 10);
+
+        SimpleWeightedGraph<Integer, DefaultWeightedEdge> g2=new SimpleWeightedGraph<Integer, DefaultWeightedEdge>(DefaultWeightedEdge.class);
+        Graphs.addAllVertices(g2, Arrays.asList(0,1));
+        g2.addEdge(0,1, edge);
+        //We need to create a mask of the second graph if we want to store the edge with a different weight. Simply setting g2.setEdgeWeight(edge,20) would override the edge weight for the same edge in g1 as well!
+        Map<DefaultWeightedEdge, Double> weightMap=new HashMap<DefaultWeightedEdge, Double>();
+        weightMap.put(edge, 20.0);
+        WeightedGraph<Integer, DefaultWeightedEdge> g2Masked=new AsWeightedGraph<Integer, DefaultWeightedEdge>(g2, weightMap);
+
+        GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>> graphUnionSum=new GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>>(g1, g2Masked, WeightCombiner.SUM);
+        assertEquals(30.0, graphUnionSum.getEdgeWeight(edge));
+        GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>> graphUnionFirst=new GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>>(g1, g2Masked, WeightCombiner.FIRST);
+        assertEquals(10.0, graphUnionFirst.getEdgeWeight(edge));
+        GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>> graphUnionSecond=new GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>>(g1, g2Masked, WeightCombiner.SECOND);
+        assertEquals(20.0, graphUnionSecond.getEdgeWeight(edge));
+        GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>> graphUnionMax=new GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>>(g1, g2Masked, WeightCombiner.MAX);
+        assertEquals(20.0, graphUnionMax.getEdgeWeight(edge));
+        GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>> graphUnionMin=new GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>>(g1, g2Masked, WeightCombiner.MIN);
+        assertEquals(10.0, graphUnionMin.getEdgeWeight(edge));
+        GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>> graphUnionMult=new GraphUnion<Integer, DefaultWeightedEdge, WeightedGraph<Integer, DefaultWeightedEdge>>(g1, g2Masked, WeightCombiner.MULT);
+        assertEquals(200.0, graphUnionMult.getEdgeWeight(edge));
+
+        assertEquals(10.0, g1.getEdgeWeight(edge));
+        assertEquals(10.0, g2.getEdgeWeight(edge));
+        assertEquals(20.0, g2Masked.getEdgeWeight(edge));
+    }
+
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/UnionGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/UnionGraphTest.java
@@ -1,0 +1,177 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* ------------------------
+ * UnionGraphTest.java
+ * ------------------------
+ * (C) Copyright 2003-2008, by Joris Kinable and Contributors.
+ *
+ * Original Author:  Joris Kinable
+ * Contributor(s):   -
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 24-Aug-2015 : Initial revision (JK);
+ *
+ */
+package org.jgrapht.graph;
+
+import junit.framework.TestCase;
+import org.jgrapht.*;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+/**
+ * Unit test for the {@link DirectedGraphUnion} class, {@link UndirectedGraphUnion} class, {@link MixedGraphUnion} class.
+ *
+ * @author Joris Kinable
+ * @since Aug 24, 2015
+ */
+public class UnionGraphTest extends TestCase {
+
+    //~ Instance fields --------------------------------------------------------
+
+    private String v0 = "v0";
+    private String v1 = "v1";
+    private String v2 = "v2";
+    private String v3 = "v3";
+    private String v4 = "v4";
+
+    private DefaultEdge e1= new DefaultEdge(); //(v0,v1);
+    private DefaultEdge e2 = new DefaultEdge(); //(v1,v4);
+    private DefaultEdge e3= new DefaultEdge(); //(v4,v0);
+    private DefaultEdge e4= new DefaultEdge(); //(v1,v2);
+    private DefaultEdge e5= new DefaultEdge(); //(v2,v3);
+    private DefaultEdge e6= new DefaultEdge(); //(v3,v4);
+    private DefaultEdge e7= new DefaultEdge(); //(v4,v1);
+    
+    SimpleGraph<String, DefaultEdge> undirectedGraph1;
+    SimpleGraph<String, DefaultEdge> undirectedGraph2;
+
+    DirectedGraph<String, DefaultEdge> directedGraph1;
+    DirectedGraph<String, DefaultEdge> directedGraph2;
+
+
+    //~ Methods ----------------------------------------------------------------
+    
+    @Override
+    public void setUp(){
+        undirectedGraph1=new SimpleWeightedGraph<String, DefaultEdge>(DefaultEdge.class);
+        undirectedGraph2=new SimpleWeightedGraph<String, DefaultEdge>(DefaultEdge.class);
+        directedGraph1=new SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge.class);
+        directedGraph2=new SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge.class);
+
+        Graphs.addAllVertices(undirectedGraph1, Arrays.asList(v0, v1, v4));
+        Graphs.addAllVertices(undirectedGraph2, Arrays.asList(v1, v2, v3, v4));
+        Graphs.addAllVertices(directedGraph1, Arrays.asList(v0, v1, v4));
+        Graphs.addAllVertices(directedGraph2, Arrays.asList(v1, v2, v3, v4));
+
+        undirectedGraph1.addEdge(v0, v1, e1);
+        undirectedGraph1.addEdge(v1, v4, e2);
+        undirectedGraph1.addEdge(v4, v0, e3);
+
+        directedGraph1.addEdge(v0, v1, e1);
+        directedGraph1.addEdge(v1, v4, e2);
+        directedGraph1.addEdge(v4, v0, e3);
+
+        undirectedGraph2.addEdge(v4, v1, e7);
+        undirectedGraph2.addEdge(v1, v2, e4);
+        undirectedGraph2.addEdge(v2, v3, e5);
+        undirectedGraph2.addEdge(v3, v4, e6);
+
+        directedGraph2.addEdge(v4, v1, e7);
+        directedGraph2.addEdge(v1, v2, e4);
+        directedGraph2.addEdge(v2, v3, e5);
+        directedGraph2.addEdge(v3, v4, e6);
+    }
+
+    /**
+     * Create and test the union of two Undirected Graphs
+     */
+    public void testUndirectedGraphUnion(){
+        GraphUnion<String, DefaultEdge, UndirectedGraph<String, DefaultEdge>> graphUnion=new UndirectedGraphUnion<String, DefaultEdge>(undirectedGraph1, undirectedGraph2);
+        assertEquals(new HashSet<String>(Arrays.asList(v0, v1, v2, v3, v4)), graphUnion.vertexSet());
+        assertEquals(new HashSet<DefaultEdge>(Arrays.asList(e1, e2, e3, e4, e5, e6, e7)), graphUnion.edgeSet());
+        assertEquals(new HashSet<DefaultEdge>(Arrays.asList(e2, e3, e6, e7)), graphUnion.edgesOf(v4));
+
+        assertTrue(graphUnion.getG1()==undirectedGraph1);
+        assertTrue(graphUnion.getG2()==undirectedGraph2);
+
+        assertTrue(graphUnion.getEdge(v1, v4)==e2);
+        assertTrue(graphUnion.getEdge(v4, v1)==e2);
+    }
+
+    /**
+     * Create and test the union of two Directed Graphs
+     */
+    public void testDirectedGraphUnion(){
+        DirectedGraphUnion<String, DefaultEdge> graphUnion=new DirectedGraphUnion<String, DefaultEdge>(directedGraph1, directedGraph2);
+        assertEquals(new HashSet<String>(Arrays.asList(v0, v1, v2, v3, v4)), graphUnion.vertexSet());
+        assertEquals(new HashSet<DefaultEdge>(Arrays.asList(e1, e2, e3, e4, e5, e6, e7)), graphUnion.edgeSet());
+        assertEquals(new HashSet<DefaultEdge>(Arrays.asList(e2, e3, e6, e7)), graphUnion.edgesOf(v4));
+        assertEquals(new HashSet<DefaultEdge>(Arrays.asList(e3, e7)), graphUnion.outgoingEdgesOf(v4));
+        assertEquals(new HashSet<DefaultEdge>(Arrays.asList(e2, e6)), graphUnion.incomingEdgesOf(v4));
+
+        assertTrue(graphUnion.getG1()==directedGraph1);
+        assertTrue(graphUnion.getG2()==directedGraph2);
+        assertTrue(graphUnion instanceof DirectedGraph);
+
+        assertFalse(directedGraph1.containsEdge(v4,v1));
+        assertFalse(directedGraph2.containsEdge(v1,v4));
+        assertTrue(graphUnion.getEdge(v1, v4)==e2);
+        assertTrue(graphUnion.getEdge(v4, v1)==e7);
+
+        assertEquals(2, graphUnion.outDegreeOf(v1));
+        assertEquals(2, graphUnion.outDegreeOf(v4));
+        assertEquals(2, graphUnion.inDegreeOf(v1));
+        assertEquals(2, graphUnion.inDegreeOf(v4));
+    }
+
+    /**
+     * Create and test a Mixed-Graph, obtained by taking the union of a undirected and a directed graph
+     */
+    public void testMixedGraphUnion(){
+        MixedGraphUnion<String, DefaultEdge> graphUnion=new MixedGraphUnion<String, DefaultEdge>(undirectedGraph1, directedGraph2);
+        assertEquals(new HashSet<String>(Arrays.asList(v0, v1, v2, v3, v4)), graphUnion.vertexSet());
+        assertEquals(new HashSet<DefaultEdge>(Arrays.asList(e1, e2, e3, e4, e5, e6, e7)), graphUnion.edgeSet());
+        assertEquals(new HashSet<DefaultEdge>(Arrays.asList(e2, e3, e6, e7)), graphUnion.edgesOf(v4));
+        assertEquals(new HashSet<DefaultEdge>(Arrays.asList(e2, e3, e7)), graphUnion.outgoingEdgesOf(v4));
+        assertEquals(new HashSet<DefaultEdge>(Arrays.asList(e2, e3, e6)), graphUnion.incomingEdgesOf(v4));
+
+        assertTrue(graphUnion.getG1()==undirectedGraph1);
+        assertTrue(graphUnion.getG2()==directedGraph2);
+        assertTrue(graphUnion instanceof DirectedGraph);
+
+        assertTrue(graphUnion.containsEdge(v0, v1)); //undirected edge
+        assertTrue(graphUnion.containsEdge(v1, v0)); //undirected edge
+        assertTrue(graphUnion.containsEdge(v3,v4)); //directed edge
+        assertFalse(graphUnion.containsEdge(v4, v3)); //directed edge
+
+        assertEquals(3, graphUnion.outDegreeOf(v1));
+        assertEquals(3, graphUnion.outDegreeOf(v4));
+        assertEquals(3, graphUnion.inDegreeOf(v1));
+        assertEquals(3, graphUnion.inDegreeOf(v4));
+
+    }
+}


### PR DESCRIPTION
Revision of the FloydWarshallShortestPaths implementation. I made several performance improvements while simultaneously reducing the amount of code.

Improvements:
-Replaced recursive algorithm by simple, more efficient loop.
-For some reason, if the user would query the shortest path from i to j, the previous version of the code would first calculate ALL shortest paths for every possible i,j pair and then return the requested one. This is highly inefficient if the user only needs a few (which is almost always the case). 
-Removed a lot of unnecessary code

Made some changes to the As(Un)Weighted(Directed)Graph classes. The AsUnweightedDirectedGraph now simply extends the AsUnweightedGraph class, thereby reducing code. Furthermore, I've added the AsWeightedDirectedGraph which did not exist (the AsWeightedGraph class already existed).

Added a Mixed-Graph implementation to support graphs which have both edges and arcs. Furthermore, replaced the HashSets and HashMaps in GraphUnion.java with their Linked equivalents.