### PR TITLE
Improved GraphML support

### DIFF
--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLExportDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLExportDemo.java
@@ -1,0 +1,260 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* --------------------
+ * GraphMLExportDemo.java
+ * --------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author:  Dimitrios Michail
+ * Contributor(s):   -
+ *
+ * Changes
+ * -------
+ * 26-July-2016 : Initial revision (DM); 
+ *
+ */
+package org.jgrapht.demo;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import org.jgrapht.VertexFactory;
+import org.jgrapht.ext.ComponentAttributeProvider;
+import org.jgrapht.ext.ExportException;
+import org.jgrapht.ext.GraphMLExporter;
+import org.jgrapht.ext.VertexNameProvider;
+import org.jgrapht.ext.GraphMLExporter.AttributeCategory;
+import org.jgrapht.ext.GraphMLExporter.AttributeType;
+import org.jgrapht.ext.IntegerEdgeNameProvider;
+import org.jgrapht.generate.CompleteGraphGenerator;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedPseudograph;
+
+public final class GraphMLExportDemo
+{
+    // Number of vertices
+    private static final int size = 6;
+
+    private static Random generator = new Random(17);
+
+    enum Color
+    {
+        BLACK("black"),
+        WHITE("white");
+
+        private final String value;
+
+        private Color(String value)
+        {
+            this.value = value;
+        }
+
+        public String toString()
+        {
+            return value;
+        }
+
+    }
+
+    static class GraphVertex
+    {
+        private String id;
+        private Color color;
+
+        public GraphVertex(String id)
+        {
+            this(id, null);
+        }
+
+        public GraphVertex(String id, Color color)
+        {
+            this.id = id;
+            this.color = color;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((id == null) ? 0 : id.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            GraphVertex other = (GraphVertex) obj;
+            if (id == null) {
+                if (other.id != null)
+                    return false;
+            } else if (!id.equals(other.id))
+                return false;
+            return true;
+        }
+
+        public Color getColor()
+        {
+            return color;
+        }
+
+        public void setColor(Color color)
+        {
+            this.color = color;
+        }
+
+        public String getId()
+        {
+            return id;
+        }
+
+        public void setId(String id)
+        {
+            this.id = id;
+        }
+
+        @Override
+        public String toString()
+        {
+            return id;
+        }
+    }
+
+    public static void main(String[] args)
+    {
+        /*
+         * Generate complete graph.
+         * 
+         * Vertices have random colors and edges have random edge weights.
+         */
+        DirectedPseudograph<GraphVertex, DefaultWeightedEdge> g = new DirectedPseudograph<>(
+            DefaultWeightedEdge.class);
+        CompleteGraphGenerator<GraphVertex, DefaultWeightedEdge> completeGenerator = new CompleteGraphGenerator<>(
+            size);
+        VertexFactory<GraphVertex> vFactory = new VertexFactory<GraphVertex>()
+        {
+            private int id = 0;
+
+            @Override
+            public GraphVertex createVertex()
+            {
+                GraphVertex v = new GraphVertex(String.valueOf(id++));
+                if (generator.nextBoolean()) {
+                    v.setColor(Color.BLACK);
+                } else {
+                    v.setColor(Color.WHITE);
+                }
+                return v;
+            }
+
+        };
+        completeGenerator.generateGraph(g, vFactory, null);
+
+        // assign random weights
+        for (DefaultWeightedEdge e : g.edgeSet()) {
+            g.setEdgeWeight(e, generator.nextInt(100));
+        }
+
+        // create GraphML exporter
+        GraphMLExporter<GraphVertex, DefaultWeightedEdge> exporter = new GraphMLExporter<>(
+            new VertexNameProvider<GraphVertex>()
+            {
+                @Override
+                public String getVertexName(GraphVertex v)
+                {
+                    return v.id;
+                }
+            },
+            null,
+            new IntegerEdgeNameProvider<>(),
+            null);
+
+        // set to export the internal edge weights
+        exporter.setExportEdgeWeights(true);
+
+        // register additional color attribute for vertices
+        exporter.registerAttribute(
+            "color",
+            AttributeCategory.NODE,
+            AttributeType.STRING);
+
+        // register additional name attribute for vertices and edges
+        exporter.registerAttribute(
+            "name",
+            AttributeCategory.ALL,
+            AttributeType.STRING);
+
+        // create provider of vertex attributes
+        ComponentAttributeProvider<GraphVertex> vertexAttributeProvider = new ComponentAttributeProvider<GraphVertex>()
+        {
+            @Override
+            public Map<String, String> getComponentAttributes(GraphVertex v)
+            {
+                Map<String, String> m = new HashMap<String, String>();
+                if (v.getColor() != null) {
+                    m.put("color", v.getColor().toString());
+                }
+                m.put("name", "node-" + v.id);
+                return m;
+            }
+        };
+        exporter.setVertexAttributeProvider(vertexAttributeProvider);
+
+        // create provider of edge attributes
+        ComponentAttributeProvider<DefaultWeightedEdge> edgeAttributeProvider = new ComponentAttributeProvider<DefaultWeightedEdge>()
+        {
+            @Override
+            public Map<String, String> getComponentAttributes(
+                DefaultWeightedEdge e)
+            {
+                Map<String, String> m = new HashMap<String, String>();
+                m.put("name", e.toString());
+                return m;
+            }
+        };
+        exporter.setEdgeAttributeProvider(edgeAttributeProvider);
+
+        // export
+        try {
+            Writer writer = new BufferedWriter(
+                new OutputStreamWriter(System.out));
+            exporter.export(writer, g);
+            writer.flush();
+        } catch (ExportException | IOException e) {
+            System.err.println("Error: " + e.getMessage());
+            System.exit(-1);
+        }
+
+    }
+
+}

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLExportDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLExportDemo.java
@@ -54,6 +54,12 @@ import org.jgrapht.generate.CompleteGraphGenerator;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.DirectedPseudograph;
 
+/**
+ * This class demonstrates exporting a graph with custom vertex and 
+ * edge attributes as GraphML. Vertices of the graph have an attribute
+ * called "color" and a "name" attribute. Edges have a "weight" attribute
+ * as well as a "name" attribute.
+ */
 public final class GraphMLExportDemo
 {
     // Number of vertices
@@ -99,10 +105,7 @@ public final class GraphMLExportDemo
         @Override
         public int hashCode()
         {
-            final int prime = 31;
-            int result = 1;
-            result = prime * result + ((id == null) ? 0 : id.hashCode());
-            return result;
+            return (id == null) ? 0 : id.hashCode();
         }
 
         @Override
@@ -116,11 +119,10 @@ public final class GraphMLExportDemo
                 return false;
             GraphVertex other = (GraphVertex) obj;
             if (id == null) {
-                if (other.id != null)
-                    return false;
-            } else if (!id.equals(other.id))
-                return false;
-            return true;
+                return other.id == null;
+            } else { 
+                return id.equals(other.id);
+            }
         }
 
         public Color getColor()

--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -64,6 +64,11 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-resources-plugin</artifactId>
+				<version>3.0.1</version>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.felix</groupId>
 				<artifactId>maven-bundle-plugin</artifactId>
 				<version>3.0.1</version>

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/ExportException.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/ExportException.java
@@ -19,6 +19,21 @@
  * (b) the terms of the Eclipse Public License v1.0 as published by
  * the Eclipse Foundation.
  */
+/* -------------------
+ * ExportException.java
+ * -------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author:  Dimitrios Michail
+ * Contributor(s): 
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 17-July-2016 : Initial revision (DM);
+ *
+ */
 package org.jgrapht.ext;
 
 /**

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/ExportException.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/ExportException.java
@@ -19,46 +19,38 @@
  * (b) the terms of the Eclipse Public License v1.0 as published by
  * the Eclipse Foundation.
  */
-/* ------------------
- * ImportException.java
- * ------------------
- * (C) Copyright 2015, by  Wil Selwood.
- *
- * Original Author:  Wil Selwood <wselwood@ijento.com>
- *
- */
 package org.jgrapht.ext;
 
 /**
- * An exception that the library throws in case of graph import errors.
+ * An exception that the library throws in case of graph export errors.
  */
-public class ImportException
+public class ExportException
     extends Exception
 {
     private static final long serialVersionUID = 1L;
 
     /**
-     * Constructs an {@code ImportException} with {@code null} as its error
+     * Constructs an {@code ExportException} with {@code null} as its error
      * detail message.
      */
-    public ImportException()
+    public ExportException()
     {
         super();
     }
 
     /**
-     * Constructs an {@code ImportException} with the specified detail message.
+     * Constructs an {@code ExportException} with the specified detail message.
      *
      * @param message The detail message (which is saved for later retrieval by
      *        the {@link #getMessage()} method)
      */
-    public ImportException(String message)
+    public ExportException(String message)
     {
         super(message);
     }
 
     /**
-     * Constructs an {@code ImportException} with the specified detail message
+     * Constructs an {@code ExportException} with the specified detail message
      * and cause.
      *
      * <p>
@@ -72,13 +64,13 @@ public class ImportException
      *        {@link #getCause()} method). (A null value is permitted, and
      *        indicates that the cause is nonexistent or unknown.)
      */
-    public ImportException(String message, Throwable cause)
+    public ExportException(String message, Throwable cause)
     {
         super(message, cause);
     }
 
     /**
-     * Constructs an {@code ImportException} with the specified cause and a
+     * Constructs an {@code ExportException} with the specified cause and a
      * detail message of {@code (cause==null ? null : cause.toString())} (which
      * typically contains the class and detail message of {@code cause}). This
      * constructor is useful for IO exceptions that are little more than
@@ -89,11 +81,11 @@ public class ImportException
      *        indicates that the cause is nonexistent or unknown.)
      *
      */
-    public ImportException(Throwable cause)
+    public ExportException(Throwable cause)
     {
         super(cause);
     }
 
 }
 
-// End ImportException.java
+// End ExportException.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -327,10 +327,11 @@ public class GraphMLExporter<V, E>
             throw new IllegalArgumentException(
                 "Vertex label attribute name cannot be null");
         }
-        if (registeredAttributes.containsKey(vertexLabelAttributeName)) {
+        String key = vertexLabelAttributeName.trim();
+        if (registeredAttributes.containsKey(key)) {
             throw new IllegalArgumentException("Reserved attribute name");
         }
-        this.vertexLabelAttributeName = vertexLabelAttributeName;
+        this.vertexLabelAttributeName = key;
     }
 
     /**
@@ -354,10 +355,11 @@ public class GraphMLExporter<V, E>
             throw new IllegalArgumentException(
                 "Edge label attribute name cannot be null");
         }
-        if (registeredAttributes.containsKey(edgeLabelAttributeName)) {
+        String key = edgeLabelAttributeName.trim();
+        if (registeredAttributes.containsKey(key)) {
             throw new IllegalArgumentException("Reserved attribute name");
         }
-        this.edgeLabelAttributeName = edgeLabelAttributeName;
+        this.edgeLabelAttributeName = key;
     }
 
     /**
@@ -381,10 +383,11 @@ public class GraphMLExporter<V, E>
             throw new IllegalArgumentException(
                 "Edge weight attribute name cannot be null");
         }
-        if (registeredAttributes.containsKey(edgeWeightAttributeName)) {
+        String key = edgeWeightAttributeName.trim();
+        if (registeredAttributes.containsKey(key)) {
             throw new IllegalArgumentException("Reserved attribute name");
         }
-        this.edgeWeightAttributeName = edgeWeightAttributeName;
+        this.edgeWeightAttributeName = key;
     }
 
     /**

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -44,6 +44,7 @@ import javax.xml.transform.stream.StreamResult;
 
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.Graph;
+import org.jgrapht.WeightedGraph;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.AttributesImpl;
 
@@ -591,7 +592,7 @@ public class GraphMLExporter<V, E>
                     "edge_weight_key",
                     AttributeCategory.EDGE,
                     AttributeType.DOUBLE,
-                    Double.toString(1.0)));
+                    Double.toString(WeightedGraph.DEFAULT_EDGE_WEIGHT)));
         }
 
         for (String attributeName : registeredAttributes.keySet()) {
@@ -684,7 +685,7 @@ public class GraphMLExporter<V, E>
                     if (vertexAttributes.containsKey(name)) {
                         String value = vertexAttributes.get(name);
                         if (defaultValue == null
-                            || !value.equals(defaultValue))
+                            || !defaultValue.equals(value))
                         {
                             if (value != null) {
                                 writeData(handler, details.key, value);
@@ -735,7 +736,7 @@ public class GraphMLExporter<V, E>
 
             if (exportEdgeWeights) {
                 Double weight = g.getEdgeWeight(e);
-                if (weight != 1.0) { // not default value
+                if (!weight.equals(WeightedGraph.DEFAULT_EDGE_WEIGHT)) { // not default value
                     writeData(
                         handler,
                         "edge_weight_key",
@@ -766,7 +767,7 @@ public class GraphMLExporter<V, E>
                     if (edgeAttributes.containsKey(name)) {
                         String value = edgeAttributes.get(name);
                         if (defaultValue == null
-                            || !value.equals(defaultValue))
+                            || !defaultValue.equals(value))
                         {
                             if (value != null) {
                                 writeData(handler, details.key, value);

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -326,6 +326,9 @@ public class GraphMLExporter<V, E>
             throw new IllegalArgumentException(
                 "Vertex label attribute name cannot be null");
         }
+        if (registeredAttributes.containsKey(vertexLabelAttributeName)) {
+            throw new IllegalArgumentException("Reserved attribute name");
+        }
         this.vertexLabelAttributeName = vertexLabelAttributeName;
     }
 
@@ -350,6 +353,9 @@ public class GraphMLExporter<V, E>
             throw new IllegalArgumentException(
                 "Edge label attribute name cannot be null");
         }
+        if (registeredAttributes.containsKey(edgeLabelAttributeName)) {
+            throw new IllegalArgumentException("Reserved attribute name");
+        }
         this.edgeLabelAttributeName = edgeLabelAttributeName;
     }
 
@@ -373,6 +379,9 @@ public class GraphMLExporter<V, E>
         if (edgeWeightAttributeName == null) {
             throw new IllegalArgumentException(
                 "Edge weight attribute name cannot be null");
+        }
+        if (registeredAttributes.containsKey(edgeWeightAttributeName)) {
+            throw new IllegalArgumentException("Reserved attribute name");
         }
         this.edgeWeightAttributeName = edgeWeightAttributeName;
     }
@@ -653,11 +662,12 @@ public class GraphMLExporter<V, E>
             }
 
             // find vertex attributes
-            Map<String, String> vertexAttributes;
+            Map<String, String> vertexAttributes = null;
             if (vertexAttributeProvider != null) {
                 vertexAttributes = vertexAttributeProvider
                     .getComponentAttributes(v);
-            } else {
+            }
+            if (vertexAttributes == null) {
                 vertexAttributes = Collections.emptyMap();
             }
 
@@ -734,11 +744,12 @@ public class GraphMLExporter<V, E>
             }
 
             // find edge attributes
-            Map<String, String> edgeAttributes;
+            Map<String, String> edgeAttributes = null;
             if (edgeAttributeProvider != null) {
                 edgeAttributes = edgeAttributeProvider
                     .getComponentAttributes(e);
-            } else {
+            }
+            if (edgeAttributes == null) {
                 edgeAttributes = Collections.emptyMap();
             }
 

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
@@ -375,12 +375,10 @@ public class GraphMLImporter<V, E>
                         finalAttributes.put(
                             validKey.attributeName,
                             collectedAttributes.get(validId));
-                    } else {
-                        if (validKey.defaultValue != null) {
-                            finalAttributes.put(
-                                validKey.attributeName,
-                                validKey.defaultValue);
-                        }
+                    } else if (validKey.defaultValue != null) {
+                        finalAttributes.put(
+                            validKey.attributeName,
+                            validKey.defaultValue);
                     }
                 }
 
@@ -392,7 +390,7 @@ public class GraphMLImporter<V, E>
 
             // check how to handle special edge weight
             boolean handleSpecialEdgeWeights = false;
-            double defaultSpecialEdgeWeight = 1.0;
+            double defaultSpecialEdgeWeight = WeightedGraph.DEFAULT_EDGE_WEIGHT;
             if (graph instanceof WeightedGraph<?, ?>) {
                 for (Key k : edgeValidKeys.values()) {
                     if (k.attributeName.equals(edgeWeightAttributeName)) {
@@ -512,12 +510,16 @@ public class GraphMLImporter<V, E>
                 String keyAttrName = findAttribute(KEY_ATTR_NAME, attributes);
                 currentKey = new Key(keyId, keyAttrName, null, null);
                 if (keyFor != null) {
-                    if (keyFor.equals(EDGE)) {
+                    switch(keyFor) { 
+                    case EDGE: 
                         currentKey.target = KeyTarget.EDGE;
-                    } else if (keyFor.equals(NODE)) {
+                        break;
+                    case NODE: 
                         currentKey.target = KeyTarget.NODE;
-                    } else if (keyFor.equals(ALL)) {
+                        break;
+                    case ALL: 
                         currentKey.target = KeyTarget.ALL;
+                        break;
                     }
                 }
                 break;

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
@@ -1,0 +1,664 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -------------------
+ * GmlImporter.java
+ * -------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author:  Dimitrios Michail
+ * Contributor(s): 
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 17-July-2016 : Initial revision (DM);
+ *
+ */
+package org.jgrapht.ext;
+
+import java.io.File;
+import java.io.Reader;
+import java.net.URL;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.jgrapht.Graph;
+import org.jgrapht.WeightedGraph;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Imports a graph from a GraphML data source.
+ * 
+ * <p>
+ * For a description of the format see
+ * <a href="http://en.wikipedia.org/wiki/GraphML"> http://en.wikipedia.org/wiki/
+ * GraphML</a> or the
+ * <a href="http://graphml.graphdrawing.org/primer/graphml-primer.html">GraphML
+ * Primer</a>.
+ * </p>
+ * 
+ * <p>
+ * Below is small example of a graph in GraphML format.
+ * 
+ * <pre>
+ * {@code
+ * <?xml version="1.0" encoding="UTF-8"?>
+ * <graphml xmlns="http://graphml.graphdrawing.org/xmlns"  
+ *     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ *     xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns 
+ *     http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">
+ *   <key id="d0" for="node" attr.name="color" attr.type="string">
+ *     <default>yellow</default>
+ *   </key>
+ *   <key id="d1" for="edge" attr.name="weight" attr.type="double"/>
+ *   <graph id="G" edgedefault="undirected">
+ *     <node id="n0">
+ *       <data key="d0">green</data>
+ *     </node>
+ *     <node id="n1"/>
+ *     <node id="n2">
+ *       <data key="d0">blue</data>
+ *     </node>
+ *     <node id="n3">
+ *       <data key="d0">red</data>
+ *     </node>
+ *     <node id="n4"/>
+ *     <node id="n5">
+ *       <data key="d0">turquoise</data>
+ *     </node>
+ *     <edge id="e0" source="n0" target="n2">
+ *       <data key="d1">1.0</data>
+ *     </edge>
+ *     <edge id="e1" source="n0" target="n1">
+ *       <data key="d1">1.0</data>
+ *     </edge>
+ *     <edge id="e2" source="n1" target="n3">
+ *       <data key="d1">2.0</data>
+ *     </edge>
+ *     <edge id="e3" source="n3" target="n2"/>
+ *     <edge id="e4" source="n2" target="n4"/>
+ *     <edge id="e5" source="n3" target="n5"/>
+ *     <edge id="e6" source="n5" target="n4">
+ *       <data key="d1">1.1</data>
+ *     </edge>
+ *   </graph>
+ * </graphml>
+ * }
+ * </pre>
+ * 
+ * <p>
+ * The importer reads the input into a graph which is provided by the user. In
+ * case the graph is an instance of {@link org.jgrapht.WeightedGraph} and the
+ * corresponding edge key with attr.name="weight" is defined, the importer also
+ * reads edge weights. Otherwise edge weights are ignored.
+ * 
+ * <p>
+ * GraphML-Attributes Values are read as string key-value pairs and passed on to
+ * the {@link VertexProvider} and {@link EdgeProvider} respectively.
+ * 
+ * <p>
+ * The provided graph object, where the imported graph will be stored, must be
+ * able to support the features of the graph that is read. For example if the
+ * GraphML file contains self-loops then the graph provided must also support
+ * self-loops. The same for multiple edges. Moreover, the parser completely
+ * ignores the attribute "edgedefault" which denotes whether an edge is directed
+ * or not. Whether edges are directed or not depends on the underlying
+ * implementation of the user provided graph object.
+ * 
+ * <p>
+ * The importer validates the input using the 1.0
+ * <a href="http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">GraphML
+ * Schema</a>.
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ * 
+ * @author Dimitrios Michail
+ * @since July 2016
+ */
+public class GraphMLImporter<V, E>
+{
+    private static final String GRAPHML_SCHEMA_FILENAME = "graphml.xsd";
+
+    private VertexProvider<V> vertexProvider;
+    private EdgeProvider<V, E> edgeProvider;
+
+    /**
+     * Constructs a new importer.
+     * 
+     * @param vertexProvider provider for the generation of vertices. Must not
+     *        be null.
+     * @param edgeProvider provider for the generation of edges. Must not be
+     *        null.
+     */
+    public GraphMLImporter(
+        VertexProvider<V> vertexProvider,
+        EdgeProvider<V, E> edgeProvider)
+    {
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
+        }
+        this.vertexProvider = vertexProvider;
+        if (edgeProvider == null) {
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
+    }
+
+    /**
+     * Get the vertex provider
+     * 
+     * @return the vertex provider
+     */
+    public VertexProvider<V> getVertexProvider()
+    {
+        return vertexProvider;
+    }
+
+    /**
+     * Set the vertex provider
+     * 
+     * @param vertexProvider the new vertex provider. Must not be null.
+     */
+    public void setVertexProvider(VertexProvider<V> vertexProvider)
+    {
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
+        }
+        this.vertexProvider = vertexProvider;
+    }
+
+    /**
+     * Get the edge provider
+     * 
+     * @return The edge provider
+     */
+    public EdgeProvider<V, E> getEdgeProvider()
+    {
+        return edgeProvider;
+    }
+
+    /**
+     * Set the edge provider.
+     * 
+     * @param edgeProvider the new edge provider. Must not be null.
+     */
+    public void setEdgeProvider(EdgeProvider<V, E> edgeProvider)
+    {
+        if (edgeProvider == null) {
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
+    }
+
+    /**
+     * Import a graph.
+     * 
+     * <p>
+     * The provided graph must be able to support the features of the graph that
+     * is read. For example if the GraphML file contains self-loops then the
+     * graph provided must also support self-loops. The same for multiple edges.
+     * 
+     * <p>
+     * If the provided graph is a weighted graph, the importer also reads edge
+     * weights.
+     * 
+     * <p>
+     * GraphML-Attributes Values are read as string key-value pairs and passed
+     * on to the {@link VertexProvider} and {@link EdgeProvider} respectively.
+     * 
+     * @param input the input stream
+     * @param graph the output graph
+     * @throws ImportException in case an error occurs, such as I/O or parse
+     *         error
+     */
+    public void read(Reader input, Graph<V, E> graph)
+        throws ImportException
+    {
+        try {
+            SchemaFactory schemaFactory = SchemaFactory
+                .newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+            // load schema
+            URL xsd = Thread.currentThread()
+                .getContextClassLoader()
+                .getResource(GRAPHML_SCHEMA_FILENAME);
+            if (xsd == null) {
+                throw new ImportException("Failed to locate GraphML xsd");
+            }
+            Schema schema = schemaFactory.newSchema(new File(xsd.getFile()));
+
+            // create parser
+            SAXParserFactory spf = SAXParserFactory.newInstance();
+            spf.setNamespaceAware(true);
+            spf.setSchema(schema);
+            SAXParser saxParser = spf.newSAXParser();
+
+            // parse
+            XMLReader xmlReader = saxParser.getXMLReader();
+            GraphMLHandler handler = new GraphMLHandler();
+            xmlReader.setContentHandler(handler);
+            xmlReader.setErrorHandler(handler);
+            xmlReader.parse(new InputSource(input));
+
+            // read result
+            handler.updateGraph(graph);
+        } catch (Exception se) {
+            throw new ImportException("Failed to parse GraphML", se);
+        }
+    }
+
+    // content handler
+    private class GraphMLHandler
+        extends DefaultHandler
+    {
+        private static final String NODE = "node";
+        private static final String NODE_ID = "id";
+        private static final String EDGE = "edge";
+        private static final String EDGE_SOURCE = "source";
+        private static final String EDGE_TARGET = "target";
+        private static final String KEY = "key";
+        private static final String KEY_FOR = "for";
+        private static final String KEY_ATTR_NAME = "attr.name";
+        private static final String KEY_ID = "id";
+        private static final String DEFAULT = "default";
+        private static final String DATA = "data";
+        private static final String DATA_KEY = "key";
+        private static final String SPECIAL_EDGE_WEIGHT = "weight";
+
+        // collect graph elements here
+        private Map<String, NodeOrEdge> nodes;
+        private List<NodeOrEdge> edges;
+
+        // record state of parser
+        private boolean insideDefault;
+        private boolean insideData;
+
+        // temporary state while reading elements
+        // stack needed due to nested graphs in GraphML
+        private Data currentData;
+        private Key currentKey;
+        private Deque<NodeOrEdge> currentNodeOrEdge;
+
+        // collect custom keys
+        private Map<String, Key> nodeValidKeys;
+        private Map<String, Key> edgeValidKeys;
+
+        // construct the actual graph after parsing
+        public void updateGraph(Graph<V, E> graph)
+            throws ImportException
+        {
+            if (nodes.isEmpty()) {
+                return;
+            }
+
+            // create nodes
+            Map<String, V> graphNodes = new HashMap<String, V>();
+
+            for (Entry<String, NodeOrEdge> en : nodes.entrySet()) {
+                String nodeId = en.getKey();
+
+                // create attributes
+                Map<String, String> collectedAttributes = en
+                    .getValue().attributes;
+                Map<String, String> finalAttributes = new HashMap<String, String>();
+
+                for (Key validKey : nodeValidKeys.values()) {
+                    String validId = validKey.id;
+                    if (collectedAttributes.containsKey(validId)) {
+                        finalAttributes.put(
+                            validKey.attributeName,
+                            collectedAttributes.get(validId));
+                    } else {
+                        if (validKey.defaultValue != null) {
+                            finalAttributes.put(
+                                validKey.attributeName,
+                                validKey.defaultValue);
+                        }
+                    }
+                }
+
+                // create the actual node
+                V v = vertexProvider.buildVertex(nodeId, finalAttributes);
+                graphNodes.put(nodeId, v);
+                graph.addVertex(v);
+            }
+
+            // check how to handle special edge weight
+            boolean handleSpecialEdgeWeights = false;
+            double defaultSpecialEdgeWeight = 1.0;
+            if (graph instanceof WeightedGraph<?, ?>) {
+                for (Key k : edgeValidKeys.values()) {
+                    if (k.attributeName.equals(SPECIAL_EDGE_WEIGHT)) {
+                        handleSpecialEdgeWeights = true;
+                        String defaultValue = k.defaultValue;
+                        try {
+                            defaultSpecialEdgeWeight = Double
+                                .parseDouble(defaultValue);
+                        } catch (NumberFormatException e) {
+                            // ignore
+                        }
+                        // first key only which maps to "weight"
+                        break;
+                    }
+                }
+
+            }
+
+            // create edges
+            for (NodeOrEdge p : edges) {
+                V from = graphNodes.get(p.id1);
+                if (from == null) {
+                    throw new ImportException(
+                        "Source vertex " + p.id1 + " not found");
+                }
+                V to = graphNodes.get(p.id2);
+                if (to == null) {
+                    throw new ImportException(
+                        "Target vertex " + p.id2 + " not found");
+                }
+
+                // create attributes
+                Map<String, String> collectedAttributes = p.attributes;
+                Map<String, String> finalAttributes = new HashMap<String, String>();
+
+                for (Key validKey : edgeValidKeys.values()) {
+                    String validId = validKey.id;
+                    if (collectedAttributes.containsKey(validId)) {
+                        finalAttributes.put(
+                            validKey.attributeName,
+                            collectedAttributes.get(validId));
+                    } else {
+                        if (validKey.defaultValue != null) {
+                            finalAttributes.put(
+                                validKey.attributeName,
+                                validKey.defaultValue);
+                        }
+                    }
+                }
+
+                E e = edgeProvider.buildEdge(
+                    from,
+                    to,
+                    "e_" + from + "_" + to,
+                    finalAttributes);
+                graph.addEdge(from, to, e);
+
+                // special handling for weighted graphs
+                if (handleSpecialEdgeWeights) {
+                    if (finalAttributes.containsKey(SPECIAL_EDGE_WEIGHT)) {
+                        try {
+                            ((WeightedGraph<V, E>) graph).setEdgeWeight(
+                                e,
+                                Double.parseDouble(
+                                    finalAttributes.get(SPECIAL_EDGE_WEIGHT)));
+                        } catch (NumberFormatException nfe) {
+                            ((WeightedGraph<V, E>) graph)
+                                .setEdgeWeight(e, defaultSpecialEdgeWeight);
+                        }
+                    }
+
+                }
+            }
+
+        }
+
+        @Override
+        public void startDocument()
+            throws SAXException
+        {
+            nodes = new HashMap<String, NodeOrEdge>();
+            edges = new ArrayList<NodeOrEdge>();
+            nodeValidKeys = new HashMap<String, Key>();
+            edgeValidKeys = new HashMap<String, Key>();
+            insideDefault = false;
+            insideData = false;
+            currentKey = null;
+            currentData = null;
+            currentNodeOrEdge = new ArrayDeque<NodeOrEdge>();
+        }
+
+        @Override
+        public void startElement(
+            String uri,
+            String localName,
+            String qName,
+            Attributes attributes)
+            throws SAXException
+        {
+            switch (localName) {
+            case NODE:
+                currentNodeOrEdge
+                    .push(new NodeOrEdge(findAttribute(NODE_ID, attributes)));
+                break;
+            case EDGE:
+                currentNodeOrEdge.push(
+                    new NodeOrEdge(
+                        findAttribute(EDGE_SOURCE, attributes),
+                        findAttribute(EDGE_TARGET, attributes)));
+                break;
+            case KEY:
+                String keyId = findAttribute(KEY_ID, attributes);
+                String keyFor = findAttribute(KEY_FOR, attributes);
+                String keyAttrName = findAttribute(KEY_ATTR_NAME, attributes);
+                currentKey = new Key(keyId, keyAttrName, null, null);
+                if (keyFor != null) {
+                    if (keyFor.equals(EDGE)) {
+                        currentKey.target = KeyTarget.EDGE;
+                    } else if (keyFor.equals(NODE)) {
+                        currentKey.target = KeyTarget.NODE;
+                    }
+                }
+                break;
+            case DEFAULT:
+                insideDefault = true;
+                break;
+            case DATA:
+                insideData = true;
+                currentData = new Data(
+                    findAttribute(DATA_KEY, attributes),
+                    null);
+                break;
+            default:
+                break;
+            }
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName)
+            throws SAXException
+        {
+            switch (localName) {
+            case NODE:
+                NodeOrEdge currentNode = currentNodeOrEdge.pop();
+                if (nodes.containsKey(currentNode.id1)) {
+                    throw new SAXException(
+                        "Node with id " + currentNode.id1 + " already exists");
+                }
+                nodes.put(currentNode.id1, currentNode);
+                break;
+            case EDGE:
+                NodeOrEdge currentEdge = currentNodeOrEdge.pop();
+                edges.add(currentEdge);
+                break;
+            case KEY:
+                if (currentKey.isValid()) {
+                    switch (currentKey.target) {
+                    case NODE:
+                        nodeValidKeys.put(currentKey.id, currentKey);
+                    case EDGE:
+                        edgeValidKeys.put(currentKey.id, currentKey);
+                    }
+                }
+                currentKey = null;
+                break;
+            case DEFAULT:
+                insideDefault = false;
+                break;
+            case DATA:
+                if (currentData.isValid()) {
+                    currentNodeOrEdge.peek().attributes
+                        .put(currentData.key, currentData.value);
+                }
+                insideData = false;
+                currentData = null;
+                break;
+            default:
+                break;
+            }
+        }
+
+        @Override
+        public void characters(char ch[], int start, int length)
+            throws SAXException
+        {
+            if (insideDefault) {
+                currentKey.defaultValue = new String(ch, start, length);
+            } else if (insideData) {
+                currentData.value = new String(ch, start, length);
+            }
+        }
+
+        @Override
+        public void warning(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
+
+        public void error(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
+
+        public void fatalError(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
+
+        private String findAttribute(String localName, Attributes attributes)
+        {
+            for (int i = 0; i < attributes.getLength(); i++) {
+                String attrLocalName = attributes.getLocalName(i);
+                if (attrLocalName.equals(localName)) {
+                    return attributes.getValue(i);
+                }
+            }
+            return null;
+        }
+
+    }
+
+    // ----- Helper classes for storing partial parser results -----
+
+    private enum KeyTarget
+    {
+        NODE,
+        EDGE,
+    }
+
+    private class Key
+    {
+        String id;
+        String attributeName;
+        String defaultValue;
+        KeyTarget target;
+
+        public Key(
+            String id,
+            String attributeName,
+            String defaultValue,
+            KeyTarget target)
+        {
+            this.id = id;
+            this.attributeName = attributeName;
+            this.defaultValue = defaultValue;
+            this.target = target;
+        }
+
+        public boolean isValid()
+        {
+            return id != null && attributeName != null && target != null;
+        }
+
+    }
+
+    private class Data
+    {
+        String key;
+        String value;
+
+        public Data(String key, String value)
+        {
+            this.key = key;
+            this.value = value;
+        }
+
+        public boolean isValid()
+        {
+            return key != null && value != null;
+        }
+    }
+
+    private class NodeOrEdge
+    {
+        String id1;
+        String id2;
+        Map<String, String> attributes;
+
+        public NodeOrEdge(String id1)
+        {
+            this.id1 = id1;
+            this.id2 = null;
+            this.attributes = new HashMap<String, String>();
+        }
+
+        public NodeOrEdge(String id1, String id2)
+        {
+            this.id1 = id1;
+            this.id2 = id2;
+            this.attributes = new HashMap<String, String>();
+        }
+    }
+
+}

--- a/jgrapht-ext/src/main/resources/graphml.xsd
+++ b/jgrapht-ext/src/main/resources/graphml.xsd
@@ -1,0 +1,345 @@
+<?xml version="1.0"?>
+
+<xs:schema   
+             targetNamespace="http://graphml.graphdrawing.org/xmlns"
+
+             xmlns="http://graphml.graphdrawing.org/xmlns"
+             xmlns:xs="http://www.w3.org/2001/XMLSchema"
+
+             elementFormDefault="qualified"
+             attributeFormDefault="unqualified"
+>
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+     This document defines the GraphML language including GraphML attributes and GraphML parseinfo.
+    </xs:documentation>
+  </xs:annotation>
+
+
+<xs:redefine schemaLocation="http://graphml.graphdrawing.org/xmlns/1.0/graphml-structure.xsd">
+
+  <!--redefinition as in graphml-attributes.xsd -->
+
+  <xs:attributeGroup name="key.extra.attrib">
+    <xs:attributeGroup ref="key.extra.attrib"/>
+    <xs:attributeGroup ref="key.attributes.attrib"/>
+  </xs:attributeGroup>
+
+  <!--redefinition as in graphml-parseinfo.xsd -->
+
+  <xs:attributeGroup name="graph.extra.attrib">
+    <xs:attributeGroup ref="graph.extra.attrib"/>
+    <xs:attributeGroup ref="graph.parseinfo.attrib"/>
+  </xs:attributeGroup>
+
+  <xs:attributeGroup name="node.extra.attrib">
+    <xs:attributeGroup ref="node.extra.attrib"/>
+    <xs:attributeGroup ref="node.parseinfo.attrib"/>
+  </xs:attributeGroup>
+
+</xs:redefine>
+
+
+  <!--types as in graphml-attributes.xsd -->
+
+<xs:simpleType name="key.name.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/(Dokumentation der Attributes Erweiterung; entsprechende Stelle.html)"
+        xml:lang="en">
+      Simple type for the attr.name attribute of &lt;key>.
+      key.name.type is final, that is, it may not be extended
+                          or restricted.
+      key.name.type is a restriction of xs:NMTOKEN
+      Allowed values: (no restriction)
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:NMTOKEN"/>
+
+</xs:simpleType>
+
+
+
+<xs:simpleType name="key.type.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/(Dokumentation der Attributes Erweiterung; entsprechende Stelle.html)"
+        xml:lang="en">
+      Simple type for the attr.type attribute of &lt;key>.
+      key.type.type is final, that is, it may not be extended
+                          or restricted.
+      key.type.type is a restriction of xs:NMTOKEN
+      Allowed values: boolean, int, long, float, double, string.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:NMTOKEN">  
+    <xs:enumeration value="boolean"/>
+    <xs:enumeration value="int"/>
+    <xs:enumeration value="long"/>
+    <xs:enumeration value="float"/>
+    <xs:enumeration value="double"/>
+    <xs:enumeration value="string"/>
+  </xs:restriction>
+
+</xs:simpleType>
+
+
+<xs:attributeGroup name="key.attributes.attrib">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+     Definition of the attribute group key.attributes.attrib.
+     This group consists of the two optional attributes
+         - attr.name (gives the name for the data function)
+         - attr.type ((declares the range of values for the data function)
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attribute name="attr.name" type="key.name.type" use="optional"/>
+  <xs:attribute name="attr.type" type="key.type.type" use="optional"/>
+</xs:attributeGroup>
+
+  <!--types as in graphml-parseinfo.xsd -->
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+       Simple type definitions for the new graph attributes.
+    </xs:documentation>
+  </xs:annotation>
+
+<xs:simpleType name="graph.order.type"  final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.order attribute of &lt;graph>.
+      graph.order.type is final, that is, it may not be extended
+                          or restricted.
+      graph.order.type is a restriction of xs:NMTOKEN
+      Allowed values: free, nodesfirst, adjacencylist.
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:NMTOKEN">
+    <xs:enumeration value="free"/>
+    <xs:enumeration value="nodesfirst"/>
+    <xs:enumeration value="adjacencylist"/>
+  </xs:restriction>
+</xs:simpleType>
+
+<xs:simpleType name="graph.nodes.type"  final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.nodes attribute of &lt;graph>.
+      graph.nodes.type is final, that is, it may not be extended
+                          or restricted.
+      graph.nodes.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:simpleType name="graph.edges.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.edges attribute of &lt;graph>.
+      graph.edges.type is final, that is, it may not be extended
+                          or restricted.
+      graph.edges.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:simpleType name="graph.maxindegree.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.maxindegree attribute of &lt;graph>.
+      graph.maxindegree.type is final, that is, it may not be extended
+                          or restricted.
+      graph.maxindegree.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:simpleType name="graph.maxoutdegree.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.maxoutdegree attribute of &lt;graph>.
+      graph.maxoutdegree.type is final, that is, it may not be extended
+                          or restricted.
+      graph.maxoutdegree.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:simpleType name="graph.nodeids.type"  final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.nodeids attribute of &lt;graph>.
+      graph.nodeids.type is final, that is, it may not be extended
+                          or restricted.
+      graph.nodeids.type is a restriction of xs:string
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:NMTOKEN">
+    <xs:enumeration value="canonical"/>
+    <xs:enumeration value="free"/>
+  </xs:restriction>  
+</xs:simpleType>
+
+<xs:simpleType name="graph.edgeids.type"  final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.edgeids attribute of &lt;graph>.
+      graph.edgeids.type is final, that is, it may not be extended
+                          or restricted.
+      graph.edgeids.type is a restriction of xs:string
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:NMTOKEN">
+    <xs:enumeration value="canonical"/>
+    <xs:enumeration value="free"/>
+  </xs:restriction>  
+</xs:simpleType>
+
+<xs:attributeGroup name="graph.parseinfo.attrib">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+     Definition of the attribute group graph.parseinfo.attrib.
+     This group consists of the seven attributes
+     - parse.nodeids (fixed to 'canonical' meaning that the id attribute
+                      of &lt;node> follows the pattern 'n[number]),
+     - parse.edgeids (fixed to 'canonical' meaning that the id attribute
+                      of &lt;edge> follows the pattern 'e[number]),
+     - parse.order (required; one of the values 'nodesfirst', 
+                    'adjacencylist' or 'free'),
+     - parse.nodes (required; number of nodes in this graph), 
+     - parse.edges (required; number of edges in this graph), 
+     - parse.maxindegree (optional; maximal indegree of a node in this graph),
+     - parse.maxoutdegree (optional; maximal outdegree of a node in this graph)
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attribute name="parse.nodeids" type="graph.nodeids.type"/>
+  <xs:attribute name="parse.edgeids" type="graph.edgeids.type"/>
+  <xs:attribute name="parse.order" type="graph.order.type"/>
+  <xs:attribute name="parse.nodes" type="graph.nodes.type"/>
+  <xs:attribute name="parse.edges" type="graph.edges.type"/>
+  <xs:attribute name="parse.maxindegree" type="graph.maxindegree.type" use="optional"/>
+  <xs:attribute name="parse.maxoutdegree" type="graph.maxoutdegree.type" use="optional"/>
+</xs:attributeGroup>
+
+
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+       Simple type definitions for the new node attributes.
+    </xs:documentation>
+  </xs:annotation>
+
+<xs:simpleType name="node.indegree.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.indegree attribute of &lt;node>.
+      node.indegree.type is final, that is, it may not be extended
+                          or restricted.
+      node.indegree.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:simpleType name="node.outdegree.type" final="#all">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+      Simple type for the parse.outdegree attribute of &lt;node>.
+      node.outdegree.type is final, that is, it may not be extended
+                          or restricted.
+      node.outdegree.type is a restriction of xs:nonNegativeInteger
+      Allowed values: (no restriction).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:restriction base="xs:nonNegativeInteger"/>  
+</xs:simpleType>
+
+<xs:attributeGroup name="node.parseinfo.attrib">
+
+  <xs:annotation>
+    <xs:documentation 
+        source="http://graphml.graphdrawing.org/"
+        xml:lang="en">
+     Definition of the attribute group node.parseinfo.attrib.
+     This group consists of two attributes
+     - parse.indegree (optional; indegree of this node),
+     - parse.outdegree (optional; outdegree of this node).
+    </xs:documentation>
+  </xs:annotation>
+
+  <xs:attribute name="parse.indegree" type="node.indegree.type" use="optional"/>
+  <xs:attribute name="parse.outdegree" type="node.outdegree.type" use="optional"/>
+</xs:attributeGroup>
+
+</xs:schema>
+
+<!--======================================================-->
+<!--      end of file: graphml-parseinfo.xsd             -->
+<!--======================================================-->

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
@@ -31,6 +31,8 @@
 package org.jgrapht.ext;
 
 import java.io.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 import junit.framework.*;
 
@@ -63,20 +65,20 @@ public class GraphMLExporterTest
     {
         String output =
             // @formatter:off
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
-            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
-            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
-            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
-            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
-            + "<graph edgedefault=\"undirected\">" + NL
-            + "<node id=\"1\"/>" + NL
-            + "<node id=\"2\"/>" + NL
-            + "<node id=\"3\"/>" + NL
-            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
-            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
-            + "</graph>" + NL
-            + "</graphml>" + NL;
-            // @formatter:on
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
+				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
+				+ "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "
+				+ "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+				+ "<graph edgedefault=\"undirected\">" + NL 
+				+ "<node id=\"1\"/>" + NL 
+				+ "<node id=\"2\"/>" + NL
+				+ "<node id=\"3\"/>" + NL 
+				+ "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+				+ "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL 
+				+ "</graph>" + NL 
+				+ "</graphml>" + NL;
+		    // @formatter:on
 
         UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
             DefaultEdge.class);
@@ -98,23 +100,23 @@ public class GraphMLExporterTest
     {
         String output =
             // @formatter:off
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
-            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
-            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
-            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
-            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
-            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
-            + "<default>1.0</default>" + NL
-            + "</key>" + NL
-            + "<graph edgedefault=\"undirected\">" + NL
-            + "<node id=\"1\"/>" + NL
-            + "<node id=\"2\"/>" + NL
-            + "<node id=\"3\"/>" + NL
-            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
-            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
-            + "</graph>" + NL
-            + "</graphml>" + NL;
-            // @formatter:on
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
+				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
+				+ "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "
+				+ "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+				+ "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+				+ "<default>1.0</default>" + NL 
+				+ "</key>" + NL 
+				+ "<graph edgedefault=\"undirected\">" + NL
+				+ "<node id=\"1\"/>" + NL 
+				+ "<node id=\"2\"/>" + NL 
+				+ "<node id=\"3\"/>" + NL
+				+ "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+				+ "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL 
+				+ "</graph>" + NL 
+				+ "</graphml>" + NL;
+		    // @formatter:on
 
         UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
             DefaultEdge.class);
@@ -137,20 +139,20 @@ public class GraphMLExporterTest
     {
         String output =
             // @formatter:off
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
-            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
-            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
-            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
-            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
-            + "<graph edgedefault=\"directed\">" + NL
-            + "<node id=\"1\"/>" + NL
-            + "<node id=\"2\"/>" + NL
-            + "<node id=\"3\"/>" + NL
-            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
-            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
-            + "</graph>" + NL
-            + "</graphml>" + NL;
-            // @formatter:on
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
+				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
+				+ "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "
+				+ "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+				+ "<graph edgedefault=\"directed\">" + NL 
+				+ "<node id=\"1\"/>" + NL 
+				+ "<node id=\"2\"/>" + NL
+				+ "<node id=\"3\"/>" + NL 
+				+ "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+				+ "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL 
+				+ "</graph>" + NL 
+				+ "</graphml>" + NL;
+		    // @formatter:on
 
         DirectedGraph<String, DefaultEdge> g = new SimpleDirectedGraph<String, DefaultEdge>(
             DefaultEdge.class);
@@ -172,23 +174,22 @@ public class GraphMLExporterTest
     {
         String output =
             // @formatter:off
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
-            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
-            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
-            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
-            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
-            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
-            + "<default>1.0</default>" + NL
-            + "</key>" + NL
-            + "<graph edgedefault=\"undirected\">" + NL
-            + "<node id=\"1\"/>" + NL
-            + "<node id=\"2\"/>" + NL
-            + "<node id=\"3\"/>" + NL
-            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
-            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
-            + "</graph>" + NL
-            + "</graphml>" + NL;
-            // @formatter:on
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
+				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
+				+ "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "
+				+ "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+				+ "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+				+ "<default>1.0</default>" + NL 
+				+ "</key>" + NL 
+				+ "<graph edgedefault=\"undirected\">" + NL
+				+ "<node id=\"1\"/>" + NL 
+				+ "<node id=\"2\"/>" + NL + "<node id=\"3\"/>" + NL
+				+ "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+				+ "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL 
+				+ "</graph>" + NL 
+				+ "</graphml>" + NL;
+		    // @formatter:on
 
         UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
             DefaultEdge.class);
@@ -211,25 +212,24 @@ public class GraphMLExporterTest
     {
         String output =
             // @formatter:off
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
-            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
-            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
-            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
-            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
-            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
-            + "<default>1.0</default>" + NL
-            + "</key>" + NL
-            + "<graph edgedefault=\"undirected\">" + NL
-            + "<node id=\"1\"/>" + NL
-            + "<node id=\"2\"/>" + NL
-            + "<node id=\"3\"/>" + NL
-            + "<edge id=\"1\" source=\"1\" target=\"2\">" + NL
-            + "<data key=\"edge_weight\">3.0</data>" + NL
-            + "</edge>" + NL
-            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
-            + "</graph>" + NL
-            + "</graphml>" + NL;
-            // @formatter:on
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
+				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
+				+ "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "
+				+ "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+				+ "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+				+ "<default>1.0</default>" + NL 
+				+ "</key>" + NL 
+				+ "<graph edgedefault=\"undirected\">" + NL
+				+ "<node id=\"1\"/>" + NL 
+				+ "<node id=\"2\"/>" + NL + "<node id=\"3\"/>" + NL
+				+ "<edge id=\"1\" source=\"1\" target=\"2\">" + NL 
+				+ "<data key=\"edge_weight\">3.0</data>" + NL
+				+ "</edge>" + NL 
+				+ "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL 
+				+ "</graph>" + NL
+				+ "</graphml>" + NL;
+		// @formatter:on
 
         SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
             DefaultWeightedEdge.class);
@@ -253,37 +253,37 @@ public class GraphMLExporterTest
     {
         String output =
             // @formatter:off
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
-            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
-            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
-            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
-            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
-            + "<key id=\"vertex_label\" for=\"node\" attr.name=\"Vertex Label\" attr.type=\"string\"/>" + NL
-            + "<key id=\"edge_label\" for=\"edge\" attr.name=\"Edge Label\" attr.type=\"string\"/>" + NL
-            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
-            + "<default>1.0</default>" + NL
-            + "</key>" + NL
-            + "<graph edgedefault=\"undirected\">" + NL
-            + "<node id=\"1\">" + NL
-            + "<data key=\"vertex_label\">v1</data>" + NL
-            + "</node>" + NL
-            + "<node id=\"2\">" + NL
-            + "<data key=\"vertex_label\">v2</data>" + NL
-            + "</node>" + NL            
-            + "<node id=\"3\">" + NL
-            + "<data key=\"vertex_label\">v3</data>" + NL
-            + "</node>" + NL            
-            + "<edge id=\"1\" source=\"1\" target=\"2\">" + NL
-            + "<data key=\"edge_label\">(v1 : v2)</data>" + NL
-            + "<data key=\"edge_weight\">3.0</data>" + NL
-            + "</edge>" + NL
-            + "<edge id=\"2\" source=\"3\" target=\"1\">" + NL
-            + "<data key=\"edge_label\">(v3 : v1)</data>" + NL            
-            + "<data key=\"edge_weight\">15.0</data>" + NL            
-            + "</edge>" + NL
-            + "</graph>" + NL
-            + "</graphml>" + NL;
-            // @formatter:on
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
+				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
+				+ "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "
+				+ "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+				+ "<key id=\"vertex_label\" for=\"node\" attr.name=\"Vertex Label\" attr.type=\"string\"/>" + NL
+				+ "<key id=\"edge_label\" for=\"edge\" attr.name=\"Edge Label\" attr.type=\"string\"/>" + NL
+				+ "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+				+ "<default>1.0</default>" + NL 
+				+ "</key>" + NL 
+				+ "<graph edgedefault=\"undirected\">" + NL
+				+ "<node id=\"1\">" + NL 
+				+ "<data key=\"vertex_label\">v1</data>" + NL 
+				+ "</node>" + NL
+				+ "<node id=\"2\">" + NL 
+				+ "<data key=\"vertex_label\">v2</data>" + NL 
+				+ "</node>" + NL
+				+ "<node id=\"3\">" + NL 
+				+ "<data key=\"vertex_label\">v3</data>" + NL 
+				+ "</node>" + NL
+				+ "<edge id=\"1\" source=\"1\" target=\"2\">" + NL 
+				+ "<data key=\"edge_label\">(v1 : v2)</data>" + NL 
+				+ "<data key=\"edge_weight\">3.0</data>" + NL 
+				+ "</edge>" + NL
+				+ "<edge id=\"2\" source=\"3\" target=\"1\">" + NL 
+				+ "<data key=\"edge_label\">(v3 : v1)</data>"+ NL 
+				+ "<data key=\"edge_weight\">15.0</data>" + NL 
+				+ "</edge>" + NL 
+				+ "</graph>" + NL
+				+ "</graphml>" + NL;
+		    // @formatter:on
 
         SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
             DefaultWeightedEdge.class);
@@ -317,6 +317,121 @@ public class GraphMLExporterTest
             });
         StringWriter w = new StringWriter();
         exporter.setExportEdgeWeights(true);
+        exporter.export(w, g);
+
+        XMLAssert.assertXMLEqual(output, w.toString());
+    }
+
+    public void testUndirectedWeightedWithWeightsAndColor()
+        throws Exception
+    {
+        String output =
+            // @formatter:off
+				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
+				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
+				+ "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "
+				+ "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+				+ "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+				+ "<default>1.0</default>" + NL 
+				+ "</key>" + NL
+				+ "<key id=\"key0\" for=\"node\" attr.name=\"color\" attr.type=\"string\">" + NL
+				+ "<default>yellow</default>" + NL 
+                + "</key>" + NL
+                + "<key id=\"key1\" for=\"all\" attr.name=\"name\" attr.type=\"string\">" + NL
+                + "<default>johndoe</default>" + NL 
+                + "</key>" + NL                        
+				+ "<graph edgedefault=\"undirected\">" + NL
+				+ "<node id=\"1\">" + NL
+				+ "<data key=\"key1\">V1</data>" + NL
+				+ "</node>" + NL
+				+ "<node id=\"2\">" + NL
+				+ "<data key=\"key0\">red</data>" + NL
+				+ "<data key=\"key1\">V2</data>" + NL
+				+ "</node>" + NL
+				+ "<node id=\"3\">" + NL
+				+ "<data key=\"key1\">V3</data>" + NL
+				+ "</node>" + NL
+				+ "<edge id=\"1\" source=\"1\" target=\"2\">" + NL 
+				+ "<data key=\"edge_weight\">3.0</data>" + NL
+				+ "<data key=\"key1\">e12</data>" + NL
+				+ "</edge>" + NL 
+				+ "<edge id=\"2\" source=\"3\" target=\"1\">" + NL
+				+ "<data key=\"key1\">e31</data>" + NL
+                + "</edge>" + NL
+				+ "</graph>" + NL
+				+ "</graphml>" + NL;
+		    // @formatter:on
+
+        SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
+            DefaultWeightedEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+        g.setEdgeWeight(g.getEdge(V1, V2), 3.0);
+
+        ComponentAttributeProvider<String> vertexAttributeProvider = new ComponentAttributeProvider<String>()
+        {
+            @Override
+            public Map<String, String> getComponentAttributes(String v)
+            {
+                Map<String, String> map = new LinkedHashMap<>();
+                switch (v) {
+                case V1:
+                    map.put("color", "yellow");
+                    map.put("name", "V1");
+                    break;
+                case V2:
+                    map.put("color", "red");
+                    map.put("name", "V2");
+                    break;
+                case V3:
+                    map.put("name", "V3");
+                    break;
+                default:
+                    break;
+                }
+                return map;
+            }
+        };
+
+        ComponentAttributeProvider<DefaultWeightedEdge> edgeAttributeProvider = new ComponentAttributeProvider<DefaultWeightedEdge>()
+        {
+            @Override
+            public Map<String, String> getComponentAttributes(
+                DefaultWeightedEdge e)
+            {
+                Map<String, String> map = new LinkedHashMap<>();
+                if (e.equals(g.getEdge(V1, V2))) {
+                    map.put("color", "what?");
+                    map.put("name", "e12");
+                } else if (e.equals(g.getEdge(V3, V1))) {
+                    map.put("color", "I have no color!");
+                    map.put("name", "e31");
+                }
+                return map;
+            }
+        };
+
+        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<String, DefaultWeightedEdge>(
+            new IntegerNameProvider<>(),
+            null,
+            vertexAttributeProvider,
+            new IntegerEdgeNameProvider<>(),
+            null,
+            edgeAttributeProvider);
+        StringWriter w = new StringWriter();
+        exporter.setExportEdgeWeights(true);
+        exporter.registerAttribute(
+            "color",
+            GraphMLExporter.AttributeCategory.NODE,
+            "yellow");
+        exporter.registerAttribute(
+            "name",
+            GraphMLExporter.AttributeCategory.ALL,
+            "johndoe");
         exporter.export(w, g);
 
         XMLAssert.assertXMLEqual(output, w.toString());

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
@@ -22,9 +22,10 @@
 /* ------------------------------
  * GraphMLExporterTest.java
  * ------------------------------
- * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ * (C) Copyright 2006-2016, by Trevor Harmon and Contributors.
  *
  * Original Author:  Trevor Harmon
+ * Contributors: Dimitrios Michail
  *
  */
 package org.jgrapht.ext;
@@ -38,16 +39,15 @@ import org.custommonkey.xmlunit.*;
 import org.jgrapht.*;
 import org.jgrapht.graph.*;
 
-
 /**
- * .
- *
  * @author Trevor Harmon
+ * @author Dimitrios Michail
  */
 public class GraphMLExporterTest
     extends TestCase
 {
-    //~ Static fields/initializers ---------------------------------------------
+    // ~ Static fields/initializers
+    // ---------------------------------------------
 
     private static final String V1 = "v1";
     private static final String V2 = "v2";
@@ -55,49 +55,273 @@ public class GraphMLExporterTest
 
     private static final String NL = System.getProperty("line.separator");
 
-    // TODO jvs 23-Dec-2006:  externalized diff-based testing framework
-
-    private static final String UNDIRECTED =
-        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
-        + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">"
-        + NL
-        + "<graph edgedefault=\"undirected\">" + NL
-        + "<node id=\"1\"/>" + NL
-        + "<node id=\"2\"/>" + NL
-        + "<node id=\"3\"/>" + NL
-        + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
-        + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
-        + "</graph>" + NL
-        + "</graphml>" + NL;
-
-    private static final GraphMLExporter<String, DefaultEdge> exporter =
-        new GraphMLExporter<String, DefaultEdge>();
-
-    //~ Methods ----------------------------------------------------------------
+    // ~ Methods
+    // ----------------------------------------------------------------
 
     public void testUndirected()
         throws Exception
     {
-        UndirectedGraph<String, DefaultEdge> g =
-            new SimpleGraph<String, DefaultEdge>(DefaultEdge.class);
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<graph edgedefault=\"undirected\">" + NL
+            + "<node id=\"1\"/>" + NL
+            + "<node id=\"2\"/>" + NL
+            + "<node id=\"3\"/>" + NL
+            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
+            DefaultEdge.class);
         g.addVertex(V1);
         g.addVertex(V2);
         g.addEdge(V1, V2);
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
         StringWriter w = new StringWriter();
         exporter.export(w, g);
 
-        if (System.getProperty("java.vm.version").startsWith("1.4")) {
-            // NOTE jvs 16-Mar-2007:  XML prefix mapping comes out
-            // with missing info on 1.4, so skip the verification part
-            // of the test.
-            return;
-        }
-
-        XMLAssert.assertXMLEqual(UNDIRECTED, w.toString());
+        XMLAssert.assertXMLEqual(output, w.toString());
     }
+
+    public void testUndirectedWeighted()
+        throws Exception
+    {
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+            + "<default>1.0</default>" + NL
+            + "</key>" + NL
+            + "<graph edgedefault=\"undirected\">" + NL
+            + "<node id=\"1\"/>" + NL
+            + "<node id=\"2\"/>" + NL
+            + "<node id=\"3\"/>" + NL
+            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
+            DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
+        StringWriter w = new StringWriter();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(w, g);
+
+        XMLAssert.assertXMLEqual(output, w.toString());
+    }
+
+    public void testDirected()
+        throws Exception
+    {
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<graph edgedefault=\"directed\">" + NL
+            + "<node id=\"1\"/>" + NL
+            + "<node id=\"2\"/>" + NL
+            + "<node id=\"3\"/>" + NL
+            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        DirectedGraph<String, DefaultEdge> g = new SimpleDirectedGraph<String, DefaultEdge>(
+            DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
+        StringWriter w = new StringWriter();
+        exporter.export(w, g);
+
+        XMLAssert.assertXMLEqual(output, w.toString());
+    }
+
+    public void testUndirectedUnweightedWithWeights()
+        throws Exception
+    {
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+            + "<default>1.0</default>" + NL
+            + "</key>" + NL
+            + "<graph edgedefault=\"undirected\">" + NL
+            + "<node id=\"1\"/>" + NL
+            + "<node id=\"2\"/>" + NL
+            + "<node id=\"3\"/>" + NL
+            + "<edge id=\"1\" source=\"1\" target=\"2\"/>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
+            DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
+        StringWriter w = new StringWriter();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(w, g);
+
+        XMLAssert.assertXMLEqual(output, w.toString());
+    }
+
+    public void testUndirectedWeightedWithWeights()
+        throws Exception
+    {
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+            + "<default>1.0</default>" + NL
+            + "</key>" + NL
+            + "<graph edgedefault=\"undirected\">" + NL
+            + "<node id=\"1\"/>" + NL
+            + "<node id=\"2\"/>" + NL
+            + "<node id=\"3\"/>" + NL
+            + "<edge id=\"1\" source=\"1\" target=\"2\">" + NL
+            + "<data key=\"edge_weight\">3.0</data>" + NL
+            + "</edge>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\"/>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
+            DefaultWeightedEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+        g.setEdgeWeight(g.getEdge(V1, V2), 3.0);
+
+        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<String, DefaultWeightedEdge>();
+        StringWriter w = new StringWriter();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(w, g);
+
+        XMLAssert.assertXMLEqual(output, w.toString());
+    }
+
+    public void testUndirectedWeightedWithWeightsAndLabels()
+        throws Exception
+    {
+        String output =
+            // @formatter:off
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
+            + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "  
+            + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "  
+            + "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "  
+            + "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
+            + "<key id=\"vertex_label\" for=\"node\" attr.name=\"Vertex Label\" attr.type=\"string\"/>" + NL
+            + "<key id=\"edge_label\" for=\"edge\" attr.name=\"Edge Label\" attr.type=\"string\"/>" + NL
+            + "<key id=\"edge_weight\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
+            + "<default>1.0</default>" + NL
+            + "</key>" + NL
+            + "<graph edgedefault=\"undirected\">" + NL
+            + "<node id=\"1\">" + NL
+            + "<data key=\"vertex_label\">v1</data>" + NL
+            + "</node>" + NL
+            + "<node id=\"2\">" + NL
+            + "<data key=\"vertex_label\">v2</data>" + NL
+            + "</node>" + NL            
+            + "<node id=\"3\">" + NL
+            + "<data key=\"vertex_label\">v3</data>" + NL
+            + "</node>" + NL            
+            + "<edge id=\"1\" source=\"1\" target=\"2\">" + NL
+            + "<data key=\"edge_label\">(v1 : v2)</data>" + NL
+            + "<data key=\"edge_weight\">3.0</data>" + NL
+            + "</edge>" + NL
+            + "<edge id=\"2\" source=\"3\" target=\"1\">" + NL
+            + "<data key=\"edge_label\">(v3 : v1)</data>" + NL            
+            + "<data key=\"edge_weight\">15.0</data>" + NL            
+            + "</edge>" + NL
+            + "</graph>" + NL
+            + "</graphml>" + NL;
+            // @formatter:on
+
+        SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
+            DefaultWeightedEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+        g.setEdgeWeight(g.getEdge(V1, V2), 3.0);
+        g.setEdgeWeight(g.getEdge(V3, V1), 15.0);
+
+        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<String, DefaultWeightedEdge>(
+            new IntegerNameProvider<String>(),
+            new VertexNameProvider<String>()
+            {
+                @Override
+                public String getVertexName(String vertex)
+                {
+                    return vertex;
+                }
+            },
+            new IntegerEdgeNameProvider<DefaultWeightedEdge>(),
+            new EdgeNameProvider<DefaultWeightedEdge>()
+            {
+                @Override
+                public String getEdgeName(DefaultWeightedEdge edge)
+                {
+                    return edge.toString();
+                }
+
+            });
+        StringWriter w = new StringWriter();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(w, g);
+
+        XMLAssert.assertXMLEqual(output, w.toString());
+    }
+
 }
 
 // End GraphMLExporterTest.java

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
@@ -1,0 +1,758 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* ------------------------------
+ * GmlImporterTest.java
+ * ------------------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author: Dimitrios Michail
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ * 17-July-2016 : Initial revision (DM);
+ *
+ */
+package org.jgrapht.ext;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.jgrapht.graph.Pseudograph;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.WeightedPseudograph;
+
+import junit.framework.TestCase;
+
+/**
+ * @author Dimitrios Michail
+ */
+public class GraphMLImporterTest
+    extends TestCase
+{
+
+    private static final String NL = System.getProperty("line.separator");
+
+    public void testUndirectedUnweighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL +  
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testUndirectedUnweightedPseudoGraph()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL + 
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<edge source=\"1\" target=\"1\"/>"+ NL +
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(5, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+        assertTrue(g.containsEdge("1", "1"));
+    }
+
+    public void testUndirectedUnweightedStringKeys()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph edgedefault=\"undirected\">" + NL + 
+            "<node id=\"n1\"/>" + NL +
+            "<node id=\"n2\"/>" + NL + 
+            "<node id=\"n3\"/>" + NL + 
+            "<edge source=\"n1\" target=\"n2\"/>" + NL + 
+            "<edge source=\"n2\" target=\"n3\"/>" + NL + 
+            "<edge source=\"n3\" target=\"n1\"/>"+ NL +
+            "<edge source=\"n1\" target=\"n1\"/>"+ NL +
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(4, g.edgeSet().size());
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsVertex("n3"));
+        assertTrue(g.containsEdge("n1", "n2"));
+        assertTrue(g.containsEdge("n2", "n3"));
+        assertTrue(g.containsEdge("n3", "n1"));
+        assertTrue(g.containsEdge("n1", "n1"));
+    }
+
+    public void testUndirectedUnweightedWrongOrder()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testDirectedUnweighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"directed\">" + NL + 
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            true,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertFalse(g.containsEdge("2", "1"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertFalse(g.containsEdge("3", "2"));
+        assertTrue(g.containsEdge("3", "1"));
+        assertFalse(g.containsEdge("1", "3"));
+    }
+
+    public void testUndirectedUnweightedPrefix()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<gml:graphml xmlns:gml=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<gml:graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<gml:node id=\"1\"/>" + NL +
+            "<gml:node id=\"2\"/>" + NL + 
+            "<gml:node id=\"3\"/>" + NL + 
+            "<gml:edge source=\"1\" target=\"2\"/>" + NL + 
+            "<gml:edge source=\"2\" target=\"3\"/>" + NL + 
+            "<gml:edge source=\"3\" target=\"1\"/>"+ NL + 
+            "</gml:graph>" + NL + 
+            "</gml:graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testWithAttributes()
+        throws ImportException
+    {
+        // @formatter:off
+        String input =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" " + 
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<key id=\"d0\" for=\"node\" attr.name=\"color\" attr.type=\"string\">" + NL +
+            "<default>yellow</default>" + NL +
+            "</key>" + NL +
+            "<key id=\"d1\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\"/>" + NL +
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL +
+            "<node id=\"n0\">" + NL +
+            "<data key=\"d0\">green</data>" + NL +
+            "</node>" + NL +
+            "<node id=\"n1\"/>" + NL +
+            "<node id=\"n2\">" + NL +
+            "<data key=\"d0\">blue</data>" + NL +
+            "</node>" + NL+
+            "<edge id=\"e0\" source=\"n0\" target=\"n2\">" + NL +
+            "<data key=\"d1\">2.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e1\" source=\"n0\" target=\"n1\">" + NL +
+            "<data key=\"d1\">1.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e2\" source=\"n1\" target=\"n2\"/>" + NL +
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("n0"));
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsEdge("n0", "n2"));
+        assertTrue(g.containsEdge("n0", "n1"));
+        assertTrue(g.containsEdge("n1", "n2"));
+    }
+
+    public void testWithMapAttributes()
+        throws ImportException
+    {
+        // @formatter:off
+        String input =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" " + 
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<key id=\"d0\" for=\"node\" attr.name=\"color\" attr.type=\"string\">" + NL +
+            "<default>yellow</default>" + NL +
+            "</key>" + NL +
+            "<key id=\"d1\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\"/>" + NL +
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL +
+            "<node id=\"n0\">" + NL +
+            "<data key=\"d0\">green</data>" + NL +
+            "</node>" + NL +
+            "<node id=\"n1\"/>" + NL +
+            "<node id=\"n2\">" + NL +
+            "<data key=\"d0\">blue</data>" + NL +
+            "</node>" + NL+
+            "<edge id=\"e0\" source=\"n0\" target=\"n2\">" + NL +
+            "<data key=\"d1\">2.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e1\" source=\"n0\" target=\"n1\">" + NL +
+            "<data key=\"d1\">1.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e2\" source=\"n1\" target=\"n2\"/>" + NL +
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Map<String, Map<String, String>> vAttributes = new HashMap<String, Map<String, String>>();
+        Map<DefaultEdge, Map<String, String>> eAttributes = new HashMap<DefaultEdge, Map<String, String>>();
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false,
+            vAttributes,
+            eAttributes);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("n0"));
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsEdge("n0", "n2"));
+        assertTrue(g.containsEdge("n0", "n1"));
+        assertTrue(g.containsEdge("n1", "n2"));
+        assertEquals("green", vAttributes.get("n0").get("color"));
+        assertEquals("yellow", vAttributes.get("n1").get("color"));
+        assertEquals("blue", vAttributes.get("n2").get("color"));
+        assertEquals(
+            "2.0",
+            eAttributes.get(g.getEdge("n0", "n2")).get("weight"));
+        assertEquals(
+            "1.0",
+            eAttributes.get(g.getEdge("n0", "n1")).get("weight"));
+        assertFalse(
+            eAttributes.get(g.getEdge("n1", "n2")).containsKey("weight"));
+    }
+
+    public void testWithAttributesWeightedGraphs()
+        throws ImportException
+    {
+        // @formatter:off
+        String input =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" " + 
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<key id=\"d0\" for=\"node\" attr.name=\"color\" attr.type=\"string\">" + NL +
+            "<default>yellow</default>" + NL +
+            "</key>" + NL +
+            "<key id=\"d1\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL +
+            "<default>3.0</default>" + NL +
+            "</key>" + NL +
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL +
+            "<node id=\"n0\">" + NL +
+            "<data key=\"d0\">green</data>" + NL +
+            "</node>" + NL +
+            "<node id=\"n1\"/>" + NL +
+            "<node id=\"n2\">" + NL +
+            "<data key=\"d0\">blue</data>" + NL +
+            "</node>" + NL+
+            "<edge id=\"e0\" source=\"n0\" target=\"n2\">" + NL +
+            "<data key=\"d1\">2.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e1\" source=\"n0\" target=\"n1\">" + NL +
+            "<data key=\"d1\">1.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e2\" source=\"n1\" target=\"n2\"/>" + NL +
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultWeightedEdge> g = readGraph(
+            input,
+            DefaultWeightedEdge.class,
+            true,
+            true);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("n0"));
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsEdge("n0", "n2"));
+        assertTrue(g.containsEdge("n0", "n1"));
+        assertTrue(g.containsEdge("n1", "n2"));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("n0", "n2")));
+        assertEquals(1.0, g.getEdgeWeight(g.getEdge("n0", "n1")));
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("n1", "n2")));
+    }
+
+    public void testWithHyperEdges()
+        throws ImportException
+    {
+        // @formatter:off
+        String input =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" " + 
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL +
+            "<node id=\"n0\"/>" + NL +
+            "<node id=\"n1\"/>" + NL +
+            "<node id=\"n2\"/>" + NL +
+            "<node id=\"n3\">" + NL +
+            "  <port name=\"North\"/>" + NL +
+            "  <port name=\"South\"/>" + NL +
+            "</node>" + NL +
+            "<edge source=\"n0\" target=\"n1\"/>" + NL +
+            "<edge source=\"n0\" target=\"n3\"/>" + NL +
+            "<hyperedge>" + NL +
+            "  <endpoint node=\"n0\"/>" + NL +
+            "  <endpoint node=\"n1\"/>" + NL +
+            "  <endpoint node=\"n2\"/>" + NL +
+            "  <endpoint node=\"n3\" port=\"South\"/>" + NL +
+            "</hyperedge>" + NL +
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(2, g.edgeSet().size());
+        assertTrue(g.containsVertex("n0"));
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsVertex("n3"));
+        assertTrue(g.containsEdge("n0", "n1"));
+        assertTrue(g.containsEdge("n0", "n3"));
+    }
+
+    public void testValidate()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<nOde id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<myedge source=\"1\" target=\"2\"/>" + NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        try {
+            readGraph(input, DefaultEdge.class, false, false);
+            fail("No!");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testValidateNoNodeId()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<node/>" + NL +
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        try {
+            readGraph(input, DefaultEdge.class, false, false);
+            fail("No!");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testValidateDuplicateNode()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL +  
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"1\"/>" + NL +
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        try {
+            readGraph(input, DefaultEdge.class, false, false);
+            fail("No!");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testExportImport()
+        throws Exception
+    {
+        DirectedPseudograph<String, DefaultEdge> g1 = new DirectedPseudograph<String, DefaultEdge>(
+            DefaultEdge.class);
+        g1.addVertex("1");
+        g1.addVertex("2");
+        g1.addVertex("3");
+        g1.addEdge("1", "2");
+        g1.addEdge("2", "3");
+        g1.addEdge("3", "3");
+
+        StringWriter sw = new StringWriter();
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
+        exporter.export(sw, g1);
+        String output = sw.toString();
+
+        Graph<String, DefaultEdge> g2 = readGraph(
+            output,
+            DefaultEdge.class,
+            true,
+            false);
+
+        assertEquals(3, g2.vertexSet().size());
+        assertEquals(3, g2.edgeSet().size());
+        assertTrue(g2.containsEdge("1", "2"));
+        assertTrue(g2.containsEdge("2", "3"));
+        assertTrue(g2.containsEdge("3", "3"));
+    }
+
+    public void testUnsupportedGraph()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL + 
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<edge source=\"3\" target=\"1\"/>"+ NL +
+            "<edge source=\"1\" target=\"1\"/>"+ NL +
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        final Graph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
+            DefaultEdge.class);
+
+        VertexProvider<String> vp = new VertexProvider<String>()
+        {
+            @Override
+            public String buildVertex(
+                String label,
+                Map<String, String> attributes)
+            {
+                return label;
+            }
+        };
+
+        EdgeProvider<String, DefaultEdge> ep = new EdgeProvider<String, DefaultEdge>()
+        {
+
+            @Override
+            public DefaultEdge buildEdge(
+                String from,
+                String to,
+                String label,
+                Map<String, String> attributes)
+            {
+                return g.getEdgeFactory().createEdge(from, to);
+            }
+
+        };
+
+        try {
+            GraphMLImporter<String, DefaultEdge> importer = new GraphMLImporter<String, DefaultEdge>(
+                vp,
+                ep);
+            importer.read(new StringReader(input), g);
+            fail("No!");
+        } catch (Exception e) {
+            // nothing
+        }
+    }
+
+    public <E> Graph<String, E> readGraph(
+        String input,
+        Class<? extends E> edgeClass,
+        boolean directed,
+        boolean weighted)
+        throws ImportException
+    {
+        return readGraph(
+            input,
+            edgeClass,
+            directed,
+            weighted,
+            new HashMap<String, Map<String, String>>(),
+            new HashMap<E, Map<String, String>>());
+    }
+
+    public <E> Graph<String, E> readGraph(
+        String input,
+        Graph<String, E> g,
+        VertexProvider<String> vp,
+        EdgeProvider<String, E> ep)
+        throws ImportException
+    {
+        GraphMLImporter<String, E> importer = new GraphMLImporter<String, E>(
+            vp,
+            ep);
+        importer.read(new StringReader(input), g);
+
+        return g;
+    }
+
+    public <E> Graph<String, E> readGraph(
+        String input,
+        Class<? extends E> edgeClass,
+        boolean directed,
+        boolean weighted,
+        Map<String, Map<String, String>> vertexAttributes,
+        Map<E, Map<String, String>> edgeAttributes)
+        throws ImportException
+    {
+        Graph<String, E> g;
+        if (directed) {
+            if (weighted) {
+                g = new DirectedWeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new DirectedPseudograph<String, E>(edgeClass);
+            }
+        } else {
+            if (weighted) {
+                g = new WeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new Pseudograph<String, E>(edgeClass);
+            }
+        }
+
+        VertexProvider<String> vp = new VertexProvider<String>()
+        {
+            @Override
+            public String buildVertex(
+                String label,
+                Map<String, String> attributes)
+            {
+                vertexAttributes.put(label, attributes);
+                return label;
+            }
+        };
+
+        EdgeProvider<String, E> ep = new EdgeProvider<String, E>()
+        {
+
+            @Override
+            public E buildEdge(
+                String from,
+                String to,
+                String label,
+                Map<String, String> attributes)
+            {
+                E e = g.getEdgeFactory().createEdge(from, to);
+                edgeAttributes.put(e, attributes);
+                return e;
+            }
+
+        };
+
+        return readGraph(input, g, vp, ep);
+    }
+
+}

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
@@ -582,6 +582,16 @@ public class GraphMLImporterTest
         assertEquals("3.0", vAttributes.get("n0").get("myvalue"));
         assertEquals("3.0", vAttributes.get("n1").get("myvalue"));
         assertEquals("3.0", vAttributes.get("n2").get("myvalue"));
+
+        assertFalse(vAttributes.get("n0").containsKey("onemore"));
+        assertEquals("value1", vAttributes.get("n1").get("onemore"));
+        assertFalse(vAttributes.get("n2").containsKey("onemore"));
+        assertFalse(
+            eAttributes.get(g.getEdge("n0", "n2")).containsKey("onemore"));
+        assertFalse(
+            eAttributes.get(g.getEdge("n0", "n1")).containsKey("onemore"));
+        assertFalse(
+            eAttributes.get(g.getEdge("n1", "n2")).containsKey("onemore"));
     }
 
     public void testWithHyperEdges()

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
@@ -457,6 +457,133 @@ public class GraphMLImporterTest
         assertEquals(3.0, g.getEdgeWeight(g.getEdge("n1", "n2")));
     }
 
+    public void testWithAttributesCustomNamedWeightedGraphs()
+        throws ImportException
+    {
+        // @formatter:off
+        String input =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" " + 
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<key id=\"d0\" for=\"node\" attr.name=\"color\" attr.type=\"string\">" + NL +
+            "<default>yellow</default>" + NL +
+            "</key>" + NL +
+            "<key id=\"d1\" for=\"edge\" attr.name=\"myvalue\" attr.type=\"double\">" + NL +
+            "<default>3.0</default>" + NL +
+            "</key>" + NL +
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL +
+            "<node id=\"n0\">" + NL +
+            "<data key=\"d0\">green</data>" + NL +
+            "</node>" + NL +
+            "<node id=\"n1\"/>" + NL +
+            "<node id=\"n2\">" + NL +
+            "<data key=\"d0\">blue</data>" + NL +
+            "</node>" + NL+
+            "<edge id=\"e0\" source=\"n0\" target=\"n2\">" + NL +
+            "<data key=\"d1\">2.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e1\" source=\"n0\" target=\"n1\">" + NL +
+            "<data key=\"d1\">1.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e2\" source=\"n1\" target=\"n2\"/>" + NL +
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultWeightedEdge> g = new DirectedWeightedPseudograph<>(
+            DefaultWeightedEdge.class);
+        Map<String, Map<String, String>> vAttributes = new HashMap<String, Map<String, String>>();
+        Map<DefaultWeightedEdge, Map<String, String>> eAttributes = new HashMap<DefaultWeightedEdge, Map<String, String>>();
+
+        GraphMLImporter<String, DefaultWeightedEdge> importer = createGraphImporter(
+            g,
+            vAttributes,
+            eAttributes);
+        importer.setEdgeWeightAttributeName("myvalue");
+        importer.read(new StringReader(input), g);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("n0"));
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsEdge("n0", "n2"));
+        assertTrue(g.containsEdge("n0", "n1"));
+        assertTrue(g.containsEdge("n1", "n2"));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("n0", "n2")));
+        assertEquals(1.0, g.getEdgeWeight(g.getEdge("n0", "n1")));
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("n1", "n2")));
+    }
+
+    public void testWithAttributesCustomNamedWeightedForAllGraphs()
+        throws ImportException
+    {
+        // @formatter:off
+        String input =
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?> " + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" " + 
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<key id=\"d0\" for=\"node\" attr.name=\"color\" attr.type=\"string\">" + NL +
+            "<default>yellow</default>" + NL +
+            "</key>" + NL +
+            "<key id=\"d1\" for=\"all\" attr.name=\"myvalue\" attr.type=\"double\">" + NL +
+            "<default>3.0</default>" + NL +
+            "</key>" + NL +
+            "<key id=\"d2\" for=\"all\" attr.name=\"onemore\" attr.type=\"string\"/>" + NL +
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL +
+            "<node id=\"n0\">" + NL +
+            "<data key=\"d0\">green</data>" + NL +
+            "</node>" + NL +
+            "<node id=\"n1\">" + NL +
+            "<data key=\"d2\">value1</data>" + NL +
+            "</node>" + NL +
+            "<node id=\"n2\">" + NL +
+            "<data key=\"d0\">blue</data>" + NL +
+            "</node>" + NL+
+            "<edge id=\"e0\" source=\"n0\" target=\"n2\">" + NL +
+            "<data key=\"d1\">2.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e1\" source=\"n0\" target=\"n1\">" + NL +
+            "<data key=\"d1\">1.0</data>" + NL +
+            "</edge>" + NL +
+            "<edge id=\"e2\" source=\"n1\" target=\"n2\"/>" + NL +
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultWeightedEdge> g = new DirectedWeightedPseudograph<>(
+            DefaultWeightedEdge.class);
+        Map<String, Map<String, String>> vAttributes = new HashMap<String, Map<String, String>>();
+        Map<DefaultWeightedEdge, Map<String, String>> eAttributes = new HashMap<DefaultWeightedEdge, Map<String, String>>();
+
+        GraphMLImporter<String, DefaultWeightedEdge> importer = createGraphImporter(
+            g,
+            vAttributes,
+            eAttributes);
+        importer.setEdgeWeightAttributeName("myvalue");
+        importer.read(new StringReader(input), g);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("n0"));
+        assertTrue(g.containsVertex("n1"));
+        assertTrue(g.containsVertex("n2"));
+        assertTrue(g.containsEdge("n0", "n2"));
+        assertTrue(g.containsEdge("n0", "n1"));
+        assertTrue(g.containsEdge("n1", "n2"));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("n0", "n2")));
+        assertEquals(1.0, g.getEdgeWeight(g.getEdge("n0", "n1")));
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("n1", "n2")));
+
+        assertEquals("3.0", vAttributes.get("n0").get("myvalue"));
+        assertEquals("3.0", vAttributes.get("n1").get("myvalue"));
+        assertEquals("3.0", vAttributes.get("n2").get("myvalue"));
+    }
+
     public void testWithHyperEdges()
         throws ImportException
     {
@@ -691,38 +818,16 @@ public class GraphMLImporterTest
         EdgeProvider<String, E> ep)
         throws ImportException
     {
-        GraphMLImporter<String, E> importer = new GraphMLImporter<String, E>(
-            vp,
-            ep);
+        GraphMLImporter<String, E> importer = createGraphImporter(g, vp, ep);
         importer.read(new StringReader(input), g);
-
         return g;
     }
 
-    public <E> Graph<String, E> readGraph(
-        String input,
-        Class<? extends E> edgeClass,
-        boolean directed,
-        boolean weighted,
+    public <E> GraphMLImporter<String, E> createGraphImporter(
+        Graph<String, E> g,
         Map<String, Map<String, String>> vertexAttributes,
         Map<E, Map<String, String>> edgeAttributes)
-        throws ImportException
     {
-        Graph<String, E> g;
-        if (directed) {
-            if (weighted) {
-                g = new DirectedWeightedPseudograph<String, E>(edgeClass);
-            } else {
-                g = new DirectedPseudograph<String, E>(edgeClass);
-            }
-        } else {
-            if (weighted) {
-                g = new WeightedPseudograph<String, E>(edgeClass);
-            } else {
-                g = new Pseudograph<String, E>(edgeClass);
-            }
-        }
-
         VertexProvider<String> vp = new VertexProvider<String>()
         {
             @Override
@@ -752,7 +857,51 @@ public class GraphMLImporterTest
 
         };
 
-        return readGraph(input, g, vp, ep);
+        return createGraphImporter(g, vp, ep);
+    }
+
+    public <E> GraphMLImporter<String, E> createGraphImporter(
+        Graph<String, E> g,
+        VertexProvider<String> vp,
+        EdgeProvider<String, E> ep)
+    {
+        GraphMLImporter<String, E> importer = new GraphMLImporter<String, E>(
+            vp,
+            ep);
+
+        return importer;
+    }
+
+    public <E> Graph<String, E> readGraph(
+        String input,
+        Class<? extends E> edgeClass,
+        boolean directed,
+        boolean weighted,
+        Map<String, Map<String, String>> vertexAttributes,
+        Map<E, Map<String, String>> edgeAttributes)
+        throws ImportException
+    {
+        Graph<String, E> g;
+        if (directed) {
+            if (weighted) {
+                g = new DirectedWeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new DirectedPseudograph<String, E>(edgeClass);
+            }
+        } else {
+            if (weighted) {
+                g = new WeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new Pseudograph<String, E>(edgeClass);
+            }
+        }
+
+        GraphMLImporter<String, E> importer = createGraphImporter(
+            g,
+            vertexAttributes,
+            edgeAttributes);
+        importer.read(new StringReader(input), g);
+        return g;
     }
 
 }


### PR DESCRIPTION
Implementation of GraphMLImporter along with all necessary tests
  - The parser validates inputs and can parse any 1.0 valid GraphML document.
  - Features that do not make sense such as nested graphs are simply ignored.
  - The implementation is fully tested
  - Closes issue #52.

Refactored GraphMLExporter
  - Added support for exporting edge weights as a GraphML-Attribute
  - Cleanup code
  - Added missing tests for GraphMLExporter

