### PR TITLE
Update JDK version to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,8 +160,8 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>3.1</version>
 					<configuration>
-						<source>1.6</source>
-						<target>1.6</target>
+						<source>1.7</source>
+						<target>1.7</target>
 					</configuration>
 				</plugin> 
 				<plugin>


### PR DESCRIPTION
Closes #179 by updating maven-compiler-plugin to use JDK 1.7, as specified in the project README.