### PR TITLE
Specifics optimization

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -50,8 +50,8 @@ import java.util.*;
 
 import org.jgrapht.*;
 import org.jgrapht.graph.specifics.FastLookupDirectedSpecifics;
+import org.jgrapht.graph.specifics.FastLookupUndirectedSpecifics;
 import org.jgrapht.graph.specifics.Specifics;
-import org.jgrapht.graph.specifics.UndirectedSpecifics;
 import org.jgrapht.util.*;
 
 
@@ -535,13 +535,12 @@ public abstract class AbstractBaseGraph<V, E>
 
     protected Specifics<V,E> createUndirectedSpecifics()
     {
-        return new UndirectedSpecifics<>(this);
+        return new FastLookupUndirectedSpecifics<>(this);
     }
 
     protected Specifics<V,E> createDirectedSpecifics()
     {
         return new FastLookupDirectedSpecifics<>(this);
-        //return new DirectedSpecifics<>(this);
     }
 
     private static class ArrayListFactory<VV, EE>

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -49,6 +49,9 @@ import java.io.*;
 import java.util.*;
 
 import org.jgrapht.*;
+import org.jgrapht.graph.specifics.DirectedSpecifics;
+import org.jgrapht.graph.specifics.Specifics;
+import org.jgrapht.graph.specifics.UndirectedSpecifics;
 import org.jgrapht.util.*;
 
 
@@ -81,7 +84,7 @@ public abstract class AbstractBaseGraph<V, E>
     private Map<E, IntrusiveEdge> edgeMap;
     private transient Set<E> unmodifiableEdgeSet = null;
     private transient Set<V> unmodifiableVertexSet = null;
-    private Specifics specifics;
+    private Specifics<V,E> specifics;
     private boolean allowingMultipleEdges;
 
     private transient TypeUtil<V> vertexTypeDecl = null;
@@ -106,14 +109,14 @@ public abstract class AbstractBaseGraph<V, E>
             throw new NullPointerException();
         }
 
-        edgeMap = new LinkedHashMap<E, IntrusiveEdge>();
+        edgeMap = new LinkedHashMap<>();
         edgeFactory = ef;
         allowingLoops = allowLoops;
         allowingMultipleEdges = allowMultipleEdges;
 
+        this.edgeSetFactory = new ArrayListFactory<>();
         specifics = createSpecifics();
 
-        this.edgeSetFactory = new ArrayListFactory<V, E>();
     }
 
     /**
@@ -175,6 +178,16 @@ public abstract class AbstractBaseGraph<V, E>
     public void setEdgeSetFactory(EdgeSetFactory<V, E> edgeSetFactory)
     {
         this.edgeSetFactory = edgeSetFactory;
+    }
+
+    /**
+     * Returns the {@link EdgeSetFactory} used by this graph. The default is {@link
+     * java.util.ArrayList} with capacity 1.
+     * @return edgeSetFactory used by this graph
+     */
+    public EdgeSetFactory<V,E> getEdgeSetFactory()
+    {
+        return edgeSetFactory;
     }
 
     /**
@@ -318,12 +331,10 @@ public abstract class AbstractBaseGraph<V, E>
     @Override public Object clone()
     {
         try {
-            TypeUtil<AbstractBaseGraph<V, E>> typeDecl = null;
-
             AbstractBaseGraph<V, E> newGraph =
-                TypeUtil.uncheckedCast(super.clone(), typeDecl);
+                TypeUtil.uncheckedCast(super.clone(), null);
 
-            newGraph.edgeMap = new LinkedHashMap<E, IntrusiveEdge>();
+            newGraph.edgeMap = new LinkedHashMap<>();
 
             newGraph.edgeFactory = this.edgeFactory;
             newGraph.unmodifiableEdgeSet = null;
@@ -384,6 +395,7 @@ public abstract class AbstractBaseGraph<V, E>
      */
     @Override public Set<E> edgesOf(V vertex)
     {
+        assertVertexExist(vertex);
         return specifics.edgesOf(vertex);
     }
 
@@ -392,6 +404,7 @@ public abstract class AbstractBaseGraph<V, E>
      */
     public int inDegreeOf(V vertex)
     {
+        assertVertexExist(vertex);
         return specifics.inDegreeOf(vertex);
     }
 
@@ -400,6 +413,7 @@ public abstract class AbstractBaseGraph<V, E>
      */
     public Set<E> incomingEdgesOf(V vertex)
     {
+        assertVertexExist(vertex);
         return specifics.incomingEdgesOf(vertex);
     }
 
@@ -408,6 +422,7 @@ public abstract class AbstractBaseGraph<V, E>
      */
     public int outDegreeOf(V vertex)
     {
+        assertVertexExist(vertex);
         return specifics.outDegreeOf(vertex);
     }
 
@@ -416,6 +431,7 @@ public abstract class AbstractBaseGraph<V, E>
      */
     public Set<E> outgoingEdgesOf(V vertex)
     {
+        assertVertexExist(vertex);
         return specifics.outgoingEdgesOf(vertex);
     }
 
@@ -459,7 +475,7 @@ public abstract class AbstractBaseGraph<V, E>
 
             // cannot iterate over list - will cause
             // ConcurrentModificationException
-            removeAllEdges(new ArrayList<E>(touchingEdgesList));
+            removeAllEdges(new ArrayList<>(touchingEdgesList));
 
             specifics.getVertexSet().remove(v); // remove the vertex itself
 
@@ -505,7 +521,7 @@ public abstract class AbstractBaseGraph<V, E>
         ((DefaultWeightedEdge) e).weight = weight;
     }
 
-    private Specifics createSpecifics()
+    private Specifics<V,E> createSpecifics()
     {
         if (this instanceof DirectedGraph<?, ?>) {
             return createDirectedSpecifics();
@@ -517,120 +533,14 @@ public abstract class AbstractBaseGraph<V, E>
         }
     }
 
-    protected UndirectedSpecifics createUndirectedSpecifics()
+    protected UndirectedSpecifics<V,E> createUndirectedSpecifics()
     {
-        return new UndirectedSpecifics();
+        return new UndirectedSpecifics<>(this);
     }
 
-    protected DirectedSpecifics createDirectedSpecifics()
+    protected DirectedSpecifics<V,E> createDirectedSpecifics()
     {
-        return new DirectedSpecifics();
-    }
-
-    /**
-     * .
-     *
-     * @author Barak Naveh
-     */
-    private abstract class Specifics
-        implements Serializable
-    {
-        private static final long serialVersionUID = 785196247314761183L;
-
-        public abstract void addVertex(V vertex);
-
-        public abstract Set<V> getVertexSet();
-
-        /**
-         * .
-         *
-         * @param sourceVertex
-         * @param targetVertex
-         *
-         * @return
-         */
-        public abstract Set<E> getAllEdges(V sourceVertex,
-            V targetVertex);
-
-        /**
-         * .
-         *
-         * @param sourceVertex
-         * @param targetVertex
-         *
-         * @return
-         */
-        public abstract E getEdge(V sourceVertex, V targetVertex);
-
-        /**
-         * Adds the specified edge to the edge containers of its source and
-         * target vertices.
-         *
-         * @param e
-         */
-        public abstract void addEdgeToTouchingVertices(E e);
-
-        /**
-         * .
-         *
-         * @param vertex
-         *
-         * @return
-         */
-        public abstract int degreeOf(V vertex);
-
-        /**
-         * .
-         *
-         * @param vertex
-         *
-         * @return
-         */
-        public abstract Set<E> edgesOf(V vertex);
-
-        /**
-         * .
-         *
-         * @param vertex
-         *
-         * @return
-         */
-        public abstract int inDegreeOf(V vertex);
-
-        /**
-         * .
-         *
-         * @param vertex
-         *
-         * @return
-         */
-        public abstract Set<E> incomingEdgesOf(V vertex);
-
-        /**
-         * .
-         *
-         * @param vertex
-         *
-         * @return
-         */
-        public abstract int outDegreeOf(V vertex);
-
-        /**
-         * .
-         *
-         * @param vertex
-         *
-         * @return
-         */
-        public abstract Set<E> outgoingEdgesOf(V vertex);
-
-        /**
-         * Removes the specified edge from the edge containers of its source and
-         * target vertices.
-         *
-         * @param e
-         */
-        public abstract void removeEdgeFromTouchingVertices(E e);
+        return new DirectedSpecifics<>(this);
     }
 
     private static class ArrayListFactory<VV, EE>
@@ -640,597 +550,16 @@ public abstract class AbstractBaseGraph<V, E>
         private static final long serialVersionUID = 5936902837403445985L;
 
         /**
-         * @see EdgeSetFactory.createEdgeSet
+         * @see EdgeSetFactory
          */
         @Override public Set<EE> createEdgeSet(VV vertex)
         {
             // NOTE:  use size 1 to keep memory usage under control
             // for the common case of vertices with low degree
-            return new ArrayUnenforcedSet<EE>(1);
+            return new ArrayUnenforcedSet<>(1);
         }
     }
 
-    /**
-     * A container for vertex edges.
-     *
-     * <p>In this edge container we use array lists to minimize memory toll.
-     * However, for high-degree vertices we replace the entire edge container
-     * with a direct access subclass (to be implemented).</p>
-     *
-     * @author Barak Naveh
-     */
-    protected static class DirectedEdgeContainer<VV, EE>
-        implements Serializable
-    {
-        private static final long serialVersionUID = 7494242245729767106L;
-        Set<EE> incoming;
-        Set<EE> outgoing;
-        private transient Set<EE> unmodifiableIncoming = null;
-        private transient Set<EE> unmodifiableOutgoing = null;
-
-        DirectedEdgeContainer(EdgeSetFactory<VV, EE> edgeSetFactory,
-            VV vertex)
-        {
-            incoming = edgeSetFactory.createEdgeSet(vertex);
-            outgoing = edgeSetFactory.createEdgeSet(vertex);
-        }
-
-        /**
-         * A lazy build of unmodifiable incoming edge set.
-         *
-         * @return
-         */
-        public Set<EE> getUnmodifiableIncomingEdges()
-        {
-            if (unmodifiableIncoming == null) {
-                unmodifiableIncoming = Collections.unmodifiableSet(incoming);
-            }
-
-            return unmodifiableIncoming;
-        }
-
-        /**
-         * A lazy build of unmodifiable outgoing edge set.
-         *
-         * @return
-         */
-        public Set<EE> getUnmodifiableOutgoingEdges()
-        {
-            if (unmodifiableOutgoing == null) {
-                unmodifiableOutgoing = Collections.unmodifiableSet(outgoing);
-            }
-
-            return unmodifiableOutgoing;
-        }
-
-        /**
-         * .
-         *
-         * @param e
-         */
-        public void addIncomingEdge(EE e)
-        {
-            incoming.add(e);
-        }
-
-        /**
-         * .
-         *
-         * @param e
-         */
-        public void addOutgoingEdge(EE e)
-        {
-            outgoing.add(e);
-        }
-
-        /**
-         * .
-         *
-         * @param e
-         */
-        public void removeIncomingEdge(EE e)
-        {
-            incoming.remove(e);
-        }
-
-        /**
-         * .
-         *
-         * @param e
-         */
-        public void removeOutgoingEdge(EE e)
-        {
-            outgoing.remove(e);
-        }
-    }
-
-    /**
-     * .
-     *
-     * @author Barak Naveh
-     */
-    protected class DirectedSpecifics
-        extends Specifics
-        implements Serializable
-    {
-        private static final long serialVersionUID = 8971725103718958232L;
-        private static final String NOT_IN_DIRECTED_GRAPH =
-            "no such operation in a directed graph";
-
-        protected Map<V, DirectedEdgeContainer<V, E>> vertexMapDirected;
-
-        public DirectedSpecifics()
-        {
-            this(new LinkedHashMap<V, DirectedEdgeContainer<V, E>>());
-        }
-
-        public DirectedSpecifics(Map<V, DirectedEdgeContainer<V, E>> vertexMap)
-        {
-            this.vertexMapDirected = vertexMap;
-        }
-
-        @Override public void addVertex(V v)
-        {
-            // add with a lazy edge container entry
-            vertexMapDirected.put(v, null);
-        }
-
-        @Override public Set<V> getVertexSet()
-        {
-            return vertexMapDirected.keySet();
-        }
-
-        /**
-         * @see Graph#getAllEdges(Object, Object)
-         */
-        @Override public Set<E> getAllEdges(V sourceVertex, V targetVertex)
-        {
-            Set<E> edges = null;
-
-            if (containsVertex(sourceVertex)
-                && containsVertex(targetVertex))
-            {
-                edges = new ArrayUnenforcedSet<E>();
-
-                DirectedEdgeContainer<V, E> ec = getEdgeContainer(sourceVertex);
-
-                Iterator<E> iter = ec.outgoing.iterator();
-
-                while (iter.hasNext()) {
-                    E e = iter.next();
-
-                    if (getEdgeTarget(e).equals(targetVertex)) {
-                        edges.add(e);
-                    }
-                }
-            }
-
-            return edges;
-        }
-
-        /**
-         * @see Graph#getEdge(Object, Object)
-         */
-        @Override public E getEdge(V sourceVertex, V targetVertex)
-        {
-            if (containsVertex(sourceVertex)
-                && containsVertex(targetVertex))
-            {
-                DirectedEdgeContainer<V, E> ec = getEdgeContainer(sourceVertex);
-
-                Iterator<E> iter = ec.outgoing.iterator();
-
-                while (iter.hasNext()) {
-                    E e = iter.next();
-
-                    if (getEdgeTarget(e).equals(targetVertex)) {
-                        return e;
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        @Override public void addEdgeToTouchingVertices(E e)
-        {
-            V source = getEdgeSource(e);
-            V target = getEdgeTarget(e);
-
-            getEdgeContainer(source).addOutgoingEdge(e);
-            getEdgeContainer(target).addIncomingEdge(e);
-        }
-
-        /**
-         * @see UndirectedGraph#degreeOf(Object)
-         */
-        @Override public int degreeOf(V vertex)
-        {
-            throw new UnsupportedOperationException(NOT_IN_DIRECTED_GRAPH);
-        }
-
-        /**
-         * @see Graph#edgesOf(Object)
-         */
-        @Override public Set<E> edgesOf(V vertex)
-        {
-            ArrayUnenforcedSet<E> inAndOut =
-                new ArrayUnenforcedSet<E>(getEdgeContainer(vertex).incoming);
-            inAndOut.addAll(getEdgeContainer(vertex).outgoing);
-
-            // we have two copies for each self-loop - remove one of them.
-            if (allowingLoops) {
-                Set<E> loops = getAllEdges(vertex, vertex);
-
-                for (int i = 0; i < inAndOut.size();) {
-                    Object e = inAndOut.get(i);
-
-                    if (loops.contains(e)) {
-                        inAndOut.remove(i);
-                        loops.remove(e); // so we remove it only once
-                    } else {
-                        i++;
-                    }
-                }
-            }
-
-            return Collections.unmodifiableSet(inAndOut);
-        }
-
-        /**
-         * @see DirectedGraph#inDegreeOf(Object)
-         */
-        @Override public int inDegreeOf(V vertex)
-        {
-            return getEdgeContainer(vertex).incoming.size();
-        }
-
-        /**
-         * @see DirectedGraph#incomingEdgesOf(Object)
-         */
-        @Override public Set<E> incomingEdgesOf(V vertex)
-        {
-            return getEdgeContainer(vertex).getUnmodifiableIncomingEdges();
-        }
-
-        /**
-         * @see DirectedGraph#outDegreeOf(Object)
-         */
-        @Override public int outDegreeOf(V vertex)
-        {
-            return getEdgeContainer(vertex).outgoing.size();
-        }
-
-        /**
-         * @see DirectedGraph#outgoingEdgesOf(Object)
-         */
-        @Override public Set<E> outgoingEdgesOf(V vertex)
-        {
-            return getEdgeContainer(vertex).getUnmodifiableOutgoingEdges();
-        }
-
-        @Override public void removeEdgeFromTouchingVertices(E e)
-        {
-            V source = getEdgeSource(e);
-            V target = getEdgeTarget(e);
-
-            getEdgeContainer(source).removeOutgoingEdge(e);
-            getEdgeContainer(target).removeIncomingEdge(e);
-        }
-
-        /**
-         * A lazy build of edge container for specified vertex.
-         *
-         * @param vertex a vertex in this graph.
-         *
-         * @return EdgeContainer
-         */
-        private DirectedEdgeContainer<V, E> getEdgeContainer(V vertex)
-        {
-            assertVertexExist(vertex);
-
-            DirectedEdgeContainer<V, E> ec = vertexMapDirected.get(vertex);
-
-            if (ec == null) {
-                ec = new DirectedEdgeContainer<V, E>(edgeSetFactory, vertex);
-                vertexMapDirected.put(vertex, ec);
-            }
-
-            return ec;
-        }
-    }
-
-    /**
-     * A container of for vertex edges.
-     *
-     * <p>In this edge container we use array lists to minimize memory toll.
-     * However, for high-degree vertices we replace the entire edge container
-     * with a direct access subclass (to be implemented).</p>
-     *
-     * @author Barak Naveh
-     */
-    private static class UndirectedEdgeContainer<VV, EE>
-        implements Serializable
-    {
-        private static final long serialVersionUID = -6623207588411170010L;
-        Set<EE> vertexEdges;
-        private transient Set<EE> unmodifiableVertexEdges = null;
-
-        UndirectedEdgeContainer(
-            EdgeSetFactory<VV, EE> edgeSetFactory,
-            VV vertex)
-        {
-            vertexEdges = edgeSetFactory.createEdgeSet(vertex);
-        }
-
-        /**
-         * A lazy build of unmodifiable list of vertex edges
-         *
-         * @return
-         */
-        public Set<EE> getUnmodifiableVertexEdges()
-        {
-            if (unmodifiableVertexEdges == null) {
-                unmodifiableVertexEdges =
-                    Collections.unmodifiableSet(vertexEdges);
-            }
-
-            return unmodifiableVertexEdges;
-        }
-
-        /**
-         * .
-         *
-         * @param e
-         */
-        public void addEdge(EE e)
-        {
-            vertexEdges.add(e);
-        }
-
-        /**
-         * .
-         *
-         * @return
-         */
-        public int edgeCount()
-        {
-            return vertexEdges.size();
-        }
-
-        /**
-         * .
-         *
-         * @param e
-         */
-        public void removeEdge(EE e)
-        {
-            vertexEdges.remove(e);
-        }
-    }
-
-    /**
-     * .
-     *
-     * @author Barak Naveh
-     */
-    protected class UndirectedSpecifics
-        extends Specifics
-        implements Serializable
-    {
-        private static final long serialVersionUID = 6494588405178655873L;
-        private static final String NOT_IN_UNDIRECTED_GRAPH =
-            "no such operation in an undirected graph";
-
-        private Map<V, UndirectedEdgeContainer<V, E>> vertexMapUndirected;
-
-        public UndirectedSpecifics()
-        {
-            this(new LinkedHashMap<V, UndirectedEdgeContainer<V, E>>());
-        }
-
-        public UndirectedSpecifics(
-            Map<V, UndirectedEdgeContainer<V, E>> vertexMap)
-        {
-            this.vertexMapUndirected = vertexMap;
-        }
-
-        @Override public void addVertex(V v)
-        {
-            // add with a lazy edge container entry
-            vertexMapUndirected.put(v, null);
-        }
-
-        @Override public Set<V> getVertexSet()
-        {
-            return vertexMapUndirected.keySet();
-        }
-
-        /**
-         * @see Graph#getAllEdges(Object, Object)
-         */
-        @Override public Set<E> getAllEdges(V sourceVertex, V targetVertex)
-        {
-            Set<E> edges = null;
-
-            if (containsVertex(sourceVertex)
-                && containsVertex(targetVertex))
-            {
-                edges = new ArrayUnenforcedSet<E>();
-
-                Iterator<E> iter =
-                    getEdgeContainer(sourceVertex).vertexEdges.iterator();
-
-                while (iter.hasNext()) {
-                    E e = iter.next();
-
-                    boolean equal =
-                        isEqualsStraightOrInverted(
-                            sourceVertex,
-                            targetVertex,
-                            e);
-
-                    if (equal) {
-                        edges.add(e);
-                    }
-                }
-            }
-
-            return edges;
-        }
-
-        /**
-         * @see Graph#getEdge(Object, Object)
-         */
-        @Override public E getEdge(V sourceVertex, V targetVertex)
-        {
-            if (containsVertex(sourceVertex)
-                && containsVertex(targetVertex))
-            {
-                Iterator<E> iter =
-                    getEdgeContainer(sourceVertex).vertexEdges.iterator();
-
-                while (iter.hasNext()) {
-                    E e = iter.next();
-
-                    boolean equal =
-                        isEqualsStraightOrInverted(
-                            sourceVertex,
-                            targetVertex,
-                            e);
-
-                    if (equal) {
-                        return e;
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        private boolean isEqualsStraightOrInverted(
-            Object sourceVertex,
-            Object targetVertex,
-            E e)
-        {
-            boolean equalStraight =
-                sourceVertex.equals(getEdgeSource(e))
-                && targetVertex.equals(getEdgeTarget(e));
-
-            boolean equalInverted =
-                sourceVertex.equals(getEdgeTarget(e))
-                && targetVertex.equals(getEdgeSource(e));
-            return equalStraight || equalInverted;
-        }
-
-        @Override public void addEdgeToTouchingVertices(E e)
-        {
-            V source = getEdgeSource(e);
-            V target = getEdgeTarget(e);
-
-            getEdgeContainer(source).addEdge(e);
-
-            if (!source.equals(target)) {
-                getEdgeContainer(target).addEdge(e);
-            }
-        }
-
-        @Override public int degreeOf(V vertex)
-        {
-            if (allowingLoops) { // then we must count, and add loops twice
-
-                int degree = 0;
-                Set<E> edges = getEdgeContainer(vertex).vertexEdges;
-
-                for (E e : edges) {
-                    if (getEdgeSource(e).equals(getEdgeTarget(e))) {
-                        degree += 2;
-                    } else {
-                        degree += 1;
-                    }
-                }
-
-                return degree;
-            } else {
-                return getEdgeContainer(vertex).edgeCount();
-            }
-        }
-
-        /**
-         * @see Graph#edgesOf(Object)
-         */
-        @Override public Set<E> edgesOf(V vertex)
-        {
-            return getEdgeContainer(vertex).getUnmodifiableVertexEdges();
-        }
-
-        /**
-         * @see DirectedGraph#inDegreeOf(Object)
-         */
-        @Override public int inDegreeOf(V vertex)
-        {
-            throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
-        }
-
-        /**
-         * @see DirectedGraph#incomingEdgesOf(Object)
-         */
-        @Override public Set<E> incomingEdgesOf(V vertex)
-        {
-            throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
-        }
-
-        /**
-         * @see DirectedGraph#outDegreeOf(Object)
-         */
-        @Override public int outDegreeOf(V vertex)
-        {
-            throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
-        }
-
-        /**
-         * @see DirectedGraph#outgoingEdgesOf(Object)
-         */
-        @Override public Set<E> outgoingEdgesOf(V vertex)
-        {
-            throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
-        }
-
-        @Override public void removeEdgeFromTouchingVertices(E e)
-        {
-            V source = getEdgeSource(e);
-            V target = getEdgeTarget(e);
-
-            getEdgeContainer(source).removeEdge(e);
-
-            if (!source.equals(target)) {
-                getEdgeContainer(target).removeEdge(e);
-            }
-        }
-
-        /**
-         * A lazy build of edge container for specified vertex.
-         *
-         * @param vertex a vertex in this graph.
-         *
-         * @return EdgeContainer
-         */
-        private UndirectedEdgeContainer<V, E> getEdgeContainer(V vertex)
-        {
-            assertVertexExist(vertex);
-
-            UndirectedEdgeContainer<V, E> ec = vertexMapUndirected.get(vertex);
-
-            if (ec == null) {
-                ec = new UndirectedEdgeContainer<V, E>(
-                    edgeSetFactory,
-                    vertex);
-                vertexMapUndirected.put(vertex, ec);
-            }
-
-            return ec;
-        }
-    }
 }
 
 // End AbstractBaseGraph.java

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -49,7 +49,7 @@ import java.io.*;
 import java.util.*;
 
 import org.jgrapht.*;
-import org.jgrapht.graph.specifics.DirectedSpecifics;
+import org.jgrapht.graph.specifics.FastLookupDirectedSpecifics;
 import org.jgrapht.graph.specifics.Specifics;
 import org.jgrapht.graph.specifics.UndirectedSpecifics;
 import org.jgrapht.util.*;
@@ -533,14 +533,15 @@ public abstract class AbstractBaseGraph<V, E>
         }
     }
 
-    protected UndirectedSpecifics<V,E> createUndirectedSpecifics()
+    protected Specifics<V,E> createUndirectedSpecifics()
     {
         return new UndirectedSpecifics<>(this);
     }
 
-    protected DirectedSpecifics<V,E> createDirectedSpecifics()
+    protected Specifics<V,E> createDirectedSpecifics()
     {
-        return new DirectedSpecifics<>(this);
+        return new FastLookupDirectedSpecifics<>(this);
+        //return new DirectedSpecifics<>(this);
     }
 
     private static class ArrayListFactory<VV, EE>

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedEdgeContainer.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedEdgeContainer.java
@@ -1,3 +1,37 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -----------------
+ * DirectedEdgeContainer.java
+ * -----------------
+ * (C) Copyright 2015-2015, by Barak Naveh and Contributors.
+ *
+ * Original Author:  Barak Naveh
+ * Contributor(s):
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ */
 package org.jgrapht.graph.specifics;
 
 import org.jgrapht.graph.EdgeSetFactory;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedEdgeContainer.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedEdgeContainer.java
@@ -49,17 +49,17 @@ import java.util.Set;
  *
  * @author Barak Naveh
  */
-public class DirectedEdgeContainer<VV, EE>
+public class DirectedEdgeContainer<V, E>
     implements Serializable
 {
     private static final long serialVersionUID = 7494242245729767106L;
-    Set<EE> incoming;
-    Set<EE> outgoing;
-    private transient Set<EE> unmodifiableIncoming = null;
-    private transient Set<EE> unmodifiableOutgoing = null;
+    Set<E> incoming;
+    Set<E> outgoing;
+    private transient Set<E> unmodifiableIncoming = null;
+    private transient Set<E> unmodifiableOutgoing = null;
 
-    DirectedEdgeContainer(EdgeSetFactory<VV, EE> edgeSetFactory,
-                          VV vertex)
+    DirectedEdgeContainer(EdgeSetFactory<V, E> edgeSetFactory,
+                          V vertex)
     {
         incoming = edgeSetFactory.createEdgeSet(vertex);
         outgoing = edgeSetFactory.createEdgeSet(vertex);
@@ -70,7 +70,7 @@ public class DirectedEdgeContainer<VV, EE>
      *
      * @return
      */
-    public Set<EE> getUnmodifiableIncomingEdges()
+    public Set<E> getUnmodifiableIncomingEdges()
     {
         if (unmodifiableIncoming == null) {
             unmodifiableIncoming = Collections.unmodifiableSet(incoming);
@@ -84,7 +84,7 @@ public class DirectedEdgeContainer<VV, EE>
      *
      * @return
      */
-    public Set<EE> getUnmodifiableOutgoingEdges()
+    public Set<E> getUnmodifiableOutgoingEdges()
     {
         if (unmodifiableOutgoing == null) {
             unmodifiableOutgoing = Collections.unmodifiableSet(outgoing);
@@ -98,7 +98,7 @@ public class DirectedEdgeContainer<VV, EE>
      *
      * @param e
      */
-    public void addIncomingEdge(EE e)
+    public void addIncomingEdge(E e)
     {
         incoming.add(e);
     }
@@ -108,7 +108,7 @@ public class DirectedEdgeContainer<VV, EE>
      *
      * @param e
      */
-    public void addOutgoingEdge(EE e)
+    public void addOutgoingEdge(E e)
     {
         outgoing.add(e);
     }
@@ -118,7 +118,7 @@ public class DirectedEdgeContainer<VV, EE>
      *
      * @param e
      */
-    public void removeIncomingEdge(EE e)
+    public void removeIncomingEdge(E e)
     {
         incoming.remove(e);
     }
@@ -128,7 +128,7 @@ public class DirectedEdgeContainer<VV, EE>
      *
      * @param e
      */
-    public void removeOutgoingEdge(EE e)
+    public void removeOutgoingEdge(E e)
     {
         outgoing.remove(e);
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedEdgeContainer.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedEdgeContainer.java
@@ -1,0 +1,101 @@
+package org.jgrapht.graph.specifics;
+
+import org.jgrapht.graph.EdgeSetFactory;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * A container for vertex edges.
+ *
+ * <p>In this edge container we use array lists to minimize memory toll.
+ * However, for high-degree vertices we replace the entire edge container
+ * with a direct access subclass (to be implemented).</p>
+ *
+ * @author Barak Naveh
+ */
+public class DirectedEdgeContainer<VV, EE>
+    implements Serializable
+{
+    private static final long serialVersionUID = 7494242245729767106L;
+    Set<EE> incoming;
+    Set<EE> outgoing;
+    private transient Set<EE> unmodifiableIncoming = null;
+    private transient Set<EE> unmodifiableOutgoing = null;
+
+    DirectedEdgeContainer(EdgeSetFactory<VV, EE> edgeSetFactory,
+                          VV vertex)
+    {
+        incoming = edgeSetFactory.createEdgeSet(vertex);
+        outgoing = edgeSetFactory.createEdgeSet(vertex);
+    }
+
+    /**
+     * A lazy build of unmodifiable incoming edge set.
+     *
+     * @return
+     */
+    public Set<EE> getUnmodifiableIncomingEdges()
+    {
+        if (unmodifiableIncoming == null) {
+            unmodifiableIncoming = Collections.unmodifiableSet(incoming);
+        }
+
+        return unmodifiableIncoming;
+    }
+
+    /**
+     * A lazy build of unmodifiable outgoing edge set.
+     *
+     * @return
+     */
+    public Set<EE> getUnmodifiableOutgoingEdges()
+    {
+        if (unmodifiableOutgoing == null) {
+            unmodifiableOutgoing = Collections.unmodifiableSet(outgoing);
+        }
+
+        return unmodifiableOutgoing;
+    }
+
+    /**
+     * .
+     *
+     * @param e
+     */
+    public void addIncomingEdge(EE e)
+    {
+        incoming.add(e);
+    }
+
+    /**
+     * .
+     *
+     * @param e
+     */
+    public void addOutgoingEdge(EE e)
+    {
+        outgoing.add(e);
+    }
+
+    /**
+     * .
+     *
+     * @param e
+     */
+    public void removeIncomingEdge(EE e)
+    {
+        incoming.remove(e);
+    }
+
+    /**
+     * .
+     *
+     * @param e
+     */
+    public void removeOutgoingEdge(EE e)
+    {
+        outgoing.remove(e);
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -1,3 +1,37 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -----------------
+ * DirectedSpecifics.java
+ * -----------------
+ * (C) Copyright 2015-2015, by Barak Naveh and Contributors.
+ *
+ * Original Author:  Barak Naveh
+ * Contributor(s): Joris Kinable
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ */
 package org.jgrapht.graph.specifics;
 
 import org.jgrapht.DirectedGraph;
@@ -12,8 +46,9 @@ import java.util.*;
 
 /**
  * Plain implementation of DirectedSpecifics. This implementation requires the least amount of memory, at the expense of
- * slow edge retrievals. Methods which depend on edge retrievals, i.e. getEdge(V u, V v), containsEdge(V u, V v),
- * addEdge(V u, V v), etc may be relatively slow when the average degree of a vertex is high (dense graphs).
+ * slow edge retrievals. Methods which depend on edge retrievals, e.g. getEdge(V u, V v), containsEdge(V u, V v),
+ * addEdge(V u, V v), etc may be relatively slow when the average degree of a vertex is high (dense graphs). For a fast
+ * implementation, use {@link FastLookupDirectedSpecifics}.
  *
  * @author Barak Naveh
  * @author Joris Kinable

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -11,9 +11,12 @@ import java.io.Serializable;
 import java.util.*;
 
 /**
- * .
+ * Plain implementation of DirectedSpecifics. This implementation requires the least amount of memory, at the expense of
+ * slow edge retrievals. Methods which depend on edge retrievals, i.e. getEdge(V u, V v), containsEdge(V u, V v),
+ * addEdge(V u, V v), etc may be relatively slow when the average degree of a vertex is high (dense graphs).
  *
  * @author Barak Naveh
+ * @author Joris Kinable
  */
 public class DirectedSpecifics<V,E>
     extends Specifics<V,E>
@@ -23,16 +26,16 @@ public class DirectedSpecifics<V,E>
     private static final String NOT_IN_DIRECTED_GRAPH =
         "no such operation in a directed graph";
 
-    private AbstractBaseGraph<V,E> abstractBaseGraph;
+    protected AbstractBaseGraph<V,E> abstractBaseGraph;
     protected Map<V, DirectedEdgeContainer<V, E>> vertexMapDirected;
     protected EdgeSetFactory<V, E> edgeSetFactory;
 
-    public DirectedSpecifics(AbstractBaseGraph<V,E> abstractBaseGraph)
+    public DirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph)
     {
         this(abstractBaseGraph, new LinkedHashMap<>());
     }
 
-    public DirectedSpecifics(AbstractBaseGraph<V,E> abstractBaseGraph, Map<V, DirectedEdgeContainer<V, E>> vertexMap)
+    public DirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, DirectedEdgeContainer<V, E>> vertexMap)
     {
         this.abstractBaseGraph = abstractBaseGraph;
         this.vertexMapDirected = vertexMap;
@@ -187,7 +190,7 @@ public class DirectedSpecifics<V,E>
      *
      * @return EdgeContainer
      */
-    private DirectedEdgeContainer<V, E> getEdgeContainer(V vertex)
+    protected DirectedEdgeContainer<V, E> getEdgeContainer(V vertex)
     {
         //abstractBaseGraph.assertVertexExist(vertex); //JK: I don't think we need this here. This should have been verified upstream
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -1,0 +1,203 @@
+package org.jgrapht.graph.specifics;
+
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.Graph;
+import org.jgrapht.UndirectedGraph;
+import org.jgrapht.graph.AbstractBaseGraph;
+import org.jgrapht.graph.EdgeSetFactory;
+import org.jgrapht.util.ArrayUnenforcedSet;
+
+import java.io.Serializable;
+import java.util.*;
+
+/**
+ * .
+ *
+ * @author Barak Naveh
+ */
+public class DirectedSpecifics<V,E>
+    extends Specifics<V,E>
+    implements Serializable
+{
+    private static final long serialVersionUID = 8971725103718958232L;
+    private static final String NOT_IN_DIRECTED_GRAPH =
+        "no such operation in a directed graph";
+
+    private AbstractBaseGraph<V,E> abstractBaseGraph;
+    protected Map<V, DirectedEdgeContainer<V, E>> vertexMapDirected;
+    protected EdgeSetFactory<V, E> edgeSetFactory;
+
+    public DirectedSpecifics(AbstractBaseGraph<V,E> abstractBaseGraph)
+    {
+        this(abstractBaseGraph, new LinkedHashMap<>());
+    }
+
+    public DirectedSpecifics(AbstractBaseGraph<V,E> abstractBaseGraph, Map<V, DirectedEdgeContainer<V, E>> vertexMap)
+    {
+        this.abstractBaseGraph = abstractBaseGraph;
+        this.vertexMapDirected = vertexMap;
+        this.edgeSetFactory=abstractBaseGraph.getEdgeSetFactory();
+    }
+
+    @Override public void addVertex(V v)
+    {
+        // add with a lazy edge container entry
+        vertexMapDirected.put(v, null);
+    }
+
+    @Override public Set<V> getVertexSet()
+    {
+        return vertexMapDirected.keySet();
+    }
+
+    /**
+     * @see Graph#getAllEdges(Object, Object)
+     */
+    @Override public Set<E> getAllEdges(V sourceVertex, V targetVertex)
+    {
+        Set<E> edges = null;
+
+        if (abstractBaseGraph.containsVertex(sourceVertex)
+            && abstractBaseGraph.containsVertex(targetVertex))
+        {
+            edges = new ArrayUnenforcedSet<>();
+
+            DirectedEdgeContainer<V, E> ec = getEdgeContainer(sourceVertex);
+
+            for (E e : ec.outgoing) {
+                if (abstractBaseGraph.getEdgeTarget(e).equals(targetVertex)) {
+                    edges.add(e);
+                }
+            }
+        }
+
+        return edges;
+    }
+
+    /**
+     * @see Graph#getEdge(Object, Object)
+     */
+    @Override public E getEdge(V sourceVertex, V targetVertex)
+    {
+        if (abstractBaseGraph.containsVertex(sourceVertex)
+            && abstractBaseGraph.containsVertex(targetVertex))
+        {
+            DirectedEdgeContainer<V, E> ec = getEdgeContainer(sourceVertex);
+
+            for (E e : ec.outgoing) {
+                if (abstractBaseGraph.getEdgeTarget(e).equals(targetVertex)) {
+                    return e;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    @Override public void addEdgeToTouchingVertices(E e)
+    {
+        V source = abstractBaseGraph.getEdgeSource(e);
+        V target = abstractBaseGraph.getEdgeTarget(e);
+
+        getEdgeContainer(source).addOutgoingEdge(e);
+        getEdgeContainer(target).addIncomingEdge(e);
+    }
+
+    /**
+     * @see UndirectedGraph#degreeOf(Object)
+     */
+    @Override public int degreeOf(V vertex)
+    {
+        throw new UnsupportedOperationException(NOT_IN_DIRECTED_GRAPH);
+    }
+
+    /**
+     * @see Graph#edgesOf(Object)
+     */
+    @Override public Set<E> edgesOf(V vertex)
+    {
+        ArrayUnenforcedSet<E> inAndOut =
+                new ArrayUnenforcedSet<>(getEdgeContainer(vertex).incoming);
+        inAndOut.addAll(getEdgeContainer(vertex).outgoing);
+
+        // we have two copies for each self-loop - remove one of them.
+        if (abstractBaseGraph.isAllowingLoops()) {
+            Set<E> loops = getAllEdges(vertex, vertex);
+
+            for (int i = 0; i < inAndOut.size();) {
+                E e = inAndOut.get(i);
+
+                if (loops.contains(e)) {
+                    inAndOut.remove(i);
+                    loops.remove(e); // so we remove it only once
+                } else {
+                    i++;
+                }
+            }
+        }
+
+        return Collections.unmodifiableSet(inAndOut);
+    }
+
+    /**
+     * @see DirectedGraph#inDegreeOf(Object)
+     */
+    @Override public int inDegreeOf(V vertex)
+    {
+        return getEdgeContainer(vertex).incoming.size();
+    }
+
+    /**
+     * @see DirectedGraph#incomingEdgesOf(Object)
+     */
+    @Override public Set<E> incomingEdgesOf(V vertex)
+    {
+        return getEdgeContainer(vertex).getUnmodifiableIncomingEdges();
+    }
+
+    /**
+     * @see DirectedGraph#outDegreeOf(Object)
+     */
+    @Override public int outDegreeOf(V vertex)
+    {
+        return getEdgeContainer(vertex).outgoing.size();
+    }
+
+    /**
+     * @see DirectedGraph#outgoingEdgesOf(Object)
+     */
+    @Override public Set<E> outgoingEdgesOf(V vertex)
+    {
+        return getEdgeContainer(vertex).getUnmodifiableOutgoingEdges();
+    }
+
+    @Override public void removeEdgeFromTouchingVertices(E e)
+    {
+        V source = abstractBaseGraph.getEdgeSource(e);
+        V target = abstractBaseGraph.getEdgeTarget(e);
+
+        getEdgeContainer(source).removeOutgoingEdge(e);
+        getEdgeContainer(target).removeIncomingEdge(e);
+    }
+
+    /**
+     * A lazy build of edge container for specified vertex.
+     *
+     * @param vertex a vertex in this graph.
+     *
+     * @return EdgeContainer
+     */
+    private DirectedEdgeContainer<V, E> getEdgeContainer(V vertex)
+    {
+        //abstractBaseGraph.assertVertexExist(vertex); //JK: I don't think we need this here. This should have been verified upstream
+
+        DirectedEdgeContainer<V, E> ec = vertexMapDirected.get(vertex);
+
+        if (ec == null) {
+            ec = new DirectedEdgeContainer<>(edgeSetFactory, vertex);
+            vertexMapDirected.put(vertex, ec);
+        }
+
+        return ec;
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
@@ -55,7 +55,7 @@ public class FastLookupDirectedSpecifics<V,E>
 {
     private static final long serialVersionUID = 4089085208843722263L;
 
-    /* Maps a pair of vertices <u,v> to an set of edges {(u,v)}. In case of a multigraph, all edges which touch both u,v are included in the set */
+    /* Maps a pair of vertices <u,v> to a set of edges {(u,v)}. In case of a multigraph, all edges which touch both u,v are included in the set */
     protected Map<VertexPair<V>, ArrayUnenforcedSet<E>> touchingVerticesToEdgeMap;
 
     public FastLookupDirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph)
@@ -104,9 +104,12 @@ public class FastLookupDirectedSpecifics<V,E>
         getEdgeContainer(target).addIncomingEdge(e);
 
         VertexPair<V> vertexPair=new VertexPair<>(source, target);
-        if(!touchingVerticesToEdgeMap.containsKey(vertexPair))
-            touchingVerticesToEdgeMap.put(vertexPair, new ArrayUnenforcedSet<>());
-        touchingVerticesToEdgeMap.get(vertexPair).add(e);
+        if(!touchingVerticesToEdgeMap.containsKey(vertexPair)) {
+            ArrayUnenforcedSet<E> edgeSet=new ArrayUnenforcedSet<>();
+            edgeSet.add(e);
+            touchingVerticesToEdgeMap.put(vertexPair, edgeSet);
+        }else
+            touchingVerticesToEdgeMap.get(vertexPair).add(e);
     }
 
 
@@ -122,8 +125,9 @@ public class FastLookupDirectedSpecifics<V,E>
         //of touching vertices, remove the pair from the map.
         VertexPair<V> vertexPair=new VertexPair<>(source, target);
         if(touchingVerticesToEdgeMap.containsKey(vertexPair)){
-            touchingVerticesToEdgeMap.get(vertexPair).remove(e);
-            if(touchingVerticesToEdgeMap.get(vertexPair).isEmpty())
+            ArrayUnenforcedSet<E> edgeSet=touchingVerticesToEdgeMap.get(vertexPair);
+            edgeSet.remove(e);
+            if(edgeSet.isEmpty())
                 touchingVerticesToEdgeMap.remove(vertexPair);
         }
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
@@ -1,0 +1,97 @@
+package org.jgrapht.graph.specifics;
+
+import org.jgrapht.Graph;
+import org.jgrapht.graph.AbstractBaseGraph;
+import org.jgrapht.util.ArrayUnenforcedSet;
+import org.jgrapht.util.VertexPair;
+
+import java.io.Serializable;
+import java.util.*;
+
+/**
+ * Fast implementation of DirectedSpecifics. This class uses additional data structures to improve the performance of methods which depend
+ * on edge retrievals, e.g. getEdge(V u, V v), containsEdge(V u, V v),addEdge(V u, V v). A disadvantage is an increate is memory consumption.
+ * If memory utilization is an issue, use a {@link DirectedSpecifics} instead.
+ *
+ * @author Joris Kinable
+ */
+public class FastLookupDirectedSpecifics<V,E>
+    extends DirectedSpecifics<V,E>
+    implements Serializable
+{
+    private static final long serialVersionUID = 4089085208843722263L;
+
+    /* Maps a pair of vertices <u,v> to an set of edges {(u,v)}. In case of a multigraph, all edges which touch both u,v are included in the set */
+    protected Map<VertexPair<V>, ArrayUnenforcedSet<E>> touchingVerticesToEdgeMap;
+
+    public FastLookupDirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph)
+    {
+        this(abstractBaseGraph, new LinkedHashMap<>());
+    }
+
+    public FastLookupDirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, DirectedEdgeContainer<V, E>> vertexMap)
+    {
+        super(abstractBaseGraph, vertexMap);
+        this.touchingVerticesToEdgeMap=new HashMap<>();
+    }
+
+
+    /**
+     * @see Graph#getAllEdges(Object, Object)
+     */
+    @Override public Set<E> getAllEdges(V sourceVertex, V targetVertex)
+    {
+        if (abstractBaseGraph.containsVertex(sourceVertex)&& abstractBaseGraph.containsVertex(targetVertex)) {
+            Set<E> edges = touchingVerticesToEdgeMap.get(new VertexPair<>(sourceVertex, targetVertex));
+            return edges == null ? Collections.emptySet() : new ArrayUnenforcedSet<>(edges);
+        }else{
+            return null;
+        }
+    }
+
+    /**
+     * @see Graph#getEdge(Object, Object)
+     */
+    @Override public E getEdge(V sourceVertex, V targetVertex)
+    {
+        List<E> edges = touchingVerticesToEdgeMap.get(new VertexPair<>(sourceVertex, targetVertex));
+        if(edges==null || edges.isEmpty())
+            return null;
+        else
+            return edges.get(0);
+    }
+
+    @Override public void addEdgeToTouchingVertices(E e)
+    {
+        V source = abstractBaseGraph.getEdgeSource(e);
+        V target = abstractBaseGraph.getEdgeTarget(e);
+
+        getEdgeContainer(source).addOutgoingEdge(e);
+        getEdgeContainer(target).addIncomingEdge(e);
+
+        VertexPair<V> vertexPair=new VertexPair<>(source, target);
+        if(!touchingVerticesToEdgeMap.containsKey(vertexPair))
+            touchingVerticesToEdgeMap.put(vertexPair, new ArrayUnenforcedSet<>());
+        touchingVerticesToEdgeMap.get(vertexPair).add(e);
+    }
+
+
+    @Override public void removeEdgeFromTouchingVertices(E e)
+    {
+        V source = abstractBaseGraph.getEdgeSource(e);
+        V target = abstractBaseGraph.getEdgeTarget(e);
+
+        getEdgeContainer(source).removeOutgoingEdge(e);
+        getEdgeContainer(target).removeIncomingEdge(e);
+
+        //Remove the edge from the touchingVerticesToEdgeMap. If there are no more remaining edges for a pair
+        //of touching vertices, remove the pair from the map.
+        VertexPair<V> vertexPair=new VertexPair<>(source, target);
+        if(touchingVerticesToEdgeMap.containsKey(vertexPair)){
+            touchingVerticesToEdgeMap.get(vertexPair).remove(e);
+            if(touchingVerticesToEdgeMap.get(vertexPair).isEmpty())
+                touchingVerticesToEdgeMap.remove(vertexPair);
+        }
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
@@ -37,6 +37,7 @@ package org.jgrapht.graph.specifics;
 import org.jgrapht.Graph;
 import org.jgrapht.graph.AbstractBaseGraph;
 import org.jgrapht.util.ArrayUnenforcedSet;
+import org.jgrapht.util.UnorderedVertexPair;
 import org.jgrapht.util.VertexPair;
 
 import java.io.Serializable;
@@ -55,7 +56,7 @@ public class FastLookupUndirectedSpecifics<V,E>
 {
     private static final long serialVersionUID = 225772727571597846L;
 
-    /* Maps a pair of vertices <u,v> to an set of edges {(u,v)}. In case of a multigraph, all edges which touch both u,v are included in the set */
+    /* Maps a pair of vertices <u,v> to a set of edges {(u,v)}. In case of a multigraph, all edges which touch both u,v are included in the set */
     protected Map<VertexPair<V>, ArrayUnenforcedSet<E>> touchingVerticesToEdgeMap;
 
     public FastLookupUndirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph)
@@ -75,7 +76,7 @@ public class FastLookupUndirectedSpecifics<V,E>
     @Override public Set<E> getAllEdges(V sourceVertex, V targetVertex)
     {
         if (abstractBaseGraph.containsVertex(sourceVertex)&& abstractBaseGraph.containsVertex(targetVertex)) {
-            Set<E> edges = touchingVerticesToEdgeMap.get(new VertexPair<>(sourceVertex, targetVertex));
+            Set<E> edges = touchingVerticesToEdgeMap.get(new UnorderedVertexPair<>(sourceVertex, targetVertex));
             return edges == null ? Collections.emptySet() : new ArrayUnenforcedSet<>(edges);
         }else{
             return null;
@@ -87,7 +88,7 @@ public class FastLookupUndirectedSpecifics<V,E>
      */
     @Override public E getEdge(V sourceVertex, V targetVertex)
     {
-        List<E> edges = touchingVerticesToEdgeMap.get(new VertexPair<>(sourceVertex, targetVertex));
+        List<E> edges = touchingVerticesToEdgeMap.get(new UnorderedVertexPair<>(sourceVertex, targetVertex));
         if(edges==null || edges.isEmpty())
             return null;
         else
@@ -102,17 +103,14 @@ public class FastLookupUndirectedSpecifics<V,E>
         getEdgeContainer(source).addEdge(e);
 
 
-        //Add edge to both touchingVerticesToEdgeMap.get(u,v) and touchingVerticesToEdgeMap.get(v,u)
-        VertexPair<V> vertexPair1=new VertexPair<>(source, target);
-        if(!touchingVerticesToEdgeMap.containsKey(vertexPair1)) {
-            ArrayUnenforcedSet<E> edges=new ArrayUnenforcedSet<>();
-            touchingVerticesToEdgeMap.put(vertexPair1, edges);
-            if (!source.equals(target)) {//If not a self loop
-                VertexPair<V> vertexPair2=new VertexPair<>(target, source);
-                touchingVerticesToEdgeMap.put(vertexPair2, edges);
-            }
-        }
-        touchingVerticesToEdgeMap.get(vertexPair1).add(e);
+        //Add edge to touchingVerticesToEdgeMap for the UnorderedPair {u,v}
+        VertexPair<V> vertexPair=new UnorderedVertexPair<>(source, target);
+        if(!touchingVerticesToEdgeMap.containsKey(vertexPair)) {
+            ArrayUnenforcedSet<E> edgeSet=new ArrayUnenforcedSet<>();
+            edgeSet.add(e);
+            touchingVerticesToEdgeMap.put(vertexPair, edgeSet);
+        }else
+            touchingVerticesToEdgeMap.get(vertexPair).add(e);
 
         if (!source.equals(target)) { //If not a self loop
             getEdgeContainer(target).addEdge(e);
@@ -126,20 +124,17 @@ public class FastLookupUndirectedSpecifics<V,E>
 
         getEdgeContainer(source).removeEdge(e);
 
-        if (!source.equals(target)) {
+        if (!source.equals(target))
             getEdgeContainer(target).removeEdge(e);
-        }
 
         //Remove the edge from the touchingVerticesToEdgeMap. If there are no more remaining edges for a pair
         //of touching vertices, remove the pair from the map.
-        VertexPair<V> vertexPair1=new VertexPair<>(source, target);
-        if(touchingVerticesToEdgeMap.containsKey(vertexPair1)){
-            touchingVerticesToEdgeMap.get(vertexPair1).remove(e);
-            if(touchingVerticesToEdgeMap.get(vertexPair1).isEmpty()) {
-                touchingVerticesToEdgeMap.remove(vertexPair1);
-                VertexPair<V> vertexPair2=new VertexPair<>(target, source);
-                touchingVerticesToEdgeMap.remove(vertexPair2);
-            }
+        VertexPair<V> vertexPair=new UnorderedVertexPair<>(source, target);
+        if(touchingVerticesToEdgeMap.containsKey(vertexPair)){
+            ArrayUnenforcedSet<E> edgeSet=touchingVerticesToEdgeMap.get(vertexPair);
+            edgeSet.remove(e);
+            if(edgeSet.isEmpty())
+                touchingVerticesToEdgeMap.remove(vertexPair);
         }
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
@@ -1,0 +1,110 @@
+package org.jgrapht.graph.specifics;
+
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * .
+ *
+ * @author Barak Naveh
+ */
+public abstract class Specifics<V, E>
+    implements Serializable
+{
+    private static final long serialVersionUID = 785196247314761183L;
+
+    public abstract void addVertex(V vertex);
+
+    public abstract Set<V> getVertexSet();
+
+    /**
+     * .
+     *
+     * @param sourceVertex
+     * @param targetVertex
+     *
+     * @return
+     */
+    public abstract Set<E> getAllEdges(V sourceVertex,
+        V targetVertex);
+
+    /**
+     * .
+     *
+     * @param sourceVertex
+     * @param targetVertex
+     *
+     * @return
+     */
+    public abstract E getEdge(V sourceVertex, V targetVertex);
+
+    /**
+     * Adds the specified edge to the edge containers of its source and
+     * target vertices.
+     *
+     * @param e
+     */
+    public abstract void addEdgeToTouchingVertices(E e);
+
+    /**
+     * .
+     *
+     * @param vertex
+     *
+     * @return
+     */
+    public abstract int degreeOf(V vertex);
+
+    /**
+     * .
+     *
+     * @param vertex
+     *
+     * @return
+     */
+    public abstract Set<E> edgesOf(V vertex);
+
+    /**
+     * .
+     *
+     * @param vertex
+     *
+     * @return
+     */
+    public abstract int inDegreeOf(V vertex);
+
+    /**
+     * .
+     *
+     * @param vertex
+     *
+     * @return
+     */
+    public abstract Set<E> incomingEdgesOf(V vertex);
+
+    /**
+     * .
+     *
+     * @param vertex
+     *
+     * @return
+     */
+    public abstract int outDegreeOf(V vertex);
+
+    /**
+     * .
+     *
+     * @param vertex
+     *
+     * @return
+     */
+    public abstract Set<E> outgoingEdgesOf(V vertex);
+
+    /**
+     * Removes the specified edge from the edge containers of its source and
+     * target vertices.
+     *
+     * @param e
+     */
+    public abstract void removeEdgeFromTouchingVertices(E e);
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
@@ -1,3 +1,37 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -----------------
+ * Specifics.java
+ * -----------------
+ * (C) Copyright 2015-2015, by Barak Naveh and Contributors.
+ *
+ * Original Author:  Barak Naveh
+ * Contributor(s):
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ */
 package org.jgrapht.graph.specifics;
 
 import java.io.Serializable;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedEdgeContainer.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedEdgeContainer.java
@@ -41,7 +41,7 @@ import java.util.Collections;
 import java.util.Set;
 
 /**
- * A container of for vertex edges.
+ * A container for vertex edges.
  *
  * <p>In this edge container we use array lists to minimize memory toll.
  * However, for high-degree vertices we replace the entire edge container
@@ -49,16 +49,16 @@ import java.util.Set;
  *
  * @author Barak Naveh
  */
-public class UndirectedEdgeContainer<VV, EE>
+public class UndirectedEdgeContainer<V, E>
     implements Serializable
 {
     private static final long serialVersionUID = -6623207588411170010L;
-    Set<EE> vertexEdges;
-    private transient Set<EE> unmodifiableVertexEdges = null;
+    Set<E> vertexEdges;
+    private transient Set<E> unmodifiableVertexEdges = null;
 
     UndirectedEdgeContainer(
-            EdgeSetFactory<VV, EE> edgeSetFactory,
-            VV vertex)
+            EdgeSetFactory<V, E> edgeSetFactory,
+            V vertex)
     {
         vertexEdges = edgeSetFactory.createEdgeSet(vertex);
     }
@@ -68,7 +68,7 @@ public class UndirectedEdgeContainer<VV, EE>
      *
      * @return
      */
-    public Set<EE> getUnmodifiableVertexEdges()
+    public Set<E> getUnmodifiableVertexEdges()
     {
         if (unmodifiableVertexEdges == null) {
             unmodifiableVertexEdges =Collections.unmodifiableSet(vertexEdges);
@@ -81,7 +81,7 @@ public class UndirectedEdgeContainer<VV, EE>
      *
      * @param e
      */
-    public void addEdge(EE e)
+    public void addEdge(E e)
     {
         vertexEdges.add(e);
     }
@@ -101,7 +101,7 @@ public class UndirectedEdgeContainer<VV, EE>
      *
      * @param e
      */
-    public void removeEdge(EE e)
+    public void removeEdge(E e)
     {
         vertexEdges.remove(e);
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedEdgeContainer.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedEdgeContainer.java
@@ -1,3 +1,37 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -----------------
+ * MaximumFlowAlgorithmPerformanceTest.java
+ * -----------------
+ * (C) Copyright 2015-2015, by Barak Naveh and Contributors.
+ *
+ * Original Author:  Barak Naveh
+ * Contributor(s):
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ */
 package org.jgrapht.graph.specifics;
 
 import org.jgrapht.graph.EdgeSetFactory;
@@ -37,10 +71,8 @@ public class UndirectedEdgeContainer<VV, EE>
     public Set<EE> getUnmodifiableVertexEdges()
     {
         if (unmodifiableVertexEdges == null) {
-            unmodifiableVertexEdges =
-                Collections.unmodifiableSet(vertexEdges);
+            unmodifiableVertexEdges =Collections.unmodifiableSet(vertexEdges);
         }
-
         return unmodifiableVertexEdges;
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedEdgeContainer.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedEdgeContainer.java
@@ -1,0 +1,76 @@
+package org.jgrapht.graph.specifics;
+
+import org.jgrapht.graph.EdgeSetFactory;
+
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * A container of for vertex edges.
+ *
+ * <p>In this edge container we use array lists to minimize memory toll.
+ * However, for high-degree vertices we replace the entire edge container
+ * with a direct access subclass (to be implemented).</p>
+ *
+ * @author Barak Naveh
+ */
+public class UndirectedEdgeContainer<VV, EE>
+    implements Serializable
+{
+    private static final long serialVersionUID = -6623207588411170010L;
+    Set<EE> vertexEdges;
+    private transient Set<EE> unmodifiableVertexEdges = null;
+
+    UndirectedEdgeContainer(
+            EdgeSetFactory<VV, EE> edgeSetFactory,
+            VV vertex)
+    {
+        vertexEdges = edgeSetFactory.createEdgeSet(vertex);
+    }
+
+    /**
+     * A lazy build of unmodifiable list of vertex edges
+     *
+     * @return
+     */
+    public Set<EE> getUnmodifiableVertexEdges()
+    {
+        if (unmodifiableVertexEdges == null) {
+            unmodifiableVertexEdges =
+                Collections.unmodifiableSet(vertexEdges);
+        }
+
+        return unmodifiableVertexEdges;
+    }
+
+    /**
+     * .
+     *
+     * @param e
+     */
+    public void addEdge(EE e)
+    {
+        vertexEdges.add(e);
+    }
+
+    /**
+     * .
+     *
+     * @return
+     */
+    public int edgeCount()
+    {
+        return vertexEdges.size();
+    }
+
+    /**
+     * .
+     *
+     * @param e
+     */
+    public void removeEdge(EE e)
+    {
+        vertexEdges.remove(e);
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
@@ -1,3 +1,37 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -----------------
+ * UndirectedSpecifics.java
+ * -----------------
+ * (C) Copyright 2015-2015, by Barak Naveh and Contributors.
+ *
+ * Original Author:  Barak Naveh
+ * Contributor(s): Joris Kinable
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ */
 package org.jgrapht.graph.specifics;
 
 import org.jgrapht.DirectedGraph;
@@ -12,9 +46,13 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * .
+ * Plain implementation of UndirectedSpecifics. This implementation requires the least amount of memory, at the expense of
+ * slow edge retrievals. Methods which depend on edge retrievals, e.g. getEdge(V u, V v), containsEdge(V u, V v),
+ * addEdge(V u, V v), etc may be relatively slow when the average degree of a vertex is high (dense graphs). For a fast
+ * implementation, use {@link FastLookupUndirectedSpecifics}.
  *
  * @author Barak Naveh
+ * @author Joris Kinable
  */
 public class UndirectedSpecifics<V,E>
     extends Specifics<V,E>
@@ -24,8 +62,8 @@ public class UndirectedSpecifics<V,E>
     private static final String NOT_IN_UNDIRECTED_GRAPH =
         "no such operation in an undirected graph";
 
-    private AbstractBaseGraph<V,E> abstractBaseGraph;
-    private Map<V, UndirectedEdgeContainer<V, E>> vertexMapUndirected;
+    protected AbstractBaseGraph<V,E> abstractBaseGraph;
+    protected Map<V, UndirectedEdgeContainer<V, E>> vertexMapUndirected;
     protected EdgeSetFactory<V, E> edgeSetFactory;
 
     public UndirectedSpecifics(AbstractBaseGraph<V,E> abstractBaseGraph)
@@ -212,7 +250,7 @@ public class UndirectedSpecifics<V,E>
      *
      * @return EdgeContainer
      */
-    private UndirectedEdgeContainer<V, E> getEdgeContainer(V vertex)
+    protected UndirectedEdgeContainer<V, E> getEdgeContainer(V vertex)
     {
         //abstractBaseGraph.assertVertexExist(vertex); //JK: I don't think we need this here. This should have been verified upstream
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
@@ -1,0 +1,230 @@
+package org.jgrapht.graph.specifics;
+
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.AbstractBaseGraph;
+import org.jgrapht.graph.EdgeSetFactory;
+import org.jgrapht.util.ArrayUnenforcedSet;
+
+import java.io.Serializable;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * .
+ *
+ * @author Barak Naveh
+ */
+public class UndirectedSpecifics<V,E>
+    extends Specifics<V,E>
+    implements Serializable
+{
+    private static final long serialVersionUID = 6494588405178655873L;
+    private static final String NOT_IN_UNDIRECTED_GRAPH =
+        "no such operation in an undirected graph";
+
+    private AbstractBaseGraph<V,E> abstractBaseGraph;
+    private Map<V, UndirectedEdgeContainer<V, E>> vertexMapUndirected;
+    protected EdgeSetFactory<V, E> edgeSetFactory;
+
+    public UndirectedSpecifics(AbstractBaseGraph<V,E> abstractBaseGraph)
+    {
+        this(abstractBaseGraph, new LinkedHashMap<>());
+    }
+
+    public UndirectedSpecifics(AbstractBaseGraph<V,E> abstractBaseGraph,
+                               Map<V, UndirectedEdgeContainer<V, E>> vertexMap)
+    {
+        this.abstractBaseGraph = abstractBaseGraph;
+        this.vertexMapUndirected = vertexMap;
+        this.edgeSetFactory=abstractBaseGraph.getEdgeSetFactory();
+    }
+
+    @Override public void addVertex(V v)
+    {
+        // add with a lazy edge container entry
+        vertexMapUndirected.put(v, null);
+    }
+
+    @Override public Set<V> getVertexSet()
+    {
+        return vertexMapUndirected.keySet();
+    }
+
+    /**
+     * @see Graph#getAllEdges(Object, Object)
+     */
+    @Override public Set<E> getAllEdges(V sourceVertex, V targetVertex)
+    {
+        Set<E> edges = null;
+
+        if (abstractBaseGraph.containsVertex(sourceVertex)
+            && abstractBaseGraph.containsVertex(targetVertex))
+        {
+            edges = new ArrayUnenforcedSet<>();
+
+            for (E e : getEdgeContainer(sourceVertex).vertexEdges) {
+                boolean equal =
+                        isEqualsStraightOrInverted(
+                                sourceVertex,
+                                targetVertex,
+                                e);
+
+                if (equal) {
+                    edges.add(e);
+                }
+            }
+        }
+
+        return edges;
+    }
+
+    /**
+     * @see Graph#getEdge(Object, Object)
+     */
+    @Override public E getEdge(V sourceVertex, V targetVertex)
+    {
+        if (abstractBaseGraph.containsVertex(sourceVertex)
+            && abstractBaseGraph.containsVertex(targetVertex))
+        {
+
+            for (E e : getEdgeContainer(sourceVertex).vertexEdges) {
+                boolean equal =
+                        isEqualsStraightOrInverted(
+                                sourceVertex,
+                                targetVertex,
+                                e);
+
+                if (equal) {
+                    return e;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private boolean isEqualsStraightOrInverted(
+        Object sourceVertex,
+        Object targetVertex,
+        E e)
+    {
+        boolean equalStraight =
+            sourceVertex.equals(abstractBaseGraph.getEdgeSource(e))
+            && targetVertex.equals(abstractBaseGraph.getEdgeTarget(e));
+
+        boolean equalInverted =
+            sourceVertex.equals(abstractBaseGraph.getEdgeTarget(e))
+            && targetVertex.equals(abstractBaseGraph.getEdgeSource(e));
+        return equalStraight || equalInverted;
+    }
+
+    @Override public void addEdgeToTouchingVertices(E e)
+    {
+        V source = abstractBaseGraph.getEdgeSource(e);
+        V target = abstractBaseGraph.getEdgeTarget(e);
+
+        getEdgeContainer(source).addEdge(e);
+
+        if (!source.equals(target)) {
+            getEdgeContainer(target).addEdge(e);
+        }
+    }
+
+    @Override public int degreeOf(V vertex)
+    {
+        if (abstractBaseGraph.isAllowingLoops()) { // then we must count, and add loops twice
+
+            int degree = 0;
+            Set<E> edges = getEdgeContainer(vertex).vertexEdges;
+
+            for (E e : edges) {
+                if (abstractBaseGraph.getEdgeSource(e).equals(abstractBaseGraph.getEdgeTarget(e))) {
+                    degree += 2;
+                } else {
+                    degree += 1;
+                }
+            }
+
+            return degree;
+        } else {
+            return getEdgeContainer(vertex).edgeCount();
+        }
+    }
+
+    /**
+     * @see Graph#edgesOf(Object)
+     */
+    @Override public Set<E> edgesOf(V vertex)
+    {
+        return getEdgeContainer(vertex).getUnmodifiableVertexEdges();
+    }
+
+    /**
+     * @see DirectedGraph#inDegreeOf(Object)
+     */
+    @Override public int inDegreeOf(V vertex)
+    {
+        throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
+    }
+
+    /**
+     * @see DirectedGraph#incomingEdgesOf(Object)
+     */
+    @Override public Set<E> incomingEdgesOf(V vertex)
+    {
+        throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
+    }
+
+    /**
+     * @see DirectedGraph#outDegreeOf(Object)
+     */
+    @Override public int outDegreeOf(V vertex)
+    {
+        throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
+    }
+
+    /**
+     * @see DirectedGraph#outgoingEdgesOf(Object)
+     */
+    @Override public Set<E> outgoingEdgesOf(V vertex)
+    {
+        throw new UnsupportedOperationException(NOT_IN_UNDIRECTED_GRAPH);
+    }
+
+    @Override public void removeEdgeFromTouchingVertices(E e)
+    {
+        V source = abstractBaseGraph.getEdgeSource(e);
+        V target = abstractBaseGraph.getEdgeTarget(e);
+
+        getEdgeContainer(source).removeEdge(e);
+
+        if (!source.equals(target)) {
+            getEdgeContainer(target).removeEdge(e);
+        }
+    }
+
+    /**
+     * A lazy build of edge container for specified vertex.
+     *
+     * @param vertex a vertex in this graph.
+     *
+     * @return EdgeContainer
+     */
+    private UndirectedEdgeContainer<V, E> getEdgeContainer(V vertex)
+    {
+        //abstractBaseGraph.assertVertexExist(vertex); //JK: I don't think we need this here. This should have been verified upstream
+
+        UndirectedEdgeContainer<V, E> ec = vertexMapUndirected.get(vertex);
+
+        if (ec == null) {
+            ec = new UndirectedEdgeContainer<>(
+                    edgeSetFactory,
+                    vertex);
+            vertexMapUndirected.put(vertex, ec);
+        }
+
+        return ec;
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/util/UnorderedVertexPair.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/UnorderedVertexPair.java
@@ -1,0 +1,74 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2009, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -------------------------
+ * UnorderedVertexPair.java
+ * -------------------------
+ * (C) Copyright 2003-2016, by Joris Kinable and Contributors
+ *
+ * Original Author:  Joris Kinable
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ *
+ */
+package org.jgrapht.util;
+
+/**
+ * Representation of an unordered pair of vertices. For a given pair of vertices V u, V w,
+ * UnorderedVertexPair(u,v) equals UnorderedVertexPair(v,u).
+ *
+ * @author Joris Kinable
+ */
+public class UnorderedVertexPair<V> extends VertexPair<V>{
+
+    public UnorderedVertexPair(V n1, V n2) {
+        super(n1, n2);
+    }
+
+    @Override public String toString()
+    {
+        return "{"+n1 + "," + n2+"}";
+    }
+
+    @Override public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        else if(!(o instanceof UnorderedVertexPair))
+            return false;
+
+        @SuppressWarnings("unchecked")
+        UnorderedVertexPair<V> other = (UnorderedVertexPair<V>) o;
+
+        return (elementEquals(n1, other.n1) && elementEquals(n2, other.n2)) ||
+                (elementEquals(n1, other.n2) && elementEquals(n2, other.n1));
+    }
+
+    @Override public int hashCode()
+    {
+        int hash1=n1.hashCode();
+        int hash2=n2.hashCode();
+        return hash1 > hash2 ? hash1*31+hash2 : hash2*31+hash1;
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/util/VertexPair.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/VertexPair.java
@@ -48,8 +48,8 @@ import java.util.Objects;
 public class VertexPair<V> implements Serializable
 {
     private static final long serialVersionUID = -852258620031566794L;
-    private V n1;
-    private V n2;
+    protected final V n1;
+    protected final V n2;
 
     public VertexPair(V n1, V n2)
     {
@@ -92,7 +92,7 @@ public class VertexPair<V> implements Serializable
 
     @Override public String toString()
     {
-        return n1 + "," + n2;
+        return "("+n1 + "," + n2+")";
     }
 
     @Override public boolean equals(Object o)
@@ -105,12 +105,20 @@ public class VertexPair<V> implements Serializable
         @SuppressWarnings("unchecked")
         VertexPair<V> other = (VertexPair<V>) o;
 
-        if ((n1 != null) ? (!n1.equals(other.n1)) : (other.n1 != null))
-            return false;
-        else if ((n2 != null) ? (!n2.equals(other.n2)) : (other.n2 != null))
-            return false;
+        return (elementEquals(n1, other.n1) && elementEquals(n2, other.n2));
+    }
+
+    /**
+     * Compares two elements. Returns true if they are both null, or when they are equal.
+     * @param element1
+     * @param element2
+     * @return true if they are both null, or when they are equal, false otherwise.
+     */
+    protected boolean elementEquals(V element1, V element2){
+        if(element1 == null)
+            return element2 == null;
         else
-            return true;
+            return element1.equals(element2);
     }
 
     @Override public int hashCode()

--- a/jgrapht-core/src/main/java/org/jgrapht/util/VertexPair.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/VertexPair.java
@@ -35,14 +35,19 @@
  */
 package org.jgrapht.util;
 
+import java.io.Serializable;
+import java.util.Objects;
+
 /**
  * Representation of a pair of vertices; to be replaced by Pair&lt;V,V&gt; if
  * Sun ever gets around to adding Pair to java.util.
  *
  * @author Soren (soren@tanesha.net)
+ * @author Joris Kinable
  */
-public class VertexPair<V>
+public class VertexPair<V> implements Serializable
 {
+    private static final long serialVersionUID = -852258620031566794L;
     private V n1;
     private V n2;
 
@@ -92,31 +97,25 @@ public class VertexPair<V>
 
     @Override public boolean equals(Object o)
     {
-        if (this == o) {
+        if (this == o)
             return true;
-        }
-        if ((o == null) || (getClass() != o.getClass())) {
+        else if(!(o instanceof VertexPair))
             return false;
-        }
 
         @SuppressWarnings("unchecked")
-        VertexPair<V> that = (VertexPair<V>) o;
+        VertexPair<V> other = (VertexPair<V>) o;
 
-        if ((n1 != null) ? (!n1.equals(that.n1)) : (that.n1 != null)) {
+        if ((n1 != null) ? (!n1.equals(other.n1)) : (other.n1 != null))
             return false;
-        }
-        if ((n2 != null) ? (!n2.equals(that.n2)) : (that.n2 != null)) {
+        else if ((n2 != null) ? (!n2.equals(other.n2)) : (other.n2 != null))
             return false;
-        }
-
-        return true;
+        else
+            return true;
     }
 
     @Override public int hashCode()
     {
-        int result = (n1 != null) ? n1.hashCode() : 0;
-        result = (31 * result) + ((n2 != null) ? n2.hashCode() : 0);
-        return result;
+        return Objects.hash(n1, n2);
     }
 }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/AllAlgTests.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/AllAlgTests.java
@@ -49,7 +49,7 @@ import org.junit.runners.Suite;
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
     AStarShortestPathTest.class,
-    AllDirectedPaths.class,
+    AllDirectedPathsTest.class,
     BellmanFordShortestPathTest.class,
     BiconnectivityInspectorTest.class,
     BlockCutpointGraphTest.class,

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleIdentityDirectedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleIdentityDirectedGraphTest.java
@@ -25,7 +25,7 @@
  * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
  *
  * Original Author:  Barak Naveh
- * Contributor(s):   -
+ * Contributor(s):   Joris Kinable
  *
  * $Id$
  *
@@ -39,7 +39,6 @@ package org.jgrapht.graph;
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.EdgeFactory;
 import org.jgrapht.EnhancedTestCase;
-import org.jgrapht.graph.specifics.DirectedEdgeContainer;
 import org.jgrapht.graph.specifics.DirectedSpecifics;
 
 import java.util.Collections;
@@ -77,9 +76,8 @@ public class SimpleIdentityDirectedGraphTest
 
             Holder holder = (Holder) o;
 
-            if (t != null ? !t.equals(holder.t) : holder.t != null) return false;
+            return !(t != null ? !t.equals(holder.t) : holder.t != null);
 
-            return true;
         }
 
         @Override
@@ -99,8 +97,8 @@ public class SimpleIdentityDirectedGraphTest
         }
 
         @Override
-        protected DirectedSpecifics createDirectedSpecifics() {
-            return new DirectedSpecifics(this, new IdentityHashMap<V, DirectedEdgeContainer<V, E>>());
+        protected DirectedSpecifics<V,E> createDirectedSpecifics() {
+            return new DirectedSpecifics<>(this, new IdentityHashMap<>());
         }
     }
 
@@ -113,10 +111,10 @@ public class SimpleIdentityDirectedGraphTest
     private DirectedGraph<Holder<String>, DefaultEdge> g4;
     private DefaultEdge eLoop;
     private EdgeFactory<Holder<String>, DefaultEdge> eFactory;
-    private Holder<String> v1 = new Holder<String>("v1") ;
-    private Holder<String> v2 = new Holder<String>("v2");
-    private Holder<String> v3 = new Holder<String>("v3");
-    private Holder<String> v4 = new Holder<String>("v4");
+    private Holder<String> v1 = new Holder<>("v1") ;
+    private Holder<String> v2 = new Holder<>("v2");
+    private Holder<String> v3 = new Holder<>("v3");
+    private Holder<String> v4 = new Holder<>("v4");
 
     //~ Constructors -----------------------------------------------------------
 
@@ -154,7 +152,7 @@ public class SimpleIdentityDirectedGraphTest
         DefaultEdge e = eFactory.createEdge(v2, v1);
 
         try {
-            g1.addEdge(new Holder<String>("ya"), new Holder<String>("ya"), e); // no such vertex in graph
+            g1.addEdge(new Holder<>("ya"), new Holder<>("ya"), e); // no such vertex in graph
             assertFalse();
         } catch (IllegalArgumentException ile) {
             assertTrue();
@@ -344,7 +342,7 @@ public class SimpleIdentityDirectedGraphTest
         assertEquals(1, g4.inDegreeOf(v4));
 
         try {
-            g3.inDegreeOf(new Holder<String>(""));
+            g3.inDegreeOf(new Holder<>(""));
             assertFalse();
         } catch (IllegalArgumentException e) {
             assertTrue();
@@ -429,7 +427,7 @@ public class SimpleIdentityDirectedGraphTest
         assertEquals(Collections.emptySet(), g4.removeAllEdges(v3, v2));
         assertEquals(3, g4.edgeSet().size());
         // Missing vertex.
-        assertEquals(null, g4.removeAllEdges(v1, new Holder<String>("v5")));
+        assertEquals(null, g4.removeAllEdges(v1, new Holder<>("v5")));
     }
 
     /**
@@ -465,10 +463,8 @@ public class SimpleIdentityDirectedGraphTest
     {
         init();
 
-        DirectedGraph<Holder<String>, DefaultEdge> g =
-            new SimpleIdentityDirectedGraph<Holder<String>, DefaultEdge>(DefaultEdge.class);
-        DirectedGraph<Holder<String>, DefaultEdge> r =
-            new EdgeReversedGraph<Holder<String>, DefaultEdge>(g);
+        DirectedGraph<Holder<String>, DefaultEdge> g =new SimpleIdentityDirectedGraph<>(DefaultEdge.class);
+        DirectedGraph<Holder<String>, DefaultEdge> r =new EdgeReversedGraph<>(g);
 
         g.addVertex(v1);
         g.addVertex(v2);
@@ -528,23 +524,15 @@ public class SimpleIdentityDirectedGraphTest
 
         assertSame(v2, r.getEdgeSource(e));
         assertSame(v1, r.getEdgeTarget(e));
-
-//        assertEquals("([v1, v2], [(v2,v1)])", r.toString());
     }
 
     private void init()
     {
-        gEmpty =
-            new SimpleIdentityDirectedGraph<Holder<String>, DefaultEdge>(
-                DefaultEdge.class);
-        g1 = new SimpleIdentityDirectedGraph<Holder<String>, DefaultEdge>(
-            DefaultEdge.class);
-        g2 = new SimpleIdentityDirectedGraph<Holder<String>, DefaultEdge>(
-            DefaultEdge.class);
-        g3 = new SimpleIdentityDirectedGraph<Holder<String>, DefaultEdge>(
-            DefaultEdge.class);
-        g4 = new SimpleIdentityDirectedGraph<Holder<String>, DefaultEdge>(
-            DefaultEdge.class);
+        gEmpty =new SimpleIdentityDirectedGraph<>(DefaultEdge.class);
+        g1 = new SimpleIdentityDirectedGraph<>(DefaultEdge.class);
+        g2 = new SimpleIdentityDirectedGraph<>(DefaultEdge.class);
+        g3 = new SimpleIdentityDirectedGraph<>(DefaultEdge.class);
+        g4 = new SimpleIdentityDirectedGraph<>(DefaultEdge.class);
 
         eFactory = g1.getEdgeFactory();
         eLoop = eFactory.createEdge(v1, v1);

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleIdentityDirectedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleIdentityDirectedGraphTest.java
@@ -39,6 +39,8 @@ package org.jgrapht.graph;
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.EdgeFactory;
 import org.jgrapht.EnhancedTestCase;
+import org.jgrapht.graph.specifics.DirectedEdgeContainer;
+import org.jgrapht.graph.specifics.DirectedSpecifics;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
@@ -98,7 +100,7 @@ public class SimpleIdentityDirectedGraphTest
 
         @Override
         protected DirectedSpecifics createDirectedSpecifics() {
-            return new DirectedSpecifics(new IdentityHashMap<V, AbstractBaseGraph.DirectedEdgeContainer<V, E>>());
+            return new DirectedSpecifics(this, new IdentityHashMap<V, DirectedEdgeContainer<V, E>>());
         }
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/flow/MaximumFlowAlgorithmPerformanceTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/flow/MaximumFlowAlgorithmPerformanceTest.java
@@ -37,7 +37,6 @@ package org.jgrapht.perf.flow;
 
 import junit.framework.TestCase;
 import org.jgrapht.DirectedGraph;
-import org.jgrapht.EdgeFactory;
 import org.jgrapht.VertexFactory;
 import org.jgrapht.alg.flow.EdmondsKarpMaximumFlow;
 import org.jgrapht.alg.flow.PushRelabelMaximumFlow;
@@ -74,14 +73,11 @@ public class MaximumFlowAlgorithmPerformanceTest extends TestCase {
         @Setup
         public void setup() {
             RandomGraphGenerator<Integer, DefaultWeightedEdge> rgg
-                = new RandomGraphGenerator<Integer, DefaultWeightedEdge>(PERF_BENCHMARK_VERTICES_COUNT, PERF_BENCHMARK_EDGES_COUNT, SEED);
+                = new RandomGraphGenerator<>(PERF_BENCHMARK_VERTICES_COUNT, PERF_BENCHMARK_EDGES_COUNT, SEED);
 
             SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> network
-                = new SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge>(new EdgeFactory<Integer, DefaultWeightedEdge>() {
-                @Override
-                public DefaultWeightedEdge createEdge(Integer sourceVertex, Integer targetVertex) {
-                    return new DefaultWeightedEdge();
-                }
+                = new SimpleDirectedWeightedGraph<>((sourceVertex, targetVertex) -> {
+                return new DefaultWeightedEdge();
             });
 
             rgg.generateGraph(
@@ -113,14 +109,14 @@ public class MaximumFlowAlgorithmPerformanceTest extends TestCase {
     public static class EdmondsKarpMaximumFlowRandomGraphBenchmark extends RandomGraphBenchmarkBase {
         @Override
         MaximumFlowAlgorithm<Integer, DefaultWeightedEdge> createSolver(DirectedGraph<Integer, DefaultWeightedEdge> network) {
-            return new EdmondsKarpMaximumFlow<Integer, DefaultWeightedEdge>(network);
+            return new EdmondsKarpMaximumFlow<>(network);
         }
     }
 
     public static class PushRelabelMaximumFlowRandomGraphBenchmark extends RandomGraphBenchmarkBase {
         @Override
         MaximumFlowAlgorithm<Integer, DefaultWeightedEdge> createSolver(DirectedGraph<Integer, DefaultWeightedEdge> network) {
-            return new PushRelabelMaximumFlow<Integer, DefaultWeightedEdge>(network);
+            return new PushRelabelMaximumFlow<>(network);
         }
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/graph/GraphPerformanceTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/graph/GraphPerformanceTest.java
@@ -104,7 +104,7 @@ public class GraphPerformanceTest extends TestCase{
          * Benchmark 2: Simulate graph usage: Create a graph, perform various algorithms, partially destroy graph
          */
         @Benchmark
-        public void graphPermanceBenchmark() {
+        public void graphPerformanceBenchmark() {
             for(int i=0; i<NR_GRAPHS; i++) {
                 rgg = new RandomGraphGenerator<>(PERF_BENCHMARK_VERTICES_COUNT, PERF_BENCHMARK_EDGES_COUNT, SEED + i);
                 //Create a graph

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/graph/GraphPerformanceTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/graph/GraphPerformanceTest.java
@@ -1,0 +1,240 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -----------------
+ * GraphPerformanceTest.java
+ * -----------------
+ * (C) Copyright 2015-2015, by Joris Kinable and Contributors.
+ *
+ * Original Author:  Joris Kinable
+ * Contributor(s):
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ */
+package org.jgrapht.perf.graph;
+
+import junit.framework.TestCase;
+import org.jgrapht.VertexFactory;
+import org.jgrapht.alg.DijkstraShortestPath;
+import org.jgrapht.alg.GabowStrongConnectivityInspector;
+import org.jgrapht.alg.flow.EdmondsKarpMaximumFlow;
+import org.jgrapht.alg.interfaces.StrongConnectivityAlgorithm;
+import org.jgrapht.generate.RandomGraphGenerator;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleDirectedWeightedGraph;
+import org.jgrapht.graph.specifics.DirectedSpecifics;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark class to compare different graph implementations. The benchmark creates a graph, runs various algorithms on
+ * the graph and finally destroys (part of) the graph. This is an attempt to simulate common usage of the graph.
+ *
+ * Note: Currently the tests are performed on a single graph. It would be better to run it on multiple graphs. Not sure how
+ * to achieve that through the JMH framework.
+ */
+public class GraphPerformanceTest extends TestCase{
+
+    public static final int PERF_BENCHMARK_VERTICES_COUNT   = 1000;
+    public static final int PERF_BENCHMARK_EDGES_COUNT      = 100000;
+    public static final long SEED = 1446523573696201013l;
+    public static final int NR_GRAPHS=5; //Number of unique graphs on which the tests are repeated
+
+    @State(Scope.Benchmark)
+    private static abstract class DirectedGraphBenchmarkBase {
+
+        private Blackhole blackhole;
+        protected RandomGraphGenerator<Integer, DefaultWeightedEdge> rgg;
+        private SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph;
+
+
+        /**
+         * Creates a random graph using the Random Graph Generator
+         * @return random graph
+         */
+        abstract SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> constructGraph();
+
+        @Setup
+        public void setup() {
+            blackhole=new Blackhole();
+        }
+
+        /**
+         * Benchmark 1: graph construction
+         */
+        @Benchmark
+        public void generateGraphBenchmark(){
+            for(int i=0; i<NR_GRAPHS; i++) {
+                rgg= new RandomGraphGenerator<>(PERF_BENCHMARK_VERTICES_COUNT, PERF_BENCHMARK_EDGES_COUNT, SEED+i);
+                //Create a graph
+                graph = constructGraph();
+
+            }
+        }
+
+        /**
+         * Benchmark 2: Simulate graph usage: Create a graph, perform various algorithms, partially destroy graph
+         */
+        @Benchmark
+        public void graphPermanceBenchmark() {
+            for(int i=0; i<NR_GRAPHS; i++) {
+                rgg = new RandomGraphGenerator<>(PERF_BENCHMARK_VERTICES_COUNT, PERF_BENCHMARK_EDGES_COUNT, SEED + i);
+                //Create a graph
+                graph = constructGraph();
+
+                Integer[] vertices = graph.vertexSet().toArray(new Integer[graph.vertexSet().size()]);
+                Integer source = vertices[0];
+                Integer sink = vertices[vertices.length - 1];
+
+                //Run various algorithms on the graph
+                double length = this.calculateShorestPath(graph, source, sink);
+                blackhole.consume(length);
+
+                double maxFlow = this.calculateMaxFlow(graph, source, sink);
+                blackhole.consume(maxFlow);
+
+                boolean isStronglyConnected = this.isStronglyConnected(graph);
+                blackhole.consume(isStronglyConnected);
+
+                //Destroy some random edges in the graph
+                destroyRandomEdges(graph);
+            }
+        }
+
+        private double calculateShorestPath(SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph, Integer source, Integer sink){
+            DijkstraShortestPath<Integer, DefaultWeightedEdge> shortestPathAlg=new DijkstraShortestPath<>(graph, source, sink);
+            return shortestPathAlg.getPathLength();
+        }
+
+        private double calculateMaxFlow(SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph, Integer source, Integer sink){
+            EdmondsKarpMaximumFlow<Integer, DefaultWeightedEdge> maximumFlowAlg= new EdmondsKarpMaximumFlow<>(graph);
+            return maximumFlowAlg.buildMaximumFlow(source, sink).getValue();
+        }
+
+        private boolean isStronglyConnected(SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph){
+            StrongConnectivityAlgorithm<Integer, DefaultWeightedEdge> strongConnectivityAlg=new GabowStrongConnectivityInspector<>(graph);
+            return strongConnectivityAlg.isStronglyConnected();
+        }
+
+        private void destroyRandomEdges(SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph){
+            int nrVertices=graph.vertexSet().size();
+            Random rand=new Random(SEED);
+            for(int i=0; i<PERF_BENCHMARK_EDGES_COUNT/2; i++){
+                int u=rand.nextInt(nrVertices);
+                int v=rand.nextInt(nrVertices);
+                graph.removeEdge(u, v);
+            }
+        }
+
+    }
+
+    /**
+     * Graph class which relies on the (legacy) DirectedSpecifics implementation. This class is optimized for low memory
+     * usage, but performs edge retrieval operations fairly slow.
+     */
+    public static class MemoryEfficientDirectedGraphBenchmark extends DirectedGraphBenchmarkBase {
+        @Override
+        SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> constructGraph() {
+            SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph=new MemoryEfficientDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+            rgg.generateGraph(
+                    graph,
+                    new VertexFactory<Integer>() {
+                        int i;
+                        @Override
+                        public Integer createVertex() {
+                            return ++i;
+                        }
+                    },
+                    null
+            );
+            return graph;
+        }
+    }
+
+    /**
+     * Graph class which relies on the FastLookupDirectedSpecifics. This class is optimized to perform quick edge retrievals.
+     */
+    public static class FastLookupDirectedGraphBenchmark extends DirectedGraphBenchmarkBase {
+        @Override
+        SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> constructGraph() {
+            SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph=new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+            rgg.generateGraph(
+                    graph,
+                    new VertexFactory<Integer>() {
+                        int i;
+                        @Override
+                        public Integer createVertex() {
+                            return ++i;
+                        }
+                    },
+                    null
+            );
+            return graph;
+        }
+    }
+
+    public void testRandomGraphBenchmark() throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(".*" + MemoryEfficientDirectedGraphBenchmark.class.getSimpleName() + ".*")
+                .include(".*" + FastLookupDirectedGraphBenchmark.class.getSimpleName() + ".*")
+
+                .mode(Mode.AverageTime)
+                .timeUnit(TimeUnit.MILLISECONDS)
+//                .warmupTime(TimeValue.seconds(1))
+                .warmupIterations(3)
+//                .measurementTime(TimeValue.seconds(1))
+                .measurementIterations(5)
+                .forks(1)
+                .shouldFailOnError(true)
+                .shouldDoGC(true)
+                .build();
+
+        new Runner(opt).run();
+    }
+
+
+    /**
+     * Creates an memory efficient graph implementation.
+     * @param <V>
+     * @param <E>
+     */
+    public static class MemoryEfficientDirectedWeightedGraph<V,E> extends SimpleDirectedWeightedGraph<V,E> {
+
+        public MemoryEfficientDirectedWeightedGraph(Class<? extends E> edgeClass) {
+            super(edgeClass);
+        }
+
+        @Override
+        protected DirectedSpecifics<V,E> createDirectedSpecifics() {
+            return new DirectedSpecifics<>(this);
+        }
+    }
+}


### PR DESCRIPTION
This is a first round of performance improvements for jgrapht. Here's a summary of changes I've made:
-Moved the Specifics class (and subclasses) from AbstractBaseGraph to their own package
-Introduced two new Specifics classes (FastLookupDirectedSpecifics and FastLookupUndirectedSpecifics) which significantly speed up edge retrieval operations such as getEdge(V u, V, v), containsEdge(V u, V, v), removeEdge(V u, V, v). I've made these the default classes. The orginal (Legacy) classes are still available if a more memory conservative solution is required.
-Updated the classes I've modified to comply with Java 1.8
-Included a performance Benchmark class to compare different Graph implementations.

Here are some Benchmark results (smaller scores are better):

Benchmark                                                                          Mode  Cnt     Score     Error  Units
GraphPerformanceTest.FastLookupDirectedGraphBenchmark.generateGraphBenchmark       avgt    5   660.644 ± 198.290  ms/op
GraphPerformanceTest.FastLookupDirectedGraphBenchmark.graphPermanceBenchmark       avgt    5  1691.779 ±  41.430  ms/op
GraphPerformanceTest.MemoryEfficientDirectedGraphBenchmark.generateGraphBenchmark  avgt    5   703.238 ± 122.080  ms/op
GraphPerformanceTest.MemoryEfficientDirectedGraphBenchmark.graphPermanceBenchmark  avgt    5  2419.216 ± 542.112  ms/op

These tests were performed with 5 different graphs consisting of 1000 vertices and 100000 edges each. The new FastLookup implementation is significantly faster in these tests.