### PR TITLE
Greedy algorithm for spanner construction

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/GreedyMultiplicativeSpanner.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/GreedyMultiplicativeSpanner.java
@@ -1,0 +1,293 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+ /* -------------------------
+ * GreedyMultiplicativeSpanner.java
+ * -------------------------
+ * (C) Copyright 2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author:  Dimitrios Michail
+ * Contributor(s):
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 15-July-2016 : Initial revision (DM);
+ *
+ */
+package org.jgrapht.alg;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import org.jgrapht.Graphs;
+import org.jgrapht.UndirectedGraph;
+import org.jgrapht.WeightedGraph;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.SimpleWeightedGraph;
+import org.jgrapht.util.FibonacciHeap;
+import org.jgrapht.util.FibonacciHeapNode;
+
+/**
+ * Greedy algorithm for (2k-1)-multiplicative spanner construction (for any
+ * integer k >= 1).
+ *
+ * <p>
+ * The spanner is guaranteed to contain O(n^{1+1/k}) edges and the shortest path
+ * distance between any two vertices in the spanner is at most 2k-1 times the
+ * corresponding shortest path distance in the original graph. Here n denotes
+ * the number of vertices of the graph.
+ *
+ * <p>
+ * The algorithm is described in: Althoefer, Das, Dobkin, Joseph, Soares.
+ * <a href="https://doi.org/10.1007/BF02189308">On Sparse Spanners of Weighted
+ * Graphs</a>. Discrete Computational Geometry 9(1):81-100, 1993.
+ *
+ * <p>
+ * If the graph is unweighted the algorithm runs in O(m n^{1+1/k}) time. Setting
+ * k to infinity will result in a slow version of Kruskal's algorithm where
+ * cycle detection is performed by a BFS computation. In such a case use the
+ * implementation of Kruskal with union-find. Here n and m are the number of
+ * vertices and edges of the graph respectively.
+ *
+ * <p>
+ * If the graph is weighted the algorithm runs in O(m (n^{1+1/k} + nlogn)) time
+ * by using Dijkstra's algorithm. Edge weights must be non-negative.
+ *
+ * @author Dimitrios Michail
+ * @since July 15, 2016
+ */
+public class GreedyMultiplicativeSpanner<V, E> {
+
+    private final Set<E> edgeList;
+    private final UndirectedGraph<V, E> graph;
+    private final int k;
+    private static final int MAX_K = 1 << 29;
+
+    /**
+     * Constructs instance to compute a (2k-1)-spanner of a graph.
+     * 
+     * @param graph the input graph
+     * @param k positive integer.
+     */
+    public GreedyMultiplicativeSpanner(UndirectedGraph<V, E> graph, int k) {
+        this.graph = graph;
+        this.edgeList = new LinkedHashSet<>();
+        if (k <= 0) {
+            throw new IllegalArgumentException("k should be positive in (2k-1)-spanner construction");
+        }
+        this.k = Math.min(k, MAX_K);
+        if (graph instanceof WeightedGraph) {
+            new WeightedSpannerAlgorithm().run();
+        } else {
+            new UnweightedSpannerAlgorithm().run();
+        }
+    }
+
+    /**
+     * Get the edge set of the spanner.
+     *
+     * @return the set of edges of the spanner
+     */
+    public Set<E> getSpannerEdgeSet() {
+        return edgeList;
+    }
+
+    // base algorithm implementation
+    private abstract class SpannerAlgorithmBase {
+
+        public abstract boolean isSpannerReachable(V s, V t, double distance);
+
+        public abstract void addSpannerEdge(V s, V t, double weight);
+
+        public void run() {
+            // sort edges
+            ArrayList<E> allEdges = new ArrayList<>(graph.edgeSet());
+            Collections.sort(
+                    allEdges,
+                    (e1, e2) -> Double.valueOf(graph.getEdgeWeight(e1)).compareTo(
+                    graph.getEdgeWeight(e2)));
+
+            // check precondition
+            double minWeight = graph.getEdgeWeight(allEdges.get(0));
+            if (minWeight < 0.0) {
+                throw new IllegalArgumentException("Illegal edge weight: negative");
+            }
+
+            // run main loop
+            for (E e : allEdges) {
+                V s = graph.getEdgeSource(e);
+                V t = graph.getEdgeTarget(e);
+
+                if (!s.equals(t)) { // self-loop?
+                    double distance = (2 * k - 1) * graph.getEdgeWeight(e);
+                    if (!isSpannerReachable(s, t, distance)) {
+                        edgeList.add(e);
+                        addSpannerEdge(s, t, graph.getEdgeWeight(e));
+                    }
+                }
+            }
+        }
+
+    }
+
+    private class UnweightedSpannerAlgorithm extends SpannerAlgorithmBase {
+
+        protected UndirectedGraph<V, E> spanner;
+        protected Map<V, Integer> vertexDistance;
+        protected Deque<V> queue;
+        protected Deque<V> touchedVertices;
+
+        public UnweightedSpannerAlgorithm() {
+            spanner = new SimpleGraph<V, E>(graph.getEdgeFactory());
+            touchedVertices = new ArrayDeque<V>(graph.vertexSet().size());
+            for (V v : graph.vertexSet()) {
+                spanner.addVertex(v);
+                touchedVertices.push(v);
+            }
+            vertexDistance = new HashMap<V, Integer>(graph.vertexSet().size());
+            queue = new ArrayDeque<>();
+        }
+
+        @Override
+        public void addSpannerEdge(V s, V t, double weight) {
+            spanner.addEdge(s, t);
+        }
+
+        /**
+         * Check if two vertices are reachable by a BFS in the spanner graph
+         * using only a certain number of hops.
+         *
+         * We execute this procedure repeatedly, therefore we need to keep track
+         * of what it touches and only clean those before the next execution.
+         */
+        @Override
+        public boolean isSpannerReachable(V s, V t, double hops) {
+            // initialize distances and queue
+            while (!touchedVertices.isEmpty()) {
+                V u = touchedVertices.pop();
+                vertexDistance.put(u, Integer.MAX_VALUE);
+            }
+            while (!queue.isEmpty()) {
+                queue.pop();
+            }
+
+            // do BFS
+            touchedVertices.push(s);
+            queue.push(s);
+            vertexDistance.put(s, 0);
+
+            while (!queue.isEmpty()) {
+                V u = queue.pop();
+                Integer uDistance = vertexDistance.get(u);
+
+                if (u.equals(t)) { // found
+                    return uDistance <= hops;
+                }
+
+                for (E e : spanner.edgesOf(u)) {
+                    V v = Graphs.getOppositeVertex(spanner, e, u);
+                    Integer vDistance = vertexDistance.get(v);
+
+                    if (vDistance == Integer.MAX_VALUE) {
+                        touchedVertices.push(v);
+                        vertexDistance.put(v, uDistance + 1);
+                        queue.push(v);
+                    }
+                }
+            }
+
+            return false;
+        }
+
+    }
+
+    private class WeightedSpannerAlgorithm extends SpannerAlgorithmBase {
+
+        protected WeightedGraph<V, E> spanner;
+        protected FibonacciHeap<V> heap;
+        protected Map<V, FibonacciHeapNode<V>> nodes;
+
+        public WeightedSpannerAlgorithm() {
+            this.spanner = new SimpleWeightedGraph<V, E>(graph.getEdgeFactory());
+            for (V v : graph.vertexSet()) {
+                spanner.addVertex(v);
+            }
+            this.heap = new FibonacciHeap<V>();
+            this.nodes = new LinkedHashMap<V, FibonacciHeapNode<V>>();
+        }
+
+        @Override
+        public boolean isSpannerReachable(V s, V t, double distance) {
+            // init
+            heap.clear();
+            nodes.clear();
+
+            FibonacciHeapNode<V> sNode = new FibonacciHeapNode<V>(s);
+            nodes.put(s, sNode);
+            heap.insert(sNode, 0d);
+
+            while (!heap.isEmpty()) {
+                FibonacciHeapNode<V> uNode = heap.removeMin();
+                double uDistance = uNode.getKey();
+                V u = uNode.getData();
+
+                if (uDistance > distance) {
+                    return false;
+                }
+
+                if (u.equals(t)) { // found
+                    return true;
+                }
+
+                for (E e : spanner.edgesOf(u)) {
+                    V v = Graphs.getOppositeVertex(spanner, e, u);
+                    FibonacciHeapNode<V> vNode = nodes.get(v);
+                    double vDistance = uDistance + spanner.getEdgeWeight(e);
+
+                    if (vNode == null) { // no distance
+                        vNode = new FibonacciHeapNode<V>(v);
+                        nodes.put(v, vNode);
+                        heap.insert(vNode, vDistance);
+                    } else if (vDistance < vNode.getKey()) {
+                        heap.decreaseKey(vNode, vDistance);
+                    }
+                }
+
+            }
+
+            return false;
+        }
+
+        @Override
+        public void addSpannerEdge(V s, V t, double weight) {
+            Graphs.addEdge(spanner, s, t, weight);
+        }
+
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/GreedyMultiplicativeSpanner.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/GreedyMultiplicativeSpanner.java
@@ -19,20 +19,20 @@
  * (b) the terms of the Eclipse Public License v1.0 as published by
  * the Eclipse Foundation.
  */
- /* -------------------------
- * GreedyMultiplicativeSpanner.java
- * -------------------------
- * (C) Copyright 2016, by Dimitrios Michail and Contributors.
- *
- * Original Author:  Dimitrios Michail
- * Contributor(s):
- * $Id$
- *
- * Changes
- * -------
- * 15-July-2016 : Initial revision (DM);
- *
- */
+/* -------------------------
+* GreedyMultiplicativeSpanner.java
+* -------------------------
+* (C) Copyright 2016, by Dimitrios Michail and Contributors.
+*
+* Original Author:  Dimitrios Michail
+* Contributor(s):
+* $Id$
+*
+* Changes
+* -------
+* 15-July-2016 : Initial revision (DM);
+*
+*/
 package org.jgrapht.alg;
 
 import java.util.ArrayDeque;
@@ -81,8 +81,8 @@ import org.jgrapht.util.FibonacciHeapNode;
  * @author Dimitrios Michail
  * @since July 15, 2016
  */
-public class GreedyMultiplicativeSpanner<V, E> {
-
+public class GreedyMultiplicativeSpanner<V, E>
+{
     private final Set<E> edgeList;
     private final UndirectedGraph<V, E> graph;
     private final int k;
@@ -94,11 +94,13 @@ public class GreedyMultiplicativeSpanner<V, E> {
      * @param graph the input graph
      * @param k positive integer.
      */
-    public GreedyMultiplicativeSpanner(UndirectedGraph<V, E> graph, int k) {
+    public GreedyMultiplicativeSpanner(UndirectedGraph<V, E> graph, int k)
+    {
         this.graph = graph;
         this.edgeList = new LinkedHashSet<>();
         if (k <= 0) {
-            throw new IllegalArgumentException("k should be positive in (2k-1)-spanner construction");
+            throw new IllegalArgumentException(
+                "k should be positive in (2k-1)-spanner construction");
         }
         this.k = Math.min(k, MAX_K);
         if (graph instanceof WeightedGraph) {
@@ -113,29 +115,33 @@ public class GreedyMultiplicativeSpanner<V, E> {
      *
      * @return the set of edges of the spanner
      */
-    public Set<E> getSpannerEdgeSet() {
+    public Set<E> getSpannerEdgeSet()
+    {
         return edgeList;
     }
 
     // base algorithm implementation
-    private abstract class SpannerAlgorithmBase {
+    private abstract class SpannerAlgorithmBase
+    {
 
         public abstract boolean isSpannerReachable(V s, V t, double distance);
 
         public abstract void addSpannerEdge(V s, V t, double weight);
 
-        public void run() {
+        public void run()
+        {
             // sort edges
             ArrayList<E> allEdges = new ArrayList<>(graph.edgeSet());
             Collections.sort(
-                    allEdges,
-                    (e1, e2) -> Double.valueOf(graph.getEdgeWeight(e1)).compareTo(
-                    graph.getEdgeWeight(e2)));
+                allEdges,
+                (e1, e2) -> Double.valueOf(graph.getEdgeWeight(e1))
+                    .compareTo(graph.getEdgeWeight(e2)));
 
             // check precondition
             double minWeight = graph.getEdgeWeight(allEdges.get(0));
             if (minWeight < 0.0) {
-                throw new IllegalArgumentException("Illegal edge weight: negative");
+                throw new IllegalArgumentException(
+                    "Illegal edge weight: negative");
             }
 
             // run main loop
@@ -155,14 +161,17 @@ public class GreedyMultiplicativeSpanner<V, E> {
 
     }
 
-    private class UnweightedSpannerAlgorithm extends SpannerAlgorithmBase {
+    private class UnweightedSpannerAlgorithm
+        extends SpannerAlgorithmBase
+    {
 
         protected UndirectedGraph<V, E> spanner;
         protected Map<V, Integer> vertexDistance;
         protected Deque<V> queue;
         protected Deque<V> touchedVertices;
 
-        public UnweightedSpannerAlgorithm() {
+        public UnweightedSpannerAlgorithm()
+        {
             spanner = new SimpleGraph<V, E>(graph.getEdgeFactory());
             touchedVertices = new ArrayDeque<V>(graph.vertexSet().size());
             for (V v : graph.vertexSet()) {
@@ -174,7 +183,8 @@ public class GreedyMultiplicativeSpanner<V, E> {
         }
 
         @Override
-        public void addSpannerEdge(V s, V t, double weight) {
+        public void addSpannerEdge(V s, V t, double weight)
+        {
             spanner.addEdge(s, t);
         }
 
@@ -186,7 +196,8 @@ public class GreedyMultiplicativeSpanner<V, E> {
          * of what it touches and only clean those before the next execution.
          */
         @Override
-        public boolean isSpannerReachable(V s, V t, double hops) {
+        public boolean isSpannerReachable(V s, V t, double hops)
+        {
             // initialize distances and queue
             while (!touchedVertices.isEmpty()) {
                 V u = touchedVertices.pop();
@@ -226,14 +237,18 @@ public class GreedyMultiplicativeSpanner<V, E> {
 
     }
 
-    private class WeightedSpannerAlgorithm extends SpannerAlgorithmBase {
+    private class WeightedSpannerAlgorithm
+        extends SpannerAlgorithmBase
+    {
 
         protected WeightedGraph<V, E> spanner;
         protected FibonacciHeap<V> heap;
         protected Map<V, FibonacciHeapNode<V>> nodes;
 
-        public WeightedSpannerAlgorithm() {
-            this.spanner = new SimpleWeightedGraph<V, E>(graph.getEdgeFactory());
+        public WeightedSpannerAlgorithm()
+        {
+            this.spanner = new SimpleWeightedGraph<V, E>(
+                graph.getEdgeFactory());
             for (V v : graph.vertexSet()) {
                 spanner.addVertex(v);
             }
@@ -242,7 +257,8 @@ public class GreedyMultiplicativeSpanner<V, E> {
         }
 
         @Override
-        public boolean isSpannerReachable(V s, V t, double distance) {
+        public boolean isSpannerReachable(V s, V t, double distance)
+        {
             // init
             heap.clear();
             nodes.clear();
@@ -284,7 +300,8 @@ public class GreedyMultiplicativeSpanner<V, E> {
         }
 
         @Override
-        public void addSpannerEdge(V s, V t, double weight) {
+        public void addSpannerEdge(V s, V t, double weight)
+        {
             Graphs.addEdge(spanner, s, t, weight);
         }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/GreedyMultiplicativeSpannerTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/GreedyMultiplicativeSpannerTest.java
@@ -38,9 +38,6 @@ package org.jgrapht.alg;
 
 import java.util.HashSet;
 import java.util.Set;
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
-import static junit.framework.Assert.fail;
 import junit.framework.TestCase;
 import org.jgrapht.UndirectedGraph;
 import org.jgrapht.WeightedGraph;
@@ -54,9 +51,11 @@ import org.jgrapht.graph.WeightedPseudograph;
  * @since July 15, 2016
  */
 public class GreedyMultiplicativeSpannerTest
-        extends TestCase {
+    extends TestCase
+{
 
-    //~ Static fields/initializers ---------------------------------------------
+    // ~ Static fields/initializers
+    // ---------------------------------------------
     private static final String V0 = "v0";
     private static final String V1 = "v1";
     private static final String V2 = "v2";
@@ -74,8 +73,10 @@ public class GreedyMultiplicativeSpannerTest
     private static final String V14 = "v14";
     private static final String V15 = "v15";
 
-    //~ Methods ----------------------------------------------------------------
-    public void createGraph1(UndirectedGraph<String, DefaultEdge> g) {
+    // ~ Methods
+    // ----------------------------------------------------------------
+    public void createGraph1(UndirectedGraph<String, DefaultEdge> g)
+    {
         g.addVertex(V0);
         g.addVertex(V1);
         g.addVertex(V2);
@@ -101,7 +102,8 @@ public class GreedyMultiplicativeSpannerTest
         g.addEdge(V6, V7);
     }
 
-    public void createGraph2(UndirectedGraph<String, DefaultEdge> g) {
+    public void createGraph2(UndirectedGraph<String, DefaultEdge> g)
+    {
         g.addVertex(V0);
         g.addVertex(V1);
         g.addVertex(V2);
@@ -144,8 +146,10 @@ public class GreedyMultiplicativeSpannerTest
         g.addEdge(V13, V15);
     }
 
-    //~ Methods ----------------------------------------------------------------
-    public void createGraph3(WeightedGraph<String, DefaultWeightedEdge> g) {
+    // ~ Methods
+    // ----------------------------------------------------------------
+    public void createGraph3(WeightedGraph<String, DefaultWeightedEdge> g)
+    {
         g.addVertex(V0);
         g.addVertex(V1);
         g.addVertex(V2);
@@ -171,11 +175,10 @@ public class GreedyMultiplicativeSpannerTest
         g.setEdgeWeight(g.addEdge(V6, V7), 5.0);
     }
 
-    private <V, E> void runTest(
-            UndirectedGraph<V, E> g,
-            int k,
-            Set<E> correct) {
-        Set<E> result = new GreedyMultiplicativeSpanner(g, k).getSpannerEdgeSet();
+    private <V, E> void runTest(UndirectedGraph<V, E> g, int k, Set<E> correct)
+    {
+        Set<E> result = new GreedyMultiplicativeSpanner<V,E>(g, k)
+            .getSpannerEdgeSet();
 
         assertEquals(correct.size(), result.size());
         for (E e : correct) {
@@ -183,10 +186,10 @@ public class GreedyMultiplicativeSpannerTest
         }
     }
 
-    public void testGraph1() {
-        UndirectedGraph<String, DefaultEdge> g
-                = new Pseudograph<>(
-                        DefaultEdge.class);
+    public void testGraph1()
+    {
+        UndirectedGraph<String, DefaultEdge> g = new Pseudograph<>(
+            DefaultEdge.class);
 
         createGraph1(g);
 
@@ -233,10 +236,10 @@ public class GreedyMultiplicativeSpannerTest
         runTest(g, 100, spanner7);
     }
 
-    public void testGraph1WithLoops() {
-        UndirectedGraph<String, DefaultEdge> g
-                = new Pseudograph<>(
-                        DefaultEdge.class);
+    public void testGraph1WithLoops()
+    {
+        UndirectedGraph<String, DefaultEdge> g = new Pseudograph<>(
+            DefaultEdge.class);
 
         createGraph1(g);
 
@@ -259,10 +262,10 @@ public class GreedyMultiplicativeSpannerTest
         runTest(g, 2, spanner3);
     }
 
-    public void testGraph1WithMultipleEdges() {
-        UndirectedGraph<String, DefaultEdge> g
-                = new Pseudograph<>(
-                        DefaultEdge.class);
+    public void testGraph1WithMultipleEdges()
+    {
+        UndirectedGraph<String, DefaultEdge> g = new Pseudograph<>(
+            DefaultEdge.class);
 
         createGraph1(g);
 
@@ -285,10 +288,10 @@ public class GreedyMultiplicativeSpannerTest
         runTest(g, 2, spanner3);
     }
 
-    public void testGraph2() {
-        UndirectedGraph<String, DefaultEdge> g
-                = new Pseudograph<>(
-                        DefaultEdge.class);
+    public void testGraph2()
+    {
+        UndirectedGraph<String, DefaultEdge> g = new Pseudograph<>(
+            DefaultEdge.class);
 
         createGraph2(g);
 
@@ -355,9 +358,10 @@ public class GreedyMultiplicativeSpannerTest
         runTest(g, 100, spanner7);
     }
 
-    public void testGraph3() {
-        WeightedPseudograph<String, DefaultWeightedEdge> g
-                = new WeightedPseudograph<>(DefaultWeightedEdge.class);
+    public void testGraph3()
+    {
+        WeightedPseudograph<String, DefaultWeightedEdge> g = new WeightedPseudograph<>(
+            DefaultWeightedEdge.class);
 
         createGraph3(g);
 
@@ -377,9 +381,10 @@ public class GreedyMultiplicativeSpannerTest
         runTest(g, Integer.MAX_VALUE, spanner3);
     }
 
-    public void testNegativeWeightsGraph() {
-        WeightedPseudograph<String, DefaultWeightedEdge> g
-                = new WeightedPseudograph<>(DefaultWeightedEdge.class);
+    public void testNegativeWeightsGraph()
+    {
+        WeightedPseudograph<String, DefaultWeightedEdge> g = new WeightedPseudograph<>(
+            DefaultWeightedEdge.class);
 
         g.addVertex(V0);
         g.addVertex(V1);
@@ -390,7 +395,7 @@ public class GreedyMultiplicativeSpannerTest
         g.setEdgeWeight(g.addEdge(V2, V0), 1.0);
 
         try {
-            new GreedyMultiplicativeSpanner(g, 2).getSpannerEdgeSet();
+            new GreedyMultiplicativeSpanner<String, DefaultWeightedEdge>(g, 2).getSpannerEdgeSet();
             fail("Negative edge weights not permitted.");
         } catch (IllegalArgumentException e) {
         }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/GreedyMultiplicativeSpannerTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/GreedyMultiplicativeSpannerTest.java
@@ -1,0 +1,401 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -------------------------
+ * GreedyMultiplicativeSpannerTest.java
+ * -------------------------
+ * (C) Copyright 2016, by Dimitrios Michail and Contributors
+ *
+ * Original Author:  Dimitrios Michail
+ * Contributor(s):
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 15-July-2016 : Initial revision (DM);
+ *
+ */
+package org.jgrapht.alg;
+
+import java.util.HashSet;
+import java.util.Set;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.Assert.fail;
+import junit.framework.TestCase;
+import org.jgrapht.UndirectedGraph;
+import org.jgrapht.WeightedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.Pseudograph;
+import org.jgrapht.graph.WeightedPseudograph;
+
+/*
+ * @author Dimitrios Michail
+ * @since July 15, 2016
+ */
+public class GreedyMultiplicativeSpannerTest
+        extends TestCase {
+
+    //~ Static fields/initializers ---------------------------------------------
+    private static final String V0 = "v0";
+    private static final String V1 = "v1";
+    private static final String V2 = "v2";
+    private static final String V3 = "v3";
+    private static final String V4 = "v4";
+    private static final String V5 = "v5";
+    private static final String V6 = "v6";
+    private static final String V7 = "v7";
+    private static final String V8 = "v8";
+    private static final String V9 = "v9";
+    private static final String V10 = "v10";
+    private static final String V11 = "v11";
+    private static final String V12 = "v12";
+    private static final String V13 = "v13";
+    private static final String V14 = "v14";
+    private static final String V15 = "v15";
+
+    //~ Methods ----------------------------------------------------------------
+    public void createGraph1(UndirectedGraph<String, DefaultEdge> g) {
+        g.addVertex(V0);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addVertex(V3);
+        g.addVertex(V4);
+        g.addVertex(V5);
+        g.addVertex(V6);
+        g.addVertex(V7);
+
+        g.addEdge(V0, V1);
+        g.addEdge(V1, V2);
+        g.addEdge(V0, V5);
+        g.addEdge(V1, V5);
+        g.addEdge(V1, V4);
+        g.addEdge(V2, V4);
+        g.addEdge(V2, V3);
+        g.addEdge(V5, V4);
+        g.addEdge(V4, V3);
+        g.addEdge(V5, V6);
+        g.addEdge(V4, V6);
+        g.addEdge(V3, V6);
+        g.addEdge(V3, V7);
+        g.addEdge(V6, V7);
+    }
+
+    public void createGraph2(UndirectedGraph<String, DefaultEdge> g) {
+        g.addVertex(V0);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addVertex(V3);
+        g.addVertex(V4);
+        g.addVertex(V5);
+        g.addVertex(V6);
+        g.addVertex(V7);
+        g.addVertex(V8);
+        g.addVertex(V9);
+        g.addVertex(V10);
+        g.addVertex(V11);
+        g.addVertex(V12);
+        g.addVertex(V13);
+        g.addVertex(V14);
+        g.addVertex(V15);
+
+        g.addEdge(V0, V1);
+        g.addEdge(V0, V3);
+        g.addEdge(V0, V2);
+        g.addEdge(V1, V3);
+        g.addEdge(V1, V2);
+        g.addEdge(V3, V2);
+        g.addEdge(V3, V4);
+        g.addEdge(V2, V5);
+        g.addEdge(V4, V5);
+        g.addEdge(V4, V6);
+        g.addEdge(V5, V7);
+        g.addEdge(V6, V7);
+
+        g.addEdge(V8, V9);
+        g.addEdge(V8, V10);
+        g.addEdge(V8, V11);
+        g.addEdge(V9, V10);
+        g.addEdge(V9, V11);
+        g.addEdge(V10, V11);
+        g.addEdge(V10, V12);
+        g.addEdge(V11, V13);
+        g.addEdge(V12, V14);
+        g.addEdge(V13, V15);
+    }
+
+    //~ Methods ----------------------------------------------------------------
+    public void createGraph3(WeightedGraph<String, DefaultWeightedEdge> g) {
+        g.addVertex(V0);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addVertex(V3);
+        g.addVertex(V4);
+        g.addVertex(V5);
+        g.addVertex(V6);
+        g.addVertex(V7);
+
+        g.setEdgeWeight(g.addEdge(V0, V1), 3.0);
+        g.setEdgeWeight(g.addEdge(V1, V2), 15.0);
+        g.setEdgeWeight(g.addEdge(V0, V5), 5.0);
+        g.setEdgeWeight(g.addEdge(V1, V5), 20.0);
+        g.setEdgeWeight(g.addEdge(V1, V4), 100.0);
+        g.setEdgeWeight(g.addEdge(V2, V4), 5.0);
+        g.setEdgeWeight(g.addEdge(V2, V3), 10.0);
+        g.setEdgeWeight(g.addEdge(V5, V4), 1.0);
+        g.setEdgeWeight(g.addEdge(V4, V3), 100.0);
+        g.setEdgeWeight(g.addEdge(V5, V6), 10.0);
+        g.setEdgeWeight(g.addEdge(V4, V6), 20.0);
+        g.setEdgeWeight(g.addEdge(V3, V6), 100.0);
+        g.setEdgeWeight(g.addEdge(V3, V7), 1000.0);
+        g.setEdgeWeight(g.addEdge(V6, V7), 5.0);
+    }
+
+    private <V, E> void runTest(
+            UndirectedGraph<V, E> g,
+            int k,
+            Set<E> correct) {
+        Set<E> result = new GreedyMultiplicativeSpanner(g, k).getSpannerEdgeSet();
+
+        assertEquals(correct.size(), result.size());
+        for (E e : correct) {
+            assertTrue(result.contains(e));
+        }
+    }
+
+    public void testGraph1() {
+        UndirectedGraph<String, DefaultEdge> g
+                = new Pseudograph<>(
+                        DefaultEdge.class);
+
+        createGraph1(g);
+
+        // test 3-spanner using k = 2
+        Set<DefaultEdge> spanner3 = new HashSet<DefaultEdge>();
+        spanner3.add(g.getEdge(V0, V1));
+        spanner3.add(g.getEdge(V1, V2));
+        spanner3.add(g.getEdge(V0, V5));
+        spanner3.add(g.getEdge(V1, V4));
+        spanner3.add(g.getEdge(V2, V3));
+        spanner3.add(g.getEdge(V5, V6));
+        spanner3.add(g.getEdge(V4, V6));
+        spanner3.add(g.getEdge(V3, V6));
+        spanner3.add(g.getEdge(V3, V7));
+
+        runTest(g, 2, spanner3);
+
+        // test 5-spanner using k = 3
+        Set<DefaultEdge> spanner5 = new HashSet<DefaultEdge>();
+        spanner5.add(g.getEdge(V0, V1));
+        spanner5.add(g.getEdge(V1, V2));
+        spanner5.add(g.getEdge(V0, V5));
+        spanner5.add(g.getEdge(V1, V4));
+        spanner5.add(g.getEdge(V2, V3));
+        spanner5.add(g.getEdge(V5, V6));
+        spanner5.add(g.getEdge(V3, V7));
+        spanner5.add(g.getEdge(V6, V7));
+
+        runTest(g, 3, spanner5);
+
+        // test 7-spanner using k = 4
+        Set<DefaultEdge> spanner7 = new HashSet<DefaultEdge>();
+        spanner7.add(g.getEdge(V0, V1));
+        spanner7.add(g.getEdge(V1, V2));
+        spanner7.add(g.getEdge(V0, V5));
+        spanner7.add(g.getEdge(V1, V4));
+        spanner7.add(g.getEdge(V2, V3));
+        spanner7.add(g.getEdge(V5, V6));
+        spanner7.add(g.getEdge(V3, V7));
+
+        runTest(g, 4, spanner7);
+
+        // test minimum spanning tree using large k
+        runTest(g, 100, spanner7);
+    }
+
+    public void testGraph1WithLoops() {
+        UndirectedGraph<String, DefaultEdge> g
+                = new Pseudograph<>(
+                        DefaultEdge.class);
+
+        createGraph1(g);
+
+        g.addEdge(V0, V0);
+        g.addEdge(V1, V1);
+        g.addEdge(V2, V2);
+
+        // test 3-spanner using k = 2
+        Set<DefaultEdge> spanner3 = new HashSet<DefaultEdge>();
+        spanner3.add(g.getEdge(V0, V1));
+        spanner3.add(g.getEdge(V1, V2));
+        spanner3.add(g.getEdge(V0, V5));
+        spanner3.add(g.getEdge(V1, V4));
+        spanner3.add(g.getEdge(V2, V3));
+        spanner3.add(g.getEdge(V5, V6));
+        spanner3.add(g.getEdge(V4, V6));
+        spanner3.add(g.getEdge(V3, V6));
+        spanner3.add(g.getEdge(V3, V7));
+
+        runTest(g, 2, spanner3);
+    }
+
+    public void testGraph1WithMultipleEdges() {
+        UndirectedGraph<String, DefaultEdge> g
+                = new Pseudograph<>(
+                        DefaultEdge.class);
+
+        createGraph1(g);
+
+        g.addEdge(V0, V1);
+        g.addEdge(V1, V2);
+        g.addEdge(V0, V5);
+
+        // test 3-spanner using k = 2
+        Set<DefaultEdge> spanner3 = new HashSet<DefaultEdge>();
+        spanner3.add(g.getEdge(V0, V1));
+        spanner3.add(g.getEdge(V1, V2));
+        spanner3.add(g.getEdge(V0, V5));
+        spanner3.add(g.getEdge(V1, V4));
+        spanner3.add(g.getEdge(V2, V3));
+        spanner3.add(g.getEdge(V5, V6));
+        spanner3.add(g.getEdge(V4, V6));
+        spanner3.add(g.getEdge(V3, V6));
+        spanner3.add(g.getEdge(V3, V7));
+
+        runTest(g, 2, spanner3);
+    }
+
+    public void testGraph2() {
+        UndirectedGraph<String, DefaultEdge> g
+                = new Pseudograph<>(
+                        DefaultEdge.class);
+
+        createGraph2(g);
+
+        // test 3-spanner using k = 2
+        Set<DefaultEdge> spanner3 = new HashSet<DefaultEdge>();
+        spanner3.add(g.getEdge(V0, V1));
+        spanner3.add(g.getEdge(V0, V3));
+        spanner3.add(g.getEdge(V0, V2));
+        spanner3.add(g.getEdge(V3, V4));
+        spanner3.add(g.getEdge(V2, V5));
+        spanner3.add(g.getEdge(V4, V5));
+        spanner3.add(g.getEdge(V4, V6));
+        spanner3.add(g.getEdge(V5, V7));
+        spanner3.add(g.getEdge(V8, V9));
+        spanner3.add(g.getEdge(V8, V10));
+        spanner3.add(g.getEdge(V8, V11));
+        spanner3.add(g.getEdge(V10, V12));
+        spanner3.add(g.getEdge(V11, V13));
+        spanner3.add(g.getEdge(V12, V14));
+        spanner3.add(g.getEdge(V13, V15));
+
+        runTest(g, 2, spanner3);
+
+        // test 5-spanner using k = 3
+        Set<DefaultEdge> spanner5 = new HashSet<DefaultEdge>();
+        spanner5.add(g.getEdge(V0, V1));
+        spanner5.add(g.getEdge(V0, V3));
+        spanner5.add(g.getEdge(V0, V2));
+        spanner5.add(g.getEdge(V3, V4));
+        spanner5.add(g.getEdge(V2, V5));
+        spanner5.add(g.getEdge(V4, V6));
+        spanner5.add(g.getEdge(V5, V7));
+        spanner5.add(g.getEdge(V6, V7));
+        spanner5.add(g.getEdge(V8, V9));
+        spanner5.add(g.getEdge(V8, V10));
+        spanner5.add(g.getEdge(V8, V11));
+        spanner5.add(g.getEdge(V10, V12));
+        spanner5.add(g.getEdge(V11, V13));
+        spanner5.add(g.getEdge(V12, V14));
+        spanner5.add(g.getEdge(V13, V15));
+
+        runTest(g, 3, spanner5);
+
+        // test 7-spanner using k = 4
+        Set<DefaultEdge> spanner7 = new HashSet<DefaultEdge>();
+        spanner7.add(g.getEdge(V0, V1));
+        spanner7.add(g.getEdge(V0, V3));
+        spanner7.add(g.getEdge(V0, V2));
+        spanner7.add(g.getEdge(V3, V4));
+        spanner7.add(g.getEdge(V2, V5));
+        spanner7.add(g.getEdge(V4, V6));
+        spanner7.add(g.getEdge(V5, V7));
+        spanner7.add(g.getEdge(V8, V9));
+        spanner7.add(g.getEdge(V8, V10));
+        spanner7.add(g.getEdge(V8, V11));
+        spanner7.add(g.getEdge(V10, V12));
+        spanner7.add(g.getEdge(V11, V13));
+        spanner7.add(g.getEdge(V12, V14));
+        spanner7.add(g.getEdge(V13, V15));
+
+        runTest(g, 4, spanner7);
+
+        // test minimum spanning tree using large k
+        runTest(g, 100, spanner7);
+    }
+
+    public void testGraph3() {
+        WeightedPseudograph<String, DefaultWeightedEdge> g
+                = new WeightedPseudograph<>(DefaultWeightedEdge.class);
+
+        createGraph3(g);
+
+        // test 3-spanner using k = 2
+        Set<DefaultWeightedEdge> spanner3 = new HashSet<DefaultWeightedEdge>();
+        spanner3.add(g.getEdge(V5, V4));
+        spanner3.add(g.getEdge(V0, V1));
+        spanner3.add(g.getEdge(V0, V5));
+        spanner3.add(g.getEdge(V2, V4));
+        spanner3.add(g.getEdge(V2, V3));
+        spanner3.add(g.getEdge(V5, V6));
+        spanner3.add(g.getEdge(V6, V7));
+
+        runTest(g, 2, spanner3);
+
+        // compute minimum-spanning-tree
+        runTest(g, Integer.MAX_VALUE, spanner3);
+    }
+
+    public void testNegativeWeightsGraph() {
+        WeightedPseudograph<String, DefaultWeightedEdge> g
+                = new WeightedPseudograph<>(DefaultWeightedEdge.class);
+
+        g.addVertex(V0);
+        g.addVertex(V1);
+        g.addVertex(V2);
+
+        g.setEdgeWeight(g.addEdge(V0, V1), 1.0);
+        g.setEdgeWeight(g.addEdge(V1, V2), -1.0);
+        g.setEdgeWeight(g.addEdge(V2, V0), 1.0);
+
+        try {
+            new GreedyMultiplicativeSpanner(g, 2).getSpannerEdgeSet();
+            fail("Negative edge weights not permitted.");
+        } catch (IllegalArgumentException e) {
+        }
+    }
+
+}
+
+// End GreedyMultiplicativeSpannerTest.java


### PR DESCRIPTION
A multiplicative spanner of an undirected graph is a subgraph which preserves shortest path distances up to some factor. 

This is an implementation of a greedy algorithm which constructs a (2k-1)-multiplicative spanner for any integer k>=1. The spanner is guaranteed to contain O(n^{1+1/k}) edges and the shortest path distance between any two vertices in the spanner is at most 2k-1 times the corresponding shortest path distance in the original graph. Here n denotes the number of vertices of the graph.

Setting for example k=2 returns a 3-spanner which is a subgraph where every distance is at most 3 times the original distance. As another example k=3 returns a 5-spanner. Setting k to a very large value results in computing the minimum spanning tree which is always contained in the spanner.

The algorithm is described in the following paper.
 
Althoefer, Das, Dobkin, Joseph, Soares. <a href="https://doi.org/10.1007/BF02189308">On Sparse Spanners of Weighted Graphs</a>. Discrete Computational Geometry 9(1):81-100, 1993.

If the graph is unweighted the algorithm runs in O(m n^{1+1/k}) time. If the graph is weighted the algorithm runs in O(m (n^{1+1/k} + nlogn)) time by using Dijkstra's algorithm. Edge weights must be non-negative. Here n and m are the number of vertices and edges of the graph respectively.

Sparse spanners can be used in similar ways as minimum-spanning-trees. Especially in applications which need the extra property of shortest path distances preservation (up to some constant factor).