### PR TITLE
better handling of invalid attribute sets

### DIFF
--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
@@ -311,6 +311,45 @@ public class DOTImporterTest extends TestCase
       testGarbageGraph(input, "input asks for undirected graph and directed graph provided.", result);
    }
 
+   public void testInvalidAttributes() {
+      String input = "graph G {\n"
+              + "  1 [ label = \"bob\" \"foo\" ];\n"
+              + "  2 [ label = \"fred\" ];\n"
+              // the extra label will be ignored but not cause any problems.
+              + "  1 -- 2 [ label = friend foo];\n"
+              + "}";
+
+      Multigraph<TestVertex, TestEdge> graph
+              = new Multigraph<TestVertex, TestEdge>(TestEdge.class);
+
+      DOTImporter<TestVertex, TestEdge> importer
+              = new DOTImporter<TestVertex, TestEdge>(
+              new VertexProvider<TestVertex>() {
+                 @Override
+                 public TestVertex buildVertex(String label,
+                                               Map<String, String> attributes) {
+                    return new TestVertex(label, attributes);
+                 }
+              },
+              new EdgeProvider<TestVertex, TestEdge>() {
+                 @Override
+                 public TestEdge buildEdge(TestVertex from,
+                                           TestVertex to,
+                                           String label,
+                                           Map<String, String> attributes) {
+                    return new TestEdge(label, attributes);
+                 }
+              }
+      );
+
+      try {
+         importer.read(input, graph);
+         Assert.fail("Should not get here");
+      } catch (ImportException e) {
+         Assert.assertEquals("Invalid attributes", e.getMessage());
+      }
+   }
+
    public void testUpdatingVertex() throws ImportException {
       String input = "graph G {\n"
                      + "a -- b;\n"


### PR DESCRIPTION
having slept on the change to deal with unquoted attributes I realised that problems would happen if we had spaces in an attribute by accident. 

This will cause a slightly better error message. Unfortunately where the problem is detectable we also don't have enough context to be able to give a really useful error message.