### PR TITLE
A more general version of GraphPath

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
@@ -125,6 +125,14 @@ public interface GraphPath<V, E>
      */
     double getWeight();
 
+    /**
+     * Returns the length of the path, measured in the number of vertices.
+     * @return the length of the path, measured in the number of vertices
+     */
+    default int getLength(){
+        return getVertexList().size();
+    }
+
 }
 
 // End GraphPath.java

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
@@ -41,9 +41,9 @@ import java.util.*;
 
 /**
  * A GraphPath represents a <a href="http://mathworld.wolfram.com/Path.html">
- * path</a> in a {@link Graph}. Note that a path is defined primarily in terms
- * of edges (rather than vertices) so that multiple edges between the same pair
- * of vertices can be discriminated.
+ * path</a> in a {@link Graph}. Unlike some definitions, the path is not required
+ * to be a <a href="https://en.wikipedia.org/wiki/Simple_path>Simple Path</a>.
+ *
  *
  * @author John Sichi
  * @since Jan 1, 2008

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
@@ -86,9 +86,12 @@ public interface GraphPath<V, E>
      * @return list of edges traversed by the path
      */
     default List<E> getEdgeList(){
+        List<V> vertexList=this.getVertexList();
+        if(vertexList.size() < 2)
+            return Collections.emptyList();
+
         Graph<V, E> g = this.getGraph();
         List<E> edgeList = new ArrayList<>();
-        List<V> vertexList = this.getVertexList();
         Iterator<V> vertexIterator=vertexList.iterator();
         V u=vertexIterator.next();
         while (vertexIterator.hasNext()){
@@ -105,11 +108,16 @@ public interface GraphPath<V, E>
      * @return path, denoted by a list of vertices
      */
     default List<V> getVertexList(){
+        List<E> edgeList=this.getEdgeList();
+
+        if(edgeList.isEmpty())
+            return Collections.emptyList();
+
         Graph<V, E> g = this.getGraph();
         List<V> list = new ArrayList<>();
         V v = this.getStartVertex();
         list.add(v);
-        for (E e : this.getEdgeList()) {
+        for (E e : edgeList) {
             v = Graphs.getOppositeVertex(g, e, v);
             list.add(v);
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
@@ -25,7 +25,7 @@
  * (C) Copyright 2008-2008, by John V. Sichi and Contributors.
  *
  * Original Author:  John V. Sichi
- * Contributor(s):   -
+ * Contributor(s):   Joris Kinable
  *
  * $Id$
  *
@@ -85,7 +85,36 @@ public interface GraphPath<V, E>
      *
      * @return list of edges traversed by the path
      */
-    List<E> getEdgeList();
+    default List<E> getEdgeList(){
+        Graph<V, E> g = this.getGraph();
+        List<E> edgeList = new ArrayList<>();
+        List<V> vertexList = this.getVertexList();
+        Iterator<V> vertexIterator=vertexList.iterator();
+        V u=vertexIterator.next();
+        while (vertexIterator.hasNext()){
+            V v=vertexIterator.next();
+            edgeList.add(g.getEdge(u,v));
+            u=v;
+        }
+        return edgeList;
+    }
+
+    /**
+     * Returns the path as a sequence of vertices.
+     *
+     * @return path, denoted by a list of vertices
+     */
+    default List<V> getVertexList(){
+        Graph<V, E> g = this.getGraph();
+        List<V> list = new ArrayList<>();
+        V v = this.getStartVertex();
+        list.add(v);
+        for (E e : this.getEdgeList()) {
+            v = Graphs.getOppositeVertex(g, e, v);
+            list.add(v);
+        }
+        return list;
+    }
 
     /**
      * Returns the weight assigned to the path. Typically, this will be the sum
@@ -95,6 +124,7 @@ public interface GraphPath<V, E>
      * @return the weight of the path
      */
     double getWeight();
+
 }
 
 // End GraphPath.java

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
@@ -77,8 +77,8 @@ public interface GraphPath<V, E>
      * incident to the start vertex. The last edge is incident to the end
      * vertex. The vertices along the path can be obtained by traversing from
      * the start vertex, finding its opposite across the first edge, and then
-     * doing the same successively across subsequent edges; {@link
-     * Graphs#getPathVertexList} provides a convenience method for this.
+     * doing the same successively across subsequent edges; {@see
+     * GraphPath#getVertexList}.
      *
      * <p>Whether or not the returned edge list is modifiable depends on the
      * path implementation.
@@ -126,11 +126,11 @@ public interface GraphPath<V, E>
     double getWeight();
 
     /**
-     * Returns the length of the path, measured in the number of vertices.
-     * @return the length of the path, measured in the number of vertices
+     * Returns the length of the path, measured in the number of edges.
+     * @return the length of the path, measured in the number of edges
      */
     default int getLength(){
-        return getVertexList().size();
+        return getEdgeList().size();
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
@@ -422,6 +422,7 @@ public abstract class Graphs
      * @param path path of interest
      *
      * @return corresponding vertex list
+     * @deprecated This functionality is now directly provided by any GraphPath, see {@link GraphPath#getVertexList()}
      */
     public static <V, E> List<V> getPathVertexList(GraphPath<V, E> path)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/AStarShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/AStarShortestPath.java
@@ -226,38 +226,19 @@ public class AStarShortestPath<V, E>
         V targetVertex,
         double pathLength)
     {
-        List<E> edgeList = this.buildPath(targetVertex);
-        return new GraphPathImpl<>(
-                graph,
-                startVertex,
-                targetVertex,
-                edgeList,
-                pathLength);
-    }
+        List<E> edgeList=new ArrayList<>();
+        List<V> vertexList=new ArrayList<>();
+        vertexList.add(targetVertex);
 
-    /**
-     * Recursive method which traces the path from the targetVertex to the
-     * startVertex. The method traces back the path over the edges, so the
-     * method is safe to use for multi-graphs.
-     *
-     * @param currentNode node
-     *
-     * @return List of edges/arcs that constitutes the path
-     */
-    private List<E> buildPath(V currentNode)
-    {
-        if (cameFrom.containsKey(currentNode)) {
-            List<E> path =
-                buildPath(
-                    Graphs.getOppositeVertex(
-                        graph,
-                        cameFrom.get(currentNode),
-                        currentNode));
-            path.add(cameFrom.get(currentNode));
-            return path;
-        } else {
-            return new ArrayList<>();
+        V v=targetVertex;
+        while (v != startVertex){
+            edgeList.add(cameFrom.get(v));
+            v = Graphs.getOppositeVertex(graph,cameFrom.get(v),v);
+            vertexList.add(v);
         }
+        Collections.reverse(edgeList);
+        Collections.reverse(vertexList);
+        return new GraphWalk<>(graph, startVertex, targetVertex, vertexList, edgeList, pathLength);
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/AllDirectedPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/AllDirectedPaths.java
@@ -347,7 +347,7 @@ public class AllDirectedPaths<V, E>
         V source = graph.getEdgeSource(edges.get(0));
         V target = graph.getEdgeTarget(edges.get(edges.size() - 1));
         double weight = edges.size();
-        return new GraphPathImpl<>(graph, source, target, edges, weight);
+        return new GraphWalk<>(graph, source, target, edges, weight);
     }
 }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/DijkstraShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/DijkstraShortestPath.java
@@ -180,6 +180,8 @@ public final class DijkstraShortestPath<V, E>
         V endVertex)
     {
         List<E> edgeList = new ArrayList<>();
+        List<V> vertexList=new ArrayList<>();
+        vertexList.add(endVertex);
 
         V v = endVertex;
 
@@ -192,15 +194,18 @@ public final class DijkstraShortestPath<V, E>
 
             edgeList.add(edge);
             v = Graphs.getOppositeVertex(graph, edge, v);
+            vertexList.add(v);
         }
 
         Collections.reverse(edgeList);
+        Collections.reverse(vertexList);
         double pathLength = iter.getShortestPathLength(endVertex);
         path =
-                new GraphPathImpl<>(
+                new GraphWalk<>(
                         graph,
                         startVertex,
                         endVertex,
+                        vertexList,
                         edgeList,
                         pathLength);
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/FloydWarshallShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/FloydWarshallShortestPaths.java
@@ -225,14 +225,17 @@ public class FloydWarshallShortestPaths<V, E>
         }
 
         //Reconstruct the path
+        List<V> pathVertexList = new ArrayList<>();
+        pathVertexList.add(a);
         List<E> edges = new ArrayList<>();
         int u = v_a;
         while (u != v_b) {
             int v = backtrace[u][v_b];
             edges.add(graph.getEdge(vertices.get(u), vertices.get(v)));
+            pathVertexList.add(vertices.get(v));
             u = v;
         }
-        return new GraphPathImpl<>(graph, a, b, edges, d[v_a][v_b]);
+        return new GraphWalk<>(graph, a, b, pathVertexList, edges, d[v_a][v_b]);
     }
 
     public List<V> getShortestPathAsVertexList(V a, V b)

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphPathImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphPathImpl.java
@@ -46,7 +46,7 @@ import org.jgrapht.*;
  * @author John Sichi
  * @version $Id$
  *
- * @deprecated use {@link #GraphWalk} instead
+ * @deprecated use {@link GraphWalk} instead
  */
 
 public class GraphPathImpl<V, E>

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphPathImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphPathImpl.java
@@ -25,7 +25,6 @@
  * (C) Copyright 2009-2009, by John V. Sichi and Contributors.
  *
  * Original Author:  John V. Sichi
- * Contributor(s):   Joris Kinable
  *
  * $Id$
  *
@@ -52,7 +51,6 @@ public class GraphPathImpl<V, E>
 {
     private Graph<V, E> graph;
 
-    private List<V> vertexList;
     private List<E> edgeList;
 
     private V startVertex;
@@ -68,37 +66,9 @@ public class GraphPathImpl<V, E>
         List<E> edgeList,
         double weight)
     {
-        this(graph, startVertex, endVertex, null, edgeList, weight);
-    }
-
-    public GraphPathImpl(
-            Graph<V, E> graph,
-            List<V> vertexList,
-            double weight)
-    {
-        this(graph,
-                (vertexList.isEmpty() ? null : vertexList.get(0)),
-                (vertexList.isEmpty() ? null : vertexList.get(vertexList.size()-1)),
-                vertexList,
-                null,
-                weight);
-    }
-
-    public GraphPathImpl(
-            Graph<V, E> graph,
-            V startVertex,
-            V endVertex,
-            List<V> vertexList,
-            List<E> edgeList,
-            double weight)
-    {
-        if(vertexList == null && edgeList == null)
-            throw new IllegalArgumentException("Vertex list and edge list cannot both be null!");
-        
         this.graph = graph;
         this.startVertex = startVertex;
         this.endVertex = endVertex;
-        this.vertexList=vertexList;
         this.edgeList = edgeList;
         this.weight = weight;
     }
@@ -124,13 +94,7 @@ public class GraphPathImpl<V, E>
     // implement GraphPath
     @Override public List<E> getEdgeList()
     {
-        return (edgeList != null ? edgeList : GraphPath.super.getEdgeList());
-    }
-
-    // implement GraphPath
-    @Override public List<V> getVertexList()
-    {
-        return (vertexList != null ? vertexList : GraphPath.super.getVertexList());
+        return edgeList;
     }
 
     // implement GraphPath

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphPathImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphPathImpl.java
@@ -25,6 +25,7 @@
  * (C) Copyright 2009-2009, by John V. Sichi and Contributors.
  *
  * Original Author:  John V. Sichi
+ * Contributor(s):   Joris Kinable
  *
  * $Id$
  *
@@ -51,6 +52,7 @@ public class GraphPathImpl<V, E>
 {
     private Graph<V, E> graph;
 
+    private List<V> vertexList;
     private List<E> edgeList;
 
     private V startVertex;
@@ -66,9 +68,34 @@ public class GraphPathImpl<V, E>
         List<E> edgeList,
         double weight)
     {
+        this(graph, startVertex, endVertex, null, edgeList, weight);
+    }
+
+    public GraphPathImpl(
+            Graph<V, E> graph,
+            List<V> vertexList,
+            double weight)
+    {
+        this(graph,
+                (vertexList.isEmpty() ? null : vertexList.get(0)),
+                (vertexList.isEmpty() ? null : vertexList.get(vertexList.size()-1)),
+                vertexList,
+                null,
+                weight);
+    }
+
+    public GraphPathImpl(
+            Graph<V, E> graph,
+            V startVertex,
+            V endVertex,
+            List<V> vertexList,
+            List<E> edgeList,
+            double weight)
+    {
         this.graph = graph;
         this.startVertex = startVertex;
         this.endVertex = endVertex;
+        this.vertexList=vertexList;
         this.edgeList = edgeList;
         this.weight = weight;
     }
@@ -94,7 +121,13 @@ public class GraphPathImpl<V, E>
     // implement GraphPath
     @Override public List<E> getEdgeList()
     {
-        return edgeList;
+        return (edgeList != null ? edgeList : GraphPath.super.getEdgeList());
+    }
+
+    // implement GraphPath
+    @Override public List<V> getVertexList()
+    {
+        return (vertexList != null ? vertexList : GraphPath.super.getVertexList());
     }
 
     // implement GraphPath

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphPathImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphPathImpl.java
@@ -92,6 +92,9 @@ public class GraphPathImpl<V, E>
             List<E> edgeList,
             double weight)
     {
+        if(vertexList == null && edgeList == null)
+            throw new IllegalArgumentException("Vertex list and edge list cannot both be null!");
+        
         this.graph = graph;
         this.startVertex = startVertex;
         this.endVertex = endVertex;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
@@ -32,6 +32,7 @@
  * Changes
  * -------
  * 03-Jul-2009 : Initial revision (JVS);
+ * 14-Jul-2016 : Redefined class to a more generic version of a walk, expressed in terms of its edges or vertices (JK)
  *
  */
 package org.jgrapht.graph;
@@ -60,16 +61,16 @@ import org.jgrapht.*;
  */
 public class GraphWalk<V, E> implements GraphPath<V, E>
 {
-    private Graph<V, E> graph;
+    protected Graph<V, E> graph;
 
-    private List<V> vertexList;
-    private List<E> edgeList;
+    protected List<V> vertexList;
+    protected List<E> edgeList;
 
-    private V startVertex;
+    protected V startVertex;
 
-    private V endVertex;
+    protected V endVertex;
 
-    private double weight;
+    protected double weight;
 
     /**
      * Creates a walk defined by a sequence of edges. A walk defined by its edges can be specified for non-simple graphs.
@@ -181,10 +182,10 @@ public class GraphWalk<V, E> implements GraphPath<V, E>
     // implement GraphPath
     @Override public int getLength()
     {
-        if(vertexList!=null)
-            return vertexList.size();
-        else if(edgeList != null && !edgeList.isEmpty())
-            return edgeList.size()+1;
+        if(edgeList!=null)
+            return edgeList.size();
+        else if(vertexList != null && vertexList.isEmpty())
+            return vertexList.size()-1;
         else
             return 0;
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
@@ -25,6 +25,7 @@
  * (C) Copyright 2009-2009, by John V. Sichi and Contributors.
  *
  * Original Author:  John V. Sichi
+ * Contributor(s):   Joris Kinable
  *
  * $Id$
  *
@@ -45,15 +46,12 @@ import org.jgrapht.*;
  *
  * @author John Sichi
  * @version $Id$
- *
- * @deprecated use {@link #GraphWalk} instead
  */
-
-public class GraphPathImpl<V, E>
-    implements GraphPath<V, E>
+public class GraphWalk<V, E> implements GraphPath<V, E>
 {
     private Graph<V, E> graph;
 
+    private List<V> vertexList;
     private List<E> edgeList;
 
     private V startVertex;
@@ -62,16 +60,44 @@ public class GraphPathImpl<V, E>
 
     private double weight;
 
-    public GraphPathImpl(
-        Graph<V, E> graph,
-        V startVertex,
-        V endVertex,
-        List<E> edgeList,
-        double weight)
+    public GraphWalk(
+            Graph<V, E> graph,
+            V startVertex,
+            V endVertex,
+            List<E> edgeList,
+            double weight)
     {
+        this(graph, startVertex, endVertex, null, edgeList, weight);
+    }
+
+    public GraphWalk(
+            Graph<V, E> graph,
+            List<V> vertexList,
+            double weight)
+    {
+        this(graph,
+                (vertexList.isEmpty() ? null : vertexList.get(0)),
+                (vertexList.isEmpty() ? null : vertexList.get(vertexList.size()-1)),
+                vertexList,
+                null,
+                weight);
+    }
+
+    public GraphWalk(
+            Graph<V, E> graph,
+            V startVertex,
+            V endVertex,
+            List<V> vertexList,
+            List<E> edgeList,
+            double weight)
+    {
+        if(vertexList == null && edgeList == null)
+            throw new IllegalArgumentException("Vertex list and edge list cannot both be null!");
+
         this.graph = graph;
         this.startVertex = startVertex;
         this.endVertex = endVertex;
+        this.vertexList=vertexList;
         this.edgeList = edgeList;
         this.weight = weight;
     }
@@ -97,7 +123,13 @@ public class GraphPathImpl<V, E>
     // implement GraphPath
     @Override public List<E> getEdgeList()
     {
-        return edgeList;
+        return (edgeList != null ? edgeList : GraphPath.super.getEdgeList());
+    }
+
+    // implement GraphPath
+    @Override public List<V> getVertexList()
+    {
+        return (vertexList != null ? vertexList : GraphPath.super.getVertexList());
     }
 
     // implement GraphPath

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
@@ -20,7 +20,7 @@
  * the Eclipse Foundation.
  */
 /* ----------------
- * GraphPathImpl.java
+ * GraphWalk.java
  * ----------------
  * (C) Copyright 2009-2009, by John V. Sichi and Contributors.
  *
@@ -42,7 +42,18 @@ import org.jgrapht.*;
 
 
 /**
- * GraphPathImpl is a default implementation of {@link GraphPath}.
+ * A walk in a graph is an alternating sequence of vertices and edges, starting and ending at a vertex, in which each edge
+ * is adjacent in the sequence to its two endpoints. More precisely, a walk is a connected sequence of vertices and edges
+ * in a graph <code>v0, e0, v1, e1, v2,....vk-1, ek-1, vk</code>, such that for <code>1<=i<=k</code>, the edge <code>e_i</code>
+ * has endpoints <code>v_(i-1)</code> and <code>v_i</code>. The class makes no assumptions with respect to the shape of the walk:
+ * edges may be repeated, and the start and end point of the walk may be different.
+ * @see <a href="http://mathworld.wolfram.com/Walk.html">http://mathworld.wolfram.com/Walk.html</a>
+ *
+ * GraphWalk is the default implementation of {@link GraphPath}.
+ *
+ * This class is implemented as a light-weight data structure; this class does not verify whether the sequence of edges
+ * or the sequence of vertices provided during construction forms an actual walk. It is the responsibility of the invoking
+ * class to provide correct input data.
  *
  * @author John Sichi
  * @version $Id$
@@ -60,6 +71,16 @@ public class GraphWalk<V, E> implements GraphPath<V, E>
 
     private double weight;
 
+    /**
+     * Creates a walk defined by a sequence of edges. A walk defined by its edges can be specified for non-simple graphs.
+     * Edge repetition is permitted, the start and end point points (v0 and vk) can be different.
+     *
+     * @param graph
+     * @param startVertex
+     * @param endVertex
+     * @param edgeList
+     * @param weight
+     */
     public GraphWalk(
             Graph<V, E> graph,
             V startVertex,
@@ -70,6 +91,13 @@ public class GraphWalk<V, E> implements GraphPath<V, E>
         this(graph, startVertex, endVertex, null, edgeList, weight);
     }
 
+    /**
+     * Creates a walk defined by a sequence of vertices. Note that the input graph must be simple, otherwise
+     * the vertex sequence does not necessarily define a unique path. Furthermore, all vertices must be pairwise adjacent.
+     * @param graph
+     * @param vertexList
+     * @param weight
+     */
     public GraphWalk(
             Graph<V, E> graph,
             List<V> vertexList,
@@ -83,6 +111,18 @@ public class GraphWalk<V, E> implements GraphPath<V, E>
                 weight);
     }
 
+    /**
+     * Creates a walk defined by both a sequence of edges and a sequence of vertices. Note that both the sequence of edges
+     * and the sequence of vertices must describe the same path! This is not verified during the construction of the walk.
+     * This constructor makes it possible to store both a vertex and an edge view of the same walk, thereby saving computational
+     * overhead when switching from one to the other.
+     * @param graph
+     * @param startVertex
+     * @param endVertex
+     * @param vertexList
+     * @param edgeList
+     * @param weight
+     */
     public GraphWalk(
             Graph<V, E> graph,
             V startVertex,
@@ -138,10 +178,24 @@ public class GraphWalk<V, E> implements GraphPath<V, E>
         return weight;
     }
 
+    // implement GraphPath
+    @Override public int getLength()
+    {
+        if(vertexList!=null)
+            return vertexList.size();
+        else if(edgeList != null && !edgeList.isEmpty())
+            return edgeList.size()+1;
+        else
+            return 0;
+    }
+
     // override Object
     @Override public String toString()
     {
-        return edgeList.toString();
+        if(vertexList!=null)
+            return vertexList.toString();
+        else
+            return edgeList.toString();
     }
 }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
@@ -184,7 +184,7 @@ public class GraphWalk<V, E> implements GraphPath<V, E>
     {
         if(edgeList!=null)
             return edgeList.size();
-        else if(vertexList != null && vertexList.isEmpty())
+        else if(vertexList != null && !vertexList.isEmpty())
             return vertexList.size()-1;
         else
             return 0;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleGraphPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleGraphPath.java
@@ -45,7 +45,7 @@ import org.jgrapht.*;
  * A vertex-based representation of a simple path. The graph must be simple for
  * the vertices to uniquely determine a path. See {@link SimpleGraph}
  *
- * @deprecated This class is ambiguous. Unlike the name or the description  suggests,
+ * @deprecated This class is ambiguous. Unlike the name or the description suggests,
  * this class does NOT implement a Simple Path (a path in a graph without vertex repetition).
  * Instead it implements a walk in a SimpleGraph. This functionality is now implemented by the class
  * {@link GraphWalk}.

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleGraphPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleGraphPath.java
@@ -44,6 +44,11 @@ import org.jgrapht.*;
 /**
  * A vertex-based representation of a simple path. The graph must be simple for
  * the vertices to uniquely determine a path. See {@link SimpleGraph}
+ *
+ * @deprecated This class is ambiguous. Unlike the name or the description  suggests,
+ * this class does NOT implement a Simple Path (a path in a graph without vertex repetition).
+ * Instead it implements a walk in a SimpleGraph. This functionality is now implemented by the class
+ * {@link GraphWalk}.
  */
 public class SimpleGraphPath<V, E>
     implements GraphPath<V, E>

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/AStarShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/AStarShortestPathTest.java
@@ -136,7 +136,7 @@ public class AStarShortestPathTest extends TestCase{
         assertNotNull(path);
         assertEquals((int)path.getWeight(), 47);
         assertEquals(path.getEdgeList().size(), 47);
-        assertEquals(Graphs.getPathVertexList(path).size(), 48);
+        assertEquals(path.getLength()+1, 48);
 
         path=aStarShortestPath.getShortestPath(sourceNode, targetNode, new EuclideanDistance());
         assertNotNull(path);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/FloydWarshallShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/FloydWarshallShortestPathsTest.java
@@ -125,16 +125,22 @@ public class FloydWarshallShortestPathsTest
     private <V,E> void verifyPath(Graph<V,E> graph, GraphPath<V,E> path, double pathCost){
         assertEquals(pathCost, path.getWeight(), .00000001);
         double verifiedEdgeCost=0;
+        List<V> vertexList=new ArrayList<>();
+        vertexList.add(path.getStartVertex());
+
+        V v=path.getStartVertex();
         for (E e : path.getEdgeList()) {
             assertNotNull(e);
             verifiedEdgeCost+=graph.getEdgeWeight(e);
+            try {
+                v = Graphs.getOppositeVertex(graph, e, v);
+            }catch (IllegalArgumentException ex){
+                fail("Invalid path encountered: the sequence of edges does not present a valid path through the graph");
+            }
         }
         assertEquals(pathCost, verifiedEdgeCost, .00000001);
-        try{
-            Graphs.getPathVertexList(path);
-        }catch (IllegalArgumentException e){
-            fail("Invalid path encountered: the sequence of edges does not present a valid path through the graph");
-        }
+        assertEquals(path.getStartVertex(), path.getVertexList().get(0));
+        assertEquals(path.getEndVertex(), path.getVertexList().get(path.getLength()));
     }
 
     private static UndirectedGraph<String, DefaultEdge> createStringGraph()

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathCostTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathCostTest.java
@@ -101,7 +101,7 @@ public class KShortestPathCostTest
                 }),
             pathElement.getEdgeList());
 
-        List vertices = Graphs.getPathVertexList(pathElement);
+        List vertices = pathElement.getVertexList();
         assertEquals(
             Arrays.asList(new Object[] { "vS", "v1", "v5" }),
             vertices);
@@ -115,7 +115,7 @@ public class KShortestPathCostTest
                 }),
             pathElement.getEdgeList());
 
-        vertices = Graphs.getPathVertexList(pathElement);
+        vertices = pathElement.getVertexList();
         assertEquals(
             Arrays.asList(new Object[] { "vS", "v2", "v5" }),
             vertices);

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
@@ -1,0 +1,101 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* ------------------------
+ * SimpleGraphPathTest.java
+ * ------------------------
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * Original Author:  Joris Kinable
+ * Contributor(s):   -
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 14-Jul-2016 : Initial revision;
+ */
+package org.jgrapht.graph;
+
+import org.jgrapht.EnhancedTestCase;
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.VertexFactory;
+import org.jgrapht.generate.CompleteGraphGenerator;
+
+import java.util.*;
+
+/**
+ * .
+ *
+ * @author Joris Kinable
+ */
+public class GraphWalkTest extends EnhancedTestCase {
+
+    private Graph<Integer, DefaultEdge> completeGraph;
+
+    public void setUp(){
+        VertexFactory<Integer> vertexFactory=new IntegerVertexFactory();
+        CompleteGraphGenerator<Integer, DefaultEdge> completeGraphGenerator=new CompleteGraphGenerator<>(5);
+        completeGraph=new SimpleGraph<>(DefaultEdge.class);
+        completeGraphGenerator.generateGraph(completeGraph, vertexFactory, new HashMap<>());
+    }
+
+    public void testEmptyPath(){
+        List<GraphPath<Integer, DefaultEdge>> paths=new ArrayList<>();
+        paths.add(new GraphWalk<>(completeGraph, null, null, Collections.emptyList(), 0));
+        paths.add(new GraphWalk<>(completeGraph, Collections.emptyList(), 0));
+        for(GraphPath<Integer, DefaultEdge> path : paths) {
+            assertEquals(0, path.getLength());
+            assertEquals(Collections.emptyList(), path.getVertexList());
+            assertEquals(Collections.emptyList(), path.getEdgeList());
+        }
+    }
+
+    public void testNonSimplePath(){
+        List<Integer> vertexList= Arrays.asList(0,1,2,3,2,3,4);
+        List<DefaultEdge> edgeList=new ArrayList<>();
+        for(int i=0; i<vertexList.size()-1; i++)
+            edgeList.add(completeGraph.getEdge(vertexList.get(i), vertexList.get(i+1)));
+        GraphPath<Integer, DefaultEdge> p1=new GraphWalk<>(completeGraph, 0, 4, edgeList, 10);
+        assertEquals(0, p1.getStartVertex().intValue());
+        assertEquals(4, p1.getEndVertex().intValue());
+        assertEquals(vertexList, p1.getVertexList());
+        assertEquals(edgeList.size(), p1.getLength());
+        assertEquals(10.0, p1.getWeight());
+
+        GraphPath<Integer, DefaultEdge> p2=new GraphWalk<>(completeGraph, vertexList, 10);
+        assertEquals(0, p2.getStartVertex().intValue());
+        assertEquals(4, p2.getEndVertex().intValue());
+        assertEquals(edgeList, p2.getEdgeList());
+        assertEquals(edgeList.size(), p2.getLength());
+        assertEquals(10.0, p2.getWeight());
+    }
+
+    private class IntegerVertexFactory implements VertexFactory<Integer>{
+        int count;
+
+        @Override
+        public Integer createVertex() {
+            return count++;
+        }
+    }
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleGraphPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleGraphPathTest.java
@@ -40,6 +40,9 @@ import java.util.*;
 
 import org.jgrapht.*;
 
+/**
+ * @deprecated The class SimpleGraphPath will be removed from jgrapht
+ */
 public class SimpleGraphPathTest
     extends EnhancedTestCase
 {


### PR DESCRIPTION
A path in a graph can be expressed both in terms of its vertices, and in terms of its edges. The original class GraphPath encoded a path solely in terms of its edges. In many applications however, you also need the path in terms of its vertices. To convert a GraphPath to a 'VertexPath', there was a 'hidden' method in the class Graphs (public static <V, E> List<V> getPathVertexList(GraphPath<V, E> path)). It seems more natural to include this method in the GraphPath interface itself.
Furthermore, a number of algorithms naturally produce a path as a vertex list (e.g. FloydWarshall). Originally, when the algorithm returned the path as a GraphPath, a conversion from a vertex list to an edge list was required. If the user then needed the path as a vertex list, he/she needed to convert the edge list back to a vertex list. This step is no longer necessary, thereby reducing computational overhead.

I've made the following changes to GraphPath:
1. A graph may now be expressed in terms of its edges, in terms of its vertices, or both.
2. GraphPath now has 2 methods: getEdgeList and getVertexList. If the path was originally specified in terms of its edges, then getVertexList will automatically convert the path to a vertex list. Similar for getEdgeList. Default methods for getEdgeList and getVertexList are provided, but any class implementing the GraphPath interface may provide more efficient methods.

Note: none of the changes I made will compromise any existing classes implementing the original GraphPath interface.