### PR TITLE
GmlImporter implementation

### DIFF
--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -93,6 +93,19 @@
 					</instructions>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.antlr</groupId>
+				<artifactId>antlr4-maven-plugin</artifactId>
+				<version>4.5</version>
+				<executions>
+					<execution>
+						<id>antlr</id>
+						<goals>
+							<goal>antlr4</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>
@@ -117,6 +130,11 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.antlr</groupId>
+			<artifactId>antlr4-runtime</artifactId>
+			<version>4.5.3</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/jgrapht-ext/src/main/antlr4/org/jgrapht/ext/Gml.g4
+++ b/jgrapht-ext/src/main/antlr4/org/jgrapht/ext/Gml.g4
@@ -1,0 +1,48 @@
+
+// define a grammar called GML
+
+grammar Gml;
+
+gml
+    : 
+	keyValuePair*
+	;
+
+keyValuePair
+    : ID STRING   #StringKeyValue  
+    | ID NUMBER   #NumberKeyValue  
+    | ID '[' keyValuePair* ']' #ListKeyValue
+    ;
+      
+/** "a numeral [-]?(.[0-9]+ | [0-9]+(.[0-9]*)? )" */ NUMBER
+   : '-'? ( '.' DIGIT+ | DIGIT+ ( '.' DIGIT* )? )
+   ;
+
+fragment DIGIT
+   : [0-9]
+   ;
+   
+fragment LETTER
+   : [a-zA-Z\u0080-\u00FF_]
+;   
+
+/** "any double-quoted string ("...") possibly containing escaped quotes" */ STRING
+   : '"' ( '\\"' | . )*? '"'
+   ;
+
+/** "Any string of alphabetic ([a-zA-Z\200-\377]) characters, underscores
+ *  ('_') or digits ([0-9]), not beginning with a digit"
+ */ ID
+   : LETTER ( LETTER | DIGIT )*
+   ;
+
+/** "a '#' character is considered a line output from a C preprocessor (e.g.,
+ *  # 34 to indicate line 34 ) and discarded"
+ */ PREPROC
+   : '#' .*? '\n' -> skip
+   ;
+
+WS
+   : [ \t\n\r]+ -> skip
+   ;
+   

--- a/jgrapht-ext/src/main/antlr4/org/jgrapht/ext/Gml.g4
+++ b/jgrapht-ext/src/main/antlr4/org/jgrapht/ext/Gml.g4
@@ -1,5 +1,37 @@
-
-// define a grammar called GML
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -------------------
+ * Gml.g4
+ * -------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author:  Dimitrios Michail
+ * Contributor(s): 
+ *
+ * Changes
+ * -------
+ * 16-July-2016 : Initial revision (DM);
+ *
+ */
 
 grammar Gml;
 
@@ -14,7 +46,7 @@ keyValuePair
     | ID '[' keyValuePair* ']' #ListKeyValue
     ;
       
-/** "a numeral [-]?(.[0-9]+ | [0-9]+(.[0-9]*)? )" */ NUMBER
+NUMBER
    : '-'? ( '.' DIGIT+ | DIGIT+ ( '.' DIGIT* )? )
    ;
 
@@ -26,19 +58,15 @@ fragment LETTER
    : [a-zA-Z\u0080-\u00FF_]
 ;   
 
-/** "any double-quoted string ("...") possibly containing escaped quotes" */ STRING
+STRING
    : '"' ( '\\"' | . )*? '"'
    ;
 
-/** "Any string of alphabetic ([a-zA-Z\200-\377]) characters, underscores
- *  ('_') or digits ([0-9]), not beginning with a digit"
- */ ID
+ID
    : LETTER ( LETTER | DIGIT )*
    ;
 
-/** "a '#' character is considered a line output from a C preprocessor (e.g.,
- *  # 34 to indicate line 34 ) and discarded"
- */ PREPROC
+COMMENT
    : '#' .*? '\n' -> skip
    ;
 

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
@@ -215,9 +215,17 @@ public class GmlImporter<V, E>
             // update graph
             listener.updateGraph(graph);
         } catch (IOException e) {
-            throw new ImportException("Failed to import gml graph", e);
+            throw new ImportException(
+                "Failed to import gml graph: " + e.getMessage(),
+                e);
         } catch (ParseCancellationException pe) {
-            throw new ImportException("Failed to import gml graph", pe);
+            throw new ImportException(
+                "Failed to import gml graph: " + pe.getMessage(),
+                pe);
+        } catch (IllegalArgumentException iae) {
+            throw new ImportException(
+                "Failed to import gml graph: " + iae.getMessage(),
+                iae);
         }
     }
 

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
@@ -1,0 +1,426 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* -------------------
+ * GmlImporter.java
+ * -------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author:  Dimitrios Michail
+ * Contributor(s): 
+ *
+ * Changes
+ * -------
+ * 16-July-2016 : Initial revision (DM);
+ *
+ */
+package org.jgrapht.ext;
+
+import org.antlr.v4.runtime.ANTLRInputStream;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.jgrapht.Graph;
+import org.jgrapht.WeightedGraph;
+import org.jgrapht.ext.GmlParser.GmlContext;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Imports a graph from a GML file (Graph Modeling Language).
+ * 
+ * <p>
+ * For a description of the format see
+ * <a href="http://www.infosun.fmi.uni-passau.de/Graphlet/GML/"> http://www.
+ * infosun.fmi.uni-passau.de/Graphlet/GML/</a>.
+ *
+ * <p>
+ * Below is small example of a graph in GML format.
+ * 
+ * <pre>
+ * graph [
+ *   node [ 
+ *     id 1
+ *   ]
+ *   node [
+ *     id 2
+ *   ]
+ *   node [
+ *     id 3
+ *   ]
+ *   edge [
+ *     source 1
+ *     target 2 
+ *     weight 2.0
+ *   ]
+ *   edge [
+ *     source 2
+ *     target 3
+ *     weight 3.0
+ *   ]
+ * ]
+ * </pre>
+ * 
+ * <p>
+ * In case the graph is an instance of {@link org.jgrapht.WeightedGraph} then
+ * the importer also reads edge weights. Otherwise edge weights are ignored.
+ *
+ * @param <V> the vertex type
+ * @param <E> the edge type
+ */
+public class GmlImporter<V, E>
+{
+    private VertexProvider<V> vertexProvider;
+    private EdgeProvider<V, E> edgeProvider;
+
+    /**
+     * Constructs a new importer.
+     * 
+     * @param vertexProvider provider for the generation of vertices. Must not
+     *        be null.
+     * @param edgeProvider provider for the generation of edges. Must not be
+     *        null.
+     */
+    public GmlImporter(
+        VertexProvider<V> vertexProvider,
+        EdgeProvider<V, E> edgeProvider)
+    {
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
+        }
+        this.vertexProvider = vertexProvider;
+        if (edgeProvider == null) {
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
+    }
+
+    /**
+     * Get the vertex provider
+     * 
+     * @return the vertex provider
+     */
+    public VertexProvider<V> getVertexProvider()
+    {
+        return vertexProvider;
+    }
+
+    /**
+     * Set the vertex provider
+     * 
+     * @param vertexProvider the new vertex provider. Must not be null.
+     */
+    public void setVertexProvider(VertexProvider<V> vertexProvider)
+    {
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
+        }
+        this.vertexProvider = vertexProvider;
+    }
+
+    /**
+     * Get the edge provider
+     * 
+     * @return The edge provider
+     */
+    public EdgeProvider<V, E> getEdgeProvider()
+    {
+        return edgeProvider;
+    }
+
+    /**
+     * Set the edge provider.
+     * 
+     * @param edgeProvider the new edge provider. Must not be null.
+     */
+    public void setEdgeProvider(EdgeProvider<V, E> edgeProvider)
+    {
+        if (edgeProvider == null) {
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
+    }
+
+    /**
+     * Import a graph.
+     * 
+     * <p>
+     * The provided graph must be able to support the features of the graph that
+     * is read. For example if the gml file contains self-loops then the graph
+     * provided must also support self-loops. The same for multiple edges.
+     * 
+     * <p>
+     * If the provided graph is a weighted graph, the importer also reads edge
+     * weights. Otherwise edge weights are ignored.
+     * 
+     * @param input the input stream
+     * @param graph the output graph
+     * @throws ImportException in case an error occurs, such as I/O or parse
+     *         error
+     */
+    public void read(Reader input, Graph<V, E> graph)
+        throws ImportException
+    {
+        try {
+            ThrowingErrorListener errorListener = new ThrowingErrorListener();
+
+            // create lexer
+            GmlLexer lexer = new GmlLexer(new ANTLRInputStream(input));
+            lexer.removeErrorListeners();
+            lexer.addErrorListener(errorListener);
+
+            // create parser
+            GmlParser parser = new GmlParser(new CommonTokenStream(lexer));
+            parser.removeErrorListeners();
+            parser.addErrorListener(errorListener);
+
+            // Specify our entry point
+            GmlContext graphContext = parser.gml();
+
+            // Walk it and attach our listener
+            ParseTreeWalker walker = new ParseTreeWalker();
+            CreateGraphGmlListener listener = new CreateGraphGmlListener();
+            walker.walk(listener, graphContext);
+
+            // update graph
+            listener.updateGraph(graph);
+        } catch (IOException e) {
+            throw new ImportException("Failed to import gml graph", e);
+        } catch (ParseCancellationException pe) {
+            throw new ImportException("Failed to import gml graph", pe);
+        }
+    }
+
+    private class ThrowingErrorListener
+        extends BaseErrorListener
+    {
+
+        @Override
+        public void syntaxError(
+            Recognizer<?, ?> recognizer,
+            Object offendingSymbol,
+            int line,
+            int charPositionInLine,
+            String msg,
+            RecognitionException e)
+            throws ParseCancellationException
+        {
+            throw new ParseCancellationException(
+                "line " + line + ":" + charPositionInLine + " " + msg);
+        }
+    }
+
+    // create graph from parse tree
+    private class CreateGraphGmlListener
+        extends GmlBaseListener
+    {
+        private static final String NODE = "node";
+        private static final String EDGE = "edge";
+        private static final String GRAPH = "graph";
+        private static final String WEIGHT = "weight";
+        private static final String ID = "id";
+        private static final String SOURCE = "source";
+        private static final String TARGET = "target";
+
+        private boolean foundGraph;
+        private boolean insideGraph;
+        private boolean insideNode;
+        private boolean insideEdge;
+        private int level;
+        private Integer nodeId;
+        private Integer sourceId;
+        private Integer targetId;
+        private Double weight;
+
+        private Set<Integer> nodes;
+        private int singletons;
+        private List<PartialEdge> edges;
+
+        public void updateGraph(Graph<V, E> graph)
+            throws ImportException
+        {
+            if (foundGraph) {
+                // add nodes
+                int maxV = 1;
+                Map<Integer, V> map = new HashMap<Integer, V>();
+                for (Integer id : nodes) {
+                    maxV = Math.max(maxV, id);
+                    V vertex = vertexProvider.buildVertex(
+                        id.toString(),
+                        new HashMap<String, String>());
+                    map.put(id, vertex);
+                    graph.addVertex(vertex);
+                }
+
+                // add singleton nodes
+                for (int i = 0; i < singletons; i++) {
+                    String label = String.valueOf(maxV + 1 + i);
+                    graph.addVertex(
+                        vertexProvider
+                            .buildVertex(label, new HashMap<String, String>()));
+                }
+
+                // add edges
+                for (PartialEdge pe : edges) {
+                    String label = "e_" + pe.source + "_" + pe.target;
+                    V from = map.get(pe.source);
+                    if (from == null) {
+                        throw new ImportException(
+                            "Node " + pe.source + " does not exist");
+                    }
+                    V to = map.get(pe.target);
+                    if (to == null) {
+                        throw new ImportException(
+                            "Node " + pe.target + " does not exist");
+                    }
+                    E e = edgeProvider.buildEdge(
+                        from,
+                        to,
+                        label,
+                        new HashMap<String, String>());
+                    graph.addEdge(from, to, e);
+                    if (pe.weight != null) {
+                        if (graph instanceof WeightedGraph<?, ?>) {
+                            ((WeightedGraph<V, E>) graph)
+                                .setEdgeWeight(e, pe.weight);
+                        }
+                    }
+                }
+
+            }
+        }
+
+        @Override
+        public void enterGml(GmlParser.GmlContext ctx)
+        {
+            foundGraph = false;
+            insideGraph = false;
+            insideNode = false;
+            insideEdge = false;
+            nodes = new HashSet<Integer>();
+            singletons = 0;
+            edges = new ArrayList<PartialEdge>();
+            level = 0;
+        }
+
+        @Override
+        public void enterNumberKeyValue(GmlParser.NumberKeyValueContext ctx)
+        {
+            String key = ctx.ID().getText();
+
+            if (insideNode && level == 2 && key.equals(ID)) {
+                try {
+                    nodeId = Integer.parseInt(ctx.NUMBER().getText());
+                } catch (NumberFormatException e) {
+                    // ignore error
+                }
+            } else if (insideEdge && level == 2 && key.equals(SOURCE)) {
+                try {
+                    sourceId = Integer.parseInt(ctx.NUMBER().getText());
+                } catch (NumberFormatException e) {
+                    // ignore error
+                }
+            } else if (insideEdge && level == 2 && key.equals(TARGET)) {
+                try {
+                    targetId = Integer.parseInt(ctx.NUMBER().getText());
+                } catch (NumberFormatException e) {
+                    // ignore error
+                }
+            } else if (insideEdge && level == 2 && key.equals(WEIGHT)) {
+                try {
+                    weight = Double.parseDouble(ctx.NUMBER().getText());
+                } catch (NumberFormatException e) {
+                    // ignore error
+                }
+            }
+        }
+
+        @Override
+        public void enterListKeyValue(GmlParser.ListKeyValueContext ctx)
+        {
+            String key = ctx.ID().getText();
+            if (level == 0 && key.equals(GRAPH)) {
+                foundGraph = true;
+                insideGraph = true;
+            } else if (level == 1 && insideGraph && key.equals(NODE)) {
+                insideNode = true;
+                nodeId = null;
+            } else if (level == 1 && insideGraph && key.equals(EDGE)) {
+                insideEdge = true;
+                sourceId = null;
+                targetId = null;
+                weight = null;
+            }
+            level++;
+        }
+
+        @Override
+        public void exitListKeyValue(GmlParser.ListKeyValueContext ctx)
+        {
+            String key = ctx.ID().getText();
+            level--;
+            if (level == 0 && key.equals(GRAPH)) {
+                insideGraph = false;
+            } else if (level == 1 && insideGraph && key.equals(NODE)) {
+                if (nodeId == null) {
+                    singletons++;
+                } else {
+                    nodes.add(nodeId);
+                }
+                insideNode = false;
+            } else if (level == 1 && insideGraph && key.equals(EDGE)) {
+                if (sourceId != null && targetId != null) {
+                    edges.add(new PartialEdge(sourceId, targetId, weight));
+                }
+                insideEdge = false;
+            }
+
+        }
+
+    }
+
+    private class PartialEdge
+    {
+        Integer source;
+        Integer target;
+        Double weight;
+
+        public PartialEdge(Integer source, Integer target, Double weight)
+        {
+            this.source = source;
+            this.target = target;
+            this.weight = weight;
+        }
+    }
+
+}

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
@@ -43,6 +43,7 @@ import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.DirectedPseudograph;
 import org.jgrapht.graph.DirectedWeightedPseudograph;
 import org.jgrapht.graph.Pseudograph;
+import org.jgrapht.graph.SimpleGraph;
 import org.jgrapht.graph.WeightedPseudograph;
 
 import junit.framework.TestCase;
@@ -574,6 +575,52 @@ public class GmlImporterTest
         assertEquals(2.0, g2.getEdgeWeight(g2.getEdge("1", "2")));
         assertEquals(3.0, g2.getEdgeWeight(g2.getEdge("2", "3")));
         assertEquals(5.0, g2.getEdgeWeight(g2.getEdge("3", "3")));
+    }
+
+    public void testNotSupportedGraph()
+    {
+        // @formatter:off
+        String input = "graph [ node [ id 1 ] " + 
+                       "edge [ source 1 target 1 ] ]"; 
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = new SimpleGraph<>(DefaultEdge.class);
+
+        VertexProvider<String> vp = new VertexProvider<String>()
+        {
+            @Override
+            public String buildVertex(
+                String label,
+                Map<String, String> attributes)
+            {
+                return label;
+            }
+        };
+
+        EdgeProvider<String, DefaultEdge> ep = new EdgeProvider<String, DefaultEdge>()
+        {
+
+            @Override
+            public DefaultEdge buildEdge(
+                String from,
+                String to,
+                String label,
+                Map<String, String> attributes)
+            {
+                return g.getEdgeFactory().createEdge(from, to);
+            }
+
+        };
+
+        try {
+            GmlImporter<String, DefaultEdge> importer = new GmlImporter<String, DefaultEdge>(
+                vp,
+                ep);
+            importer.read(new StringReader(input), g);
+            fail("No!");
+        } catch (ImportException e) {
+        }
+
     }
 
 }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
@@ -1,0 +1,579 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* ------------------------------
+ * GmlImporterTest.java
+ * ------------------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author: Dimitrios Michail
+ *
+ * Changes
+ * -------
+ * 16-July-2016 : Initial revision (DM);
+ *
+ */
+package org.jgrapht.ext;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.util.Map;
+
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.jgrapht.graph.Pseudograph;
+import org.jgrapht.graph.WeightedPseudograph;
+
+import junit.framework.TestCase;
+
+/**
+ * 
+ * @author Dimitrios Michail
+ */
+public class GmlImporterTest
+    extends TestCase
+{
+
+    public <E> Graph<String, E> readGraph(
+        String input,
+        Class<? extends E> edgeClass,
+        boolean directed,
+        boolean weighted)
+        throws ImportException
+    {
+        Graph<String, E> g;
+        if (directed) {
+            if (weighted) {
+                g = new DirectedWeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new DirectedPseudograph<String, E>(edgeClass);
+            }
+        } else {
+            if (weighted) {
+                g = new WeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new Pseudograph<String, E>(edgeClass);
+            }
+        }
+
+        VertexProvider<String> vp = new VertexProvider<String>()
+        {
+            @Override
+            public String buildVertex(
+                String label,
+                Map<String, String> attributes)
+            {
+                return label;
+            }
+        };
+
+        EdgeProvider<String, E> ep = new EdgeProvider<String, E>()
+        {
+
+            @Override
+            public E buildEdge(
+                String from,
+                String to,
+                String label,
+                Map<String, String> attributes)
+            {
+                return g.getEdgeFactory().createEdge(from, to);
+            }
+
+        };
+
+        GmlImporter<String, E> importer = new GmlImporter<String, E>(vp, ep);
+        importer.read(new StringReader(input), g);
+
+        return g;
+    }
+
+    public void testUndirectedUnweighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 3\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "  ]\n"                     
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 2\n"
+                     + "    target 3\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsVertex("4"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testIgnoreWeightsUndirectedUnweighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "    weight 2.0\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 2.0\n"
+                     + "    target 3\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3.3\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(2, g.vertexSet().size());
+        assertEquals(1, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsEdge("1", "2"));
+    }
+
+    public void testNoGraph()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "GRAPH [\n"
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g1 = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(0, g1.vertexSet().size());
+        assertEquals(0, g1.edgeSet().size());
+
+        Graph<String, DefaultEdge> g2 = readGraph(
+            input.toLowerCase(),
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(0, g2.vertexSet().size());
+        assertEquals(0, g2.edgeSet().size());
+    }
+
+    public void testIgnore()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  ignore [\n"
+                     + "     node [\n"
+                     + "       id 5\n"
+                     + "     ]"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 3\n"
+                     + "    label \"3\""
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "  ]\n"                     
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"
+                     + "  ignore [\n"
+                     + "     edge [\n"
+                     + "       source 5\n"
+                     + "       target 1\n"
+                     + "       label \"edge51\""
+                     + "     ]"
+                     + "  ]\n"                     
+                     + "  edge [\n"
+                     + "    source 2\n"
+                     + "    target 3\n"
+                     + "    label \"23\""                     
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "]"
+                     + "node [\n"
+                     + "  id 6\n"
+                     + "]\n"
+                     ;
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsVertex("4"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testUndirectedUnweightedWrongOrder()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 2\n"
+                     + "    target 3\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 3\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "  ]\n"                     
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            false,
+            false);
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsVertex("4"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    public void testDirectedPseudographUnweighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 3\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "  ]\n"                     
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "  ]\n"                     
+                     + "  edge [\n"
+                     + "    source 2\n"
+                     + "    target 3\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 1\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 2\n"
+                     + "    target 2\n"
+                     + "  ]\n"                     
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = readGraph(
+            input,
+            DefaultEdge.class,
+            true,
+            false);
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(7, g.edgeSet().size());
+    }
+
+    public void testDirectedWeighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 3\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "    weight 2.0\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3\n"
+                     + "    target 1\n"
+                     + "    weight 3.0\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultWeightedEdge> g = readGraph(
+            input,
+            DefaultWeightedEdge.class,
+            true,
+            true);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(2, g.edgeSet().size());
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("3", "1"));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")));
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")));
+    }
+
+    public void testDirectedWeightedWithComments()
+        throws ImportException
+    {
+        // @formatter:off
+            String input = "# A comment line\n" 
+            		     + "graph [\n"
+                         + "  comment \"Sample Graph\"\n"
+                         + "  directed 1\n"
+                         + "  node [\n"
+                         + "    id 1\n"
+                         + "  ]\n"
+                         + "  node [\n"
+                         + "    id 2\n"
+                         + "  ]\n"
+                         + "# Another comment line\n"
+                         + "  node [\n"
+                         + "    id 3\n"
+                         + "  ]\n"
+                         + "  edge [\n"
+                         + "    source 1\n"
+                         + "    target 2\n"
+                         + "    weight 2.0\n"
+                         + "  ]\n"
+                         + "  edge [\n"
+                         + "    source 3\n"
+                         + "    target 1\n"
+                         + "    weight 3.0\n"
+                         + "  ]\n"
+                         + "]";
+            // @formatter:on
+
+        Graph<String, DefaultWeightedEdge> g = readGraph(
+            input,
+            DefaultWeightedEdge.class,
+            true,
+            true);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(2, g.edgeSet().size());
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("3", "1"));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")));
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")));
+    }
+
+    public void testDirectedWeightedSingleLine()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [ node [ id 1 ] node [ id 2 ] node [ id 3 ] " + 
+                       "edge [ source 1 target 2 weight 2.0 ] " + 
+                       "edge [ source 3 target 1 weight 3.0 ] ]"; 
+        // @formatter:on
+
+        Graph<String, DefaultWeightedEdge> g = readGraph(
+            input,
+            DefaultWeightedEdge.class,
+            true,
+            true);
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(2, g.edgeSet().size());
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("3", "1"));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")));
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")));
+    }
+
+    public void testParserError()
+    {
+        // @formatter:off
+        String input = "graph [ [ node ] ]";
+        // @formatter:on
+
+        try {
+            readGraph(input, DefaultEdge.class, false, false);
+            fail("Managed to parse wrong input");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testMissingVertices()
+    {
+        // @formatter:off
+        String input = "graph [ edge [ source 1 target 2 ] ]";
+        // @formatter:on
+
+        try {
+            readGraph(input, DefaultEdge.class, false, false);
+            fail("Node is missing?");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testExportImport()
+        throws ImportException
+    {
+        DirectedWeightedPseudograph<String, DefaultWeightedEdge> g1 = new DirectedWeightedPseudograph<String, DefaultWeightedEdge>(
+            DefaultWeightedEdge.class);
+        g1.addVertex("1");
+        g1.addVertex("2");
+        g1.addVertex("3");
+        g1.setEdgeWeight(g1.addEdge("1", "2"), 2.0);
+        g1.setEdgeWeight(g1.addEdge("2", "3"), 3.0);
+        g1.setEdgeWeight(g1.addEdge("3", "3"), 5.0);
+
+        StringWriter sw = new StringWriter();
+        GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<String, DefaultWeightedEdge>();
+        exporter.setExportEdgeWeights(true);
+        exporter.export(sw, g1);
+        String output = sw.toString();
+
+        Graph<String, DefaultWeightedEdge> g2 = readGraph(
+            output,
+            DefaultWeightedEdge.class,
+            true,
+            true);
+
+        assertEquals(3, g2.vertexSet().size());
+        assertEquals(3, g2.edgeSet().size());
+        assertTrue(g2.containsEdge("1", "2"));
+        assertTrue(g2.containsEdge("2", "3"));
+        assertTrue(g2.containsEdge("3", "3"));
+        assertEquals(2.0, g2.getEdgeWeight(g2.getEdge("1", "2")));
+        assertEquals(3.0, g2.getEdgeWeight(g2.getEdge("2", "3")));
+        assertEquals(5.0, g2.getEdgeWeight(g2.getEdge("3", "3")));
+    }
+
+}

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
@@ -557,7 +557,7 @@ public class GmlImporterTest
 
         StringWriter sw = new StringWriter();
         GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<String, DefaultWeightedEdge>();
-        exporter.setExportEdgeWeights(true);
+        exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
         exporter.export(sw, g1);
         String output = sw.toString();
 


### PR DESCRIPTION
This is an implementation of GmlImporter using the antlr4 engine for lexer-parser generation.
  - This parser uses antlr4 to perform the parsing and thus adds an extra jar dependency.
  - Using anltr4 has the advantage that all gml features are supported.
  - Here the antlr4 maven plugin generates sources in target/generated-sources which are automatically included in the build.

The implementation is fully tested.
 
This parser will likely need an additional mention on the dependencies section of the README.md as the antlr4-runtime has a BSD license. This should not be a problem as other JGraphT dependencies also have a BSD license.

