### PR TITLE
Added getNextHop and getLastHop methods to the FloydWarshallShortestP…

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/FloydWarshallShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/FloydWarshallShortestPaths.java
@@ -289,15 +289,15 @@ public class FloydWarshallShortestPaths<V, E>
     }
 
     /**
-     * Returns the next hop, i.e., the second node on the shortest path from a to b. Lookup time is O(1).
+     * Returns the first hop, i.e., the second node on the shortest path from a to b. Lookup time is O(1).
      * If the shortest path from a to b is a,c,d,e,b, this method returns c. If the next invocation would
-     * query the next hop on the shortest path from c to b, vertex d would be returned, etc. This method is computationally
+     * query the first hop on the shortest path from c to b, vertex d would be returned, etc. This method is computationally
      * cheaper than getShortestPathAsVertexList(a,b).get(0);
      * @param a source vertex
      * @param b target vertex
      * @return next hop on the shortest path from a to b, or null when there exists no path from a to b.
      */
-    public V getNextHop(V a, V b){
+    public V getFirstHop(V a, V b){
         lazyCalculatePaths();
 
         int v_a = vertexIndices.get(a);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/FloydWarshallShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/FloydWarshallShortestPathsTest.java
@@ -116,7 +116,7 @@ public class FloydWarshallShortestPathsTest
                     if(path != null) {
                         this.verifyPath(undirected, path, fw.shortestDistance(v1, v2));
                         List<Integer> vertexPath=Graphs.getPathVertexList(path);
-                        assertEquals(fw.getNextHop(v1, v2), vertexPath.get(1));
+                        assertEquals(fw.getFirstHop(v1, v2), vertexPath.get(1));
                         assertEquals(fw.getLastHop(v1, v2), vertexPath.get(vertexPath.size()-2));
                     }
 
@@ -196,7 +196,7 @@ public class FloydWarshallShortestPathsTest
                 new FloydWarshallShortestPaths<>(graph);
         double diameter = fw.getDiameter();
         assertEquals(0.0, diameter);
-        assertNull(fw.getNextHop(a, b));
+        assertNull(fw.getFirstHop(a, b));
         assertNull(fw.getLastHop(a, b));
     }
 
@@ -219,7 +219,7 @@ public class FloydWarshallShortestPathsTest
         assertEquals(weighted, path.getGraph());
         assertNull(fw.getShortestPath("b", "a"));
         List<String> vertexPath=Graphs.getPathVertexList(path);
-        assertEquals(fw.getNextHop("a", "b"), vertexPath.get(1));
+        assertEquals(fw.getFirstHop("a", "b"), vertexPath.get(1));
         assertEquals(fw.getLastHop("a", "b"), vertexPath.get(vertexPath.size()-2));
     }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/FloydWarshallShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/FloydWarshallShortestPathsTest.java
@@ -26,6 +26,7 @@
  *
  * Original Author:  Tom Larkworthy
  * Contributors:  Andrea Pagani
+ *                Joris Kinable
  *
  * $Id: FloydWarshallShortestPathsTest.java 715 2010-06-13 01:25:00Z perfecthash $
  *
@@ -112,8 +113,13 @@ public class FloydWarshallShortestPathsTest
                                     v2).getPathLength();
                     assertTrue((Math.abs(dijSp - fwSp) < .01) || (Double.isInfinite(fwSp) && Double.isInfinite(dijSp)));
                     GraphPath<Integer, DefaultWeightedEdge> path=fw.getShortestPath(v1, v2);
-                    if(path != null)
+                    if(path != null) {
                         this.verifyPath(undirected, path, fw.shortestDistance(v1, v2));
+                        List<Integer> vertexPath=Graphs.getPathVertexList(path);
+                        assertEquals(fw.getNextHop(v1, v2), vertexPath.get(1));
+                        assertEquals(fw.getLastHop(v1, v2), vertexPath.get(vertexPath.size()-2));
+                    }
+
                 }
             }
         }
@@ -190,6 +196,8 @@ public class FloydWarshallShortestPathsTest
                 new FloydWarshallShortestPaths<>(graph);
         double diameter = fw.getDiameter();
         assertEquals(0.0, diameter);
+        assertNull(fw.getNextHop(a, b));
+        assertNull(fw.getLastHop(a, b));
     }
 
     public void testWeightedEdges() {
@@ -210,6 +218,9 @@ public class FloydWarshallShortestPathsTest
         assertEquals(5.0, path.getWeight());
         assertEquals(weighted, path.getGraph());
         assertNull(fw.getShortestPath("b", "a"));
+        List<String> vertexPath=Graphs.getPathVertexList(path);
+        assertEquals(fw.getNextHop("a", "b"), vertexPath.get(1));
+        assertEquals(fw.getLastHop("a", "b"), vertexPath.get(vertexPath.size()-2));
     }
 }
 


### PR DESCRIPTION
Added two convenience methods, getNextHop and getLastHop, to the FloydWarshallShortestPaths algorithm (and corresponding tests). In a number of applications, it is not necessary to compute an entire path from i to j. Instead, you are merely interested in the next hop from i towards j, or in the last hop, from i to j. Both methods run in O(1) time.
Examples (assuming that the graph is a road network):
-if I'm traveling on the road (u,v) towards destination w, should I make a u-turn?
-if I want to go from u to v, should I head north?