### PR TITLE
Use unique OSGi bundle symbolic name for uber artifact.

### DIFF
--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -35,6 +35,17 @@
 					</execution>
 				</executions>
 				<configuration>
+					<transformers>
+						<transformer
+							implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+							<manifestEntries>
+								<!-- Use unique OSGi bundle symbolic name for uber artifact. Otherwise
+									e.g. jgrapht-ext-1.0.0.jar and jgrapht-ext-1.0.0-uber.jar could not be deployed
+									to the same P2 repository. -->
+								<Bundle-SymbolicName>org.jgrapht.ext.uber</Bundle-SymbolicName>
+							</manifestEntries>
+						</transformer>
+					</transformers>
                     <shadedArtifactAttached>true</shadedArtifactAttached>
                     <shadedClassifierName>uber</shadedClassifierName>
                     <!--


### PR DESCRIPTION
Otherwise e.g. jgrapht-ext-1.0.0.jar and jgrapht-ext-1.0.0-uber.jar
could not be deployed to the same P2 repository.

This fix has been part of PR https://github.com/jgrapht/jgrapht/pull/197/commits/eefabb14b7547db6b9d46873c8a79792b1d454b5#r61621956. It was requested to create a new PR for this fix.