### PR TITLE
Weighted graphs support in GmlExporter

### DIFF
--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
@@ -24,7 +24,7 @@
  * ------------------
  * (C) Copyright 2006, by Dimitrios Michail.
  *
- * Original Author:  Dimitrios Michail <dmichail@yahoo.com>
+ * Original Author:  Dimitrios Michail <dimitrios.michail@gmail.com>
  *
  * $Id$
  *
@@ -41,7 +41,7 @@ import org.jgrapht.*;
 
 
 /**
- * Exports a graph into a GML file (Graph Modelling Language).
+ * Exports a graph into a GML file (Graph Modeling Language).
  *
  * <p>For a description of the format see <a
  * href="http://www.infosun.fmi.uni-passau.de/Graphlet/GML/">
@@ -56,12 +56,12 @@ import org.jgrapht.*;
  */
 public class GmlExporter<V, E>
 {
-    private static final String creator = "JGraphT GML Exporter";
-    private static final String version = "1";
+    private static final String CREATOR = "JGraphT GML Exporter";
+    private static final String VERSION = "1";
 
-    private static final String delim = " ";
-    private static final String tab1 = "\t";
-    private static final String tab2 = "\t\t";
+    private static final String DELIM = " ";
+    private static final String TAB1 = "\t";
+    private static final String TAB2 = "\t\t";
 
     // TODO jvs 27-Jan-2008:  convert these to enum
 
@@ -86,6 +86,11 @@ public class GmlExporter<V, E>
     public static final Integer PRINT_VERTEX_LABELS = 4;
 
     private Integer printLabels = PRINT_NO_LABELS;
+    
+    /**
+     * Whether to print edge weights in case the graph is weighted.
+     */
+    private boolean exportEdgeWeights = false;
 
     private VertexNameProvider<V> vertexIDProvider;
     private VertexNameProvider<V> vertexLabelProvider;
@@ -136,8 +141,8 @@ public class GmlExporter<V, E>
 
     private void exportHeader(PrintWriter out)
     {
-        out.println("Creator" + delim + quoted(creator));
-        out.println("Version" + delim + version);
+        out.println("Creator" + DELIM + quoted(CREATOR));
+        out.println("Version" + DELIM + VERSION);
     }
 
     private void exportVertices(
@@ -145,19 +150,19 @@ public class GmlExporter<V, E>
         Graph<V, E> g)
     {
         for (V from : g.vertexSet()) {
-            out.println(tab1 + "node");
-            out.println(tab1 + "[");
+            out.println(TAB1 + "node");
+            out.println(TAB1 + "[");
             out.println(
-                tab2 + "id" + delim + vertexIDProvider.getVertexName(from));
+                TAB2 + "id" + DELIM + vertexIDProvider.getVertexName(from));
             if ((printLabels == PRINT_VERTEX_LABELS)
                 || (printLabels == PRINT_EDGE_VERTEX_LABELS))
             {
                 String label =
                     (vertexLabelProvider == null) ? from.toString()
                     : vertexLabelProvider.getVertexName(from);
-                out.println(tab2 + "label" + delim + quoted(label));
+                out.println(TAB2 + "label" + DELIM + quoted(label));
             }
-            out.println(tab1 + "]");
+            out.println(TAB1 + "]");
         }
     }
 
@@ -166,23 +171,30 @@ public class GmlExporter<V, E>
         Graph<V, E> g)
     {
         for (E edge : g.edgeSet()) {
-            out.println(tab1 + "edge");
-            out.println(tab1 + "[");
+            out.println(TAB1 + "edge");
+            out.println(TAB1 + "[");
             String id = edgeIDProvider.getEdgeName(edge);
-            out.println(tab2 + "id" + delim + id);
+            out.println(TAB2 + "id" + DELIM + id);
             String s = vertexIDProvider.getVertexName(g.getEdgeSource(edge));
-            out.println(tab2 + "source" + delim + s);
+            out.println(TAB2 + "source" + DELIM + s);
             String t = vertexIDProvider.getVertexName(g.getEdgeTarget(edge));
-            out.println(tab2 + "target" + delim + t);
+            out.println(TAB2 + "target" + DELIM + t);
             if ((printLabels == PRINT_EDGE_LABELS)
                 || (printLabels == PRINT_EDGE_VERTEX_LABELS))
             {
                 String label =
                     (edgeLabelProvider == null) ? edge.toString()
                     : edgeLabelProvider.getEdgeName(edge);
-                out.println(tab2 + "label" + delim + quoted(label));
+                out.println(TAB2 + "label" + DELIM + quoted(label));
             }
-            out.println(tab1 + "]");
+            if (exportEdgeWeights) {
+                if (g instanceof WeightedGraph) {
+                    WeightedGraph<V, E> gw = (WeightedGraph<V, E>) g;
+                    double weight = gw.getEdgeWeight(edge);
+                    out.println(TAB2 + "weight" + DELIM + Double.toString(weight));
+                }
+            }
+            out.println(TAB1 + "]");
         }
     }
 
@@ -198,11 +210,11 @@ public class GmlExporter<V, E>
         exportHeader(out);
         out.println("graph");
         out.println("[");
-        out.println(tab1 + "label" + delim + quoted(""));
+        out.println(TAB1 + "label" + DELIM + quoted(""));
         if (directed) {
-            out.println(tab1 + "directed" + delim + "1");
+            out.println(TAB1 + "directed" + DELIM + "1");
         } else {
-            out.println(tab1 + "directed" + delim + "0");
+            out.println(TAB1 + "directed" + DELIM + "0");
         }
         exportVertices(out, g);
         exportEdges(out, g);
@@ -269,6 +281,27 @@ public class GmlExporter<V, E>
     public Integer getPrintLabels()
     {
         return printLabels;
+    }
+    
+    /**
+     * Whether the exporter will print edge weights in case the graph is edge
+     * weighted.
+     *
+     * @return {@code true} if the exporter prints edge weights, {@code false}
+     * otherwise
+     */
+    public boolean isExportEdgeWeights() {
+        return exportEdgeWeights;
+    }
+
+    /**
+     * Set whether the exporter will print edge weights in case the graph is
+     * edge weighted.
+     *
+     * @param exportEdgeWeights value to set
+     */
+    public void setExportEdgeWeights(boolean exportEdgeWeights) {
+        this.exportEdgeWeights = exportEdgeWeights;
     }
 }
 

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlExporterTest.java
@@ -56,6 +56,8 @@ public class GmlExporterTest
     private static final String V1 = "v1";
     private static final String V2 = "v2";
     private static final String V3 = "v3";
+    private static final String V4 = "v4";
+    private static final String V5 = "v5";
 
     private static final String NL = System.getProperty("line.separator");
 
@@ -93,9 +95,102 @@ public class GmlExporterTest
         + "\t\ttarget 1" + NL
         + "\t]" + NL
         + "]" + NL;
+    
+    private static final String UNDIRECTED_WEIGHTED
+            = "Creator \"JGraphT GML Exporter\"" + NL
+            + "Version 1" + NL
+            + "graph" + NL
+            + "[" + NL
+            + "\tlabel \"\"" + NL
+            + "\tdirected 0" + NL
+            + "\tnode" + NL
+            + "\t[" + NL            
+            + "\t\tid 1" + NL
+            + "\t]" + NL
+            + "\tnode" + NL
+            + "\t[" + NL            
+            + "\t\tid 2" + NL
+            + "\t]" + NL
+            + "\tnode" + NL
+            + "\t[" + NL            
+            + "\t\tid 3" + NL
+            + "\t]" + NL
+            + "\tedge" + NL
+            + "\t[" + NL            
+            + "\t\tid 1" + NL
+            + "\t\tsource 1" + NL
+            + "\t\ttarget 2" + NL
+            + "\t\tweight 2.0" + NL
+            + "\t]" + NL
+            + "\tedge" + NL
+            + "\t[" + NL            
+            + "\t\tid 2" + NL
+            + "\t\tsource 3" + NL
+            + "\t\ttarget 1" + NL
+            + "\t\tweight 5.0" + NL
+            + "\t]" + NL
+            + "]" + NL;
+    
+    private static final String DIRECTED
+            = "Creator \"JGraphT GML Exporter\"" + NL
+            + "Version 1" + NL
+            + "graph" + NL
+            + "[" + NL            
+            + "\tlabel \"\"" + NL
+            + "\tdirected 1" + NL
+            + "\tnode" + NL
+            + "\t[" + NL            
+            + "\t\tid 1" + NL
+            + "\t]" + NL
+            + "\tnode" + NL
+            + "\t[" + NL            
+            + "\t\tid 2" + NL
+            + "\t]" + NL
+            + "\tnode" + NL
+            + "\t[" + NL            
+            + "\t\tid 3" + NL
+            + "\t]" + NL
+            + "\tnode" + NL
+            + "\t[" + NL            
+            + "\t\tid 4" + NL
+            + "\t]" + NL
+            + "\tnode" + NL
+            + "\t[" + NL            
+            + "\t\tid 5" + NL
+            + "\t]" + NL
+            + "\tedge" + NL
+            + "\t[" + NL            
+            + "\t\tid 1" + NL
+            + "\t\tsource 1" + NL
+            + "\t\ttarget 2" + NL
+            + "\t]" + NL
+            + "\tedge" + NL
+            + "\t[" + NL            
+            + "\t\tid 2" + NL
+            + "\t\tsource 3" + NL
+            + "\t\ttarget 1" + NL
+            + "\t]" + NL
+            + "\tedge" + NL
+            + "\t[" + NL            
+            + "\t\tid 3" + NL
+            + "\t\tsource 2" + NL
+            + "\t\ttarget 3" + NL
+            + "\t]" + NL
+            + "\tedge" + NL
+            + "\t[" + NL            
+            + "\t\tid 4" + NL
+            + "\t\tsource 3" + NL
+            + "\t\ttarget 4" + NL
+            + "\t]" + NL
+            + "\tedge" + NL
+            + "\t[" + NL            
+            + "\t\tid 5" + NL
+            + "\t\tsource 4" + NL
+            + "\t\ttarget 5" + NL
+            + "\t]" + NL
+            + "]" + NL;
 
-    private static final GmlExporter<String, DefaultEdge> exporter =
-        new GmlExporter<String, DefaultEdge>();
+
 
     //~ Methods ----------------------------------------------------------------
 
@@ -110,8 +205,69 @@ public class GmlExporterTest
         g.addEdge(V3, V1);
 
         StringWriter w = new StringWriter();
+        GmlExporter<String, DefaultEdge> exporter
+            = new GmlExporter<String, DefaultEdge>();        
         exporter.export(w, g);
         assertEquals(UNDIRECTED, w.toString());
+    }
+    
+    public void testUnweightedUndirected()
+    {
+        UndirectedGraph<String, DefaultEdge> g =
+            new SimpleGraph<String, DefaultEdge>(DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+
+        StringWriter w = new StringWriter();
+        GmlExporter<String, DefaultEdge> exporter
+            = new GmlExporter<String, DefaultEdge>();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(w, g);
+        assertEquals(UNDIRECTED, w.toString());
+    }
+    
+    public void testDirected() {
+        DirectedGraph<String, DefaultEdge> g
+                = new SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addVertex(V3);
+        g.addVertex(V4);
+        g.addVertex(V5);
+        g.addEdge(V1, V2);
+        g.addEdge(V3, V1);
+        g.addEdge(V2, V3);
+        g.addEdge(V3, V4);
+        g.addEdge(V4, V5);
+
+        StringWriter w = new StringWriter();
+        GmlExporter<String, DefaultEdge> exporter
+                = new GmlExporter<String, DefaultEdge>();
+        exporter.export(w, g);
+        assertEquals(DIRECTED, w.toString());
+    }
+
+    public void testWeightedUndirected() {
+        SimpleGraph<String, DefaultWeightedEdge> g
+                = new SimpleWeightedGraph<String, DefaultWeightedEdge>(DefaultWeightedEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addVertex(V3);
+        DefaultWeightedEdge e1 = g.addEdge(V1, V2);
+        g.setEdgeWeight(e1, 2.0);
+        DefaultWeightedEdge e2 = g.addEdge(V3, V1);
+        g.setEdgeWeight(e2, 5.0);
+
+        StringWriter w = new StringWriter();
+
+           GmlExporter<String, DefaultWeightedEdge> exporter
+                = new GmlExporter<String, DefaultWeightedEdge>();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(w, g);
+        assertEquals(UNDIRECTED_WEIGHTED, w.toString());
     }
 }
 


### PR DESCRIPTION
- Support for exporting edge weights in GmlExporter has been added
- No interface change for backwards compatibility
- Minor refactoring in GmlExporter
- Added additional tests in GmlExporterTest

