### PR TITLE
GmlImporter, GraphMLImporter implementations and refactoring

### DIFF
--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -93,6 +93,19 @@
 					</instructions>
 				</configuration>
 			</plugin>
+			<plugin>
+                <groupId>org.antlr</groupId>
+                <artifactId>antlr4-maven-plugin</artifactId>
+                <version>4.5</version>
+                <executions>
+                    <execution>
+                        <id>antlr</id>
+                        <goals>
+                            <goal>antlr4</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
 		</plugins>
 	</build>
 	<dependencies>
@@ -118,5 +131,10 @@
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>
+		 <dependency>
+            <groupId>org.antlr</groupId>
+            <artifactId>antlr4-runtime</artifactId>
+            <version>4.5.3</version>
+        </dependency>		
 	</dependencies>
 </project>

--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -64,6 +64,11 @@
 				</configuration>
 			</plugin>
 			<plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.1</version>
+            </plugin>
+			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.0.1</version>

--- a/jgrapht-ext/src/main/antlr4/org/jgrapht/ext/Gml.g4
+++ b/jgrapht-ext/src/main/antlr4/org/jgrapht/ext/Gml.g4
@@ -1,0 +1,48 @@
+
+// define a grammar called GML
+
+grammar Gml;
+
+gml
+    : 
+	keyValuePair*
+	;
+
+keyValuePair
+    : ID STRING   #StringKeyValue  
+    | ID NUMBER   #NumberKeyValue  
+    | ID '[' keyValuePair* ']' #ListKeyValue
+    ;
+      
+/** "a numeral [-]?(.[0-9]+ | [0-9]+(.[0-9]*)? )" */ NUMBER
+   : '-'? ( '.' DIGIT+ | DIGIT+ ( '.' DIGIT* )? )
+   ;
+
+fragment DIGIT
+   : [0-9]
+   ;
+   
+fragment LETTER
+   : [a-zA-Z\u0080-\u00FF_]
+;   
+
+/** "any double-quoted string ("...") possibly containing escaped quotes" */ STRING
+   : '"' ( '\\"' | . )*? '"'
+   ;
+
+/** "Any string of alphabetic ([a-zA-Z\200-\377]) characters, underscores
+ *  ('_') or digits ([0-9]), not beginning with a digit"
+ */ ID
+   : LETTER ( LETTER | DIGIT )*
+   ;
+
+/** "a '#' character is considered a line output from a C preprocessor (e.g.,
+ *  # 34 to indicate line 34 ) and discarded"
+ */ PREPROC
+   : '#' .*? '\n' -> skip
+   ;
+
+WS
+   : [ \t\n\r]+ -> skip
+   ;
+   

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
@@ -50,8 +50,10 @@ import java.util.Map;
 /**
  * Imports a graph specified in DIMACS format (http://mat.gsia.cmu.edu/COLOR/general/ccformat.ps).
  * In summary, graphs specified in DIMACS format adhere to the following structure:
- * <pre><code>
- *
+ * 
+ * <pre>
+ * {@code
+ * 
  * DIMACS G {
  *    c <comments; ignored during parsing of the graph
  *    p edge <number of nodes> <number of edges>
@@ -61,11 +63,16 @@ import java.util.Map;
  *    e <edge source 4> <edge target 4>
  *    ...
  * }
- *
- * </code></pre>
+ * 
+ * }
+ * </pre>
  *
  * Although not specified directly in the DIMACS format documentation, this implementation also allows for the a weighted variant:
- * <pre><code>e <edge source 1> <edge target 1> <edge_weight> </code></pre>
+ * <pre>{@code
+ *  
+ * e <edge source 1> <edge target 1> <edge_weight>
+ *  
+ * }</pre>
  *
  * Note: the current implementation does not fully implement the DIMACS specifications! Special (rarely used) fields
  * specified as 'Optional Descriptors' are currently not supported.
@@ -73,8 +80,8 @@ import java.util.Map;
  * @author Michael Behrisch (adaptation of GraphReader class)
  * @author Joris Kinable
  *
- * @param <V>
- * @param <E>
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
  */
 public class DIMACSImporter<V, E> implements GraphGenerator<V, E, V>{
     private final BufferedReader input;

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/ExportException.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/ExportException.java
@@ -19,46 +19,38 @@
  * (b) the terms of the Eclipse Public License v1.0 as published by
  * the Eclipse Foundation.
  */
-/* ------------------
- * ImportException.java
- * ------------------
- * (C) Copyright 2015, by  Wil Selwood.
- *
- * Original Author:  Wil Selwood <wselwood@ijento.com>
- *
- */
 package org.jgrapht.ext;
 
 /**
- * An exception that the library throws in case of graph import errors.
+ * An exception that the library throws in case of graph export errors.
  */
-public class ImportException
+public class ExportException
     extends Exception
 {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Constructs an {@code ImportException} with {@code null} as its error
+     * Constructs an {@code ExportException} with {@code null} as its error
      * detail message.
      */
-    public ImportException()
+    public ExportException()
     {
         super();
     }
 
     /**
-     * Constructs an {@code ImportException} with the specified detail message.
+     * Constructs an {@code ExportException} with the specified detail message.
      *
      * @param message The detail message (which is saved for later retrieval by
      *        the {@link #getMessage()} method)
      */
-    public ImportException(String message)
+    public ExportException(String message)
     {
         super(message);
     }
 
     /**
-     * Constructs an {@code ImportException} with the specified detail message
+     * Constructs an {@code ExportException} with the specified detail message
      * and cause.
      *
      * <p>
@@ -72,13 +64,13 @@ public class ImportException
      *        {@link #getCause()} method). (A null value is permitted, and
      *        indicates that the cause is nonexistent or unknown.)
      */
-    public ImportException(String message, Throwable cause)
+    public ExportException(String message, Throwable cause)
     {
         super(message, cause);
     }
 
     /**
-     * Constructs an {@code ImportException} with the specified cause and a
+     * Constructs an {@code ExportException} with the specified cause and a
      * detail message of {@code (cause==null ? null : cause.toString())} (which
      * typically contains the class and detail message of {@code cause}). This
      * constructor is useful for IO exceptions that are little more than
@@ -89,11 +81,11 @@ public class ImportException
      *        indicates that the cause is nonexistent or unknown.)
      *
      */
-    public ImportException(Throwable cause)
+    public ExportException(Throwable cause)
     {
         super(cause);
     }
 
 }
 
-// End ImportException.java
+// End ExportException.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
@@ -59,11 +59,13 @@ import java.util.Set;
 /**
  * Imports a graph from a GML file (Graph Modeling Language).
  * 
- * <p>For a description of the format see <a
- * href="http://www.infosun.fmi.uni-passau.de/Graphlet/GML/">
- * http://www.infosun.fmi.uni-passau.de/Graphlet/GML/</a>.
+ * <p>
+ * For a description of the format see
+ * <a href="http://www.infosun.fmi.uni-passau.de/Graphlet/GML/"> http://www.
+ * infosun.fmi.uni-passau.de/Graphlet/GML/</a>.
  *
- * <p>Below is small example of a graph in GML format. 
+ * <p>
+ * Below is small example of a graph in GML format.
  * 
  * <pre>
  * graph [
@@ -89,9 +91,10 @@ import java.util.Set;
  * ]
  * </pre>
  * 
- * <p>In case the 
- * graph is an instance of {@link org.jgrapht.WeightedGraph<V,E>} then the importer also 
- * reads edge weights. Otherwise edge weights are ignored.
+ * <p>
+ * In case the graph is an instance of {@link org.jgrapht.WeightedGraph<V,E>}
+ * then the importer also reads edge weights. Otherwise edge weights are
+ * ignored.
  *
  * @param <V> the vertex type
  * @param <E> the edge type
@@ -102,20 +105,23 @@ public class GmlImporter<V, E>
     private EdgeProvider<V, E> edgeProvider;
 
     /**
-     * Constructs a new importer. 
+     * Constructs a new importer.
      * 
-     * @param vertexProvider provider for the generation of vertices. Must not be null.
-     * @param edgeProvider provider for the generation of edges. Must not be null. 
+     * @param vertexProvider provider for the generation of vertices. Must not
+     *        be null.
+     * @param edgeProvider provider for the generation of edges. Must not be
+     *        null.
      */
     public GmlImporter(
         VertexProvider<V> vertexProvider,
         EdgeProvider<V, E> edgeProvider)
     {
-        if (vertexProvider == null) { 
-            throw new IllegalArgumentException("Vertex provider cannot be null");
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
         }
         this.vertexProvider = vertexProvider;
-        if (edgeProvider == null) { 
+        if (edgeProvider == null) {
             throw new IllegalArgumentException("Edge provider cannot be null");
         }
         this.edgeProvider = edgeProvider;
@@ -124,18 +130,21 @@ public class GmlImporter<V, E>
     // ~ Methods ---------------------------------------------------------------
 
     /**
-     * Import a graph. 
+     * Import a graph.
      * 
-     * <p>The provided graph must be able to support the features of the 
-     * graph that is read. For example if the gml file contains self-loops then the 
-     * graph provided must also support self-loops. The same for multiple edges.
+     * <p>
+     * The provided graph must be able to support the features of the graph that
+     * is read. For example if the gml file contains self-loops then the graph
+     * provided must also support self-loops. The same for multiple edges.
      * 
-     * <p>If the provided graph is a weighted graph, the importer also reads edge 
+     * <p>
+     * If the provided graph is a weighted graph, the importer also reads edge
      * weights. Otherwise edge weights are ignored.
-     *  
+     * 
      * @param input the input stream
-     * @param graph the output graph 
-     * @throws ImportException in case an error occurs, such as I/O or parse error
+     * @param graph the output graph
+     * @throws ImportException in case an error occurs, such as I/O or parse
+     *         error
      */
     public void read(Reader input, Graph<V, E> graph)
         throws ImportException
@@ -216,6 +225,7 @@ public class GmlImporter<V, E>
         private List<PartialEdge> edges;
 
         public void updateGraph(Graph<V, E> graph)
+            throws ImportException
         {
             if (foundGraph) {
                 // add nodes
@@ -242,7 +252,15 @@ public class GmlImporter<V, E>
                 for (PartialEdge pe : edges) {
                     String label = "e_" + pe.source + "_" + pe.target;
                     V from = map.get(pe.source);
+                    if (from == null) {
+                        throw new ImportException(
+                            "Node " + pe.source + " does not exist");
+                    }
                     V to = map.get(pe.target);
+                    if (to == null) {
+                        throw new ImportException(
+                            "Node " + pe.target + " does not exist");
+                    }
                     E e = edgeProvider.buildEdge(
                         from,
                         to,

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
@@ -92,7 +92,7 @@ import java.util.Set;
  * </pre>
  * 
  * <p>
- * In case the graph is an instance of {@link org.jgrapht.WeightedGraph<V,E>}
+ * In case the graph is an instance of {@link org.jgrapht.WeightedGraph}
  * then the importer also reads edge weights. Otherwise edge weights are
  * ignored.
  *

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
@@ -1,0 +1,366 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -------------------
+ * GmlImporter.java
+ * -------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author:  Dimitrios Michail
+ * Contributor(s): 
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 16-July-2016 : Initial revision (DM);
+ *
+ */
+package org.jgrapht.ext;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.jgrapht.Graph;
+import org.jgrapht.WeightedGraph;
+import org.jgrapht.ext.GmlParser.GmlContext;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Imports a graph from a GML file (Graph Modeling Language).
+ * 
+ * <p>For a description of the format see <a
+ * href="http://www.infosun.fmi.uni-passau.de/Graphlet/GML/">
+ * http://www.infosun.fmi.uni-passau.de/Graphlet/GML/</a>.
+ *
+ * <p>Below is small example of a graph in GML format. 
+ * 
+ * <pre>
+ * graph [
+ *   node [ 
+ *     id 1
+ *   ]
+ *   node [
+ *     id 2
+ *   ]
+ *   node [
+ *     id 3
+ *   ]
+ *   edge [
+ *     source 1
+ *     target 2 
+ *     weight 2.0
+ *   ]
+ *   edge [
+ *     source 2
+ *     target 3
+ *     weight 3.0
+ *   ]
+ * ]
+ * </pre>
+ * 
+ * <p>In case the 
+ * graph is an instance of {@link org.jgrapht.WeightedGraph<V,E>} then the importer also 
+ * reads edge weights. Otherwise edge weights are ignored.
+ *
+ * @param <V> the vertex type
+ * @param <E> the edge type
+ */
+public class GmlImporter<V, E>
+{
+    private VertexProvider<V> vertexProvider;
+    private EdgeProvider<V, E> edgeProvider;
+
+    /**
+     * Constructs a new importer. 
+     * 
+     * @param vertexProvider provider for the generation of vertices. Must not be null.
+     * @param edgeProvider provider for the generation of edges. Must not be null. 
+     */
+    public GmlImporter(
+        VertexProvider<V> vertexProvider,
+        EdgeProvider<V, E> edgeProvider)
+    {
+        if (vertexProvider == null) { 
+            throw new IllegalArgumentException("Vertex provider cannot be null");
+        }
+        this.vertexProvider = vertexProvider;
+        if (edgeProvider == null) { 
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
+    }
+
+    // ~ Methods ---------------------------------------------------------------
+
+    /**
+     * Import a graph. 
+     * 
+     * <p>The provided graph must be able to support the features of the 
+     * graph that is read. For example if the gml file contains self-loops then the 
+     * graph provided must also support self-loops. The same for multiple edges.
+     * 
+     * <p>If the provided graph is a weighted graph, the importer also reads edge 
+     * weights. Otherwise edge weights are ignored.
+     *  
+     * @param input the input stream
+     * @param graph the output graph 
+     * @throws ImportException in case an error occurs, such as I/O or parse error
+     */
+    public void read(Reader input, Graph<V, E> graph)
+        throws ImportException
+    {
+        try {
+            ThrowingErrorListener errorListener = new ThrowingErrorListener();
+
+            // create lexer
+            GmlLexer lexer = new GmlLexer(new ANTLRInputStream(input));
+            lexer.removeErrorListeners();
+            lexer.addErrorListener(errorListener);
+
+            // create parser
+            GmlParser parser = new GmlParser(new CommonTokenStream(lexer));
+            parser.removeErrorListeners();
+            parser.addErrorListener(errorListener);
+
+            // Specify our entry point
+            GmlContext graphContext = parser.gml();
+
+            // Walk it and attach our listener
+            ParseTreeWalker walker = new ParseTreeWalker();
+            CreateGraphGmlListener listener = new CreateGraphGmlListener();
+            walker.walk(listener, graphContext);
+
+            // update graph
+            listener.updateGraph(graph);
+        } catch (IOException e) {
+            throw new ImportException("Failed to import gml graph", e);
+        } catch (ParseCancellationException pe) {
+            throw new ImportException("Failed to import gml graph", pe);
+        }
+    }
+
+    private class ThrowingErrorListener
+        extends BaseErrorListener
+    {
+
+        @Override
+        public void syntaxError(
+            Recognizer<?, ?> recognizer,
+            Object offendingSymbol,
+            int line,
+            int charPositionInLine,
+            String msg,
+            RecognitionException e)
+            throws ParseCancellationException
+        {
+            throw new ParseCancellationException(
+                "line " + line + ":" + charPositionInLine + " " + msg);
+        }
+    }
+
+    // create graph from parse tree
+    private class CreateGraphGmlListener
+        extends GmlBaseListener
+    {
+        private static final String NODE = "node";
+        private static final String EDGE = "edge";
+        private static final String GRAPH = "graph";
+        private static final String WEIGHT = "weight";
+        private static final String ID = "id";
+        private static final String SOURCE = "source";
+        private static final String TARGET = "target";
+
+        private boolean foundGraph;
+        private boolean insideGraph;
+        private boolean insideNode;
+        private boolean insideEdge;
+        private int level;
+        private Integer nodeId;
+        private Integer sourceId;
+        private Integer targetId;
+        private Double weight;
+
+        private Set<Integer> nodes;
+        private int singletons;
+        private List<PartialEdge> edges;
+
+        public void updateGraph(Graph<V, E> graph)
+        {
+            if (foundGraph) {
+                // add nodes
+                int maxV = 1;
+                Map<Integer, V> map = new HashMap<Integer, V>();
+                for (Integer id : nodes) {
+                    maxV = Math.max(maxV, id);
+                    V vertex = vertexProvider.buildVertex(
+                        id.toString(),
+                        new HashMap<String, String>());
+                    map.put(id, vertex);
+                    graph.addVertex(vertex);
+                }
+
+                // add singleton nodes
+                for (int i = 0; i < singletons; i++) {
+                    String label = String.valueOf(maxV + 1 + i);
+                    graph.addVertex(
+                        vertexProvider
+                            .buildVertex(label, new HashMap<String, String>()));
+                }
+
+                // add edges
+                for (PartialEdge pe : edges) {
+                    String label = "e_" + pe.source + "_" + pe.target;
+                    V from = map.get(pe.source);
+                    V to = map.get(pe.target);
+                    E e = edgeProvider.buildEdge(
+                        from,
+                        to,
+                        label,
+                        new HashMap<String, String>());
+                    graph.addEdge(from, to, e);
+                    if (pe.weight != null) {
+                        if (graph instanceof WeightedGraph<?, ?>) {
+                            ((WeightedGraph<V, E>) graph)
+                                .setEdgeWeight(e, pe.weight);
+                        }
+                    }
+                }
+
+            }
+        }
+
+        @Override
+        public void enterGml(GmlParser.GmlContext ctx)
+        {
+            foundGraph = false;
+            insideGraph = false;
+            insideNode = false;
+            insideEdge = false;
+            nodes = new HashSet<Integer>();
+            singletons = 0;
+            edges = new ArrayList<PartialEdge>();
+            level = 0;
+        }
+
+        @Override
+        public void enterNumberKeyValue(GmlParser.NumberKeyValueContext ctx)
+        {
+            String key = ctx.ID().getText();
+
+            if (insideNode && level == 2 && key.equals(ID)) {
+                try {
+                    nodeId = Integer.parseInt(ctx.NUMBER().getText());
+                } catch (NumberFormatException e) {
+                    // ignore error
+                }
+            } else if (insideEdge && level == 2 && key.equals(SOURCE)) {
+                try {
+                    sourceId = Integer.parseInt(ctx.NUMBER().getText());
+                } catch (NumberFormatException e) {
+                    // ignore error
+                }
+            } else if (insideEdge && level == 2 && key.equals(TARGET)) {
+                try {
+                    targetId = Integer.parseInt(ctx.NUMBER().getText());
+                } catch (NumberFormatException e) {
+                    // ignore error
+                }
+            } else if (insideEdge && level == 2 && key.equals(WEIGHT)) {
+                try {
+                    weight = Double.parseDouble(ctx.NUMBER().getText());
+                } catch (NumberFormatException e) {
+                    // ignore error
+                }
+            }
+        }
+
+        @Override
+        public void enterListKeyValue(GmlParser.ListKeyValueContext ctx)
+        {
+            String key = ctx.ID().getText();
+            if (level == 0 && key.equals(GRAPH)) {
+                foundGraph = true;
+                insideGraph = true;
+            } else if (level == 1 && insideGraph && key.equals(NODE)) {
+                insideNode = true;
+                nodeId = null;
+            } else if (level == 1 && insideGraph && key.equals(EDGE)) {
+                insideEdge = true;
+                sourceId = null;
+                targetId = null;
+                weight = null;
+            }
+            level++;
+        }
+
+        @Override
+        public void exitListKeyValue(GmlParser.ListKeyValueContext ctx)
+        {
+            String key = ctx.ID().getText();
+            level--;
+            if (level == 0 && key.equals(GRAPH)) {
+                insideGraph = false;
+            } else if (level == 1 && insideGraph && key.equals(NODE)) {
+                if (nodeId == null) {
+                    singletons++;
+                } else {
+                    nodes.add(nodeId);
+                }
+                insideNode = false;
+            } else if (level == 1 && insideGraph && key.equals(EDGE)) {
+                if (sourceId != null && targetId != null) {
+                    edges.add(new PartialEdge(sourceId, targetId, weight));
+                }
+                insideEdge = false;
+            }
+
+        }
+
+    }
+
+    private class PartialEdge
+    {
+        Integer source;
+        Integer target;
+        Double weight;
+
+        public PartialEdge(Integer source, Integer target, Double weight)
+        {
+            this.source = source;
+            this.target = target;
+            this.weight = weight;
+        }
+    }
+
+}

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
@@ -127,7 +127,52 @@ public class GmlImporter<V, E>
         this.edgeProvider = edgeProvider;
     }
 
-    // ~ Methods ---------------------------------------------------------------
+    /**
+     * Get the vertex provider
+     * 
+     * @return the vertex provider
+     */
+    public VertexProvider<V> getVertexProvider()
+    {
+        return vertexProvider;
+    }
+
+    /**
+     * Set the vertex provider
+     * 
+     * @param vertexProvider the new vertex provider. Must not be null.
+     */
+    public void setVertexProvider(VertexProvider<V> vertexProvider)
+    {
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
+        }
+        this.vertexProvider = vertexProvider;
+    }
+
+    /**
+     * Get the edge provider
+     * 
+     * @return The edge provider
+     */
+    public EdgeProvider<V, E> getEdgeProvider()
+    {
+        return edgeProvider;
+    }
+
+    /**
+     * Set the edge provider.
+     * 
+     * @param edgeProvider the new edge provider. Must not be null.
+     */
+    public void setEdgeProvider(EdgeProvider<V, E> edgeProvider)
+    {
+        if (edgeProvider == null) {
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
+    }
 
     /**
      * Import a graph.

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -359,7 +359,7 @@ public class GraphMLExporter<V, E>
             // flush
             writer.flush();
         } catch (Exception e) {
-            throw new ExportException("Failed to export as GraphGML", e);
+            throw new ExportException("Failed to export as GraphML", e);
         }
     }
 }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -22,33 +22,38 @@
 /* ------------------
  * GraphMLExporter.java
  * ------------------
- * (C) Copyright 2006, by Trevor Harmon.
+ * (C) Copyright 2006-2016, by Trevor Harmon and Contributors.
  *
  * Original Author:  Trevor Harmon <trevor@vocaro.com>
+ * Contributors: Dimitrios Michail
  *
  */
 package org.jgrapht.ext;
 
-import java.io.*;
+import java.io.PrintWriter;
+import java.io.Writer;
 
-import javax.xml.transform.*;
-import javax.xml.transform.sax.*;
-import javax.xml.transform.stream.*;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.sax.SAXTransformerFactory;
+import javax.xml.transform.sax.TransformerHandler;
+import javax.xml.transform.stream.StreamResult;
 
-import org.jgrapht.*;
-
-import org.xml.sax.*;
-import org.xml.sax.helpers.*;
-
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.Graph;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.AttributesImpl;
 
 /**
  * Exports a graph into a GraphML file.
  *
- * <p>For a description of the format see <a
- * href="http://en.wikipedia.org/wiki/GraphML">
- * http://en.wikipedia.org/wiki/GraphML</a>.</p>
+ * <p>
+ * For a description of the format see
+ * <a href="http://en.wikipedia.org/wiki/GraphML">
+ * http://en.wikipedia.org/wiki/GraphML</a>.
+ * </p>
  *
  * @author Trevor Harmon
+ * @author Dimitrios Michail
  */
 public class GraphMLExporter<V, E>
 {
@@ -58,6 +63,11 @@ public class GraphMLExporter<V, E>
     private EdgeNameProvider<E> edgeLabelProvider;
 
     /**
+     * Whether to print edge weights in case the graph is weighted.
+     */
+    private boolean exportEdgeWeights = false;
+
+    /**
      * Constructs a new GraphMLExporter object with integer name providers for
      * the vertex and edge IDs and null providers for the vertex and edge
      * labels.
@@ -65,9 +75,9 @@ public class GraphMLExporter<V, E>
     public GraphMLExporter()
     {
         this(
-                new IntegerNameProvider<>(),
+            new IntegerNameProvider<>(),
             null,
-                new IntegerEdgeNameProvider<>(),
+            new IntegerEdgeNameProvider<>(),
             null);
     }
 
@@ -77,10 +87,10 @@ public class GraphMLExporter<V, E>
      *
      * @param vertexIDProvider for generating vertex IDs. Must not be null.
      * @param vertexLabelProvider for generating vertex labels. If null, vertex
-     * labels will not be written to the file.
+     *        labels will not be written to the file.
      * @param edgeIDProvider for generating vertex IDs. Must not be null.
      * @param edgeLabelProvider for generating edge labels. If null, edge labels
-     * will not be written to the file.
+     *        will not be written to the file.
      */
     public GraphMLExporter(
         VertexNameProvider<V> vertexIDProvider,
@@ -88,40 +98,50 @@ public class GraphMLExporter<V, E>
         EdgeNameProvider<E> edgeIDProvider,
         EdgeNameProvider<E> edgeLabelProvider)
     {
+        if (vertexIDProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex ID provider must not be null");
+        }
         this.vertexIDProvider = vertexIDProvider;
         this.vertexLabelProvider = vertexLabelProvider;
+        if (edgeIDProvider == null) {
+            throw new IllegalArgumentException(
+                "Edge ID provider must not be null");
+        }
         this.edgeIDProvider = edgeIDProvider;
         this.edgeLabelProvider = edgeLabelProvider;
     }
 
     /**
-     * Exports a graph into a plain text file in GraphML format.
+     * Whether the exporter will print edge weights.
      *
-     * @param writer the writer to which the graph to be exported
-     * @param g the graph to be exported
+     * @return {@code true} if the exporter prints edge weights, {@code false}
+     *         otherwise
      */
-    public void export(Writer writer, Graph<V, E> g)
-        throws SAXException, TransformerConfigurationException
+    public boolean isExportEdgeWeights()
     {
-        // Prepare an XML file to receive the GraphML data
-        PrintWriter out = new PrintWriter(writer);
-        StreamResult streamResult = new StreamResult(out);
-        SAXTransformerFactory factory =
-            (SAXTransformerFactory) SAXTransformerFactory.newInstance();
-        TransformerHandler handler = factory.newTransformerHandler();
-        Transformer serializer = handler.getTransformer();
-        serializer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
-        serializer.setOutputProperty(OutputKeys.INDENT, "yes");
-        handler.setResult(streamResult);
-        handler.startDocument();
-        AttributesImpl attr = new AttributesImpl();
+        return exportEdgeWeights;
+    }
 
-        // <graphml>
+    /**
+     * Set whether the exporter will print edge weights.
+     *
+     * @param exportEdgeWeights value to set
+     */
+    public void setExportEdgeWeights(boolean exportEdgeWeights)
+    {
+        this.exportEdgeWeights = exportEdgeWeights;
+    }
+
+    private void writeHeader(TransformerHandler handler)
+        throws SAXException
+    {
         handler.startPrefixMapping(
             "xsi",
             "http://www.w3.org/2001/XMLSchema-instance");
+        handler.endPrefixMapping("xsi");
 
-        // FIXME: Is this the proper way to add this attribute?
+        AttributesImpl attr = new AttributesImpl();
         attr.addAttribute(
             "",
             "",
@@ -133,8 +153,38 @@ public class GraphMLExporter<V, E>
             "",
             "graphml",
             attr);
-        handler.endPrefixMapping("xsi");
+    }
 
+    private void writeGraphStart(TransformerHandler handler, Graph<V, E> g)
+        throws SAXException
+    {
+        // <graph>
+        AttributesImpl attr = new AttributesImpl();
+        attr.addAttribute(
+            "",
+            "",
+            "edgedefault",
+            "CDATA",
+            (g instanceof DirectedGraph<?, ?>) ? "directed" : "undirected");
+        handler.startElement("", "", "graph", attr);
+    }
+
+    private void writeGraphEnd(TransformerHandler handler)
+        throws SAXException
+    {
+        handler.endElement("", "", "graph");
+    }
+
+    private void writeFooter(TransformerHandler handler)
+        throws SAXException
+    {
+        handler.endElement("", "", "graphml");
+    }
+
+    private void writeKeys(TransformerHandler handler)
+        throws SAXException
+    {
+        AttributesImpl attr = new AttributesImpl();
         if (vertexLabelProvider != null) {
             // <key> for vertex label attribute
             attr.clear();
@@ -156,17 +206,28 @@ public class GraphMLExporter<V, E>
             handler.startElement("", "", "key", attr);
             handler.endElement("", "", "key");
         }
+        if (exportEdgeWeights) {
+            attr.clear();
+            attr.addAttribute("", "", "id", "CDATA", "edge_weight");
+            attr.addAttribute("", "", "for", "CDATA", "edge");
+            attr.addAttribute("", "", "attr.name", "CDATA", "weight");
+            attr.addAttribute("", "", "attr.type", "CDATA", "double");
+            handler.startElement("", "", "key", attr);
+            handler.startElement("", "", "default", null);
+            String defaultValue = "1.0";
+            handler.characters(
+                defaultValue.toCharArray(),
+                0,
+                defaultValue.length());
+            handler.endElement("", "", "default");
+            handler.endElement("", "", "key");
+        }
+    }
 
-        // <graph>
-        attr.clear();
-        attr.addAttribute(
-            "",
-            "",
-            "edgedefault",
-            "CDATA",
-            (g instanceof DirectedGraph<?, ?>) ? "directed" : "undirected");
-        handler.startElement("", "", "graph", attr);
-
+    private void writeNodes(TransformerHandler handler, Graph<V, E> g)
+        throws SAXException
+    {
+        AttributesImpl attr = new AttributesImpl();
         // Add all the vertices as <node> elements...
         for (V v : g.vertexSet()) {
             // <node>
@@ -197,8 +258,13 @@ public class GraphMLExporter<V, E>
 
             handler.endElement("", "", "node");
         }
+    }
 
+    private void writeEdges(TransformerHandler handler, Graph<V, E> g)
+        throws SAXException
+    {
         // Add all the edges as <edge> elements...
+        AttributesImpl attr = new AttributesImpl();
         for (E e : g.edgeSet()) {
             // <edge>
             attr.clear();
@@ -230,21 +296,70 @@ public class GraphMLExporter<V, E>
 
                 // Content for <data>
                 String edgeLabel = edgeLabelProvider.getEdgeName(e);
-                handler.characters(
-                    edgeLabel.toCharArray(),
-                    0,
-                    edgeLabel.length());
+                handler
+                    .characters(edgeLabel.toCharArray(), 0, edgeLabel.length());
                 handler.endElement("", "", "data");
+            }
+            if (exportEdgeWeights) {
+                Double weight = g.getEdgeWeight(e);
+                if (weight != 1.0) { // not default value
+                    // <data>
+                    attr.clear();
+                    attr.addAttribute("", "", "key", "CDATA", "edge_weight");
+                    handler.startElement("", "", "data", attr);
+
+                    // Content for <data>
+                    String weightAsString = String.valueOf(weight);
+                    handler.characters(
+                        weightAsString.toCharArray(),
+                        0,
+                        weightAsString.length());
+                    handler.endElement("", "", "data");
+                }
             }
 
             handler.endElement("", "", "edge");
         }
+    }
 
-        handler.endElement("", "", "graph");
-        handler.endElement("", "", "graphml");
-        handler.endDocument();
+    /**
+     * Exports a graph into a plain text file in GraphML format.
+     *
+     * @param writer the writer to which the graph to be exported
+     * @param g the graph to be exported
+     */
+    public void export(Writer writer, Graph<V, E> g)
+        throws ExportException
+    {
+        try {
+            // Prepare an XML file to receive the GraphML data
+            SAXTransformerFactory factory = (SAXTransformerFactory) SAXTransformerFactory
+                .newInstance();
+            TransformerHandler handler = factory.newTransformerHandler();
+            handler.getTransformer()
+                .setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            handler.getTransformer()
+                .setOutputProperty(OutputKeys.INDENT, "yes");
+            handler.setResult(new StreamResult(new PrintWriter(writer)));
 
-        out.flush();
+            // export
+            handler.startDocument();
+
+            writeHeader(handler);
+            writeKeys(handler);
+            writeGraphStart(handler, g);
+            writeNodes(handler, g);
+            writeEdges(handler, g);
+            writeGraphEnd(handler);
+            writeFooter(handler);
+
+            handler.endDocument();
+
+            // flush
+            writer.flush();
+        } catch (Exception e) {
+            throw new ExportException("Failed to export as GraphGML", e);
+        }
     }
 }
 

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -327,6 +327,7 @@ public class GraphMLExporter<V, E>
      *
      * @param writer the writer to which the graph to be exported
      * @param g the graph to be exported
+     * @throws ExportException in case any error occurs during export
      */
     public void export(Writer writer, Graph<V, E> g)
         throws ExportException

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
@@ -1,0 +1,663 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -------------------
+ * GmlImporter.java
+ * -------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author:  Dimitrios Michail
+ * Contributor(s): 
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 17-July-2016 : Initial revision (DM);
+ *
+ */
+package org.jgrapht.ext;
+
+import java.io.File;
+import java.io.Reader;
+import java.net.URL;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.jgrapht.Graph;
+import org.jgrapht.WeightedGraph;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Imports a graph from a GraphML data source.
+ * 
+ * <p>
+ * For a description of the format see
+ * <a href="http://en.wikipedia.org/wiki/GraphML"> http://en.wikipedia.org/wiki/
+ * GraphML</a> or the
+ * <a href="http://graphml.graphdrawing.org/primer/graphml-primer.html">GraphML
+ * Primer</a>.
+ * </p>
+ * 
+ * <p>
+ * Below is small example of a graph in GraphML format.
+ * 
+ * <pre>
+ * {@code
+ * <?xml version="1.0" encoding="UTF-8"?>
+ * <graphml xmlns="http://graphml.graphdrawing.org/xmlns"  
+ *     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ *     xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns 
+ *     http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+ *   <key id="d0" for="node" attr.name="color" attr.type="string">
+ *     <default>yellow</default>
+ *   </key>
+ *   <key id="d1" for="edge" attr.name="weight" attr.type="double"/>
+ *   <graph id="G" edgedefault="undirected">
+ *     <node id="n0">
+ *       <data key="d0">green</data>
+ *     </node>
+ *     <node id="n1"/>
+ *     <node id="n2">
+ *       <data key="d0">blue</data>
+ *     </node>
+ *     <node id="n3">
+ *       <data key="d0">red</data>
+ *     </node>
+ *     <node id="n4"/>
+ *     <node id="n5">
+ *       <data key="d0">turquoise</data>
+ *     </node>
+ *     <edge id="e0" source="n0" target="n2">
+ *       <data key="d1">1.0</data>
+ *     </edge>
+ *     <edge id="e1" source="n0" target="n1">
+ *       <data key="d1">1.0</data>
+ *     </edge>
+ *     <edge id="e2" source="n1" target="n3">
+ *       <data key="d1">2.0</data>
+ *     </edge>
+ *     <edge id="e3" source="n3" target="n2"/>
+ *     <edge id="e4" source="n2" target="n4"/>
+ *     <edge id="e5" source="n3" target="n5"/>
+ *     <edge id="e6" source="n5" target="n4">
+ *       <data key="d1">1.1</data>
+ *     </edge>
+ *   </graph>
+ * </graphml>
+ * }
+ * </pre>
+ * 
+ * <p>
+ * The importer reads the input into a graph which is provided by the user. In
+ * case the graph is an instance of {@link org.jgrapht.WeightedGraph} and
+ * the corresponding edge key with attr.name="weight" is defined, the importer
+ * also reads edge weights. Otherwise edge weights are ignored.
+ * 
+ * <p>
+ * GraphML-Attributes Values are read as string key-value pairs and passed on to
+ * the {@link VertexProvider} and {@link EdgeProvider} respectively.
+ * 
+ * <p>
+ * The provided graph must be able to support the features of the graph that is
+ * read. For example if the GraphML file contains self-loops then the graph
+ * provided must also support self-loops. The same for multiple edges. Moreover,
+ * the parser completely ignores the attribute "edgedefault" which denotes
+ * whether and edge is directed or not. Whether edges are directed or not
+ * depends on the underlying implementation of the user provided graph object.
+ * 
+ * <p>
+ * The importer validates the input using the 1.0
+ * <a href="http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">GraphML
+ * Schema</a>.
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ * 
+ * @author Dimitrios Michail
+ */
+public class GraphMLImporter<V, E>
+{
+    private static final String GRAPHML_SCHEMA_FILENAME = "graphml.xsd";
+
+    private VertexProvider<V> vertexProvider;
+    private EdgeProvider<V, E> edgeProvider;
+
+    /**
+     * Constructs a new importer.
+     * 
+     * @param vertexProvider provider for the generation of vertices. Must not
+     *        be null.
+     * @param edgeProvider provider for the generation of edges. Must not be
+     *        null.
+     */
+    public GraphMLImporter(
+        VertexProvider<V> vertexProvider,
+        EdgeProvider<V, E> edgeProvider)
+    {
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
+        }
+        this.vertexProvider = vertexProvider;
+        if (edgeProvider == null) {
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
+    }
+
+    /**
+     * Get the vertex provider
+     * 
+     * @return the vertex provider
+     */
+    public VertexProvider<V> getVertexProvider()
+    {
+        return vertexProvider;
+    }
+
+    /**
+     * Set the vertex provider
+     * 
+     * @param vertexProvider the new vertex provider. Must not be null.
+     */
+    public void setVertexProvider(VertexProvider<V> vertexProvider)
+    {
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
+        }
+        this.vertexProvider = vertexProvider;
+    }
+
+    /**
+     * Get the edge provider
+     * 
+     * @return The edge provider
+     */
+    public EdgeProvider<V, E> getEdgeProvider()
+    {
+        return edgeProvider;
+    }
+
+    /**
+     * Set the edge provider.
+     * 
+     * @param edgeProvider the new edge provider. Must not be null.
+     */
+    public void setEdgeProvider(EdgeProvider<V, E> edgeProvider)
+    {
+        if (edgeProvider == null) {
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
+    }
+
+    /**
+     * Import a graph.
+     * 
+     * <p>
+     * The provided graph must be able to support the features of the graph that
+     * is read. For example if the GraphML file contains self-loops then the
+     * graph provided must also support self-loops. The same for multiple edges.
+     * 
+     * <p>
+     * If the provided graph is a weighted graph, the importer also reads edge
+     * weights.
+     * 
+     * <p>
+     * GraphML-Attributes Values are read as string key-value pairs and passed
+     * on to the {@link VertexProvider} and {@link EdgeProvider}
+     * respectively.
+     * 
+     * @param input the input stream
+     * @param graph the output graph
+     * @throws ImportException in case an error occurs, such as I/O or parse
+     *         error
+     */
+    public void read(Reader input, Graph<V, E> graph)
+        throws ImportException
+    {
+        try {
+            SchemaFactory schemaFactory = SchemaFactory
+                .newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+            // load schema
+            URL xsd = Thread.currentThread()
+                .getContextClassLoader()
+                .getResource(GRAPHML_SCHEMA_FILENAME);
+            if (xsd == null) {
+                throw new ImportException("Failed to locate GraphML xsd");
+            }
+            Schema schema = schemaFactory.newSchema(new File(xsd.getFile()));
+
+            // create parser
+            SAXParserFactory spf = SAXParserFactory.newInstance();
+            spf.setNamespaceAware(true);
+            spf.setSchema(schema);
+            SAXParser saxParser = spf.newSAXParser();
+
+            // parse
+            XMLReader xmlReader = saxParser.getXMLReader();
+            GraphMLHandler handler = new GraphMLHandler();
+            xmlReader.setContentHandler(handler);
+            xmlReader.setErrorHandler(handler);
+            xmlReader.parse(new InputSource(input));
+
+            // read result
+            handler.updateGraph(graph);
+        } catch (Exception se) {
+            throw new ImportException("Failed to parse GraphML", se);
+        }
+    }
+
+    // content handler
+    private class GraphMLHandler
+        extends DefaultHandler
+    {
+        private static final String NODE = "node";
+        private static final String NODE_ID = "id";
+        private static final String EDGE = "edge";
+        private static final String EDGE_SOURCE = "source";
+        private static final String EDGE_TARGET = "target";
+        private static final String KEY = "key";
+        private static final String KEY_FOR = "for";
+        private static final String KEY_ATTR_NAME = "attr.name";
+        private static final String KEY_ID = "id";
+        private static final String DEFAULT = "default";
+        private static final String DATA = "data";
+        private static final String DATA_KEY = "key";
+        private static final String SPECIAL_EDGE_WEIGHT = "weight";
+
+        // collect graph elements here
+        private Map<String, NodeOrEdge> nodes;
+        private List<NodeOrEdge> edges;
+
+        // record state of parser
+        private boolean insideDefault;
+        private boolean insideData;
+
+        // temporary state while reading elements
+        // stack needed due to nested graphs in GraphML
+        private Data currentData;
+        private Key currentKey;
+        private Deque<NodeOrEdge> currentNodeOrEdge;
+
+        // collect custom keys
+        private Map<String, Key> nodeValidKeys;
+        private Map<String, Key> edgeValidKeys;
+
+        // construct the actual graph after parsing
+        public void updateGraph(Graph<V, E> graph)
+            throws ImportException
+        {
+            if (nodes.isEmpty()) {
+                return;
+            }
+
+            // create nodes
+            Map<String, V> graphNodes = new HashMap<String, V>();
+
+            for (Entry<String, NodeOrEdge> en : nodes.entrySet()) {
+                String nodeId = en.getKey();
+
+                // create attributes
+                Map<String, String> collectedAttributes = en
+                    .getValue().attributes;
+                Map<String, String> finalAttributes = new HashMap<String, String>();
+
+                for (Key validKey : nodeValidKeys.values()) {
+                    String validId = validKey.id;
+                    if (collectedAttributes.containsKey(validId)) {
+                        finalAttributes.put(
+                            validKey.attributeName,
+                            collectedAttributes.get(validId));
+                    } else {
+                        if (validKey.defaultValue != null) {
+                            finalAttributes.put(
+                                validKey.attributeName,
+                                validKey.defaultValue);
+                        }
+                    }
+                }
+
+                // create the actual node
+                V v = vertexProvider.buildVertex(nodeId, finalAttributes);
+                graphNodes.put(nodeId, v);
+                graph.addVertex(v);
+            }
+
+            // check how to handle special edge weight
+            boolean handleSpecialEdgeWeights = false;
+            double defaultSpecialEdgeWeight = 1.0;
+            if (graph instanceof WeightedGraph<?, ?>) {
+                for (Key k : edgeValidKeys.values()) {
+                    if (k.attributeName.equals(SPECIAL_EDGE_WEIGHT)) {
+                        handleSpecialEdgeWeights = true;
+                        String defaultValue = k.defaultValue;
+                        try {
+                            defaultSpecialEdgeWeight = Double
+                                .parseDouble(defaultValue);
+                        } catch (NumberFormatException e) {
+                            // ignore
+                        }
+                        // first key only which maps to "weight"
+                        break;
+                    }
+                }
+
+            }
+
+            // create edges
+            for (NodeOrEdge p : edges) {
+                V from = graphNodes.get(p.id1);
+                if (from == null) {
+                    throw new ImportException(
+                        "Source vertex " + p.id1 + " not found");
+                }
+                V to = graphNodes.get(p.id2);
+                if (to == null) {
+                    throw new ImportException(
+                        "Target vertex " + p.id2 + " not found");
+                }
+
+                // create attributes
+                Map<String, String> collectedAttributes = p.attributes;
+                Map<String, String> finalAttributes = new HashMap<String, String>();
+
+                for (Key validKey : edgeValidKeys.values()) {
+                    String validId = validKey.id;
+                    if (collectedAttributes.containsKey(validId)) {
+                        finalAttributes.put(
+                            validKey.attributeName,
+                            collectedAttributes.get(validId));
+                    } else {
+                        if (validKey.defaultValue != null) {
+                            finalAttributes.put(
+                                validKey.attributeName,
+                                validKey.defaultValue);
+                        }
+                    }
+                }
+
+                E e = edgeProvider.buildEdge(
+                    from,
+                    to,
+                    "e_" + from + "_" + to,
+                    finalAttributes);
+                graph.addEdge(from, to, e);
+
+                // special handling for weighted graphs
+                if (handleSpecialEdgeWeights) {
+                    if (finalAttributes.containsKey(SPECIAL_EDGE_WEIGHT)) {
+                        try {
+                            ((WeightedGraph<V, E>) graph).setEdgeWeight(
+                                e,
+                                Double.parseDouble(
+                                    finalAttributes.get(SPECIAL_EDGE_WEIGHT)));
+                        } catch (NumberFormatException nfe) {
+                            ((WeightedGraph<V, E>) graph)
+                                .setEdgeWeight(e, defaultSpecialEdgeWeight);
+                        }
+                    }
+
+                }
+            }
+
+        }
+
+        @Override
+        public void startDocument()
+            throws SAXException
+        {
+            nodes = new HashMap<String, NodeOrEdge>();
+            edges = new ArrayList<NodeOrEdge>();
+            nodeValidKeys = new HashMap<String, Key>();
+            edgeValidKeys = new HashMap<String, Key>();
+            insideDefault = false;
+            insideData = false;
+            currentKey = null;
+            currentData = null;
+            currentNodeOrEdge = new ArrayDeque<NodeOrEdge>();
+        }
+
+        @Override
+        public void startElement(
+            String uri,
+            String localName,
+            String qName,
+            Attributes attributes)
+            throws SAXException
+        {
+            switch (localName) {
+            case NODE:
+                currentNodeOrEdge
+                    .push(new NodeOrEdge(findAttribute(NODE_ID, attributes)));
+                break;
+            case EDGE:
+                currentNodeOrEdge.push(
+                    new NodeOrEdge(
+                        findAttribute(EDGE_SOURCE, attributes),
+                        findAttribute(EDGE_TARGET, attributes)));
+                break;
+            case KEY:
+                String keyId = findAttribute(KEY_ID, attributes);
+                String keyFor = findAttribute(KEY_FOR, attributes);
+                String keyAttrName = findAttribute(KEY_ATTR_NAME, attributes);
+                currentKey = new Key(keyId, keyAttrName, null, null);
+                if (keyFor != null) {
+                    if (keyFor.equals(EDGE)) {
+                        currentKey.target = KeyTarget.EDGE;
+                    } else if (keyFor.equals(NODE)) {
+                        currentKey.target = KeyTarget.NODE;
+                    }
+                }
+                break;
+            case DEFAULT:
+                insideDefault = true;
+                break;
+            case DATA:
+                insideData = true;
+                currentData = new Data(
+                    findAttribute(DATA_KEY, attributes),
+                    null);
+                break;
+            default:
+                break;
+            }
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName)
+            throws SAXException
+        {
+            switch (localName) {
+            case NODE:
+                NodeOrEdge currentNode = currentNodeOrEdge.pop();
+                if (nodes.containsKey(currentNode.id1)) {
+                    throw new SAXException(
+                        "Node with id " + currentNode.id1 + " already exists");
+                }
+                nodes.put(currentNode.id1, currentNode);
+                break;
+            case EDGE:
+                NodeOrEdge currentEdge = currentNodeOrEdge.pop();
+                edges.add(currentEdge);
+                break;
+            case KEY:
+                if (currentKey.isValid()) {
+                    switch (currentKey.target) {
+                    case NODE:
+                        nodeValidKeys.put(currentKey.id, currentKey);
+                    case EDGE:
+                        edgeValidKeys.put(currentKey.id, currentKey);
+                    }
+                }
+                currentKey = null;
+                break;
+            case DEFAULT:
+                insideDefault = false;
+                break;
+            case DATA:
+                if (currentData.isValid()) {
+                    currentNodeOrEdge.peek().attributes
+                        .put(currentData.key, currentData.value);
+                }
+                insideData = false;
+                currentData = null;
+                break;
+            default:
+                break;
+            }
+        }
+
+        @Override
+        public void characters(char ch[], int start, int length)
+            throws SAXException
+        {
+            if (insideDefault) {
+                currentKey.defaultValue = new String(ch, start, length);
+            } else if (insideData) {
+                currentData.value = new String(ch, start, length);
+            }
+        }
+
+        @Override
+        public void warning(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
+
+        public void error(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
+
+        public void fatalError(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
+
+        private String findAttribute(String localName, Attributes attributes)
+        {
+            for (int i = 0; i < attributes.getLength(); i++) {
+                String attrLocalName = attributes.getLocalName(i);
+                if (attrLocalName.equals(localName)) {
+                    return attributes.getValue(i);
+                }
+            }
+            return null;
+        }
+
+    }
+
+    // ----- Helper classes for storing partial parser results -----
+    
+    private enum KeyTarget
+    {
+        NODE,
+        EDGE,
+    }
+
+    private class Key
+    {
+        String id;
+        String attributeName;
+        String defaultValue;
+        KeyTarget target;
+
+        public Key(
+            String id,
+            String attributeName,
+            String defaultValue,
+            KeyTarget target)
+        {
+            this.id = id;
+            this.attributeName = attributeName;
+            this.defaultValue = defaultValue;
+            this.target = target;
+        }
+
+        public boolean isValid()
+        {
+            return id != null && attributeName != null && target != null;
+        }
+
+    }
+
+    private class Data
+    {
+        String key;
+        String value;
+
+        public Data(String key, String value)
+        {
+            this.key = key;
+            this.value = value;
+        }
+
+        public boolean isValid()
+        {
+            return key != null && value != null;
+        }
+    }
+
+    private class NodeOrEdge
+    {
+        String id1;
+        String id2;
+        Map<String, String> attributes;
+
+        public NodeOrEdge(String id1)
+        {
+            this.id1 = id1;
+            this.id2 = null;
+            this.attributes = new HashMap<String, String>();
+        }
+
+        public NodeOrEdge(String id1, String id2)
+        {
+            this.id1 = id1;
+            this.id2 = id2;
+            this.attributes = new HashMap<String, String>();
+        }
+    }
+
+}

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
@@ -124,540 +124,468 @@ import org.xml.sax.helpers.DefaultHandler;
  * 
  * <p>
  * The importer reads the input into a graph which is provided by the user. In
- * case the graph is an instance of {@link org.jgrapht.WeightedGraph} and
- * the corresponding edge key with attr.name="weight" is defined, the importer
- * also reads edge weights. Otherwise edge weights are ignored.
+ * case the graph is an instance of {@link org.jgrapht.WeightedGraph} and the
+ * corresponding edge key with attr.name="weight" is defined, the importer also
+ * reads edge weights. Otherwise edge weights are ignored.
  * 
  * <p>
  * GraphML-Attributes Values are read as string key-value pairs and passed on to
  * the {@link VertexProvider} and {@link EdgeProvider} respectively.
  * 
  * <p>
- * The provided graph must be able to support the features of the graph that is
- * read. For example if the GraphML file contains self-loops then the graph
- * provided must also support self-loops. The same for multiple edges. Moreover,
- * the parser completely ignores the attribute "edgedefault" which denotes
- * whether and edge is directed or not. Whether edges are directed or not
- * depends on the underlying implementation of the user provided graph object.
+ * The provided graph object, where the imported graph will be stored, must be
+ * able to support the features of the graph that is read. For example if the
+ * GraphML file contains self-loops then the graph provided must also support
+ * self-loops. The same for multiple edges. Moreover, the parser completely
+ * ignores the attribute "edgedefault" which denotes whether an edge is directed
+ * or not. Whether edges are directed or not depends on the underlying
+ * implementation of the user provided graph object.
  * 
  * <p>
  * The importer validates the input using the 1.0
  * <a href="http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">GraphML
  * Schema</a>.
  *
- * @param <V> the graph vertex type
- * @param <E> the graph edge type
+ * @param <V>
+ *            the graph vertex type
+ * @param <E>
+ *            the graph edge type
  * 
  * @author Dimitrios Michail
  */
-public class GraphMLImporter<V, E>
-{
-    private static final String GRAPHML_SCHEMA_FILENAME = "graphml.xsd";
+public class GraphMLImporter<V, E> {
+	private static final String GRAPHML_SCHEMA_FILENAME = "graphml.xsd";
 
-    private VertexProvider<V> vertexProvider;
-    private EdgeProvider<V, E> edgeProvider;
+	private VertexProvider<V> vertexProvider;
+	private EdgeProvider<V, E> edgeProvider;
 
-    /**
-     * Constructs a new importer.
-     * 
-     * @param vertexProvider provider for the generation of vertices. Must not
-     *        be null.
-     * @param edgeProvider provider for the generation of edges. Must not be
-     *        null.
-     */
-    public GraphMLImporter(
-        VertexProvider<V> vertexProvider,
-        EdgeProvider<V, E> edgeProvider)
-    {
-        if (vertexProvider == null) {
-            throw new IllegalArgumentException(
-                "Vertex provider cannot be null");
-        }
-        this.vertexProvider = vertexProvider;
-        if (edgeProvider == null) {
-            throw new IllegalArgumentException("Edge provider cannot be null");
-        }
-        this.edgeProvider = edgeProvider;
-    }
+	/**
+	 * Constructs a new importer.
+	 * 
+	 * @param vertexProvider
+	 *            provider for the generation of vertices. Must not be null.
+	 * @param edgeProvider
+	 *            provider for the generation of edges. Must not be null.
+	 */
+	public GraphMLImporter(VertexProvider<V> vertexProvider, EdgeProvider<V, E> edgeProvider) {
+		if (vertexProvider == null) {
+			throw new IllegalArgumentException("Vertex provider cannot be null");
+		}
+		this.vertexProvider = vertexProvider;
+		if (edgeProvider == null) {
+			throw new IllegalArgumentException("Edge provider cannot be null");
+		}
+		this.edgeProvider = edgeProvider;
+	}
 
-    /**
-     * Get the vertex provider
-     * 
-     * @return the vertex provider
-     */
-    public VertexProvider<V> getVertexProvider()
-    {
-        return vertexProvider;
-    }
+	/**
+	 * Get the vertex provider
+	 * 
+	 * @return the vertex provider
+	 */
+	public VertexProvider<V> getVertexProvider() {
+		return vertexProvider;
+	}
 
-    /**
-     * Set the vertex provider
-     * 
-     * @param vertexProvider the new vertex provider. Must not be null.
-     */
-    public void setVertexProvider(VertexProvider<V> vertexProvider)
-    {
-        if (vertexProvider == null) {
-            throw new IllegalArgumentException(
-                "Vertex provider cannot be null");
-        }
-        this.vertexProvider = vertexProvider;
-    }
+	/**
+	 * Set the vertex provider
+	 * 
+	 * @param vertexProvider
+	 *            the new vertex provider. Must not be null.
+	 */
+	public void setVertexProvider(VertexProvider<V> vertexProvider) {
+		if (vertexProvider == null) {
+			throw new IllegalArgumentException("Vertex provider cannot be null");
+		}
+		this.vertexProvider = vertexProvider;
+	}
 
-    /**
-     * Get the edge provider
-     * 
-     * @return The edge provider
-     */
-    public EdgeProvider<V, E> getEdgeProvider()
-    {
-        return edgeProvider;
-    }
+	/**
+	 * Get the edge provider
+	 * 
+	 * @return The edge provider
+	 */
+	public EdgeProvider<V, E> getEdgeProvider() {
+		return edgeProvider;
+	}
 
-    /**
-     * Set the edge provider.
-     * 
-     * @param edgeProvider the new edge provider. Must not be null.
-     */
-    public void setEdgeProvider(EdgeProvider<V, E> edgeProvider)
-    {
-        if (edgeProvider == null) {
-            throw new IllegalArgumentException("Edge provider cannot be null");
-        }
-        this.edgeProvider = edgeProvider;
-    }
+	/**
+	 * Set the edge provider.
+	 * 
+	 * @param edgeProvider
+	 *            the new edge provider. Must not be null.
+	 */
+	public void setEdgeProvider(EdgeProvider<V, E> edgeProvider) {
+		if (edgeProvider == null) {
+			throw new IllegalArgumentException("Edge provider cannot be null");
+		}
+		this.edgeProvider = edgeProvider;
+	}
 
-    /**
-     * Import a graph.
-     * 
-     * <p>
-     * The provided graph must be able to support the features of the graph that
-     * is read. For example if the GraphML file contains self-loops then the
-     * graph provided must also support self-loops. The same for multiple edges.
-     * 
-     * <p>
-     * If the provided graph is a weighted graph, the importer also reads edge
-     * weights.
-     * 
-     * <p>
-     * GraphML-Attributes Values are read as string key-value pairs and passed
-     * on to the {@link VertexProvider} and {@link EdgeProvider}
-     * respectively.
-     * 
-     * @param input the input stream
-     * @param graph the output graph
-     * @throws ImportException in case an error occurs, such as I/O or parse
-     *         error
-     */
-    public void read(Reader input, Graph<V, E> graph)
-        throws ImportException
-    {
-        try {
-            SchemaFactory schemaFactory = SchemaFactory
-                .newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+	/**
+	 * Import a graph.
+	 * 
+	 * <p>
+	 * The provided graph must be able to support the features of the graph that
+	 * is read. For example if the GraphML file contains self-loops then the
+	 * graph provided must also support self-loops. The same for multiple edges.
+	 * 
+	 * <p>
+	 * If the provided graph is a weighted graph, the importer also reads edge
+	 * weights.
+	 * 
+	 * <p>
+	 * GraphML-Attributes Values are read as string key-value pairs and passed
+	 * on to the {@link VertexProvider} and {@link EdgeProvider} respectively.
+	 * 
+	 * @param input
+	 *            the input stream
+	 * @param graph
+	 *            the output graph
+	 * @throws ImportException
+	 *             in case an error occurs, such as I/O or parse error
+	 */
+	public void read(Reader input, Graph<V, E> graph) throws ImportException {
+		try {
+			SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
-            // load schema
-            URL xsd = Thread.currentThread()
-                .getContextClassLoader()
-                .getResource(GRAPHML_SCHEMA_FILENAME);
-            if (xsd == null) {
-                throw new ImportException("Failed to locate GraphML xsd");
-            }
-            Schema schema = schemaFactory.newSchema(new File(xsd.getFile()));
+			// load schema
+			URL xsd = Thread.currentThread().getContextClassLoader().getResource(GRAPHML_SCHEMA_FILENAME);
+			if (xsd == null) {
+				throw new ImportException("Failed to locate GraphML xsd");
+			}
+			Schema schema = schemaFactory.newSchema(new File(xsd.getFile()));
 
-            // create parser
-            SAXParserFactory spf = SAXParserFactory.newInstance();
-            spf.setNamespaceAware(true);
-            spf.setSchema(schema);
-            SAXParser saxParser = spf.newSAXParser();
+			// create parser
+			SAXParserFactory spf = SAXParserFactory.newInstance();
+			spf.setNamespaceAware(true);
+			spf.setSchema(schema);
+			SAXParser saxParser = spf.newSAXParser();
 
-            // parse
-            XMLReader xmlReader = saxParser.getXMLReader();
-            GraphMLHandler handler = new GraphMLHandler();
-            xmlReader.setContentHandler(handler);
-            xmlReader.setErrorHandler(handler);
-            xmlReader.parse(new InputSource(input));
+			// parse
+			XMLReader xmlReader = saxParser.getXMLReader();
+			GraphMLHandler handler = new GraphMLHandler();
+			xmlReader.setContentHandler(handler);
+			xmlReader.setErrorHandler(handler);
+			xmlReader.parse(new InputSource(input));
 
-            // read result
-            handler.updateGraph(graph);
-        } catch (Exception se) {
-            throw new ImportException("Failed to parse GraphML", se);
-        }
-    }
+			// read result
+			handler.updateGraph(graph);
+		} catch (Exception se) {
+			throw new ImportException("Failed to parse GraphML", se);
+		}
+	}
 
-    // content handler
-    private class GraphMLHandler
-        extends DefaultHandler
-    {
-        private static final String NODE = "node";
-        private static final String NODE_ID = "id";
-        private static final String EDGE = "edge";
-        private static final String EDGE_SOURCE = "source";
-        private static final String EDGE_TARGET = "target";
-        private static final String KEY = "key";
-        private static final String KEY_FOR = "for";
-        private static final String KEY_ATTR_NAME = "attr.name";
-        private static final String KEY_ID = "id";
-        private static final String DEFAULT = "default";
-        private static final String DATA = "data";
-        private static final String DATA_KEY = "key";
-        private static final String SPECIAL_EDGE_WEIGHT = "weight";
+	// content handler
+	private class GraphMLHandler extends DefaultHandler {
+		private static final String NODE = "node";
+		private static final String NODE_ID = "id";
+		private static final String EDGE = "edge";
+		private static final String EDGE_SOURCE = "source";
+		private static final String EDGE_TARGET = "target";
+		private static final String KEY = "key";
+		private static final String KEY_FOR = "for";
+		private static final String KEY_ATTR_NAME = "attr.name";
+		private static final String KEY_ID = "id";
+		private static final String DEFAULT = "default";
+		private static final String DATA = "data";
+		private static final String DATA_KEY = "key";
+		private static final String SPECIAL_EDGE_WEIGHT = "weight";
 
-        // collect graph elements here
-        private Map<String, NodeOrEdge> nodes;
-        private List<NodeOrEdge> edges;
+		// collect graph elements here
+		private Map<String, NodeOrEdge> nodes;
+		private List<NodeOrEdge> edges;
 
-        // record state of parser
-        private boolean insideDefault;
-        private boolean insideData;
+		// record state of parser
+		private boolean insideDefault;
+		private boolean insideData;
 
-        // temporary state while reading elements
-        // stack needed due to nested graphs in GraphML
-        private Data currentData;
-        private Key currentKey;
-        private Deque<NodeOrEdge> currentNodeOrEdge;
+		// temporary state while reading elements
+		// stack needed due to nested graphs in GraphML
+		private Data currentData;
+		private Key currentKey;
+		private Deque<NodeOrEdge> currentNodeOrEdge;
 
-        // collect custom keys
-        private Map<String, Key> nodeValidKeys;
-        private Map<String, Key> edgeValidKeys;
+		// collect custom keys
+		private Map<String, Key> nodeValidKeys;
+		private Map<String, Key> edgeValidKeys;
 
-        // construct the actual graph after parsing
-        public void updateGraph(Graph<V, E> graph)
-            throws ImportException
-        {
-            if (nodes.isEmpty()) {
-                return;
-            }
+		// construct the actual graph after parsing
+		public void updateGraph(Graph<V, E> graph) throws ImportException {
+			if (nodes.isEmpty()) {
+				return;
+			}
 
-            // create nodes
-            Map<String, V> graphNodes = new HashMap<String, V>();
+			// create nodes
+			Map<String, V> graphNodes = new HashMap<String, V>();
 
-            for (Entry<String, NodeOrEdge> en : nodes.entrySet()) {
-                String nodeId = en.getKey();
+			for (Entry<String, NodeOrEdge> en : nodes.entrySet()) {
+				String nodeId = en.getKey();
 
-                // create attributes
-                Map<String, String> collectedAttributes = en
-                    .getValue().attributes;
-                Map<String, String> finalAttributes = new HashMap<String, String>();
+				// create attributes
+				Map<String, String> collectedAttributes = en.getValue().attributes;
+				Map<String, String> finalAttributes = new HashMap<String, String>();
 
-                for (Key validKey : nodeValidKeys.values()) {
-                    String validId = validKey.id;
-                    if (collectedAttributes.containsKey(validId)) {
-                        finalAttributes.put(
-                            validKey.attributeName,
-                            collectedAttributes.get(validId));
-                    } else {
-                        if (validKey.defaultValue != null) {
-                            finalAttributes.put(
-                                validKey.attributeName,
-                                validKey.defaultValue);
-                        }
-                    }
-                }
+				for (Key validKey : nodeValidKeys.values()) {
+					String validId = validKey.id;
+					if (collectedAttributes.containsKey(validId)) {
+						finalAttributes.put(validKey.attributeName, collectedAttributes.get(validId));
+					} else {
+						if (validKey.defaultValue != null) {
+							finalAttributes.put(validKey.attributeName, validKey.defaultValue);
+						}
+					}
+				}
 
-                // create the actual node
-                V v = vertexProvider.buildVertex(nodeId, finalAttributes);
-                graphNodes.put(nodeId, v);
-                graph.addVertex(v);
-            }
+				// create the actual node
+				V v = vertexProvider.buildVertex(nodeId, finalAttributes);
+				graphNodes.put(nodeId, v);
+				graph.addVertex(v);
+			}
 
-            // check how to handle special edge weight
-            boolean handleSpecialEdgeWeights = false;
-            double defaultSpecialEdgeWeight = 1.0;
-            if (graph instanceof WeightedGraph<?, ?>) {
-                for (Key k : edgeValidKeys.values()) {
-                    if (k.attributeName.equals(SPECIAL_EDGE_WEIGHT)) {
-                        handleSpecialEdgeWeights = true;
-                        String defaultValue = k.defaultValue;
-                        try {
-                            defaultSpecialEdgeWeight = Double
-                                .parseDouble(defaultValue);
-                        } catch (NumberFormatException e) {
-                            // ignore
-                        }
-                        // first key only which maps to "weight"
-                        break;
-                    }
-                }
+			// check how to handle special edge weight
+			boolean handleSpecialEdgeWeights = false;
+			double defaultSpecialEdgeWeight = 1.0;
+			if (graph instanceof WeightedGraph<?, ?>) {
+				for (Key k : edgeValidKeys.values()) {
+					if (k.attributeName.equals(SPECIAL_EDGE_WEIGHT)) {
+						handleSpecialEdgeWeights = true;
+						String defaultValue = k.defaultValue;
+						try {
+							defaultSpecialEdgeWeight = Double.parseDouble(defaultValue);
+						} catch (NumberFormatException e) {
+							// ignore
+						}
+						// first key only which maps to "weight"
+						break;
+					}
+				}
 
-            }
+			}
 
-            // create edges
-            for (NodeOrEdge p : edges) {
-                V from = graphNodes.get(p.id1);
-                if (from == null) {
-                    throw new ImportException(
-                        "Source vertex " + p.id1 + " not found");
-                }
-                V to = graphNodes.get(p.id2);
-                if (to == null) {
-                    throw new ImportException(
-                        "Target vertex " + p.id2 + " not found");
-                }
+			// create edges
+			for (NodeOrEdge p : edges) {
+				V from = graphNodes.get(p.id1);
+				if (from == null) {
+					throw new ImportException("Source vertex " + p.id1 + " not found");
+				}
+				V to = graphNodes.get(p.id2);
+				if (to == null) {
+					throw new ImportException("Target vertex " + p.id2 + " not found");
+				}
 
-                // create attributes
-                Map<String, String> collectedAttributes = p.attributes;
-                Map<String, String> finalAttributes = new HashMap<String, String>();
+				// create attributes
+				Map<String, String> collectedAttributes = p.attributes;
+				Map<String, String> finalAttributes = new HashMap<String, String>();
 
-                for (Key validKey : edgeValidKeys.values()) {
-                    String validId = validKey.id;
-                    if (collectedAttributes.containsKey(validId)) {
-                        finalAttributes.put(
-                            validKey.attributeName,
-                            collectedAttributes.get(validId));
-                    } else {
-                        if (validKey.defaultValue != null) {
-                            finalAttributes.put(
-                                validKey.attributeName,
-                                validKey.defaultValue);
-                        }
-                    }
-                }
+				for (Key validKey : edgeValidKeys.values()) {
+					String validId = validKey.id;
+					if (collectedAttributes.containsKey(validId)) {
+						finalAttributes.put(validKey.attributeName, collectedAttributes.get(validId));
+					} else {
+						if (validKey.defaultValue != null) {
+							finalAttributes.put(validKey.attributeName, validKey.defaultValue);
+						}
+					}
+				}
 
-                E e = edgeProvider.buildEdge(
-                    from,
-                    to,
-                    "e_" + from + "_" + to,
-                    finalAttributes);
-                graph.addEdge(from, to, e);
+				E e = edgeProvider.buildEdge(from, to, "e_" + from + "_" + to, finalAttributes);
+				graph.addEdge(from, to, e);
 
-                // special handling for weighted graphs
-                if (handleSpecialEdgeWeights) {
-                    if (finalAttributes.containsKey(SPECIAL_EDGE_WEIGHT)) {
-                        try {
-                            ((WeightedGraph<V, E>) graph).setEdgeWeight(
-                                e,
-                                Double.parseDouble(
-                                    finalAttributes.get(SPECIAL_EDGE_WEIGHT)));
-                        } catch (NumberFormatException nfe) {
-                            ((WeightedGraph<V, E>) graph)
-                                .setEdgeWeight(e, defaultSpecialEdgeWeight);
-                        }
-                    }
+				// special handling for weighted graphs
+				if (handleSpecialEdgeWeights) {
+					if (finalAttributes.containsKey(SPECIAL_EDGE_WEIGHT)) {
+						try {
+							((WeightedGraph<V, E>) graph).setEdgeWeight(e,
+									Double.parseDouble(finalAttributes.get(SPECIAL_EDGE_WEIGHT)));
+						} catch (NumberFormatException nfe) {
+							((WeightedGraph<V, E>) graph).setEdgeWeight(e, defaultSpecialEdgeWeight);
+						}
+					}
 
-                }
-            }
+				}
+			}
 
-        }
+		}
 
-        @Override
-        public void startDocument()
-            throws SAXException
-        {
-            nodes = new HashMap<String, NodeOrEdge>();
-            edges = new ArrayList<NodeOrEdge>();
-            nodeValidKeys = new HashMap<String, Key>();
-            edgeValidKeys = new HashMap<String, Key>();
-            insideDefault = false;
-            insideData = false;
-            currentKey = null;
-            currentData = null;
-            currentNodeOrEdge = new ArrayDeque<NodeOrEdge>();
-        }
+		@Override
+		public void startDocument() throws SAXException {
+			nodes = new HashMap<String, NodeOrEdge>();
+			edges = new ArrayList<NodeOrEdge>();
+			nodeValidKeys = new HashMap<String, Key>();
+			edgeValidKeys = new HashMap<String, Key>();
+			insideDefault = false;
+			insideData = false;
+			currentKey = null;
+			currentData = null;
+			currentNodeOrEdge = new ArrayDeque<NodeOrEdge>();
+		}
 
-        @Override
-        public void startElement(
-            String uri,
-            String localName,
-            String qName,
-            Attributes attributes)
-            throws SAXException
-        {
-            switch (localName) {
-            case NODE:
-                currentNodeOrEdge
-                    .push(new NodeOrEdge(findAttribute(NODE_ID, attributes)));
-                break;
-            case EDGE:
-                currentNodeOrEdge.push(
-                    new NodeOrEdge(
-                        findAttribute(EDGE_SOURCE, attributes),
-                        findAttribute(EDGE_TARGET, attributes)));
-                break;
-            case KEY:
-                String keyId = findAttribute(KEY_ID, attributes);
-                String keyFor = findAttribute(KEY_FOR, attributes);
-                String keyAttrName = findAttribute(KEY_ATTR_NAME, attributes);
-                currentKey = new Key(keyId, keyAttrName, null, null);
-                if (keyFor != null) {
-                    if (keyFor.equals(EDGE)) {
-                        currentKey.target = KeyTarget.EDGE;
-                    } else if (keyFor.equals(NODE)) {
-                        currentKey.target = KeyTarget.NODE;
-                    }
-                }
-                break;
-            case DEFAULT:
-                insideDefault = true;
-                break;
-            case DATA:
-                insideData = true;
-                currentData = new Data(
-                    findAttribute(DATA_KEY, attributes),
-                    null);
-                break;
-            default:
-                break;
-            }
-        }
+		@Override
+		public void startElement(String uri, String localName, String qName, Attributes attributes)
+				throws SAXException {
+			switch (localName) {
+			case NODE:
+				currentNodeOrEdge.push(new NodeOrEdge(findAttribute(NODE_ID, attributes)));
+				break;
+			case EDGE:
+				currentNodeOrEdge.push(
+						new NodeOrEdge(findAttribute(EDGE_SOURCE, attributes), findAttribute(EDGE_TARGET, attributes)));
+				break;
+			case KEY:
+				String keyId = findAttribute(KEY_ID, attributes);
+				String keyFor = findAttribute(KEY_FOR, attributes);
+				String keyAttrName = findAttribute(KEY_ATTR_NAME, attributes);
+				currentKey = new Key(keyId, keyAttrName, null, null);
+				if (keyFor != null) {
+					if (keyFor.equals(EDGE)) {
+						currentKey.target = KeyTarget.EDGE;
+					} else if (keyFor.equals(NODE)) {
+						currentKey.target = KeyTarget.NODE;
+					}
+				}
+				break;
+			case DEFAULT:
+				insideDefault = true;
+				break;
+			case DATA:
+				insideData = true;
+				currentData = new Data(findAttribute(DATA_KEY, attributes), null);
+				break;
+			default:
+				break;
+			}
+		}
 
-        @Override
-        public void endElement(String uri, String localName, String qName)
-            throws SAXException
-        {
-            switch (localName) {
-            case NODE:
-                NodeOrEdge currentNode = currentNodeOrEdge.pop();
-                if (nodes.containsKey(currentNode.id1)) {
-                    throw new SAXException(
-                        "Node with id " + currentNode.id1 + " already exists");
-                }
-                nodes.put(currentNode.id1, currentNode);
-                break;
-            case EDGE:
-                NodeOrEdge currentEdge = currentNodeOrEdge.pop();
-                edges.add(currentEdge);
-                break;
-            case KEY:
-                if (currentKey.isValid()) {
-                    switch (currentKey.target) {
-                    case NODE:
-                        nodeValidKeys.put(currentKey.id, currentKey);
-                    case EDGE:
-                        edgeValidKeys.put(currentKey.id, currentKey);
-                    }
-                }
-                currentKey = null;
-                break;
-            case DEFAULT:
-                insideDefault = false;
-                break;
-            case DATA:
-                if (currentData.isValid()) {
-                    currentNodeOrEdge.peek().attributes
-                        .put(currentData.key, currentData.value);
-                }
-                insideData = false;
-                currentData = null;
-                break;
-            default:
-                break;
-            }
-        }
+		@Override
+		public void endElement(String uri, String localName, String qName) throws SAXException {
+			switch (localName) {
+			case NODE:
+				NodeOrEdge currentNode = currentNodeOrEdge.pop();
+				if (nodes.containsKey(currentNode.id1)) {
+					throw new SAXException("Node with id " + currentNode.id1 + " already exists");
+				}
+				nodes.put(currentNode.id1, currentNode);
+				break;
+			case EDGE:
+				NodeOrEdge currentEdge = currentNodeOrEdge.pop();
+				edges.add(currentEdge);
+				break;
+			case KEY:
+				if (currentKey.isValid()) {
+					switch (currentKey.target) {
+					case NODE:
+						nodeValidKeys.put(currentKey.id, currentKey);
+					case EDGE:
+						edgeValidKeys.put(currentKey.id, currentKey);
+					}
+				}
+				currentKey = null;
+				break;
+			case DEFAULT:
+				insideDefault = false;
+				break;
+			case DATA:
+				if (currentData.isValid()) {
+					currentNodeOrEdge.peek().attributes.put(currentData.key, currentData.value);
+				}
+				insideData = false;
+				currentData = null;
+				break;
+			default:
+				break;
+			}
+		}
 
-        @Override
-        public void characters(char ch[], int start, int length)
-            throws SAXException
-        {
-            if (insideDefault) {
-                currentKey.defaultValue = new String(ch, start, length);
-            } else if (insideData) {
-                currentData.value = new String(ch, start, length);
-            }
-        }
+		@Override
+		public void characters(char ch[], int start, int length) throws SAXException {
+			if (insideDefault) {
+				currentKey.defaultValue = new String(ch, start, length);
+			} else if (insideData) {
+				currentData.value = new String(ch, start, length);
+			}
+		}
 
-        @Override
-        public void warning(SAXParseException e)
-            throws SAXException
-        {
-            throw e;
-        }
+		@Override
+		public void warning(SAXParseException e) throws SAXException {
+			throw e;
+		}
 
-        public void error(SAXParseException e)
-            throws SAXException
-        {
-            throw e;
-        }
+		public void error(SAXParseException e) throws SAXException {
+			throw e;
+		}
 
-        public void fatalError(SAXParseException e)
-            throws SAXException
-        {
-            throw e;
-        }
+		public void fatalError(SAXParseException e) throws SAXException {
+			throw e;
+		}
 
-        private String findAttribute(String localName, Attributes attributes)
-        {
-            for (int i = 0; i < attributes.getLength(); i++) {
-                String attrLocalName = attributes.getLocalName(i);
-                if (attrLocalName.equals(localName)) {
-                    return attributes.getValue(i);
-                }
-            }
-            return null;
-        }
+		private String findAttribute(String localName, Attributes attributes) {
+			for (int i = 0; i < attributes.getLength(); i++) {
+				String attrLocalName = attributes.getLocalName(i);
+				if (attrLocalName.equals(localName)) {
+					return attributes.getValue(i);
+				}
+			}
+			return null;
+		}
 
-    }
+	}
 
-    // ----- Helper classes for storing partial parser results -----
-    
-    private enum KeyTarget
-    {
-        NODE,
-        EDGE,
-    }
+	// ----- Helper classes for storing partial parser results -----
 
-    private class Key
-    {
-        String id;
-        String attributeName;
-        String defaultValue;
-        KeyTarget target;
+	private enum KeyTarget {
+		NODE, EDGE,
+	}
 
-        public Key(
-            String id,
-            String attributeName,
-            String defaultValue,
-            KeyTarget target)
-        {
-            this.id = id;
-            this.attributeName = attributeName;
-            this.defaultValue = defaultValue;
-            this.target = target;
-        }
+	private class Key {
+		String id;
+		String attributeName;
+		String defaultValue;
+		KeyTarget target;
 
-        public boolean isValid()
-        {
-            return id != null && attributeName != null && target != null;
-        }
+		public Key(String id, String attributeName, String defaultValue, KeyTarget target) {
+			this.id = id;
+			this.attributeName = attributeName;
+			this.defaultValue = defaultValue;
+			this.target = target;
+		}
 
-    }
+		public boolean isValid() {
+			return id != null && attributeName != null && target != null;
+		}
 
-    private class Data
-    {
-        String key;
-        String value;
+	}
 
-        public Data(String key, String value)
-        {
-            this.key = key;
-            this.value = value;
-        }
+	private class Data {
+		String key;
+		String value;
 
-        public boolean isValid()
-        {
-            return key != null && value != null;
-        }
-    }
+		public Data(String key, String value) {
+			this.key = key;
+			this.value = value;
+		}
 
-    private class NodeOrEdge
-    {
-        String id1;
-        String id2;
-        Map<String, String> attributes;
+		public boolean isValid() {
+			return key != null && value != null;
+		}
+	}
 
-        public NodeOrEdge(String id1)
-        {
-            this.id1 = id1;
-            this.id2 = null;
-            this.attributes = new HashMap<String, String>();
-        }
+	private class NodeOrEdge {
+		String id1;
+		String id2;
+		Map<String, String> attributes;
 
-        public NodeOrEdge(String id1, String id2)
-        {
-            this.id1 = id1;
-            this.id2 = id2;
-            this.attributes = new HashMap<String, String>();
-        }
-    }
+		public NodeOrEdge(String id1) {
+			this.id1 = id1;
+			this.id2 = null;
+			this.attributes = new HashMap<String, String>();
+		}
+
+		public NodeOrEdge(String id1, String id2) {
+			this.id1 = id1;
+			this.id2 = id2;
+			this.attributes = new HashMap<String, String>();
+		}
+	}
 
 }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
@@ -146,446 +146,518 @@ import org.xml.sax.helpers.DefaultHandler;
  * <a href="http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">GraphML
  * Schema</a>.
  *
- * @param <V>
- *            the graph vertex type
- * @param <E>
- *            the graph edge type
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
  * 
  * @author Dimitrios Michail
  */
-public class GraphMLImporter<V, E> {
-	private static final String GRAPHML_SCHEMA_FILENAME = "graphml.xsd";
+public class GraphMLImporter<V, E>
+{
+    private static final String GRAPHML_SCHEMA_FILENAME = "graphml.xsd";
 
-	private VertexProvider<V> vertexProvider;
-	private EdgeProvider<V, E> edgeProvider;
+    private VertexProvider<V> vertexProvider;
+    private EdgeProvider<V, E> edgeProvider;
 
-	/**
-	 * Constructs a new importer.
-	 * 
-	 * @param vertexProvider
-	 *            provider for the generation of vertices. Must not be null.
-	 * @param edgeProvider
-	 *            provider for the generation of edges. Must not be null.
-	 */
-	public GraphMLImporter(VertexProvider<V> vertexProvider, EdgeProvider<V, E> edgeProvider) {
-		if (vertexProvider == null) {
-			throw new IllegalArgumentException("Vertex provider cannot be null");
-		}
-		this.vertexProvider = vertexProvider;
-		if (edgeProvider == null) {
-			throw new IllegalArgumentException("Edge provider cannot be null");
-		}
-		this.edgeProvider = edgeProvider;
-	}
+    /**
+     * Constructs a new importer.
+     * 
+     * @param vertexProvider provider for the generation of vertices. Must not
+     *        be null.
+     * @param edgeProvider provider for the generation of edges. Must not be
+     *        null.
+     */
+    public GraphMLImporter(
+        VertexProvider<V> vertexProvider,
+        EdgeProvider<V, E> edgeProvider)
+    {
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
+        }
+        this.vertexProvider = vertexProvider;
+        if (edgeProvider == null) {
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
+    }
 
-	/**
-	 * Get the vertex provider
-	 * 
-	 * @return the vertex provider
-	 */
-	public VertexProvider<V> getVertexProvider() {
-		return vertexProvider;
-	}
+    /**
+     * Get the vertex provider
+     * 
+     * @return the vertex provider
+     */
+    public VertexProvider<V> getVertexProvider()
+    {
+        return vertexProvider;
+    }
 
-	/**
-	 * Set the vertex provider
-	 * 
-	 * @param vertexProvider
-	 *            the new vertex provider. Must not be null.
-	 */
-	public void setVertexProvider(VertexProvider<V> vertexProvider) {
-		if (vertexProvider == null) {
-			throw new IllegalArgumentException("Vertex provider cannot be null");
-		}
-		this.vertexProvider = vertexProvider;
-	}
+    /**
+     * Set the vertex provider
+     * 
+     * @param vertexProvider the new vertex provider. Must not be null.
+     */
+    public void setVertexProvider(VertexProvider<V> vertexProvider)
+    {
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
+        }
+        this.vertexProvider = vertexProvider;
+    }
 
-	/**
-	 * Get the edge provider
-	 * 
-	 * @return The edge provider
-	 */
-	public EdgeProvider<V, E> getEdgeProvider() {
-		return edgeProvider;
-	}
+    /**
+     * Get the edge provider
+     * 
+     * @return The edge provider
+     */
+    public EdgeProvider<V, E> getEdgeProvider()
+    {
+        return edgeProvider;
+    }
 
-	/**
-	 * Set the edge provider.
-	 * 
-	 * @param edgeProvider
-	 *            the new edge provider. Must not be null.
-	 */
-	public void setEdgeProvider(EdgeProvider<V, E> edgeProvider) {
-		if (edgeProvider == null) {
-			throw new IllegalArgumentException("Edge provider cannot be null");
-		}
-		this.edgeProvider = edgeProvider;
-	}
+    /**
+     * Set the edge provider.
+     * 
+     * @param edgeProvider the new edge provider. Must not be null.
+     */
+    public void setEdgeProvider(EdgeProvider<V, E> edgeProvider)
+    {
+        if (edgeProvider == null) {
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
+    }
 
-	/**
-	 * Import a graph.
-	 * 
-	 * <p>
-	 * The provided graph must be able to support the features of the graph that
-	 * is read. For example if the GraphML file contains self-loops then the
-	 * graph provided must also support self-loops. The same for multiple edges.
-	 * 
-	 * <p>
-	 * If the provided graph is a weighted graph, the importer also reads edge
-	 * weights.
-	 * 
-	 * <p>
-	 * GraphML-Attributes Values are read as string key-value pairs and passed
-	 * on to the {@link VertexProvider} and {@link EdgeProvider} respectively.
-	 * 
-	 * @param input
-	 *            the input stream
-	 * @param graph
-	 *            the output graph
-	 * @throws ImportException
-	 *             in case an error occurs, such as I/O or parse error
-	 */
-	public void read(Reader input, Graph<V, E> graph) throws ImportException {
-		try {
-			SchemaFactory schemaFactory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+    /**
+     * Import a graph.
+     * 
+     * <p>
+     * The provided graph must be able to support the features of the graph that
+     * is read. For example if the GraphML file contains self-loops then the
+     * graph provided must also support self-loops. The same for multiple edges.
+     * 
+     * <p>
+     * If the provided graph is a weighted graph, the importer also reads edge
+     * weights.
+     * 
+     * <p>
+     * GraphML-Attributes Values are read as string key-value pairs and passed
+     * on to the {@link VertexProvider} and {@link EdgeProvider} respectively.
+     * 
+     * @param input the input stream
+     * @param graph the output graph
+     * @throws ImportException in case an error occurs, such as I/O or parse
+     *         error
+     */
+    public void read(Reader input, Graph<V, E> graph)
+        throws ImportException
+    {
+        try {
+            SchemaFactory schemaFactory = SchemaFactory
+                .newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
-			// load schema
-			URL xsd = Thread.currentThread().getContextClassLoader().getResource(GRAPHML_SCHEMA_FILENAME);
-			if (xsd == null) {
-				throw new ImportException("Failed to locate GraphML xsd");
-			}
-			Schema schema = schemaFactory.newSchema(new File(xsd.getFile()));
+            // load schema
+            URL xsd = Thread.currentThread()
+                .getContextClassLoader()
+                .getResource(GRAPHML_SCHEMA_FILENAME);
+            if (xsd == null) {
+                throw new ImportException("Failed to locate GraphML xsd");
+            }
+            Schema schema = schemaFactory.newSchema(new File(xsd.getFile()));
 
-			// create parser
-			SAXParserFactory spf = SAXParserFactory.newInstance();
-			spf.setNamespaceAware(true);
-			spf.setSchema(schema);
-			SAXParser saxParser = spf.newSAXParser();
+            // create parser
+            SAXParserFactory spf = SAXParserFactory.newInstance();
+            spf.setNamespaceAware(true);
+            spf.setSchema(schema);
+            SAXParser saxParser = spf.newSAXParser();
 
-			// parse
-			XMLReader xmlReader = saxParser.getXMLReader();
-			GraphMLHandler handler = new GraphMLHandler();
-			xmlReader.setContentHandler(handler);
-			xmlReader.setErrorHandler(handler);
-			xmlReader.parse(new InputSource(input));
+            // parse
+            XMLReader xmlReader = saxParser.getXMLReader();
+            GraphMLHandler handler = new GraphMLHandler();
+            xmlReader.setContentHandler(handler);
+            xmlReader.setErrorHandler(handler);
+            xmlReader.parse(new InputSource(input));
 
-			// read result
-			handler.updateGraph(graph);
-		} catch (Exception se) {
-			throw new ImportException("Failed to parse GraphML", se);
-		}
-	}
+            // read result
+            handler.updateGraph(graph);
+        } catch (Exception se) {
+            throw new ImportException("Failed to parse GraphML", se);
+        }
+    }
 
-	// content handler
-	private class GraphMLHandler extends DefaultHandler {
-		private static final String NODE = "node";
-		private static final String NODE_ID = "id";
-		private static final String EDGE = "edge";
-		private static final String EDGE_SOURCE = "source";
-		private static final String EDGE_TARGET = "target";
-		private static final String KEY = "key";
-		private static final String KEY_FOR = "for";
-		private static final String KEY_ATTR_NAME = "attr.name";
-		private static final String KEY_ID = "id";
-		private static final String DEFAULT = "default";
-		private static final String DATA = "data";
-		private static final String DATA_KEY = "key";
-		private static final String SPECIAL_EDGE_WEIGHT = "weight";
+    // content handler
+    private class GraphMLHandler
+        extends DefaultHandler
+    {
+        private static final String NODE = "node";
+        private static final String NODE_ID = "id";
+        private static final String EDGE = "edge";
+        private static final String EDGE_SOURCE = "source";
+        private static final String EDGE_TARGET = "target";
+        private static final String KEY = "key";
+        private static final String KEY_FOR = "for";
+        private static final String KEY_ATTR_NAME = "attr.name";
+        private static final String KEY_ID = "id";
+        private static final String DEFAULT = "default";
+        private static final String DATA = "data";
+        private static final String DATA_KEY = "key";
+        private static final String SPECIAL_EDGE_WEIGHT = "weight";
 
-		// collect graph elements here
-		private Map<String, NodeOrEdge> nodes;
-		private List<NodeOrEdge> edges;
+        // collect graph elements here
+        private Map<String, NodeOrEdge> nodes;
+        private List<NodeOrEdge> edges;
 
-		// record state of parser
-		private boolean insideDefault;
-		private boolean insideData;
+        // record state of parser
+        private boolean insideDefault;
+        private boolean insideData;
 
-		// temporary state while reading elements
-		// stack needed due to nested graphs in GraphML
-		private Data currentData;
-		private Key currentKey;
-		private Deque<NodeOrEdge> currentNodeOrEdge;
+        // temporary state while reading elements
+        // stack needed due to nested graphs in GraphML
+        private Data currentData;
+        private Key currentKey;
+        private Deque<NodeOrEdge> currentNodeOrEdge;
 
-		// collect custom keys
-		private Map<String, Key> nodeValidKeys;
-		private Map<String, Key> edgeValidKeys;
+        // collect custom keys
+        private Map<String, Key> nodeValidKeys;
+        private Map<String, Key> edgeValidKeys;
 
-		// construct the actual graph after parsing
-		public void updateGraph(Graph<V, E> graph) throws ImportException {
-			if (nodes.isEmpty()) {
-				return;
-			}
+        // construct the actual graph after parsing
+        public void updateGraph(Graph<V, E> graph)
+            throws ImportException
+        {
+            if (nodes.isEmpty()) {
+                return;
+            }
 
-			// create nodes
-			Map<String, V> graphNodes = new HashMap<String, V>();
+            // create nodes
+            Map<String, V> graphNodes = new HashMap<String, V>();
 
-			for (Entry<String, NodeOrEdge> en : nodes.entrySet()) {
-				String nodeId = en.getKey();
+            for (Entry<String, NodeOrEdge> en : nodes.entrySet()) {
+                String nodeId = en.getKey();
 
-				// create attributes
-				Map<String, String> collectedAttributes = en.getValue().attributes;
-				Map<String, String> finalAttributes = new HashMap<String, String>();
+                // create attributes
+                Map<String, String> collectedAttributes = en
+                    .getValue().attributes;
+                Map<String, String> finalAttributes = new HashMap<String, String>();
 
-				for (Key validKey : nodeValidKeys.values()) {
-					String validId = validKey.id;
-					if (collectedAttributes.containsKey(validId)) {
-						finalAttributes.put(validKey.attributeName, collectedAttributes.get(validId));
-					} else {
-						if (validKey.defaultValue != null) {
-							finalAttributes.put(validKey.attributeName, validKey.defaultValue);
-						}
-					}
-				}
+                for (Key validKey : nodeValidKeys.values()) {
+                    String validId = validKey.id;
+                    if (collectedAttributes.containsKey(validId)) {
+                        finalAttributes.put(
+                            validKey.attributeName,
+                            collectedAttributes.get(validId));
+                    } else {
+                        if (validKey.defaultValue != null) {
+                            finalAttributes.put(
+                                validKey.attributeName,
+                                validKey.defaultValue);
+                        }
+                    }
+                }
 
-				// create the actual node
-				V v = vertexProvider.buildVertex(nodeId, finalAttributes);
-				graphNodes.put(nodeId, v);
-				graph.addVertex(v);
-			}
+                // create the actual node
+                V v = vertexProvider.buildVertex(nodeId, finalAttributes);
+                graphNodes.put(nodeId, v);
+                graph.addVertex(v);
+            }
 
-			// check how to handle special edge weight
-			boolean handleSpecialEdgeWeights = false;
-			double defaultSpecialEdgeWeight = 1.0;
-			if (graph instanceof WeightedGraph<?, ?>) {
-				for (Key k : edgeValidKeys.values()) {
-					if (k.attributeName.equals(SPECIAL_EDGE_WEIGHT)) {
-						handleSpecialEdgeWeights = true;
-						String defaultValue = k.defaultValue;
-						try {
-							defaultSpecialEdgeWeight = Double.parseDouble(defaultValue);
-						} catch (NumberFormatException e) {
-							// ignore
-						}
-						// first key only which maps to "weight"
-						break;
-					}
-				}
+            // check how to handle special edge weight
+            boolean handleSpecialEdgeWeights = false;
+            double defaultSpecialEdgeWeight = 1.0;
+            if (graph instanceof WeightedGraph<?, ?>) {
+                for (Key k : edgeValidKeys.values()) {
+                    if (k.attributeName.equals(SPECIAL_EDGE_WEIGHT)) {
+                        handleSpecialEdgeWeights = true;
+                        String defaultValue = k.defaultValue;
+                        try {
+                            defaultSpecialEdgeWeight = Double
+                                .parseDouble(defaultValue);
+                        } catch (NumberFormatException e) {
+                            // ignore
+                        }
+                        // first key only which maps to "weight"
+                        break;
+                    }
+                }
 
-			}
+            }
 
-			// create edges
-			for (NodeOrEdge p : edges) {
-				V from = graphNodes.get(p.id1);
-				if (from == null) {
-					throw new ImportException("Source vertex " + p.id1 + " not found");
-				}
-				V to = graphNodes.get(p.id2);
-				if (to == null) {
-					throw new ImportException("Target vertex " + p.id2 + " not found");
-				}
+            // create edges
+            for (NodeOrEdge p : edges) {
+                V from = graphNodes.get(p.id1);
+                if (from == null) {
+                    throw new ImportException(
+                        "Source vertex " + p.id1 + " not found");
+                }
+                V to = graphNodes.get(p.id2);
+                if (to == null) {
+                    throw new ImportException(
+                        "Target vertex " + p.id2 + " not found");
+                }
 
-				// create attributes
-				Map<String, String> collectedAttributes = p.attributes;
-				Map<String, String> finalAttributes = new HashMap<String, String>();
+                // create attributes
+                Map<String, String> collectedAttributes = p.attributes;
+                Map<String, String> finalAttributes = new HashMap<String, String>();
 
-				for (Key validKey : edgeValidKeys.values()) {
-					String validId = validKey.id;
-					if (collectedAttributes.containsKey(validId)) {
-						finalAttributes.put(validKey.attributeName, collectedAttributes.get(validId));
-					} else {
-						if (validKey.defaultValue != null) {
-							finalAttributes.put(validKey.attributeName, validKey.defaultValue);
-						}
-					}
-				}
+                for (Key validKey : edgeValidKeys.values()) {
+                    String validId = validKey.id;
+                    if (collectedAttributes.containsKey(validId)) {
+                        finalAttributes.put(
+                            validKey.attributeName,
+                            collectedAttributes.get(validId));
+                    } else {
+                        if (validKey.defaultValue != null) {
+                            finalAttributes.put(
+                                validKey.attributeName,
+                                validKey.defaultValue);
+                        }
+                    }
+                }
 
-				E e = edgeProvider.buildEdge(from, to, "e_" + from + "_" + to, finalAttributes);
-				graph.addEdge(from, to, e);
+                E e = edgeProvider.buildEdge(
+                    from,
+                    to,
+                    "e_" + from + "_" + to,
+                    finalAttributes);
+                graph.addEdge(from, to, e);
 
-				// special handling for weighted graphs
-				if (handleSpecialEdgeWeights) {
-					if (finalAttributes.containsKey(SPECIAL_EDGE_WEIGHT)) {
-						try {
-							((WeightedGraph<V, E>) graph).setEdgeWeight(e,
-									Double.parseDouble(finalAttributes.get(SPECIAL_EDGE_WEIGHT)));
-						} catch (NumberFormatException nfe) {
-							((WeightedGraph<V, E>) graph).setEdgeWeight(e, defaultSpecialEdgeWeight);
-						}
-					}
+                // special handling for weighted graphs
+                if (handleSpecialEdgeWeights) {
+                    if (finalAttributes.containsKey(SPECIAL_EDGE_WEIGHT)) {
+                        try {
+                            ((WeightedGraph<V, E>) graph).setEdgeWeight(
+                                e,
+                                Double.parseDouble(
+                                    finalAttributes.get(SPECIAL_EDGE_WEIGHT)));
+                        } catch (NumberFormatException nfe) {
+                            ((WeightedGraph<V, E>) graph)
+                                .setEdgeWeight(e, defaultSpecialEdgeWeight);
+                        }
+                    }
 
-				}
-			}
+                }
+            }
 
-		}
+        }
 
-		@Override
-		public void startDocument() throws SAXException {
-			nodes = new HashMap<String, NodeOrEdge>();
-			edges = new ArrayList<NodeOrEdge>();
-			nodeValidKeys = new HashMap<String, Key>();
-			edgeValidKeys = new HashMap<String, Key>();
-			insideDefault = false;
-			insideData = false;
-			currentKey = null;
-			currentData = null;
-			currentNodeOrEdge = new ArrayDeque<NodeOrEdge>();
-		}
+        @Override
+        public void startDocument()
+            throws SAXException
+        {
+            nodes = new HashMap<String, NodeOrEdge>();
+            edges = new ArrayList<NodeOrEdge>();
+            nodeValidKeys = new HashMap<String, Key>();
+            edgeValidKeys = new HashMap<String, Key>();
+            insideDefault = false;
+            insideData = false;
+            currentKey = null;
+            currentData = null;
+            currentNodeOrEdge = new ArrayDeque<NodeOrEdge>();
+        }
 
-		@Override
-		public void startElement(String uri, String localName, String qName, Attributes attributes)
-				throws SAXException {
-			switch (localName) {
-			case NODE:
-				currentNodeOrEdge.push(new NodeOrEdge(findAttribute(NODE_ID, attributes)));
-				break;
-			case EDGE:
-				currentNodeOrEdge.push(
-						new NodeOrEdge(findAttribute(EDGE_SOURCE, attributes), findAttribute(EDGE_TARGET, attributes)));
-				break;
-			case KEY:
-				String keyId = findAttribute(KEY_ID, attributes);
-				String keyFor = findAttribute(KEY_FOR, attributes);
-				String keyAttrName = findAttribute(KEY_ATTR_NAME, attributes);
-				currentKey = new Key(keyId, keyAttrName, null, null);
-				if (keyFor != null) {
-					if (keyFor.equals(EDGE)) {
-						currentKey.target = KeyTarget.EDGE;
-					} else if (keyFor.equals(NODE)) {
-						currentKey.target = KeyTarget.NODE;
-					}
-				}
-				break;
-			case DEFAULT:
-				insideDefault = true;
-				break;
-			case DATA:
-				insideData = true;
-				currentData = new Data(findAttribute(DATA_KEY, attributes), null);
-				break;
-			default:
-				break;
-			}
-		}
+        @Override
+        public void startElement(
+            String uri,
+            String localName,
+            String qName,
+            Attributes attributes)
+            throws SAXException
+        {
+            switch (localName) {
+            case NODE:
+                currentNodeOrEdge
+                    .push(new NodeOrEdge(findAttribute(NODE_ID, attributes)));
+                break;
+            case EDGE:
+                currentNodeOrEdge.push(
+                    new NodeOrEdge(
+                        findAttribute(EDGE_SOURCE, attributes),
+                        findAttribute(EDGE_TARGET, attributes)));
+                break;
+            case KEY:
+                String keyId = findAttribute(KEY_ID, attributes);
+                String keyFor = findAttribute(KEY_FOR, attributes);
+                String keyAttrName = findAttribute(KEY_ATTR_NAME, attributes);
+                currentKey = new Key(keyId, keyAttrName, null, null);
+                if (keyFor != null) {
+                    if (keyFor.equals(EDGE)) {
+                        currentKey.target = KeyTarget.EDGE;
+                    } else if (keyFor.equals(NODE)) {
+                        currentKey.target = KeyTarget.NODE;
+                    }
+                }
+                break;
+            case DEFAULT:
+                insideDefault = true;
+                break;
+            case DATA:
+                insideData = true;
+                currentData = new Data(
+                    findAttribute(DATA_KEY, attributes),
+                    null);
+                break;
+            default:
+                break;
+            }
+        }
 
-		@Override
-		public void endElement(String uri, String localName, String qName) throws SAXException {
-			switch (localName) {
-			case NODE:
-				NodeOrEdge currentNode = currentNodeOrEdge.pop();
-				if (nodes.containsKey(currentNode.id1)) {
-					throw new SAXException("Node with id " + currentNode.id1 + " already exists");
-				}
-				nodes.put(currentNode.id1, currentNode);
-				break;
-			case EDGE:
-				NodeOrEdge currentEdge = currentNodeOrEdge.pop();
-				edges.add(currentEdge);
-				break;
-			case KEY:
-				if (currentKey.isValid()) {
-					switch (currentKey.target) {
-					case NODE:
-						nodeValidKeys.put(currentKey.id, currentKey);
-					case EDGE:
-						edgeValidKeys.put(currentKey.id, currentKey);
-					}
-				}
-				currentKey = null;
-				break;
-			case DEFAULT:
-				insideDefault = false;
-				break;
-			case DATA:
-				if (currentData.isValid()) {
-					currentNodeOrEdge.peek().attributes.put(currentData.key, currentData.value);
-				}
-				insideData = false;
-				currentData = null;
-				break;
-			default:
-				break;
-			}
-		}
+        @Override
+        public void endElement(String uri, String localName, String qName)
+            throws SAXException
+        {
+            switch (localName) {
+            case NODE:
+                NodeOrEdge currentNode = currentNodeOrEdge.pop();
+                if (nodes.containsKey(currentNode.id1)) {
+                    throw new SAXException(
+                        "Node with id " + currentNode.id1 + " already exists");
+                }
+                nodes.put(currentNode.id1, currentNode);
+                break;
+            case EDGE:
+                NodeOrEdge currentEdge = currentNodeOrEdge.pop();
+                edges.add(currentEdge);
+                break;
+            case KEY:
+                if (currentKey.isValid()) {
+                    switch (currentKey.target) {
+                    case NODE:
+                        nodeValidKeys.put(currentKey.id, currentKey);
+                    case EDGE:
+                        edgeValidKeys.put(currentKey.id, currentKey);
+                    }
+                }
+                currentKey = null;
+                break;
+            case DEFAULT:
+                insideDefault = false;
+                break;
+            case DATA:
+                if (currentData.isValid()) {
+                    currentNodeOrEdge.peek().attributes
+                        .put(currentData.key, currentData.value);
+                }
+                insideData = false;
+                currentData = null;
+                break;
+            default:
+                break;
+            }
+        }
 
-		@Override
-		public void characters(char ch[], int start, int length) throws SAXException {
-			if (insideDefault) {
-				currentKey.defaultValue = new String(ch, start, length);
-			} else if (insideData) {
-				currentData.value = new String(ch, start, length);
-			}
-		}
+        @Override
+        public void characters(char ch[], int start, int length)
+            throws SAXException
+        {
+            if (insideDefault) {
+                currentKey.defaultValue = new String(ch, start, length);
+            } else if (insideData) {
+                currentData.value = new String(ch, start, length);
+            }
+        }
 
-		@Override
-		public void warning(SAXParseException e) throws SAXException {
-			throw e;
-		}
+        @Override
+        public void warning(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
 
-		public void error(SAXParseException e) throws SAXException {
-			throw e;
-		}
+        public void error(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
 
-		public void fatalError(SAXParseException e) throws SAXException {
-			throw e;
-		}
+        public void fatalError(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
 
-		private String findAttribute(String localName, Attributes attributes) {
-			for (int i = 0; i < attributes.getLength(); i++) {
-				String attrLocalName = attributes.getLocalName(i);
-				if (attrLocalName.equals(localName)) {
-					return attributes.getValue(i);
-				}
-			}
-			return null;
-		}
+        private String findAttribute(String localName, Attributes attributes)
+        {
+            for (int i = 0; i < attributes.getLength(); i++) {
+                String attrLocalName = attributes.getLocalName(i);
+                if (attrLocalName.equals(localName)) {
+                    return attributes.getValue(i);
+                }
+            }
+            return null;
+        }
 
-	}
+    }
 
-	// ----- Helper classes for storing partial parser results -----
+    // ----- Helper classes for storing partial parser results -----
 
-	private enum KeyTarget {
-		NODE, EDGE,
-	}
+    private enum KeyTarget
+    {
+        NODE,
+        EDGE,
+    }
 
-	private class Key {
-		String id;
-		String attributeName;
-		String defaultValue;
-		KeyTarget target;
+    private class Key
+    {
+        String id;
+        String attributeName;
+        String defaultValue;
+        KeyTarget target;
 
-		public Key(String id, String attributeName, String defaultValue, KeyTarget target) {
-			this.id = id;
-			this.attributeName = attributeName;
-			this.defaultValue = defaultValue;
-			this.target = target;
-		}
+        public Key(
+            String id,
+            String attributeName,
+            String defaultValue,
+            KeyTarget target)
+        {
+            this.id = id;
+            this.attributeName = attributeName;
+            this.defaultValue = defaultValue;
+            this.target = target;
+        }
 
-		public boolean isValid() {
-			return id != null && attributeName != null && target != null;
-		}
+        public boolean isValid()
+        {
+            return id != null && attributeName != null && target != null;
+        }
 
-	}
+    }
 
-	private class Data {
-		String key;
-		String value;
+    private class Data
+    {
+        String key;
+        String value;
 
-		public Data(String key, String value) {
-			this.key = key;
-			this.value = value;
-		}
+        public Data(String key, String value)
+        {
+            this.key = key;
+            this.value = value;
+        }
 
-		public boolean isValid() {
-			return key != null && value != null;
-		}
-	}
+        public boolean isValid()
+        {
+            return key != null && value != null;
+        }
+    }
 
-	private class NodeOrEdge {
-		String id1;
-		String id2;
-		Map<String, String> attributes;
+    private class NodeOrEdge
+    {
+        String id1;
+        String id2;
+        Map<String, String> attributes;
 
-		public NodeOrEdge(String id1) {
-			this.id1 = id1;
-			this.id2 = null;
-			this.attributes = new HashMap<String, String>();
-		}
+        public NodeOrEdge(String id1)
+        {
+            this.id1 = id1;
+            this.id2 = null;
+            this.attributes = new HashMap<String, String>();
+        }
 
-		public NodeOrEdge(String id1, String id2) {
-			this.id1 = id1;
-			this.id2 = id2;
-			this.attributes = new HashMap<String, String>();
-		}
-	}
+        public NodeOrEdge(String id1, String id2)
+        {
+            this.id1 = id1;
+            this.id2 = id2;
+            this.attributes = new HashMap<String, String>();
+        }
+    }
 
 }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/ImportException.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/ImportException.java
@@ -30,20 +30,70 @@
 package org.jgrapht.ext;
 
 /**
- * Used to show problems with importing a graph.
+ * An exception that the library throws in case of graph import errors.
  */
 public class ImportException
     extends Exception
 {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Constructs an {@code ImportException} with {@code null} as its error
+     * detail message.
+     */
+    public ImportException()
+    {
+        super();
+    }
+
+    /**
+     * Constructs an {@code ImportException} with the specified detail message.
+     *
+     * @param message The detail message (which is saved for later retrieval by
+     *        the {@link #getMessage()} method)
+     */
     public ImportException(String message)
     {
         super(message);
     }
 
+    /**
+     * Constructs an {@code ImMportException} with the specified detail message
+     * and cause.
+     *
+     * <p>
+     * Note that the detail message associated with {@code cause} is <i>not</i>
+     * automatically incorporated into this exception's detail message.
+     *
+     * @param message The detail message (which is saved for later retrieval by
+     *        the {@link #getMessage()} method)
+     *
+     * @param cause The cause (which is saved for later retrieval by the
+     *        {@link #getCause()} method). (A null value is permitted, and
+     *        indicates that the cause is nonexistent or unknown.)
+     */
     public ImportException(String message, Throwable cause)
     {
         super(message, cause);
     }
+
+    /**
+     * Constructs an {@code ImportException} with the specified cause and a
+     * detail message of {@code (cause==null ? null : cause.toString())} (which
+     * typically contains the class and detail message of {@code cause}). This
+     * constructor is useful for IO exceptions that are little more than
+     * wrappers for other throwables.
+     *
+     * @param cause The cause (which is saved for later retrieval by the
+     *        {@link #getCause()} method). (A null value is permitted, and
+     *        indicates that the cause is nonexistent or unknown.)
+     *
+     */
+    public ImportException(Throwable cause)
+    {
+        super(cause);
+    }
+
 }
 
 // End ImportException.java

--- a/jgrapht-ext/src/main/resources/graphml.xsd
+++ b/jgrapht-ext/src/main/resources/graphml.xsd
@@ -1,0 +1,345 @@
+<?xml version="1.0"?>
+
+<xs:schema   
+             targetNamespace="http://graphml.graphdrawing.org/xmlns"
+
+             xmlns="http://graphml.graphdrawing.org/xmlns"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+
+             elementFormDefault="qualified"
+             attributeFormDefault="unqualified"
+>
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+     This document defines the GraphML language including GraphML attributes and GraphML parseinfo.
+    </xs:documentation>
+  </xs:annotation>
+
+
+<xs:redefine schemaLocation="http://graphml.graphdrawing.org/xmlns/1.0/graphml-structure.xsd">
+
+  <!--redefinition as in graphml-attributes.xsd -->
+
+  <xs:attributeGroup name="key.extra.attrib">
+    <xs:attributeGroup ref="key.extra.attrib"/>
+    <xs:attributeGroup ref="key.attributes.attrib"/>
+  </xs:attributeGroup>
+
+  <!--redefinition as in graphml-parseinfo.xsd -->
+
+  <xs:attributeGroup name="graph.extra.attrib">
+    <xs:attributeGroup ref="graph.extra.attrib"/>
+    <xs:attributeGroup ref="graph.parseinfo.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="node.extra.attrib">
+    <xs:attributeGroup ref="node.extra.attrib"/>
+    <xs:attributeGroup ref="node.parseinfo.attrib"/>
+  </xs:attributeGroup>
+
+</xs:redefine>
+
+
+  <!--types as in graphml-attributes.xsd -->
+
+<xs:simpleType name="key.name.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/(Dokumentation der Attributes Erweiterung; entsprechende Stelle.html)"
+        xml:lang="en">
+      Simple type for the attr.name attribute of &lt;key>.
+      key.name.type is final, that is, it may not be extended
+                          or restricted.
+      key.name.type is a restriction of xs:NMTOKEN
+      Allowed values: (no restriction)
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:NMTOKEN"/>
+
+</xs:simpleType>
+
+
+
+<xs:simpleType name="key.type.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/(Dokumentation der Attributes Erweiterung; entsprechende Stelle.html)"
+        xml:lang="en">
+      Simple type for the attr.type attribute of &lt;key>.
+      key.type.type is final, that is, it may not be extended
+                          or restricted.
+      key.type.type is a restriction of xs:NMTOKEN
+      Allowed values: boolean, int, long, float, double, string.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:NMTOKEN">  
+    <xs:enumeration value="boolean"/>
+    <xs:enumeration value="int"/>
+    <xs:enumeration value="long"/>
+    <xs:enumeration value="float"/>
+    <xs:enumeration value="double"/>
+    <xs:enumeration value="string"/>
+  </xs:restriction>
+
+</xs:simpleType>
+
+
+<xs:attributeGroup name="key.attributes.attrib">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+     Definition of the attribute group key.attributes.attrib.
+     This group consists of the two optional attributes
+         - attr.name (gives the name for the data function)
+         - attr.type ((declares the range of values for the data function)
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attribute name="attr.name" type="key.name.type" use="optional"/>
+  <xs:attribute name="attr.type" type="key.type.type" use="optional"/>
+</xs:attributeGroup>
+
+  <!--types as in graphml-parseinfo.xsd -->
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+       Simple type definitions for the new graph attributes.
+    </xs:documentation>
+  </xs:annotation>
+
+<xs:simpleType name="graph.order.type"  final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.order attribute of &lt;graph>.
+      graph.order.type is final, that is, it may not be extended
+                          or restricted.
+      graph.order.type is a restriction of xs:NMTOKEN
+      Allowed values: free, nodesfirst, adjacencylist.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:NMTOKEN">
+    <xs:enumeration value="free"/>
+    <xs:enumeration value="nodesfirst"/>
+    <xs:enumeration value="adjacencylist"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="graph.nodes.type"  final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.nodes attribute of &lt;graph>.
+      graph.nodes.type is final, that is, it may not be extended
+                          or restricted.
+      graph.nodes.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:simpleType name="graph.edges.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.edges attribute of &lt;graph>.
+      graph.edges.type is final, that is, it may not be extended
+                          or restricted.
+      graph.edges.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:simpleType name="graph.maxindegree.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.maxindegree attribute of &lt;graph>.
+      graph.maxindegree.type is final, that is, it may not be extended
+                          or restricted.
+      graph.maxindegree.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:simpleType name="graph.maxoutdegree.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.maxoutdegree attribute of &lt;graph>.
+      graph.maxoutdegree.type is final, that is, it may not be extended
+                          or restricted.
+      graph.maxoutdegree.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:simpleType name="graph.nodeids.type"  final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.nodeids attribute of &lt;graph>.
+      graph.nodeids.type is final, that is, it may not be extended
+                          or restricted.
+      graph.nodeids.type is a restriction of xs:string
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:NMTOKEN">
+    <xs:enumeration value="canonical"/>
+    <xs:enumeration value="free"/>
+  </xs:restriction>  
+</xs:simpleType>
+
+<xs:simpleType name="graph.edgeids.type"  final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.edgeids attribute of &lt;graph>.
+      graph.edgeids.type is final, that is, it may not be extended
+                          or restricted.
+      graph.edgeids.type is a restriction of xs:string
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:NMTOKEN">
+    <xs:enumeration value="canonical"/>
+    <xs:enumeration value="free"/>
+  </xs:restriction>  
+</xs:simpleType>
+
+<xs:attributeGroup name="graph.parseinfo.attrib">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+     Definition of the attribute group graph.parseinfo.attrib.
+     This group consists of the seven attributes
+     - parse.nodeids (fixed to 'canonical' meaning that the id attribute
+                      of &lt;node> follows the pattern 'n[number]),
+     - parse.edgeids (fixed to 'canonical' meaning that the id attribute
+                      of &lt;edge> follows the pattern 'e[number]),
+     - parse.order (required; one of the values 'nodesfirst', 
+                    'adjacencylist' or 'free'),
+     - parse.nodes (required; number of nodes in this graph), 
+     - parse.edges (required; number of edges in this graph), 
+     - parse.maxindegree (optional; maximal indegree of a node in this graph),
+     - parse.maxoutdegree (optional; maximal outdegree of a node in this graph)
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attribute name="parse.nodeids" type="graph.nodeids.type"/>
+  <xs:attribute name="parse.edgeids" type="graph.edgeids.type"/>
+  <xs:attribute name="parse.order" type="graph.order.type"/>
+  <xs:attribute name="parse.nodes" type="graph.nodes.type"/>
+  <xs:attribute name="parse.edges" type="graph.edges.type"/>
+  <xs:attribute name="parse.maxindegree" type="graph.maxindegree.type" use="optional"/>
+  <xs:attribute name="parse.maxoutdegree" type="graph.maxoutdegree.type" use="optional"/>
+</xs:attributeGroup>
+
+
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+       Simple type definitions for the new node attributes.
+    </xs:documentation>
+  </xs:annotation>
+
+<xs:simpleType name="node.indegree.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.indegree attribute of &lt;node>.
+      node.indegree.type is final, that is, it may not be extended
+                          or restricted.
+      node.indegree.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:simpleType name="node.outdegree.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.outdegree attribute of &lt;node>.
+      node.outdegree.type is final, that is, it may not be extended
+                          or restricted.
+      node.outdegree.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:attributeGroup name="node.parseinfo.attrib">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+     Definition of the attribute group node.parseinfo.attrib.
+     This group consists of two attributes
+     - parse.indegree (optional; indegree of this node),
+     - parse.outdegree (optional; outdegree of this node).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attribute name="parse.indegree" type="node.indegree.type" use="optional"/>
+  <xs:attribute name="parse.outdegree" type="node.outdegree.type" use="optional"/>
+</xs:attributeGroup>
+
+</xs:schema>
+
+<!--======================================================-->
+<!--      end of file: graphml-parseinfo.xsd             -->
+<!--======================================================-->

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
@@ -527,6 +527,19 @@ public class GmlImporterTest
         }
     }
 
+    public void testMissingVertices()
+    {
+        // @formatter:off
+        String input = "graph [ edge [ source 1 target 2 ] ]";
+        // @formatter:on
+
+        try {
+            readGraph(input, DefaultEdge.class, false, false);
+            fail("Node is missing?");
+        } catch (ImportException e) {
+        }
+    }
+
     public void testExportImport()
         throws ImportException
     {

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
@@ -49,6 +49,10 @@ import org.jgrapht.graph.WeightedPseudograph;
 
 import junit.framework.TestCase;
 
+/**
+ * 
+ * @author Dimitrios Michail
+ */
 public class GmlImporterTest
     extends TestCase
 {

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
@@ -1,0 +1,564 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* ------------------------------
+ * GmlImporterTest.java
+ * ------------------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author: Dimitrios Michail
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 16-July-2016 : Initial revision (DM);
+ *
+ */
+package org.jgrapht.ext;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Map;
+
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.jgrapht.graph.Pseudograph;
+import org.jgrapht.graph.WeightedPseudograph;
+
+import junit.framework.TestCase;
+
+public class GmlImporterTest
+    extends TestCase
+{
+
+    public <E> Graph<String, E> readGraph(
+        String input,
+        Class<? extends E> edgeClass,
+        boolean directed,
+        boolean weighted)
+        throws ImportException
+    {
+        Graph<String, E> g;
+        if (directed) {
+            if (weighted) {
+                g = new DirectedWeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new DirectedPseudograph<String, E>(edgeClass);
+            }
+        } else {
+            if (weighted) {
+                g = new WeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new Pseudograph<String, E>(edgeClass);
+            }
+        }
+
+        VertexProvider<String> vp = new VertexProvider<String>()
+        {
+            @Override
+            public String buildVertex(
+                String label,
+                Map<String, String> attributes)
+            {
+                return label;
+            }
+        };
+
+        EdgeProvider<String, E> ep = new EdgeProvider<String, E>()
+        {
+
+            @Override
+            public E buildEdge(
+                String from,
+                String to,
+                String label,
+                Map<String, String> attributes)
+            {
+                return g.getEdgeFactory().createEdge(from, to);
+            }
+
+        };
+
+        GmlImporter<String, E> importer = new GmlImporter<String, E>(vp, ep);
+        importer.read(new StringReader(input), g);
+
+        return g;
+    }
+
+    public void testUndirectedUnweighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 3\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "  ]\n"                     
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 2\n"
+                     + "    target 3\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsVertex("4"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testIgnoreWeightsUndirectedUnweighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "    weight 2.0\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 2.0\n"
+                     + "    target 3\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3.3\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(2, g.vertexSet().size());
+        assertEquals(1, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsEdge("1", "2"));
+    }
+
+    public void testNoGraph()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "GRAPH [\n"
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g1 = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(0, g1.vertexSet().size());
+        assertEquals(0, g1.edgeSet().size());
+
+        Graph<String, DefaultEdge> g2 = readGraph(
+            input.toLowerCase(),
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(0, g2.vertexSet().size());
+        assertEquals(0, g2.edgeSet().size());
+    }
+
+    public void testIgnore()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  ignore [\n"
+                     + "     node [\n"
+                     + "       id 5\n"
+                     + "     ]"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 3\n"
+                     + "    label \"3\""
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "  ]\n"                     
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"
+                     + "  ignore [\n"
+                     + "     edge [\n"
+                     + "       source 5\n"
+                     + "       target 1\n"
+                     + "       label \"edge51\""
+                     + "     ]"
+                     + "  ]\n"                     
+                     + "  edge [\n"
+                     + "    source 2\n"
+                     + "    target 3\n"
+                     + "    label \"23\""                     
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "]"
+                     + "node [\n"
+                     + "  id 6\n"
+                     + "]\n"
+                     ;
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsVertex("4"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testUndirectedUnweightedWrongOrder()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 2\n"
+                     + "    target 3\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 3\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "  ]\n"                     
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsVertex("4"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testDirectedPseudographUnweighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 3\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "  ]\n"                     
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"                     
+                     + "  edge [\n"
+                     + "    source 2\n"
+                     + "    target 3\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 2\n"
+                     + "    target 2\n"
+                     + "  ]\n"                     
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            true,
+            false);
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(7, g.edgeSet().size());
+    }
+
+    public void testDirectedWeighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 3\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "    weight 2.0\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3\n"
+                     + "    target 1\n"
+                     + "    weight 3.0\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultWeightedEdge> g = readGraph(
+            input,
+            DefaultWeightedEdge.class,
+            true,
+            true);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(2, g.edgeSet().size());
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("3", "1"));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")));
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")));
+    }
+
+    public void testDirectedWeightedWithComments()
+        throws ImportException
+    {
+        // @formatter:off
+            String input = "# A comment line\n" 
+            		     + "graph [\n"
+                         + "  comment \"Sample Graph\"\n"
+                         + "  directed 1\n"
+                         + "  node [\n"
+                         + "    id 1\n"
+                         + "  ]\n"
+                         + "  node [\n"
+                         + "    id 2\n"
+                         + "  ]\n"
+                         + "# Another comment line\n"
+                         + "  node [\n"
+                         + "    id 3\n"
+                         + "  ]\n"
+                         + "  edge [\n"
+                         + "    source 1\n"
+                         + "    target 2\n"
+                         + "    weight 2.0\n"
+                         + "  ]\n"
+                         + "  edge [\n"
+                         + "    source 3\n"
+                         + "    target 1\n"
+                         + "    weight 3.0\n"
+                         + "  ]\n"
+                         + "]";
+            // @formatter:on
+
+        Graph<String, DefaultWeightedEdge> g = readGraph(
+            input,
+            DefaultWeightedEdge.class,
+            true,
+            true);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(2, g.edgeSet().size());
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("3", "1"));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")));
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")));
+    }
+
+    public void testDirectedWeightedSingleLine()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [ node [ id 1 ] node [ id 2 ] node [ id 3 ] " + 
+                       "edge [ source 1 target 2 weight 2.0 ] " + 
+                       "edge [ source 3 target 1 weight 3.0 ] ]"; 
+        // @formatter:on
+
+        Graph<String, DefaultWeightedEdge> g = readGraph(
+            input,
+            DefaultWeightedEdge.class,
+            true,
+            true);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(2, g.edgeSet().size());
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("3", "1"));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")));
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")));
+    }
+
+    public void testParserError()
+    {
+        // @formatter:off
+        String input = "graph [ [ node ] ]";
+        // @formatter:on
+
+        try {
+            readGraph(input, DefaultEdge.class, false, false);
+            fail("Managed to parse wrong input");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testExportImport()
+        throws ImportException
+    {
+        DirectedWeightedPseudograph<String, DefaultWeightedEdge> g1 = new DirectedWeightedPseudograph<String, DefaultWeightedEdge>(
+            DefaultWeightedEdge.class);
+        g1.addVertex("1");
+        g1.addVertex("2");
+        g1.addVertex("3");
+        g1.setEdgeWeight(g1.addEdge("1", "2"), 2.0);
+        g1.setEdgeWeight(g1.addEdge("2", "3"), 3.0);
+        g1.setEdgeWeight(g1.addEdge("3", "3"), 5.0);
+
+        StringWriter sw = new StringWriter();
+        GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<String, DefaultWeightedEdge>();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(sw, g1);
+        String output = sw.toString();
+
+        Graph<String, DefaultWeightedEdge> g2 = readGraph(
+            output,
+            DefaultWeightedEdge.class,
+            true,
+            true);
+
+        assertEquals(3, g2.vertexSet().size());
+        assertEquals(3, g2.edgeSet().size());
+        assertTrue(g2.containsEdge("1", "2"));
+        assertTrue(g2.containsEdge("2", "3"));
+        assertTrue(g2.containsEdge("3", "3"));
+        assertEquals(2.0, g2.getEdgeWeight(g2.getEdge("1", "2")));
+        assertEquals(3.0, g2.getEdgeWeight(g2.getEdge("2", "3")));
+        assertEquals(5.0, g2.getEdgeWeight(g2.getEdge("3", "3")));
+    }
+
+}

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
@@ -22,9 +22,10 @@
 /* ------------------------------
  * GraphMLExporterTest.java
  * ------------------------------
- * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ * (C) Copyright 2006-2016, by Trevor Harmon and Contributors.
  *
  * Original Author:  Trevor Harmon
+ * Contributors: Dimitrios Michail
  *
  */
 package org.jgrapht.ext;
@@ -38,16 +39,15 @@ import org.custommonkey.xmlunit.*;
 import org.jgrapht.*;
 import org.jgrapht.graph.*;
 
-
 /**
- * .
- *
  * @author Trevor Harmon
+ * @author Dimitrios Michail
  */
 public class GraphMLExporterTest
     extends TestCase
 {
-    //~ Static fields/initializers ---------------------------------------------
+    // ~ Static fields/initializers
+    // ---------------------------------------------
 
     private static final String V1 = "v1";
     private static final String V2 = "v2";
@@ -55,49 +55,273 @@ public class GraphMLExporterTest
 
     private static final String NL = System.getProperty("line.separator");
 
-    // TODO jvs 23-Dec-2006:  externalized diff-based testing framework
-
-    private static final String UNDIRECTED =
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
-        + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
-        + NL
-        + "<graph edgedefault=\"undirected\">" + NL
-        + "<node id=\"1\"/>" + NL
-        + "<node id=\"2\"/>" + NL
-        + "<node id=\"3\"/>" + NL
-        + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
-        + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
-        + "</graph>" + NL
-        + "</graphml>" + NL;
-
-    private static final GraphMLExporter<String, DefaultEdge> exporter =
-        new GraphMLExporter<String, DefaultEdge>();
-
-    //~ Methods ----------------------------------------------------------------
+    // ~ Methods
+    // ----------------------------------------------------------------
 
     public void testUndirected()
         throws Exception
     {
-        UndirectedGraph<String, DefaultEdge> g =
-            new SimpleGraph<String, DefaultEdge>(DefaultEdge.class);
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<graph edgedefault=\"undirected\">" + NL
+            + "<node id=\"1\"/>" + NL
+            + "<node id=\"2\"/>" + NL
+            + "<node id=\"3\"/>" + NL
+            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
+            DefaultEdge.class);
         g.addVertex(V1);
         g.addVertex(V2);
         g.addEdge(V1, V2);
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
         StringWriter w = new StringWriter();
         exporter.export(w, g);
 
-        if (System.getProperty("java.vm.version").startsWith("1.4")) {
-            // NOTE jvs 16-Mar-2007:  XML prefix mapping comes out
-            // with missing info on 1.4, so skip the verification part
-            // of the test.
-            return;
-        }
-
-        XMLAssert.assertXMLEqual(UNDIRECTED, w.toString());
+        XMLAssert.assertXMLEqual(output, w.toString());
     }
+
+    public void testUndirectedWeighted()
+        throws Exception
+    {
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+            + "<default>1.0</default>" + NL
+            + "</key>" + NL
+            + "<graph edgedefault=\"undirected\">" + NL
+            + "<node id=\"1\"/>" + NL
+            + "<node id=\"2\"/>" + NL
+            + "<node id=\"3\"/>" + NL
+            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
+            DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
+        StringWriter w = new StringWriter();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(w, g);
+
+        XMLAssert.assertXMLEqual(output, w.toString());
+    }
+
+    public void testDirected()
+        throws Exception
+    {
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<graph edgedefault=\"directed\">" + NL
+            + "<node id=\"1\"/>" + NL
+            + "<node id=\"2\"/>" + NL
+            + "<node id=\"3\"/>" + NL
+            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        DirectedGraph<String, DefaultEdge> g = new SimpleDirectedGraph<String, DefaultEdge>(
+            DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
+        StringWriter w = new StringWriter();
+        exporter.export(w, g);
+
+        XMLAssert.assertXMLEqual(output, w.toString());
+    }
+
+    public void testUndirectedUnweightedWithWeights()
+        throws Exception
+    {
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+            + "<default>1.0</default>" + NL
+            + "</key>" + NL
+            + "<graph edgedefault=\"undirected\">" + NL
+            + "<node id=\"1\"/>" + NL
+            + "<node id=\"2\"/>" + NL
+            + "<node id=\"3\"/>" + NL
+            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
+            DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
+        StringWriter w = new StringWriter();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(w, g);
+
+        XMLAssert.assertXMLEqual(output, w.toString());
+    }
+
+    public void testUndirectedWeightedWithWeights()
+        throws Exception
+    {
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+            + "<default>1.0</default>" + NL
+            + "</key>" + NL
+            + "<graph edgedefault=\"undirected\">" + NL
+            + "<node id=\"1\"/>" + NL
+            + "<node id=\"2\"/>" + NL
+            + "<node id=\"3\"/>" + NL
+            + "<edge id=\"1\" source=\"1\" target=\"2\">" + NL
+            + "<data key=\"edge_weight\">3.0</data>" + NL
+            + "</edge>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
+            DefaultWeightedEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+        g.setEdgeWeight(g.getEdge(V1, V2), 3.0);
+
+        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<String, DefaultWeightedEdge>();
+        StringWriter w = new StringWriter();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(w, g);
+
+        XMLAssert.assertXMLEqual(output, w.toString());
+    }
+
+    public void testUndirectedWeightedWithWeightsAndLabels()
+        throws Exception
+    {
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<key id=\"vertex_label\" for=\"node\" attr.name=\"Vertex Label\" attr.type=\"string\"/>" + NL
+            + "<key id=\"edge_label\" for=\"edge\" attr.name=\"Edge Label\" attr.type=\"string\"/>" + NL
+            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+            + "<default>1.0</default>" + NL
+            + "</key>" + NL
+            + "<graph edgedefault=\"undirected\">" + NL
+            + "<node id=\"1\">" + NL
+            + "<data key=\"vertex_label\">v1</data>" + NL
+            + "</node>" + NL
+            + "<node id=\"2\">" + NL
+            + "<data key=\"vertex_label\">v2</data>" + NL
+            + "</node>" + NL            
+            + "<node id=\"3\">" + NL
+            + "<data key=\"vertex_label\">v3</data>" + NL
+            + "</node>" + NL            
+            + "<edge id=\"1\" source=\"1\" target=\"2\">" + NL
+            + "<data key=\"edge_label\">(v1 : v2)</data>" + NL
+            + "<data key=\"edge_weight\">3.0</data>" + NL
+            + "</edge>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\">" + NL
+            + "<data key=\"edge_label\">(v3 : v1)</data>" + NL            
+            + "<data key=\"edge_weight\">15.0</data>" + NL            
+            + "</edge>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
+            DefaultWeightedEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+        g.setEdgeWeight(g.getEdge(V1, V2), 3.0);
+        g.setEdgeWeight(g.getEdge(V3, V1), 15.0);
+
+        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<String, DefaultWeightedEdge>(
+            new IntegerNameProvider<String>(),
+            new VertexNameProvider<String>()
+            {
+                @Override
+                public String getVertexName(String vertex)
+                {
+                    return vertex;
+                }
+            },
+            new IntegerEdgeNameProvider<DefaultWeightedEdge>(),
+            new EdgeNameProvider<DefaultWeightedEdge>()
+            {
+                @Override
+                public String getEdgeName(DefaultWeightedEdge edge)
+                {
+                    return edge.toString();
+                }
+
+            });
+        StringWriter w = new StringWriter();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(w, g);
+
+        XMLAssert.assertXMLEqual(output, w.toString());
+    }
+
 }
 
 // End GraphMLExporterTest.java

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
@@ -1,0 +1,758 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* ------------------------------
+ * GmlImporterTest.java
+ * ------------------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author: Dimitrios Michail
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 17-July-2016 : Initial revision (DM);
+ *
+ */
+package org.jgrapht.ext;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.jgrapht.graph.Pseudograph;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.WeightedPseudograph;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Dimitrios Michail
+ */
+public class GraphMLImporterTest
+    extends TestCase
+{
+
+    private static final String NL = System.getProperty("line.separator");
+
+    public void testUndirectedUnweighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL +  
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testUndirectedUnweightedPseudoGraph()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL + 
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<edge source=\"1\" target=\"1\"/>"+ NL +
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(5, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+        assertTrue(g.containsEdge("1", "1"));
+    }
+
+    public void testUndirectedUnweightedStringKeys()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph edgedefault=\"undirected\">" + NL + 
+            "<node id=\"n1\"/>" + NL +
+            "<node id=\"n2\"/>" + NL + 
+            "<node id=\"n3\"/>" + NL + 
+            "<edge source=\"n1\" target=\"n2\"/>" + NL + 
+            "<edge source=\"n2\" target=\"n3\"/>" + NL + 
+            "<edge source=\"n3\" target=\"n1\"/>"+ NL +
+            "<edge source=\"n1\" target=\"n1\"/>"+ NL +
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(4, g.edgeSet().size());
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsVertex("n3"));
+        assertTrue(g.containsEdge("n1", "n2"));
+        assertTrue(g.containsEdge("n2", "n3"));
+        assertTrue(g.containsEdge("n3", "n1"));
+        assertTrue(g.containsEdge("n1", "n1"));
+    }
+
+    public void testUndirectedUnweightedWrongOrder()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testDirectedUnweighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"directed\">" + NL + 
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            true,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertFalse(g.containsEdge("2", "1"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertFalse(g.containsEdge("3", "2"));
+        assertTrue(g.containsEdge("3", "1"));
+        assertFalse(g.containsEdge("1", "3"));
+    }
+
+    public void testUndirectedUnweightedPrefix()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<gml:graphml xmlns:gml=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<gml:graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<gml:node id=\"1\"/>" + NL +
+            "<gml:node id=\"2\"/>" + NL + 
+            "<gml:node id=\"3\"/>" + NL + 
+            "<gml:edge source=\"1\" target=\"2\"/>" + NL + 
+            "<gml:edge source=\"2\" target=\"3\"/>" + NL + 
+            "<gml:edge source=\"3\" target=\"1\"/>"+ NL + 
+            "</gml:graph>" + NL + 
+            "</gml:graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testWithAttributes()
+        throws ImportException
+    {
+        // @formatter:off
+        String input =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" " + 
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<key id=\"d0\" for=\"node\" attr.name=\"color\" attr.type=\"string\">" + NL +
+            "<default>yellow</default>" + NL +
+            "</key>" + NL +
+            "<key id=\"d1\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\"/>" + NL +
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL +
+            "<node id=\"n0\">" + NL +
+            "<data key=\"d0\">green</data>" + NL +
+            "</node>" + NL +
+            "<node id=\"n1\"/>" + NL +
+            "<node id=\"n2\">" + NL +
+            "<data key=\"d0\">blue</data>" + NL +
+            "</node>" + NL+
+            "<edge id=\"e0\" source=\"n0\" target=\"n2\">" + NL +
+            "<data key=\"d1\">2.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e1\" source=\"n0\" target=\"n1\">" + NL +
+            "<data key=\"d1\">1.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e2\" source=\"n1\" target=\"n2\"/>" + NL +
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("n0"));
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsEdge("n0", "n2"));
+        assertTrue(g.containsEdge("n0", "n1"));
+        assertTrue(g.containsEdge("n1", "n2"));
+    }
+
+    public void testWithMapAttributes()
+        throws ImportException
+    {
+        // @formatter:off
+        String input =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" " + 
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<key id=\"d0\" for=\"node\" attr.name=\"color\" attr.type=\"string\">" + NL +
+            "<default>yellow</default>" + NL +
+            "</key>" + NL +
+            "<key id=\"d1\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\"/>" + NL +
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL +
+            "<node id=\"n0\">" + NL +
+            "<data key=\"d0\">green</data>" + NL +
+            "</node>" + NL +
+            "<node id=\"n1\"/>" + NL +
+            "<node id=\"n2\">" + NL +
+            "<data key=\"d0\">blue</data>" + NL +
+            "</node>" + NL+
+            "<edge id=\"e0\" source=\"n0\" target=\"n2\">" + NL +
+            "<data key=\"d1\">2.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e1\" source=\"n0\" target=\"n1\">" + NL +
+            "<data key=\"d1\">1.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e2\" source=\"n1\" target=\"n2\"/>" + NL +
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Map<String, Map<String, String>> vAttributes = new HashMap<String, Map<String, String>>();
+        Map<DefaultEdge, Map<String, String>> eAttributes = new HashMap<DefaultEdge, Map<String, String>>();
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false,
+            vAttributes,
+            eAttributes);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("n0"));
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsEdge("n0", "n2"));
+        assertTrue(g.containsEdge("n0", "n1"));
+        assertTrue(g.containsEdge("n1", "n2"));
+        assertEquals("green", vAttributes.get("n0").get("color"));
+        assertEquals("yellow", vAttributes.get("n1").get("color"));
+        assertEquals("blue", vAttributes.get("n2").get("color"));
+        assertEquals(
+            "2.0",
+            eAttributes.get(g.getEdge("n0", "n2")).get("weight"));
+        assertEquals(
+            "1.0",
+            eAttributes.get(g.getEdge("n0", "n1")).get("weight"));
+        assertFalse(
+            eAttributes.get(g.getEdge("n1", "n2")).containsKey("weight"));
+    }
+
+    public void testWithAttributesWeightedGraphs()
+        throws ImportException
+    {
+        // @formatter:off
+        String input =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" " + 
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<key id=\"d0\" for=\"node\" attr.name=\"color\" attr.type=\"string\">" + NL +
+            "<default>yellow</default>" + NL +
+            "</key>" + NL +
+            "<key id=\"d1\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL +
+            "<default>3.0</default>" + NL +
+            "</key>" + NL +
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL +
+            "<node id=\"n0\">" + NL +
+            "<data key=\"d0\">green</data>" + NL +
+            "</node>" + NL +
+            "<node id=\"n1\"/>" + NL +
+            "<node id=\"n2\">" + NL +
+            "<data key=\"d0\">blue</data>" + NL +
+            "</node>" + NL+
+            "<edge id=\"e0\" source=\"n0\" target=\"n2\">" + NL +
+            "<data key=\"d1\">2.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e1\" source=\"n0\" target=\"n1\">" + NL +
+            "<data key=\"d1\">1.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e2\" source=\"n1\" target=\"n2\"/>" + NL +
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultWeightedEdge> g = readGraph(
+            input,
+            DefaultWeightedEdge.class,
+            true,
+            true);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("n0"));
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsEdge("n0", "n2"));
+        assertTrue(g.containsEdge("n0", "n1"));
+        assertTrue(g.containsEdge("n1", "n2"));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("n0", "n2")));
+        assertEquals(1.0, g.getEdgeWeight(g.getEdge("n0", "n1")));
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("n1", "n2")));
+    }
+
+    public void testWithHyperEdges()
+        throws ImportException
+    {
+        // @formatter:off
+        String input =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" " + 
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL +
+            "<node id=\"n0\"/>" + NL +
+            "<node id=\"n1\"/>" + NL +
+            "<node id=\"n2\"/>" + NL +
+            "<node id=\"n3\">" + NL +
+            "  <port name=\"North\"/>" + NL +
+            "  <port name=\"South\"/>" + NL +
+            "</node>" + NL +
+            "<edge source=\"n0\" target=\"n1\"/>" + NL +
+            "<edge source=\"n0\" target=\"n3\"/>" + NL +
+            "<hyperedge>" + NL +
+            "  <endpoint node=\"n0\"/>" + NL +
+            "  <endpoint node=\"n1\"/>" + NL +
+            "  <endpoint node=\"n2\"/>" + NL +
+            "  <endpoint node=\"n3\" port=\"South\"/>" + NL +
+            "</hyperedge>" + NL +
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(2, g.edgeSet().size());
+        assertTrue(g.containsVertex("n0"));
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsVertex("n3"));
+        assertTrue(g.containsEdge("n0", "n1"));
+        assertTrue(g.containsEdge("n0", "n3"));
+    }
+
+    public void testValidate()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<nOde id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<myedge source=\"1\" target=\"2\"/>" + NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        try {
+            readGraph(input, DefaultEdge.class, false, false);
+            fail("No!");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testValidateNoNodeId()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<node/>" + NL +
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        try {
+            readGraph(input, DefaultEdge.class, false, false);
+            fail("No!");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testValidateDuplicateNode()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL +  
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"1\"/>" + NL +
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        try {
+            readGraph(input, DefaultEdge.class, false, false);
+            fail("No!");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testExportImport()
+        throws Exception
+    {
+        DirectedPseudograph<String, DefaultEdge> g1 = new DirectedPseudograph<String, DefaultEdge>(
+            DefaultEdge.class);
+        g1.addVertex("1");
+        g1.addVertex("2");
+        g1.addVertex("3");
+        g1.addEdge("1", "2");
+        g1.addEdge("2", "3");
+        g1.addEdge("3", "3");
+
+        StringWriter sw = new StringWriter();
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
+        exporter.export(sw, g1);
+        String output = sw.toString();
+
+        Graph<String, DefaultEdge> g2 = readGraph(
+            output,
+            DefaultEdge.class,
+            true,
+            false);
+
+        assertEquals(3, g2.vertexSet().size());
+        assertEquals(3, g2.edgeSet().size());
+        assertTrue(g2.containsEdge("1", "2"));
+        assertTrue(g2.containsEdge("2", "3"));
+        assertTrue(g2.containsEdge("3", "3"));
+    }
+
+    public void testUnsupportedGraph()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL + 
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<edge source=\"1\" target=\"1\"/>"+ NL +
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        final Graph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
+            DefaultEdge.class);
+
+        VertexProvider<String> vp = new VertexProvider<String>()
+        {
+            @Override
+            public String buildVertex(
+                String label,
+                Map<String, String> attributes)
+            {
+                return label;
+            }
+        };
+
+        EdgeProvider<String, DefaultEdge> ep = new EdgeProvider<String, DefaultEdge>()
+        {
+
+            @Override
+            public DefaultEdge buildEdge(
+                String from,
+                String to,
+                String label,
+                Map<String, String> attributes)
+            {
+                return g.getEdgeFactory().createEdge(from, to);
+            }
+
+        };
+
+        try {
+            GraphMLImporter<String, DefaultEdge> importer = new GraphMLImporter<String, DefaultEdge>(
+                vp,
+                ep);
+            importer.read(new StringReader(input), g);
+            fail("No!");
+        } catch (Exception e) {
+            // nothing
+        }
+    }
+
+    public <E> Graph<String, E> readGraph(
+        String input,
+        Class<? extends E> edgeClass,
+        boolean directed,
+        boolean weighted)
+        throws ImportException
+    {
+        return readGraph(
+            input,
+            edgeClass,
+            directed,
+            weighted,
+            new HashMap<String, Map<String, String>>(),
+            new HashMap<E, Map<String, String>>());
+    }
+
+    public <E> Graph<String, E> readGraph(
+        String input,
+        Graph<String, E> g,
+        VertexProvider<String> vp,
+        EdgeProvider<String, E> ep)
+        throws ImportException
+    {
+        GraphMLImporter<String, E> importer = new GraphMLImporter<String, E>(
+            vp,
+            ep);
+        importer.read(new StringReader(input), g);
+
+        return g;
+    }
+
+    public <E> Graph<String, E> readGraph(
+        String input,
+        Class<? extends E> edgeClass,
+        boolean directed,
+        boolean weighted,
+        Map<String, Map<String, String>> vertexAttributes,
+        Map<E, Map<String, String>> edgeAttributes)
+        throws ImportException
+    {
+        Graph<String, E> g;
+        if (directed) {
+            if (weighted) {
+                g = new DirectedWeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new DirectedPseudograph<String, E>(edgeClass);
+            }
+        } else {
+            if (weighted) {
+                g = new WeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new Pseudograph<String, E>(edgeClass);
+            }
+        }
+
+        VertexProvider<String> vp = new VertexProvider<String>()
+        {
+            @Override
+            public String buildVertex(
+                String label,
+                Map<String, String> attributes)
+            {
+                vertexAttributes.put(label, attributes);
+                return label;
+            }
+        };
+
+        EdgeProvider<String, E> ep = new EdgeProvider<String, E>()
+        {
+
+            @Override
+            public E buildEdge(
+                String from,
+                String to,
+                String label,
+                Map<String, String> attributes)
+            {
+                E e = g.getEdgeFactory().createEdge(from, to);
+                edgeAttributes.put(e, attributes);
+                return e;
+            }
+
+        };
+
+        return readGraph(input, g, vp, ep);
+    }
+
+}


### PR DESCRIPTION
This is a rather large but fully tested pull request. 

It is an attempt to enhance the functionality of the ext package and make it easier to use jgrapht with external input.

It contains the following changes: 

- Implementation of GraphMLImporter using a SAX parser. 
  - The parser validates inputs and can parse any 1.0 valid GraphML document. 
  - Features that do not make sense such as nested graphs are simply ignored
  - The implementation is fully tested
  - Closes issue #52
- Implementation of GmlImporter
  - This parser uses antlr4 to perform the parsing and thus adds an extra jar dependency.
  - Using anltr4 has the advantage that all gml features are supported. 
  - Antlr4 is the current state-of-the-art for lexer-parser generation
  - Additional parsers in the feature are going to be easy to implement.
  - The implementation has a test suite 
  - Here the antlr4 maven plugin generates sources in target/generated-sources which are 
    automatically included in the build. 
-  Refactored GmlExporter
   - Much better interface
   - Avoid cast to WeightGraph in order to read edge weight
-  Refactored GraphMLExporter
   -  Cleanup code
   -  Added support for exporting edge weights as a GraphML-Attribute
   -  Added new tests for GraphMLExporter
-  Other general refactoring
   -  Improved class ImportException
   -  Added class ExportException
   -  Fixed major javadoc warnings due to xml tags in javadocs.
   -  Other minor fixes