### PR TITLE
Use underlying MaskVertexSet for MaskSubgraph.containsVertex()

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/MaskSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/MaskSubgraph.java
@@ -109,7 +109,7 @@ public class MaskSubgraph<V, E>
 
     @Override public boolean containsVertex(V v)
     {
-        return !this.mask.isVertexMasked(v) && this.base.containsVertex(v);
+        return vertexSet().contains(v);
     }
 
     /**


### PR DESCRIPTION
The MaskSubgraph.containsEdge() method passes through to the underlying MaskEdgeSet.contains() method, but MaskSubgraph.containsVertex() contains its own logic, which creates a maintainability liability. This patch changes the containsVertex() behavior to match containsEdge().