### PR TITLE
GraphMLExporter now supports multiple keys per node and edge.

### DIFF
--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/EmptyAttributeProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/EmptyAttributeProvider.java
@@ -1,0 +1,13 @@
+package org.jgrapht.ext;
+
+import java.util.Collections;
+import java.util.Map;
+
+public class EmptyAttributeProvider<T> implements ComponentAttributeProvider<T> {
+
+    @Override
+    public Map<String, String> getComponentAttributes(T component) {
+        return Collections.emptyMap();
+    }
+
+}


### PR DESCRIPTION
This change allows to have more than one data key per node and edge. The previous revision only allowed vertex _vertex_label_ and _edge_label_ as key. Now a client can provide ComponentAttributeProvider for vertices and edges.

Sadly I did not manage to fix the test case undirectedWithProperties. It fails with:

````java
junit.framework.AssertionFailedError: org.custommonkey.xmlunit.Validator@17a7cec2:At line 1, column: 47 ==> Dokument ist ungültig. Keine Grammatik gefunden.
 At line 1, column: 47 ==> Document Root-Element "graphml"muss mit DOCTYPE-Root "null" übereinstimmen.
  expected:<true> but was:<false>
	at junit.framework.Assert.fail(Assert.java:50)
	at junit.framework.Assert.failNotEquals(Assert.java:287)
	at junit.framework.Assert.assertEquals(Assert.java:67)
	at junit.framework.Assert.assertEquals(Assert.java:147)
	at org.custommonkey.xmlunit.XMLAssert.assertXMLValid(XMLAssert.java:1043)
````
Perhaps someone with more expertise in XMLAssert can fix this. [yEd](https://www.yworks.com/products/yed) does not complain about big graphs which we generated with this extenstion. So I am very confident that it should work in mostly.