### PR TITLE
Added parser for DIMACS

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/experimental/GraphReader.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/experimental/GraphReader.java
@@ -43,31 +43,7 @@ import java.util.*;
 import org.jgrapht.*;
 import org.jgrapht.generate.*;
 
-/**
- * Imports a graph specified in DIMACS format (http://mat.gsia.cmu.edu/COLOR/general/ccformat.ps).
- * In summary, graphs specified in DIMACS format adhere to the following structure:
- * <pre><code>
- *
- * DIMACS G {
- *    c <comments; ignored during parsing of the graph
- *    p edge <number of nodes> <number of edges>
- *    e <edge source 1> <edge target 1>
- *    e <edge source 2> <edge target 2>
- *    e <edge source 3> <edge target 3>
- *    e <edge source 4> <edge target 4>
- *    ...
- * }
- *
- * </code></pre>
- *
- * Note: the current implementation does not fully implement the DIMACS specifications! Special (rarely used) fields
- * specified as 'Optional Descriptors' are currently not supported.
- *
- * @author unknown
- *
- * @param <V>
- * @param <E>
- */
+
 public class GraphReader<V, E>
     implements GraphGenerator<V, E, V>
 {

--- a/jgrapht-core/src/main/java/org/jgrapht/experimental/GraphReader.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/experimental/GraphReader.java
@@ -43,7 +43,31 @@ import java.util.*;
 import org.jgrapht.*;
 import org.jgrapht.generate.*;
 
-
+/**
+ * Imports a graph specified in DIMACS format (http://mat.gsia.cmu.edu/COLOR/general/ccformat.ps).
+ * In summary, graphs specified in DIMACS format adhere to the following structure:
+ * <pre><code>
+ *
+ * DIMACS G {
+ *    c <comments; ignored during parsing of the graph
+ *    p edge <number of nodes> <number of edges>
+ *    e <edge source 1> <edge target 1>
+ *    e <edge source 2> <edge target 2>
+ *    e <edge source 3> <edge target 3>
+ *    e <edge source 4> <edge target 4>
+ *    ...
+ * }
+ *
+ * </code></pre>
+ *
+ * Note: the current implementation does not fully implement the DIMACS specifications! Special (rarely used) fields
+ * specified as 'Optional Descriptors' are currently not supported.
+ *
+ * @author unknown
+ *
+ * @param <V>
+ * @param <E>
+ */
 public class GraphReader<V, E>
     implements GraphGenerator<V, E, V>
 {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
@@ -83,7 +83,7 @@ public class DIMACSImporter<V, E> implements GraphGenerator<V, E, V>{
     // ~ Constructors ----------------------------------------------------------
 
     /**
-     * Construct a new GraphReader.
+     * Construct a new DIMACSImporter.
      */
     public DIMACSImporter(Reader input, double defaultWeight)
             throws IOException
@@ -97,7 +97,7 @@ public class DIMACSImporter<V, E> implements GraphGenerator<V, E, V>{
     }
 
     /**
-     * Construct a new GraphReader.
+     * Construct a new DIMACSImporter.
      */
     public DIMACSImporter(Reader input)
             throws IOException

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
@@ -1,0 +1,179 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -------------------
+ * DIMACSImporter.java
+ * -------------------
+ * (C) Copyright 2010-2010, by Michael Behrisch and Contributors.
+ *
+ * Original Author:  Michael Behrisch
+ * Contributor(s): Joris Kinable  -
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 24-Dec-2008 : Initial revision (AN);
+ *
+ */
+package org.jgrapht.ext;
+
+import org.jgrapht.Graph;
+import org.jgrapht.VertexFactory;
+import org.jgrapht.WeightedGraph;
+import org.jgrapht.generate.GraphGenerator;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Imports a graph specified in DIMACS format (http://mat.gsia.cmu.edu/COLOR/general/ccformat.ps).
+ * In summary, graphs specified in DIMACS format adhere to the following structure:
+ * <pre><code>
+ *
+ * DIMACS G {
+ *    c <comments; ignored during parsing of the graph
+ *    p edge <number of nodes> <number of edges>
+ *    e <edge source 1> <edge target 1>
+ *    e <edge source 2> <edge target 2>
+ *    e <edge source 3> <edge target 3>
+ *    e <edge source 4> <edge target 4>
+ *    ...
+ * }
+ *
+ * </code></pre>
+ *
+ * Although not specified directly in the DIMACS format documentation, this implementation also allows for the a weighted variant:
+ * <pre><code>e <edge source 1> <edge target 1> <edge_weight> </code></pre>
+ *
+ * Note: the current implementation does not fully implement the DIMACS specifications! Special (rarely used) fields
+ * specified as 'Optional Descriptors' are currently not supported.
+ *
+ * @author Michael Behrisch (adaptation of GraphReader class)
+ * @author Joris Kinable
+ *
+ * @param <V>
+ * @param <E>
+ */
+public class DIMACSImporter<V, E> implements GraphGenerator<V, E, V>{
+    private final BufferedReader input;
+    private final double defaultWeight;
+
+    // ~ Constructors ----------------------------------------------------------
+
+    /**
+     * Construct a new GraphReader.
+     */
+    public DIMACSImporter(Reader input, double defaultWeight)
+            throws IOException
+    {
+        if (input instanceof BufferedReader) {
+            this.input = (BufferedReader) input;
+        } else {
+            this.input = new BufferedReader(input);
+        }
+        this.defaultWeight = defaultWeight;
+    }
+
+    /**
+     * Construct a new GraphReader.
+     */
+    public DIMACSImporter(Reader input)
+            throws IOException
+    {
+        this(input, 1);
+    }
+
+
+    // ~ Methods ---------------------------------------------------------------
+
+    private String [] split(final String src)
+    {
+        if (src == null) {
+            return null;
+        }
+        return src.split("\\s+");
+    }
+
+    private String [] skipComments()
+    {
+        String [] cols = null;
+        try {
+            cols = split(input.readLine());
+            while (
+                    (cols != null)
+                            && ((cols.length == 0)
+                            || cols[0].equals("c")
+                            || cols[0].startsWith("%")))
+            {
+                cols = split(input.readLine());
+            }
+        } catch (IOException e) {
+        }
+        return cols;
+    }
+
+    private int readNodeCount()
+    {
+        final String [] cols = skipComments();
+        if (cols[0].equals("p")) {
+            return Integer.parseInt(cols[2]);
+        }
+        return -1;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override public void generateGraph(
+            Graph<V, E> target,
+            VertexFactory<V> vertexFactory,
+            Map<String, V> resultMap)
+    {
+        final int size = readNodeCount();
+        if (resultMap == null) {
+            resultMap = new HashMap<>();
+        }
+
+        for (int i = 0; i < size; i++) {
+            V newVertex = vertexFactory.createVertex();
+            target.addVertex(newVertex);
+            resultMap.put(Integer.toString(i + 1), newVertex);
+        }
+        String [] cols = skipComments();
+        while (cols != null) {
+            if (cols[0].equals("e")) {
+                E edge = target.addEdge(resultMap.get(cols[1]), resultMap.get(cols[2]));
+                if (target instanceof WeightedGraph && (edge != null)) {
+                    double weight = defaultWeight;
+                    if (cols.length > 3) {
+                        weight = Double.parseDouble(cols[3]);
+                    }
+                    ((WeightedGraph<V, E>) target).setEdgeWeight(edge, weight);
+                }
+            }
+            cols = skipComments();
+        }
+    }
+}

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DIMACSImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DIMACSImporterTest.java
@@ -1,0 +1,117 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -------------------
+ * DIMACSImporterTest.java
+ * -------------------
+ * (C) Copyright 2016-2016, by Joris Kinable and Contributors.
+ *
+ * Original Author:  Joris Kinable
+ * Contributor(s):
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 24-Dec-2008 : Initial revision (AN);
+ *
+ */
+package org.jgrapht.ext;
+
+import junit.framework.TestCase;
+import org.jgrapht.Graph;
+import org.jgrapht.VertexFactory;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.SimpleWeightedGraph;
+
+import java.io.*;
+
+/**
+ * .
+ *
+ * @author Joris Kinable
+ */
+public class DIMACSImporterTest extends TestCase {
+    /**
+     * Read and parse an actual instance
+     */
+    public void testReadDIMACSInstance(){
+        InputStream fstream = getClass().getClassLoader().getResourceAsStream("myciel3.col");
+        BufferedReader in = new BufferedReader(new InputStreamReader(fstream));
+        try {
+            DIMACSImporter<Integer, DefaultEdge> reader=new DIMACSImporter<>(in);
+            VertexFactory<Integer> vf = new IntVertexFactory();
+            Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
+            reader.generateGraph(graph, vf, null);
+
+            assertEquals(graph.vertexSet().size(), 11);
+            assertEquals(graph.edgeSet().size(), 20);
+
+            int[][] edges={{1, 2}, {1, 4}, {1, 7}, {1, 9}, {2, 3}, {2, 6}, {2, 8}, {3, 5}, {3, 7}, {3, 10}, {4, 5}, {4, 6}, {4, 10}, {5, 8}, {5, 9}, {6, 11}, {7, 11}, {8, 11}, {9, 11}, {10, 11}};
+            for(int[] edge: edges)
+                assertTrue(graph.containsEdge(edge[0],edge[1]));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Read and parse an weighted instance
+     */
+    public void testReadWeightedDIMACSInstance(){
+        InputStream fstream = getClass().getClassLoader().getResourceAsStream("myciel3_weighted.col");
+        BufferedReader in = new BufferedReader(new InputStreamReader(fstream));
+        try {
+            DIMACSImporter<Integer, DefaultWeightedEdge> reader=new DIMACSImporter<>(in);
+            VertexFactory<Integer> vf = new IntVertexFactory();
+            Graph<Integer, DefaultWeightedEdge> graph = new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
+            reader.generateGraph(graph, vf, null);
+
+            assertEquals(graph.vertexSet().size(), 11);
+            assertEquals(graph.edgeSet().size(), 20);
+
+            int[][] edges={{1, 2, 1}, {1, 4, 2}, {1, 7, 3}, {1, 9, 4}, {2, 3, 5}, {2, 6, 6}, {2, 8, 7}, {3, 5, 8}, {3, 7, 9}, {3, 10, 10}, {4, 5, 11}, {4, 6, 12}, {4, 10, 13}, {5, 8, 14}, {5, 9, 15}, {6, 11, 16}, {7, 11, 17}, {8, 11, 18}, {9, 11, 19}, {10, 11, 20}};
+            for(int[] edge: edges) {
+                assertTrue(graph.containsEdge(edge[0], edge[1]));
+                DefaultWeightedEdge e=graph.getEdge(edge[0], edge[1]);
+                assertEquals((int)graph.getEdgeWeight(e), edge[2]);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    //~ Inner Classes ----------------------------------------------------------
+
+    private static final class IntVertexFactory
+            implements VertexFactory<Integer>
+    {
+        int last = 1;
+
+        @Override
+        public Integer createVertex()
+        {
+            return last++;
+        }
+    }
+}

--- a/jgrapht-ext/src/test/resources/myciel3.col
+++ b/jgrapht-ext/src/test/resources/myciel3.col
@@ -1,0 +1,26 @@
+c FILE: myciel3.col
+c SOURCE: Michael Trick (trick@cmu.edu)
+c DESCRIPTION: Graph based on Mycielski transformation. 
+c              Triangle free (clique number 2) but increasing
+c              coloring number
+p edge 11 20
+e 1 2
+e 1 4
+e 1 7
+e 1 9
+e 2 3
+e 2 6
+e 2 8
+e 3 5
+e 3 7
+e 3 10
+e 4 5
+e 4 6
+e 4 10
+e 5 8
+e 5 9
+e 6 11
+e 7 11
+e 8 11
+e 9 11
+e 10 11

--- a/jgrapht-ext/src/test/resources/myciel3_weighted.col
+++ b/jgrapht-ext/src/test/resources/myciel3_weighted.col
@@ -1,0 +1,26 @@
+c FILE: myciel3.col
+c SOURCE: Michael Trick (trick@cmu.edu)
+c DESCRIPTION: Graph based on Mycielski transformation. 
+c              Triangle free (clique number 2) but increasing
+c              coloring number
+p edge 11 20
+e 1 2 1
+e 1 4 2
+e 1 7 3
+e 1 9 4
+e 2 3 5
+e 2 6 6
+e 2 8 7
+e 3 5 8
+e 3 7 9
+e 3 10 10
+e 4 5 11
+e 4 6 12
+e 4 10 13
+e 5 8 14
+e 5 9 15
+e 6 11 16
+e 7 11 17
+e 8 11 18
+e 9 11 19
+e 10 11 20


### PR DESCRIPTION
I was looking for a way to import DIMACS graphs into jgrapht. Turns out, there's no class which could do this out of the box. In the experimental package, there is a class 'GraphReader' which could *almost* do the job. Some testing revealed that this class does not comply 100% with the DIMACS standard and as such crashes when you give it a DIMACS graph. Frankly, since GraphReader contains no comments, I'm not sure what graph format this class can parse. Furthermore, the name 'GraphReader' is too generic. Consequently, I added a new class "DIMACSImporter", analogous to the existing DOTImporter and placed it under jgrapht.ext (same package as the DOTImporter). Since the DIMACSImporter class is a modification of the original GraphReader by Michael Behrisch, I've made him an author of DIMACSImporter. I've added unit tests as well (DIMACSImporterTest.java)
My recommendation would be to make the current GraphReader class and corresponding GraphReaderTest class deprecated and delete them in one of the following releases.