### PR TITLE
Random walk iterator

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
@@ -1,0 +1,308 @@
+package org.jgrapht.traverse;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.Graph;
+import org.jgrapht.event.EdgeTraversalEvent;
+import org.jgrapht.event.VertexTraversalEvent;
+import org.jgrapht.traverse.AbstractGraphIterator;
+
+/**
+ * 
+ * A <a href="https://en.wikipedia.org/wiki/Random_walk#Random_walk_on_graphs">random-walk</a> iterator
+ * for a directed and an undirected graph. At each step selected a randomly (uniformly distributed) 
+ * edge out of the current vertex edges (in case of directed graph - from the outgoing edges),
+ * and follows it to the next vertex.
+ * 
+ * In case a weighted walk is desired (and in case the graph is weighted), edges are selected with
+ * probability respective to its weight (out of the total weight of the edges).
+ * 
+ * Walk can be bounded (default {@code Double#POSITIVE_INFINITY} by number of steps. When the bound
+ * is reached the iterator is considered exhausted. Calling {@code next()} on exhausted iterator will
+ * throw {@code NoSuchElementException}.
+ * 
+ * In case a sink (i.e. no edges) vertex is reached, iterator will return null and consecutive calls
+ * to {@code next()} will throw {@code NoSuchElementException}.
+ * 
+ * For this iterator to work correctly the graph must not be
+ * modified during iteration. Currently there are no means to ensure that, nor to fail-fast. 
+ * The results of such modifications are undefined.
+ * 
+ * @author Assaf Mizrachi
+ *
+ * @param <V> vertex type
+ * @param <E> edge type
+ */
+public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
+	
+	private V currentVertex;
+	private final Graph<V, E> graph;
+	private final boolean isDirected;
+	private final boolean isWeighted;
+	private FlyweightVertexEvent<V> reusableVertexEvent;
+	private FlyweightEdgeEvent<V, E> reusableEdgeEvent;
+	private boolean sinkReached;
+	private double maxSteps;
+
+	/**
+     * Creates a new iterator for the specified graph. Iteration will start at
+     * the specified start vertex. If the specified start vertex is <code>
+     * null</code>, Iteration will start at an arbitrary graph vertex.
+     * Walk is un-weighted and bounded by {@code Double#POSITIVE_INFINITY} steps.
+     *
+     * @param graph the graph to be iterated.
+     * @param startVertex the vertex iteration to be started.
+     *
+     * @throws IllegalArgumentException if <code>g==null</code> or does not
+     * contain <code>startVertex</code>
+     */
+	public RandomWalkIterator(Graph<V, E> graph, V startVertex) {
+		this(graph, startVertex, true);
+	}
+	
+	/**
+     * Creates a new iterator for the specified graph. Iteration will start at
+     * the specified start vertex. If the specified start vertex is <code>
+     * null</code>, Iteration will start at an arbitrary graph vertex.
+     * Walk is bounded by {@code Double#POSITIVE_INFINITY} steps.
+     *
+     * @param graph the graph to be iterated.
+     * @param startVertex the vertex iteration to be started.
+     * @param isWeighted set to <code>true</code> if a weighted walk is desired.
+     *
+     * @throws IllegalArgumentException if <code>g==null</code> or does not
+     * contain <code>startVertex</code>
+     */
+	public RandomWalkIterator(Graph<V, E> graph, V startVertex, boolean isWeighted) {
+		this(graph, startVertex, isWeighted, Double.POSITIVE_INFINITY);
+	}
+	
+	/**
+     * Creates a new iterator for the specified graph. Iteration will start at
+     * the specified start vertex. If the specified start vertex is <code>
+     * null</code>, Iteration will start at an arbitrary graph vertex.
+     * Walk is bounded by the provided number steps.
+     *
+     * @param graph the graph to be iterated.
+     * @param startVertex the vertex iteration to be started.
+     * @param isWeighted set to <code>true</code> if a weighted walk is desired.
+     * @param maxSteps number of steps before walk is exhausted.
+     *
+     * @throws IllegalArgumentException if <code>g==null</code> or does not
+     * contain <code>startVertex</code>
+     */
+	public RandomWalkIterator(Graph<V, E> graph, V startVertex, boolean isWeighted, double maxSteps) {		
+		if (graph == null) {
+            throw new IllegalArgumentException("graph must not be null");
+        }
+		//do not cross components.
+		setCrossComponentTraversal(false);
+		this.graph = graph;
+		this.isWeighted = isWeighted;
+		this.maxSteps = maxSteps;
+		this.isDirected = graph instanceof DirectedGraph<?, ?>;
+		reusableEdgeEvent = new FlyweightEdgeEvent<V, E>(this, null);
+        reusableVertexEvent = new FlyweightVertexEvent<V>(this, null);
+        //select a random start vertex in case not provided.
+		if (startVertex == null) {
+			if (graph.vertexSet().size() > 0) {
+				currentVertex = graph.vertexSet().iterator().next();
+			}
+		} else if (graph.containsVertex(startVertex)){
+			currentVertex = startVertex;			
+		} else {
+			throw new IllegalArgumentException("graph must contain the start vertex");
+		}
+		sinkReached = false;
+	}
+
+	/**
+	 * Check if this walk is exhausted. Calling {@link #next()} on
+	 * exhausted iterator will throw {@link NoSuchElementException}.
+	 * 
+	 * @return <code>true</code>if this iterator is exhausted,
+	 * <code>false</code> otherwise.
+	 */
+	protected boolean isExhausted() {
+		return maxSteps == 0;
+	}
+	
+	/**
+     * Update data structures every time we see a vertex.
+     *
+     * @param vertex the vertex encountered
+     * @param edge the edge via which the vertex was encountered, or null if the
+     * vertex is a starting point
+     */
+	protected void encounterVertex(V vertex, E edge) {
+		maxSteps--;
+	}
+
+	/**
+     * @see java.util.Iterator#hasNext()
+     */
+	@Override
+	public boolean hasNext() {
+		return currentVertex != null && !isExhausted() &&
+				!sinkReached;
+	}
+
+	/**
+     * @see java.util.Iterator#next()
+     */
+	@Override
+	public V next() {
+		
+		if (!hasNext()) {
+			throw new NoSuchElementException();
+		}
+		
+		Set<E> potentialEdges;
+		if (isDirected) {
+			potentialEdges = ((DirectedGraph<V, E>) graph).outgoingEdgesOf(currentVertex);
+		} else{
+			potentialEdges = graph.edgesOf(currentVertex);
+		}
+		//randomly select an edge from the set of potential edges.
+		E nextEdge = drawEdge(potentialEdges);
+		if (nextEdge != null) {
+			V nextVertex;
+			if (isDirected) {
+				nextVertex = graph.getEdgeTarget(nextEdge);
+			} else {
+				nextVertex = graph.getEdgeTarget(nextEdge) != currentVertex ? 
+						graph.getEdgeTarget(nextEdge) : graph.getEdgeSource(nextEdge);
+			}		
+			encounterVertex(nextVertex, nextEdge);
+			fireEdgeTraversed(createEdgeTraversalEvent(nextEdge));
+			fireVertexTraversed(createVertexTraversalEvent(nextVertex));
+			currentVertex = nextVertex;
+			return nextVertex;
+		} else {
+			sinkReached = true;
+			return currentVertex;
+		}
+	}
+	
+	/**
+	 * Randomly draws an edges out of the provided set. In case of un-weighted walk,
+	 * edge will be selected with uniform distribution across all outgoing edges.
+	 * In case of a weighted walk, edge will be selected with probability respective
+	 * to its weight across all outgoing edges.
+	 *   
+	 * @param edges the set to select the edge from
+	 * @return the drawn edges or null if set is empty.
+	 */
+	private E drawEdge(Set<E> edges) {
+		if (edges.isEmpty()) {
+			return null;
+		}
+		
+		int drawn;
+		List<E> list = new ArrayList<E>(edges);		
+		//TODO check if correct
+		if (isWeighted) {
+			Iterator<E> safeIter = list.iterator();
+			double border = Math.random() * getTotalWeight(list);
+			double d = 0;
+			drawn = -1;
+			do {
+				d += graph.getEdgeWeight(safeIter.next());
+				drawn++;
+				//TODO check if < is correct
+			} while (d < border);
+		} else {
+			drawn = (int) Math.floor(Math.random() * list.size());
+		}
+		return list.get(drawn);
+	}
+
+	private EdgeTraversalEvent<E> createEdgeTraversalEvent(E edge) {
+		if (isReuseEvents()) {
+			reusableEdgeEvent.setEdge(edge);
+
+			return reusableEdgeEvent;
+		} else {
+			return new EdgeTraversalEvent<E>(this, edge);
+		}
+	}
+
+	private VertexTraversalEvent<V> createVertexTraversalEvent(V vertex) {
+		if (isReuseEvents()) {
+			reusableVertexEvent.setVertex(vertex);
+
+			return reusableVertexEvent;
+		} else {
+			return new VertexTraversalEvent<V>(this, vertex);
+		}
+	}	
+	
+	private double getTotalWeight(Collection<E> edges) {
+		double total = 0;
+		for (E e : edges) {
+			total += graph.getEdgeWeight(e);
+		}
+		return total;
+	}
+	
+	/**
+     * A reusable vertex event.
+     *
+     * @author Barak Naveh
+     * @since Aug 11, 2003
+     */
+    static class FlyweightVertexEvent<VV> extends VertexTraversalEvent<VV> {
+		private static final long serialVersionUID = 3834024753848399924L;
+
+		/**
+		 * @see VertexTraversalEvent#VertexTraversalEvent(Object, Object)
+		 */
+		public FlyweightVertexEvent(Object eventSource, VV vertex) {
+			super(eventSource, vertex);
+		}
+
+		/**
+		 * Sets the vertex of this event.
+		 * 
+		 * @param vertex
+		 *            the vertex to be set.
+		 */
+		protected void setVertex(VV vertex) {
+			this.vertex = vertex;
+		}
+	}
+    
+    /**
+	 * A reusable edge event.
+	 * 
+	 * @author Barak Naveh
+	 * @since Aug 11, 2003
+	 */
+    static class FlyweightEdgeEvent<VV, localE> extends
+			EdgeTraversalEvent<localE> {
+		private static final long serialVersionUID = 4051327833765000755L;
+
+		/**
+		 * @see EdgeTraversalEvent#EdgeTraversalEvent(Object, Edge)
+		 */
+		public FlyweightEdgeEvent(Object eventSource, localE edge) {
+			super(eventSource, edge);
+		}
+
+		/**
+		 * Sets the edge of this event.
+		 * 
+		 * @param edge
+		 *            the edge to be set.
+		 */
+		protected void setEdge(localE edge) {
+			this.edge = edge;
+		}
+	}	
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
@@ -49,6 +49,20 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
 	private FlyweightEdgeEvent<V, E> reusableEdgeEvent;
 	private boolean sinkReached;
 	private double maxSteps;
+	
+	/**
+     * Creates a new iterator for the specified graph. Iteration will start at
+     * arbitrary vertex.
+     * Walk is un-weighted and bounded by {@code Double#POSITIVE_INFINITY} steps.
+     *
+     * @param graph the graph to be iterated.
+     *
+     * @throws IllegalArgumentException if <code>graph==null</code> or does not
+     * contain <code>startVertex</code>
+     */
+	public RandomWalkIterator(Graph<V, E> graph) {
+		this(graph, null);
+	}
 
 	/**
      * Creates a new iterator for the specified graph. Iteration will start at
@@ -59,7 +73,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
      * @param graph the graph to be iterated.
      * @param startVertex the vertex iteration to be started.
      *
-     * @throws IllegalArgumentException if <code>g==null</code> or does not
+     * @throws IllegalArgumentException if <code>graph==null</code> or does not
      * contain <code>startVertex</code>
      */
 	public RandomWalkIterator(Graph<V, E> graph, V startVertex) {
@@ -76,7 +90,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
      * @param startVertex the vertex iteration to be started.
      * @param isWeighted set to <code>true</code> if a weighted walk is desired.
      *
-     * @throws IllegalArgumentException if <code>g==null</code> or does not
+     * @throws IllegalArgumentException if <code>graph==null</code> or does not
      * contain <code>startVertex</code>
      */
 	public RandomWalkIterator(Graph<V, E> graph, V startVertex, boolean isWeighted) {
@@ -94,7 +108,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
      * @param isWeighted set to <code>true</code> if a weighted walk is desired.
      * @param maxSteps number of steps before walk is exhausted.
      *
-     * @throws IllegalArgumentException if <code>g==null</code> or does not
+     * @throws IllegalArgumentException if <code>graph==null</code> or does not
      * contain <code>startVertex</code>
      */
 	public RandomWalkIterator(Graph<V, E> graph, V startVertex, boolean isWeighted, double maxSteps) {		

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
@@ -1,3 +1,38 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2016, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* ----------------
+ * RandomWalkIterator.java
+ * ----------------
+ * (C) Copyright 2016-, by Assaf Mizrachi and Contributors.
+ *
+ * Original Author:  Assaf Mizrachi
+ * Contributor(s):   
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ *
+ */
 package org.jgrapht.traverse;
 
 import java.util.ArrayList;
@@ -219,8 +254,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
 		}
 		
 		int drawn;
-		List<E> list = new ArrayList<E>(edges);		
-		//TODO check if correct
+		List<E> list = new ArrayList<E>(edges);
 		if (isWeighted) {
 			Iterator<E> safeIter = list.iterator();
 			double border = Math.random() * getTotalWeight(list);
@@ -229,7 +263,6 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
 			do {
 				d += graph.getEdgeWeight(safeIter.next());
 				drawn++;
-				//TODO check if < is correct
 			} while (d < border);
 		} else {
 			drawn = (int) Math.floor(Math.random() * list.size());

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
@@ -40,6 +40,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Random;
 import java.util.Set;
 
 import org.jgrapht.DirectedGraph;
@@ -58,7 +59,7 @@ import org.jgrapht.traverse.AbstractGraphIterator;
  * In case a weighted walk is desired (and in case the graph is weighted), edges are selected with
  * probability respective to its weight (out of the total weight of the edges).
  * 
- * Walk can be bounded (default {@code Double#POSITIVE_INFINITY} by number of steps. When the bound
+ * Walk can be bounded by number of steps (default {@code Long#MAX_VALUE} . When the bound
  * is reached the iterator is considered exhausted. Calling {@code next()} on exhausted iterator will
  * throw {@code NoSuchElementException}.
  * 
@@ -84,11 +85,12 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
 	private FlyweightEdgeEvent<V, E> reusableEdgeEvent;
 	private boolean sinkReached;
 	private long maxSteps;
+	private Random random;
 	
 	/**
      * Creates a new iterator for the specified graph. Iteration will start at
      * arbitrary vertex.
-     * Walk is un-weighted and bounded by {@code Double#POSITIVE_INFINITY} steps.
+     * Walk is un-weighted and bounded by {@code Long#MAX_VALUE} steps.
      *
      * @param graph the graph to be iterated.
      *
@@ -103,7 +105,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
      * Creates a new iterator for the specified graph. Iteration will start at
      * the specified start vertex. If the specified start vertex is <code>
      * null</code>, Iteration will start at an arbitrary graph vertex.
-     * Walk is un-weighted and bounded by {@code Double#POSITIVE_INFINITY} steps.
+     * Walk is un-weighted and bounded by {@code Long#MAX_VALUE} steps.
      *
      * @param graph the graph to be iterated.
      * @param startVertex the vertex iteration to be started.
@@ -119,7 +121,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
      * Creates a new iterator for the specified graph. Iteration will start at
      * the specified start vertex. If the specified start vertex is <code>
      * null</code>, Iteration will start at an arbitrary graph vertex.
-     * Walk is bounded by {@code Double#POSITIVE_INFINITY} steps.
+     * Walk is bounded by {@code Long#MAX_VALUE} steps.
      *
      * @param graph the graph to be iterated.
      * @param startVertex the vertex iteration to be started.
@@ -169,6 +171,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
 			throw new IllegalArgumentException("graph must contain the start vertex");
 		}
 		sinkReached = false;
+		random = new Random();
 	}
 
 	/**
@@ -257,7 +260,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
 		List<E> list = new ArrayList<E>(edges);
 		if (isWeighted) {
 			Iterator<E> safeIter = list.iterator();
-			double border = Math.random() * getTotalWeight(list);
+			double border = random.nextDouble() * getTotalWeight(list);
 			double d = 0;
 			drawn = -1;
 			do {
@@ -265,7 +268,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
 				drawn++;
 			} while (d < border);
 		} else {
-			drawn = (int) Math.floor(Math.random() * list.size());
+			drawn = random.nextInt(list.size());
 		}
 		return list.get(drawn);
 	}

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
@@ -75,15 +75,15 @@ import org.jgrapht.event.VertexTraversalEvent;
  * @param <E> edge type
  */
 public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
-	
-	private V currentVertex;
-	private final Graph<V, E> graph;
-	private final boolean isWeighted;
-	private boolean sinkReached;
-	private long maxSteps;
-	private Random random;
-	
-	/**
+    
+    private V currentVertex;
+    private final Graph<V, E> graph;
+    private final boolean isWeighted;
+    private boolean sinkReached;
+    private long maxSteps;
+    private Random random;
+    
+    /**
      * Creates a new iterator for the specified graph. Iteration will start at
      * arbitrary vertex.
      * Walk is un-weighted and bounded by {@code Long#MAX_VALUE} steps.
@@ -93,11 +93,11 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
      * @throws IllegalArgumentException if <code>graph==null</code> or does not
      * contain <code>startVertex</code>
      */
-	public RandomWalkIterator(Graph<V, E> graph) {
-		this(graph, null);
-	}
+    public RandomWalkIterator(Graph<V, E> graph) {
+        this(graph, null);
+    }
 
-	/**
+    /**
      * Creates a new iterator for the specified graph. Iteration will start at
      * the specified start vertex. If the specified start vertex is <code>
      * null</code>, Iteration will start at an arbitrary graph vertex.
@@ -109,11 +109,11 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
      * @throws IllegalArgumentException if <code>graph==null</code> or does not
      * contain <code>startVertex</code>
      */
-	public RandomWalkIterator(Graph<V, E> graph, V startVertex) {
-		this(graph, startVertex, true);
-	}
-	
-	/**
+    public RandomWalkIterator(Graph<V, E> graph, V startVertex) {
+        this(graph, startVertex, true);
+    }
+    
+    /**
      * Creates a new iterator for the specified graph. Iteration will start at
      * the specified start vertex. If the specified start vertex is <code>
      * null</code>, Iteration will start at an arbitrary graph vertex.
@@ -126,11 +126,11 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
      * @throws IllegalArgumentException if <code>graph==null</code> or does not
      * contain <code>startVertex</code>
      */
-	public RandomWalkIterator(Graph<V, E> graph, V startVertex, boolean isWeighted) {
-		this(graph, startVertex, isWeighted, Long.MAX_VALUE);
-	}
-	
-	/**
+    public RandomWalkIterator(Graph<V, E> graph, V startVertex, boolean isWeighted) {
+        this(graph, startVertex, isWeighted, Long.MAX_VALUE);
+    }
+    
+    /**
      * Creates a new iterator for the specified graph. Iteration will start at
      * the specified start vertex. If the specified start vertex is <code>
      * null</code>, Iteration will start at an arbitrary graph vertex.
@@ -144,145 +144,145 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
      * @throws IllegalArgumentException if <code>graph==null</code> or does not
      * contain <code>startVertex</code>
      */
-	public RandomWalkIterator(Graph<V, E> graph, V startVertex, boolean isWeighted, long maxSteps) {		
-		if (graph == null) {
+    public RandomWalkIterator(Graph<V, E> graph, V startVertex, boolean isWeighted, long maxSteps) {        
+        if (graph == null) {
             throw new IllegalArgumentException("graph must not be null");
         }
-		//do not cross components.
-		setCrossComponentTraversal(false);
-		this.graph = graph;
-		this.isWeighted = isWeighted;
-		this.maxSteps = maxSteps;
-		this.specifics = createGraphSpecifics(graph);
+        //do not cross components.
+        setCrossComponentTraversal(false);
+        this.graph = graph;
+        this.isWeighted = isWeighted;
+        this.maxSteps = maxSteps;
+        this.specifics = createGraphSpecifics(graph);
         //select a random start vertex in case not provided.
-		if (startVertex == null) {
-			if (graph.vertexSet().size() > 0) {
-				currentVertex = graph.vertexSet().iterator().next();
-			}
-		} else if (graph.containsVertex(startVertex)){
-			currentVertex = startVertex;			
-		} else {
-			throw new IllegalArgumentException("graph must contain the start vertex");
-		}
-		this.sinkReached = false;
-		this.random = new Random();
-	}
+        if (startVertex == null) {
+            if (graph.vertexSet().size() > 0) {
+                currentVertex = graph.vertexSet().iterator().next();
+            }
+        } else if (graph.containsVertex(startVertex)){
+            currentVertex = startVertex;            
+        } else {
+            throw new IllegalArgumentException("graph must contain the start vertex");
+        }
+        this.sinkReached = false;
+        this.random = new Random();
+    }
 
-	/**
-	 * Check if this walk is exhausted. Calling {@link #next()} on
-	 * exhausted iterator will throw {@link NoSuchElementException}.
-	 * 
-	 * @return <code>true</code>if this iterator is exhausted,
-	 * <code>false</code> otherwise.
-	 */
-	protected boolean isExhausted() {
-		return maxSteps == 0;
-	}
-	
-	/**
+    /**
+     * Check if this walk is exhausted. Calling {@link #next()} on
+     * exhausted iterator will throw {@link NoSuchElementException}.
+     * 
+     * @return <code>true</code>if this iterator is exhausted,
+     * <code>false</code> otherwise.
+     */
+    protected boolean isExhausted() {
+        return maxSteps == 0;
+    }
+    
+    /**
      * Update data structures every time we see a vertex.
      *
      * @param vertex the vertex encountered
      * @param edge the edge via which the vertex was encountered, or null if the
      * vertex is a starting point
      */
-	protected void encounterVertex(V vertex, E edge) {
-		maxSteps--;
-	}
+    protected void encounterVertex(V vertex, E edge) {
+        maxSteps--;
+    }
 
-	/**
+    /**
      * @see java.util.Iterator#hasNext()
      */
-	@Override
-	public boolean hasNext() {
-		return currentVertex != null && !isExhausted() &&
-				!sinkReached;
-	}
+    @Override
+    public boolean hasNext() {
+        return currentVertex != null && !isExhausted() &&
+                !sinkReached;
+    }
 
-	/**
+    /**
      * @see java.util.Iterator#next()
      */
-	@Override
-	public V next() {
-		
-		if (!hasNext()) {
-			throw new NoSuchElementException();
-		}
-		
-		Set<? extends E> potentialEdges = specifics.edgesOf(currentVertex);
-		
-		//randomly select an edge from the set of potential edges.
-		E nextEdge = drawEdge(potentialEdges);
-		if (nextEdge != null) {
-			V nextVertex;
-			nextVertex = Graphs.getOppositeVertex(graph, nextEdge, currentVertex);
-			encounterVertex(nextVertex, nextEdge);
-			fireEdgeTraversed(createEdgeTraversalEvent(nextEdge));
-			fireVertexTraversed(createVertexTraversalEvent(nextVertex));
-			currentVertex = nextVertex;
-			return nextVertex;
-		} else {
-			sinkReached = true;
-			return currentVertex;
-		}
-	}
-	
-	/**
-	 * Randomly draws an edges out of the provided set. In case of un-weighted walk,
-	 * edge will be selected with uniform distribution across all outgoing edges.
-	 * In case of a weighted walk, edge will be selected with probability respective
-	 * to its weight across all outgoing edges.
-	 *   
-	 * @param edges the set to select the edge from
-	 * @return the drawn edges or null if set is empty.
-	 */
-	private E drawEdge(Set<? extends E> edges) {
-		if (edges.isEmpty()) {
-			return null;
-		}
-		
-		int drawn;
-		List<E> list = new ArrayList<E>(edges);
-		if (isWeighted) {
-			Iterator<E> safeIter = list.iterator();
-			double border = random.nextDouble() * getTotalWeight(list);
-			double d = 0;
-			drawn = -1;
-			do {
-				d += graph.getEdgeWeight(safeIter.next());
-				drawn++;
-			} while (d < border);
-		} else {
-			drawn = random.nextInt(list.size());
-		}
-		return list.get(drawn);
-	}
+    @Override
+    public V next() {
+        
+        if (!hasNext()) {
+            throw new NoSuchElementException();
+        }
+        
+        Set<? extends E> potentialEdges = specifics.edgesOf(currentVertex);
+        
+        //randomly select an edge from the set of potential edges.
+        E nextEdge = drawEdge(potentialEdges);
+        if (nextEdge != null) {
+            V nextVertex;
+            nextVertex = Graphs.getOppositeVertex(graph, nextEdge, currentVertex);
+            encounterVertex(nextVertex, nextEdge);
+            fireEdgeTraversed(createEdgeTraversalEvent(nextEdge));
+            fireVertexTraversed(createVertexTraversalEvent(nextVertex));
+            currentVertex = nextVertex;
+            return nextVertex;
+        } else {
+            sinkReached = true;
+            return currentVertex;
+        }
+    }
+    
+    /**
+     * Randomly draws an edges out of the provided set. In case of un-weighted walk,
+     * edge will be selected with uniform distribution across all outgoing edges.
+     * In case of a weighted walk, edge will be selected with probability respective
+     * to its weight across all outgoing edges.
+     *   
+     * @param edges the set to select the edge from
+     * @return the drawn edges or null if set is empty.
+     */
+    private E drawEdge(Set<? extends E> edges) {
+        if (edges.isEmpty()) {
+            return null;
+        }
+        
+        int drawn;
+        List<E> list = new ArrayList<E>(edges);
+        if (isWeighted) {
+            Iterator<E> safeIter = list.iterator();
+            double border = random.nextDouble() * getTotalWeight(list);
+            double d = 0;
+            drawn = -1;
+            do {
+                d += graph.getEdgeWeight(safeIter.next());
+                drawn++;
+            } while (d < border);
+        } else {
+            drawn = random.nextInt(list.size());
+        }
+        return list.get(drawn);
+    }
 
-	private EdgeTraversalEvent<E> createEdgeTraversalEvent(E edge) {
-		if (isReuseEvents()) {
-			reusableEdgeEvent.setEdge(edge);
+    private EdgeTraversalEvent<E> createEdgeTraversalEvent(E edge) {
+        if (isReuseEvents()) {
+            reusableEdgeEvent.setEdge(edge);
 
-			return reusableEdgeEvent;
-		} else {
-			return new EdgeTraversalEvent<E>(this, edge);
-		}
-	}
+            return reusableEdgeEvent;
+        } else {
+            return new EdgeTraversalEvent<E>(this, edge);
+        }
+    }
 
-	private VertexTraversalEvent<V> createVertexTraversalEvent(V vertex) {
-		if (isReuseEvents()) {
-			reusableVertexEvent.setVertex(vertex);
+    private VertexTraversalEvent<V> createVertexTraversalEvent(V vertex) {
+        if (isReuseEvents()) {
+            reusableVertexEvent.setVertex(vertex);
 
-			return reusableVertexEvent;
-		} else {
-			return new VertexTraversalEvent<V>(this, vertex);
-		}
-	}	
-	
-	private double getTotalWeight(Collection<E> edges) {
-		double total = 0;
-		for (E e : edges) {
-			total += graph.getEdgeWeight(e);
-		}
-		return total;
-	}
+            return reusableVertexEvent;
+        } else {
+            return new VertexTraversalEvent<V>(this, vertex);
+        }
+    }    
+    
+    private double getTotalWeight(Collection<E> edges) {
+        double total = 0;
+        for (E e : edges) {
+            total += graph.getEdgeWeight(e);
+        }
+        return total;
+    }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/RandomWalkIterator.java
@@ -83,7 +83,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
 	private FlyweightVertexEvent<V> reusableVertexEvent;
 	private FlyweightEdgeEvent<V, E> reusableEdgeEvent;
 	private boolean sinkReached;
-	private double maxSteps;
+	private long maxSteps;
 	
 	/**
      * Creates a new iterator for the specified graph. Iteration will start at
@@ -129,7 +129,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
      * contain <code>startVertex</code>
      */
 	public RandomWalkIterator(Graph<V, E> graph, V startVertex, boolean isWeighted) {
-		this(graph, startVertex, isWeighted, Double.POSITIVE_INFINITY);
+		this(graph, startVertex, isWeighted, Long.MAX_VALUE);
 	}
 	
 	/**
@@ -146,7 +146,7 @@ public class RandomWalkIterator<V, E> extends AbstractGraphIterator<V, E> {
      * @throws IllegalArgumentException if <code>graph==null</code> or does not
      * contain <code>startVertex</code>
      */
-	public RandomWalkIterator(Graph<V, E> graph, V startVertex, boolean isWeighted, double maxSteps) {		
+	public RandomWalkIterator(Graph<V, E> graph, V startVertex, boolean isWeighted, long maxSteps) {		
 		if (graph == null) {
             throw new IllegalArgumentException("graph must not be null");
         }

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/RandomWalkIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/RandomWalkIteratorTest.java
@@ -6,15 +6,22 @@ import org.jgrapht.DirectedGraph;
 import org.jgrapht.EnhancedTestCase;
 import org.jgrapht.UndirectedGraph;
 import org.jgrapht.VertexFactory;
+import org.jgrapht.generate.LinearGraphGenerator;
 import org.jgrapht.generate.RingGraphGenerator;
 import org.jgrapht.graph.DefaultDirectedGraph;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.SimpleGraph;
 
+/**
+ * Tests for the {@link RandomWalkIterator} class.
+ * 
+ * @author Assaf Mizrachi
+ *
+ */
 public class RandomWalkIteratorTest extends EnhancedTestCase {
 
 	/**
-	 * 
+	 * Tests empty graph
 	 */
 	public void testEmptyGraph() {
 		DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
@@ -23,9 +30,9 @@ public class RandomWalkIteratorTest extends EnhancedTestCase {
 	}
 	
 	/**
-	 * 
+	 * Tests single node graph
 	 */
-	public void testSink() {
+	public void testSingleNode() {
 		DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);		
 		graph.addVertex("123");
 		Iterator<String> iter = new RandomWalkIterator<>(graph);
@@ -35,7 +42,29 @@ public class RandomWalkIteratorTest extends EnhancedTestCase {
 	}
 	
 	/**
-	 * 
+	 * Tests iterator does not have more elements after reaching sink vertex.
+	 */
+	public void testSink() {
+		DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);	
+		int graphSize = 10;
+		LinearGraphGenerator<String, DefaultEdge> graphGenerator = new LinearGraphGenerator<>(graphSize);
+		graphGenerator.generateGraph(graph, new VertexFactory<String>() {
+			private int index = 1;
+			@Override
+			public String createVertex() {
+				return String.valueOf(index++);
+			}
+		}, null);
+		Iterator<String> iter = new RandomWalkIterator<>(graph);
+		for (int i = 0; i < graphSize; i++) {
+			assertTrue(iter.hasNext());
+			assertNotNull(iter.next());
+		}
+		assertFalse(iter.hasNext());
+	}	
+	
+	/**
+	 * Tests iterator is exhausted after maxSteps
 	 */
 	public void testExhausted() {
 		UndirectedGraph<String, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
@@ -58,7 +87,7 @@ public class RandomWalkIteratorTest extends EnhancedTestCase {
 	}
 	
 	/**
-	 * 
+	 * Test deterministic walk using directed ring graph.
 	 */
 	public void testDeterministic() {
 		DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);	
@@ -78,4 +107,5 @@ public class RandomWalkIteratorTest extends EnhancedTestCase {
 			assertEquals(String.valueOf(step % ringSize), iter.next());
 		}
 	}
+	
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/RandomWalkIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/RandomWalkIteratorTest.java
@@ -1,0 +1,81 @@
+package org.jgrapht.traverse;
+
+import java.util.Iterator;
+
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.EnhancedTestCase;
+import org.jgrapht.UndirectedGraph;
+import org.jgrapht.VertexFactory;
+import org.jgrapht.generate.RingGraphGenerator;
+import org.jgrapht.graph.DefaultDirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.SimpleGraph;
+
+public class RandomWalkIteratorTest extends EnhancedTestCase {
+
+	/**
+	 * 
+	 */
+	public void testEmptyGraph() {
+		DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+		Iterator<String> iter = new RandomWalkIterator<>(graph);
+		assertFalse(iter.hasNext());
+	}
+	
+	/**
+	 * 
+	 */
+	public void testSink() {
+		DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);		
+		graph.addVertex("123");
+		Iterator<String> iter = new RandomWalkIterator<>(graph);
+		assertTrue(iter.hasNext());
+		assertEquals("123", iter.next());
+		assertFalse(iter.hasNext());
+	}
+	
+	/**
+	 * 
+	 */
+	public void testExhausted() {
+		UndirectedGraph<String, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
+		RingGraphGenerator<String, DefaultEdge> graphGenerator = new RingGraphGenerator<>(10);
+		graphGenerator.generateGraph(graph, new VertexFactory<String>() {
+			private int index = 1;
+			@Override
+			public String createVertex() {
+				return String.valueOf(index++);
+			}
+		}, null);
+		
+		int maxSteps = 4;
+		Iterator<String> iter = new RandomWalkIterator<>(graph, "1", false, maxSteps);
+		for (int i = 0; i < maxSteps; i++) {
+			assertTrue(iter.hasNext());
+			assertNotNull(iter.next());
+		}
+		assertFalse(iter.hasNext());
+	}
+	
+	/**
+	 * 
+	 */
+	public void testDeterministic() {
+		DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);	
+		int ringSize = 5;
+		RingGraphGenerator<String, DefaultEdge> graphGenerator = new RingGraphGenerator<>(ringSize);
+		graphGenerator.generateGraph(graph, new VertexFactory<String>() {
+			private int index = 0;
+			@Override
+			public String createVertex() {
+				return String.valueOf(index++);
+			}
+		}, null);
+		Iterator<String> iter = new RandomWalkIterator<>(graph, "0", false, 20);
+		int step = 0;
+		while(iter.hasNext()) {
+			step++;
+			assertEquals(String.valueOf(step % ringSize), iter.next());
+		}
+	}
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/RandomWalkIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/RandomWalkIteratorTest.java
@@ -55,92 +55,92 @@ import org.jgrapht.graph.SimpleGraph;
  */
 public class RandomWalkIteratorTest extends EnhancedTestCase {
 
-	/**
-	 * Tests empty graph
-	 */
-	public void testEmptyGraph() {
-		DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
-		Iterator<String> iter = new RandomWalkIterator<>(graph);
-		assertFalse(iter.hasNext());
-	}
-	
-	/**
-	 * Tests single node graph
-	 */
-	public void testSingleNode() {
-		DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);		
-		graph.addVertex("123");
-		Iterator<String> iter = new RandomWalkIterator<>(graph);
-		assertTrue(iter.hasNext());
-		assertEquals("123", iter.next());
-		assertFalse(iter.hasNext());
-	}
-	
-	/**
-	 * Tests iterator does not have more elements after reaching sink vertex.
-	 */
-	public void testSink() {
-		DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);	
-		int graphSize = 10;
-		LinearGraphGenerator<String, DefaultEdge> graphGenerator = new LinearGraphGenerator<>(graphSize);
-		graphGenerator.generateGraph(graph, new VertexFactory<String>() {
-			private int index = 1;
-			@Override
-			public String createVertex() {
-				return String.valueOf(index++);
-			}
-		}, null);
-		Iterator<String> iter = new RandomWalkIterator<>(graph);
-		for (int i = 0; i < graphSize; i++) {
-			assertTrue(iter.hasNext());
-			assertNotNull(iter.next());
-		}
-		assertFalse(iter.hasNext());
-	}	
-	
-	/**
-	 * Tests iterator is exhausted after maxSteps
-	 */
-	public void testExhausted() {
-		UndirectedGraph<String, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
-		RingGraphGenerator<String, DefaultEdge> graphGenerator = new RingGraphGenerator<>(10);
-		graphGenerator.generateGraph(graph, new VertexFactory<String>() {
-			private int index = 1;
-			@Override
-			public String createVertex() {
-				return String.valueOf(index++);
-			}
-		}, null);
-		
-		int maxSteps = 4;
-		Iterator<String> iter = new RandomWalkIterator<>(graph, "1", false, maxSteps);
-		for (int i = 0; i < maxSteps; i++) {
-			assertTrue(iter.hasNext());
-			assertNotNull(iter.next());
-		}
-		assertFalse(iter.hasNext());
-	}
-	
-	/**
-	 * Test deterministic walk using directed ring graph.
-	 */
-	public void testDeterministic() {
-		DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);	
-		int ringSize = 5;
-		RingGraphGenerator<String, DefaultEdge> graphGenerator = new RingGraphGenerator<>(ringSize);
-		graphGenerator.generateGraph(graph, new VertexFactory<String>() {
-			private int index = 0;
-			@Override
-			public String createVertex() {
-				return String.valueOf(index++);
-			}
-		}, null);
-		Iterator<String> iter = new RandomWalkIterator<>(graph, "0", false, 20);
-		int step = 0;
-		while(iter.hasNext()) {
-			step++;
-			assertEquals(String.valueOf(step % ringSize), iter.next());
-		}
-	}
-	
+    /**
+     * Tests empty graph
+     */
+    public void testEmptyGraph() { 
+        DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        Iterator<String> iter = new RandomWalkIterator<>(graph);
+        assertFalse(iter.hasNext());
+    }
+    
+    /**
+     * Tests single node graph
+     */
+    public void testSingleNode() {
+        DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);        
+        graph.addVertex("123");
+        Iterator<String> iter = new RandomWalkIterator<>(graph);
+        assertTrue(iter.hasNext());
+        assertEquals("123", iter.next());
+        assertFalse(iter.hasNext());
+    }
+    
+    /**
+     * Tests iterator does not have more elements after reaching sink vertex.
+     */
+    public void testSink() {
+        DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);    
+        int graphSize = 10;
+        LinearGraphGenerator<String, DefaultEdge> graphGenerator = new LinearGraphGenerator<>(graphSize);
+        graphGenerator.generateGraph(graph, new VertexFactory<String>() {
+            private int index = 1;
+            @Override
+            public String createVertex() {
+                return String.valueOf(index++);
+            }
+        }, null);
+        Iterator<String> iter = new RandomWalkIterator<>(graph);
+        for (int i = 0; i < graphSize; i++) {
+            assertTrue(iter.hasNext());
+            assertNotNull(iter.next());
+        }
+        assertFalse(iter.hasNext());
+    }    
+    
+    /**
+     * Tests iterator is exhausted after maxSteps
+     */
+    public void testExhausted() {
+        UndirectedGraph<String, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
+        RingGraphGenerator<String, DefaultEdge> graphGenerator = new RingGraphGenerator<>(10);
+        graphGenerator.generateGraph(graph, new VertexFactory<String>() {
+            private int index = 1;
+            @Override
+            public String createVertex() {
+                return String.valueOf(index++);
+            }
+        }, null);
+        
+        int maxSteps = 4;
+        Iterator<String> iter = new RandomWalkIterator<>(graph, "1", false, maxSteps);
+        for (int i = 0; i < maxSteps; i++) {
+            assertTrue(iter.hasNext());
+            assertNotNull(iter.next());
+        }
+        assertFalse(iter.hasNext());
+    }
+    
+    /**
+     * Test deterministic walk using directed ring graph.
+     */
+    public void testDeterministic() {
+        DirectedGraph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);    
+        int ringSize = 5;
+        RingGraphGenerator<String, DefaultEdge> graphGenerator = new RingGraphGenerator<>(ringSize);
+        graphGenerator.generateGraph(graph, new VertexFactory<String>() {
+            private int index = 0;
+            @Override
+            public String createVertex() {
+                return String.valueOf(index++);
+            }
+        }, null);
+        Iterator<String> iter = new RandomWalkIterator<>(graph, "0", false, 20);
+        int step = 0;
+        while(iter.hasNext()) {
+            step++;
+            assertEquals(String.valueOf(step % ringSize), iter.next());
+        }
+    }
+    
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/RandomWalkIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/RandomWalkIteratorTest.java
@@ -1,3 +1,38 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2016, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* ----------------
+ * RandomWalkIteratorTest.java
+ * ----------------
+ * (C) Copyright 2016-, by Assaf Mizrachi and Contributors.
+ *
+ * Original Author:  Assaf Mizrachi
+ * Contributor(s):   
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ *
+ */
 package org.jgrapht.traverse;
 
 import java.util.Iterator;


### PR DESCRIPTION
Random walk on graphs are a matter of interest in the past years and are used at several research fields (for example, Markov Process). A random walk on graph starts at a specified or random vertex. At each step, an edge is randomly chosen from the list of outgoing edges of the vertex and traversed to the opposite vertex. In case the graph is weighted, the probability to draw an edge can be with respect to its weight compared to the total weight of all out going edges of the current vertex. When the walk reaches a sink (i.e. no outgoing edges) vertex it can not proceed further.

I have implemented a `RandomWalkGraphIterator` which is following the principles of random walk on graph given above. It is able to work in a weighted and unweighted modes, can be configured with maximum steps (after that it is considered as exhausted), and can start from a specified or random vertex.