### PR TITLE
External path validator for KShortestPaths

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/KShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/KShortestPaths.java
@@ -89,7 +89,7 @@ public class KShortestPaths<V, E>
      * Creates an object to compute ranking shortest paths between the start
      * vertex and others vertices. Providing non-null path validator may be
      * used to accept/deny paths according to some external logic. These
-     * validations will be used is addition to the basic path validations -
+     * validations will be used in addition to the basic path validations -
      * that the path is from start to target with no loops.
      *
      * @param graph graph on which shortest paths are searched.
@@ -131,7 +131,7 @@ public class KShortestPaths<V, E>
      * Creates an object to calculate ranking shortest paths between the start
      * vertex and others vertices. Providing non-null path validator may be
      * used to accept/deny paths according to some external logic. These
-     * validations will be used is addition to the basic path validations -
+     * validations will be used in addition to the basic path validations -
      * that the path is from start to target with no loops.
      *
      * @param graph graph on which shortest paths are searched.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/KShortestPathsIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/KShortestPathsIterator.java
@@ -147,7 +147,7 @@ class KShortestPathsIterator<V, E>
                 new HashMap<>();
 
         this.prevImprovedVertices = new HashSet<>();
-        this.pathValidator = null;
+        this.pathValidator = pathValidator;
     }
 
     /**
@@ -256,7 +256,8 @@ class KShortestPathsIterator<V, E>
                 this.k,
                 oppositeData,
                 edge,
-                this.endVertex);
+                this.endVertex,
+                this.pathValidator);
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/PathValidator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/PathValidator.java
@@ -1,0 +1,58 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2016, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* ----------------
+ * PathValidator.java
+ * ----------------
+ * (C) Copyright 2016-, by Assaf Mizrachi and Contributors.
+ *
+ * Original Author:  Assaf Mizrachi
+ * Contributor(s):   
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ *
+ */
+package org.jgrapht.alg;
+
+/**
+ * May be used  to provide external path validations in addition to the basic
+ * validations done by {@link KShortestPaths} - that the path is from source
+ * to target and that it does not contain loops.
+ * 
+ * @author Assaf Mizrachi
+ * @since July, 21, 2016
+ *
+ */
+public interface PathValidator<V, E> {
+
+    /**
+     * Checks if an edge can be added to a previous path element.
+     * 
+     * @param prevPathElement the previous path element
+     * @param edge the edge to be added to the path.
+     * 
+     * @return <code>true</code> if edge can be added, <code>false</code> otherwise.
+     */
+    public boolean isNotValidPath(AbstractPathElement<V, E> prevPathElement, E edge);
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/PathValidator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/PathValidator.java
@@ -54,5 +54,5 @@ public interface PathValidator<V, E> {
      * 
      * @return <code>true</code> if edge can be added, <code>false</code> otherwise.
      */
-    public boolean isNotValidPath(AbstractPathElement<V, E> prevPathElement, E edge);
+    public boolean isValidPath(AbstractPathElement<V, E> prevPathElement, E edge);
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElementList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElementList.java
@@ -67,7 +67,7 @@ final class RankingPathElementList<V, E>
      * path though they pass the basic validations done internally
      * (path is from source to target and w/o loops).
      */
-    private PathValidator<V, E> externalPathVlidator = null;  
+    private PathValidator<V, E> externalPathValidator = null;  
 
     /**
      * Creates a list with an empty path. The list size is 1.
@@ -97,7 +97,7 @@ final class RankingPathElementList<V, E>
         PathValidator<V, E> pathValidator)    
     {
         super(graph, maxSize, pathElement);
-        this.externalPathVlidator = pathValidator;
+        this.externalPathValidator = pathValidator;
     }
 
     /**
@@ -160,7 +160,7 @@ final class RankingPathElementList<V, E>
     {
         super(graph, maxSize, elementList, edge);
         this.guardVertexToNotDisconnect = guardVertexToNotDisconnect;
-        this.externalPathVlidator = pathValidator;
+        this.externalPathValidator = pathValidator;
 
         // loop over the path elements in increasing order of weight.
         for (int i = 0; (i < elementList.size()) && (size() < maxSize); i++) {
@@ -205,7 +205,7 @@ final class RankingPathElementList<V, E>
             PathValidator<V, E> pathValidator)
     {
         super(graph, maxSize, vertex);
-        this.externalPathVlidator = pathValidator;
+        this.externalPathValidator = pathValidator;
     }
 
     /**
@@ -419,7 +419,7 @@ final class RankingPathElementList<V, E>
         if (isGuardVertexDisconnected(prevPathElement)) {
             return true;
         }
-        if (externalPathVlidator != null && ! externalPathVlidator.isValidPath(prevPathElement, edge)) {
+        if (externalPathValidator != null && ! externalPathValidator.isValidPath(prevPathElement, edge)) {
             return true;
 
         } else {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElementList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElementList.java
@@ -419,7 +419,7 @@ final class RankingPathElementList<V, E>
         if (isGuardVertexDisconnected(prevPathElement)) {
             return true;
         }
-        if (externalPathVlidator != null && externalPathVlidator.isNotValidPath(prevPathElement, edge)) {
+        if (externalPathVlidator != null && ! externalPathVlidator.isValidPath(prevPathElement, edge)) {
             return true;
 
         } else {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElementList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElementList.java
@@ -160,6 +160,7 @@ final class RankingPathElementList<V, E>
     {
         super(graph, maxSize, elementList, edge);
         this.guardVertexToNotDisconnect = guardVertexToNotDisconnect;
+        this.externalPathVlidator = pathValidator;
 
         // loop over the path elements in increasing order of weight.
         for (int i = 0; (i < elementList.size()) && (size() < maxSize); i++) {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KSPPathValidatorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KSPPathValidatorTest.java
@@ -1,0 +1,246 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2016, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* ----------------
+ * KSPPathValidatorTest.java
+ * ----------------
+ * (C) Copyright 2016-, by Assaf Mizrachi and Contributors.
+ *
+ * Original Author:  Assaf Mizrachi
+ * Contributor(s):   
+ *
+ * $Id$
+ *
+ * Changes
+ * -------
+ *
+ */
+package org.jgrapht.alg;
+
+import java.util.List;
+
+import org.jgrapht.GraphPath;
+import org.jgrapht.Graphs;
+import org.jgrapht.VertexFactory;
+import org.jgrapht.generate.CompleteGraphGenerator;
+import org.jgrapht.generate.RingGraphGenerator;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.SimpleGraph;
+
+import junit.framework.TestCase;
+
+/**
+ * Tests for the {@link KShortestPaths} class using {@link PathValidator}.
+ * 
+ * @author Assaf Mizrachi
+ *
+ */
+public class KSPPathValidatorTest extends TestCase {
+
+	/**
+	 * Testing that using path validator that denies all requests
+	 * finds no paths.
+	 */
+	public void testBlockAll() {
+		int size = 5;		
+		SimpleGraph<String, DefaultEdge> clique = buildCliqueGraph(size);
+		for (int i = 0; i < size; i++) {
+			KShortestPaths<String, DefaultEdge> ksp = new KShortestPaths<String, DefaultEdge>(
+					clique, String.valueOf(i), 1, Integer.MAX_VALUE, new PathValidator<String, DefaultEdge>() {
+
+						@Override
+						public boolean isNotValidPath(AbstractPathElement<String, DefaultEdge> prevPathElement,
+								DefaultEdge edge) {
+							// block all paths
+							return true;
+						}
+					});
+			
+			for (int j = 0; j < size; j++) {
+				if (j == i) {
+					continue;
+				}
+				List<GraphPath<String, DefaultEdge>> paths = ksp.getPaths(String.valueOf(j));
+				assertNull(paths);
+			}
+		}
+	}
+	
+	/**
+	 * Testing that using path validator that accepts all requests
+	 * finds full paths.
+	 */
+	public void testAllowAll() {
+		int size = 5;		
+		SimpleGraph<String, DefaultEdge> clique = buildCliqueGraph(size);
+		for (int i = 0; i < size; i++) {
+			KShortestPaths<String, DefaultEdge> ksp = new KShortestPaths<String, DefaultEdge>(
+					clique, String.valueOf(i), 30, Integer.MAX_VALUE, new PathValidator<String, DefaultEdge>() {
+
+						@Override
+						public boolean isNotValidPath(AbstractPathElement<String, DefaultEdge> prevPathElement,
+								DefaultEdge edge) {
+							// block all paths
+							return false;
+						}
+					});
+			
+			for (int j = 0; j < size; j++) {
+				if (j == i) {
+					continue;
+				}
+				List<GraphPath<String, DefaultEdge>> paths = ksp.getPaths(String.valueOf(j));
+				assertNotNull(paths);
+				assertEquals(16, paths.size());
+			}
+		}
+	}
+	
+	/**
+	 * Testing a ring with only single path allowed between two vertices.
+	 */
+	public void testRing() {
+		int size = 10;		
+		SimpleGraph<Integer, DefaultEdge> ring = buildRingGraph(size);
+		for (int i = 0; i < size; i++) {
+			KShortestPaths<Integer, DefaultEdge> ksp = new KShortestPaths<Integer, DefaultEdge>(
+					ring, i, 2, Integer.MAX_VALUE, new PathValidator<Integer, DefaultEdge>() {
+
+						@Override
+						public boolean isNotValidPath(AbstractPathElement<Integer, DefaultEdge> prevPathElement,
+								DefaultEdge edge) {
+							if (prevPathElement == null) {
+								return false;
+							}
+							return Math.abs(prevPathElement.getVertex() - 
+									Graphs.getOppositeVertex(ring, edge, prevPathElement.getVertex())) != 1;
+						}
+					});
+			
+			for (int j = 0; j < size; j++) {
+				if (j == i) {
+					continue;
+				}
+				List<GraphPath<Integer, DefaultEdge>> paths = ksp.getPaths(j);
+				assertNotNull(paths);
+				assertEquals(1, paths.size());
+			}
+		}
+	}
+	
+	/**
+	 * Testing a graph where the validator denies the request to go
+	 * on an edge which cutting it makes the graph disconnected
+	 */
+	public void testDisconnected() {
+		int cliqueSize = 5;		
+		//generate graph of two cliques connected by single edge
+		SimpleGraph<Integer, DefaultEdge> graph = buildGraphForTestDisconnected(cliqueSize);
+		for (int i = 0; i < graph.vertexSet().size(); i++) {
+			KShortestPaths<Integer, DefaultEdge> ksp = new KShortestPaths<Integer, DefaultEdge>(
+					graph, i, 100, Integer.MAX_VALUE, new PathValidator<Integer, DefaultEdge>() {
+
+						@Override
+						public boolean isNotValidPath(AbstractPathElement<Integer, DefaultEdge> prevPathElement,
+								DefaultEdge edge) {
+							//accept all requests but the one to pass through the edge connecting
+							//the two cliques.
+							return graph.getEdge(cliqueSize - 1, cliqueSize) == edge;
+						}
+					});
+			
+			for (int j = 0; j < graph.vertexSet().size(); j++) {
+				if (j == i) {
+					continue;
+				}
+				List<GraphPath<Integer, DefaultEdge>> paths = ksp.getPaths(j);
+				if ((i < cliqueSize && j < cliqueSize) || (i >= cliqueSize && j >= cliqueSize)) {
+					//within the clique - path should exist
+					assertNotNull(paths);
+					assertTrue(paths.size() > 0);
+				} else {
+					//else - should not
+					assertNull(paths);
+				}
+				
+			}
+		}
+	}
+
+	private SimpleGraph<String, DefaultEdge> buildCliqueGraph(int size) {
+		SimpleGraph<String, DefaultEdge> clique = new SimpleGraph<>(DefaultEdge.class);
+		CompleteGraphGenerator<String, DefaultEdge> graphGenerator = new CompleteGraphGenerator<>(size);
+		graphGenerator.generateGraph(clique, 
+				new VertexFactory<String>() {
+
+			private int index = 0;
+            @Override
+            public String createVertex() {
+                return String.valueOf(index++);
+            }
+		}, null);
+		
+		return clique;
+	}
+	
+	private SimpleGraph<Integer, DefaultEdge> buildGraphForTestDisconnected(int size) {
+		VertexFactory<Integer> vertexFactory = new VertexFactory<Integer>() {
+			
+			private int index = 0;
+            @Override
+            public Integer createVertex() {
+                return index++;
+            }
+		};
+		SimpleGraph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
+		
+		CompleteGraphGenerator<Integer, DefaultEdge> completeGraphGenerator = new CompleteGraphGenerator<>(size);
+		//two complete graphs
+		SimpleGraph<Integer, DefaultEdge> east = new SimpleGraph<>(DefaultEdge.class);		
+		completeGraphGenerator.generateGraph(east, vertexFactory, null);
+		
+		SimpleGraph<Integer, DefaultEdge> west = new SimpleGraph<>(DefaultEdge.class);		
+		completeGraphGenerator.generateGraph(west, vertexFactory, null);
+		
+		Graphs.addGraph(graph, east);
+		Graphs.addGraph(graph, west);
+		//connected by single edge
+		graph.addEdge(size - 1, size);
+		
+		return graph;
+	}
+	
+	private SimpleGraph<Integer, DefaultEdge> buildRingGraph(int size) {
+		SimpleGraph<Integer, DefaultEdge> clique = new SimpleGraph<>(DefaultEdge.class);
+		RingGraphGenerator<Integer, DefaultEdge> graphGenerator = new RingGraphGenerator<>(size);
+		graphGenerator.generateGraph(clique, 
+				new VertexFactory<Integer>() {
+
+			private int index = 0;
+            @Override
+            public Integer createVertex() {
+                return index++;
+            }
+		}, null);
+		
+		return clique;
+	}
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KSPPathValidatorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KSPPathValidatorTest.java
@@ -67,10 +67,10 @@ public class KSPPathValidatorTest extends TestCase {
 					clique, String.valueOf(i), 1, Integer.MAX_VALUE, new PathValidator<String, DefaultEdge>() {
 
 						@Override
-						public boolean isNotValidPath(AbstractPathElement<String, DefaultEdge> prevPathElement,
+						public boolean isValidPath(AbstractPathElement<String, DefaultEdge> prevPathElement,
 								DefaultEdge edge) {
 							// block all paths
-							return true;
+							return false;
 						}
 					});
 			
@@ -96,10 +96,10 @@ public class KSPPathValidatorTest extends TestCase {
 					clique, String.valueOf(i), 30, Integer.MAX_VALUE, new PathValidator<String, DefaultEdge>() {
 
 						@Override
-						public boolean isNotValidPath(AbstractPathElement<String, DefaultEdge> prevPathElement,
+						public boolean isValidPath(AbstractPathElement<String, DefaultEdge> prevPathElement,
 								DefaultEdge edge) {
 							// block all paths
-							return false;
+							return true;
 						}
 					});
 			
@@ -125,13 +125,13 @@ public class KSPPathValidatorTest extends TestCase {
 					ring, i, 2, Integer.MAX_VALUE, new PathValidator<Integer, DefaultEdge>() {
 
 						@Override
-						public boolean isNotValidPath(AbstractPathElement<Integer, DefaultEdge> prevPathElement,
+						public boolean isValidPath(AbstractPathElement<Integer, DefaultEdge> prevPathElement,
 								DefaultEdge edge) {
 							if (prevPathElement == null) {
-								return false;
+								return true;
 							}
 							return Math.abs(prevPathElement.getVertex() - 
-									Graphs.getOppositeVertex(ring, edge, prevPathElement.getVertex())) != 1;
+									Graphs.getOppositeVertex(ring, edge, prevPathElement.getVertex())) == 1;
 						}
 					});
 			
@@ -159,11 +159,12 @@ public class KSPPathValidatorTest extends TestCase {
 					graph, i, 100, Integer.MAX_VALUE, new PathValidator<Integer, DefaultEdge>() {
 
 						@Override
-						public boolean isNotValidPath(AbstractPathElement<Integer, DefaultEdge> prevPathElement,
+						public boolean isValidPath(AbstractPathElement<Integer, DefaultEdge> prevPathElement,
 								DefaultEdge edge) {
 							//accept all requests but the one to pass through the edge connecting
 							//the two cliques.
-							return graph.getEdge(cliqueSize - 1, cliqueSize) == edge;
+							DefaultEdge connectingEdge = graph.getEdge(cliqueSize - 1, cliqueSize);
+							return connectingEdge != edge;
 						}
 					});
 			

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KSPPathValidatorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KSPPathValidatorTest.java
@@ -55,193 +55,193 @@ import junit.framework.TestCase;
  */
 public class KSPPathValidatorTest extends TestCase {
 
-	/**
-	 * Testing that using path validator that denies all requests
-	 * finds no paths.
-	 */
-	public void testBlockAll() {
-		int size = 5;		
-		SimpleGraph<String, DefaultEdge> clique = buildCliqueGraph(size);
-		for (int i = 0; i < size; i++) {
-			KShortestPaths<String, DefaultEdge> ksp = new KShortestPaths<String, DefaultEdge>(
-					clique, String.valueOf(i), 1, Integer.MAX_VALUE, new PathValidator<String, DefaultEdge>() {
+    /**
+     * Testing that using path validator that denies all requests
+     * finds no paths.
+     */
+    public void testBlockAll() {
+        int size = 5;
+        SimpleGraph<String, DefaultEdge> clique = buildCliqueGraph(size);
+        for (int i = 0; i < size; i++) {
+            KShortestPaths<String, DefaultEdge> ksp = new KShortestPaths<String, DefaultEdge>(
+                    clique, String.valueOf(i), 1, Integer.MAX_VALUE, new PathValidator<String, DefaultEdge>() {
 
-						@Override
-						public boolean isValidPath(AbstractPathElement<String, DefaultEdge> prevPathElement,
-								DefaultEdge edge) {
-							// block all paths
-							return false;
-						}
-					});
-			
-			for (int j = 0; j < size; j++) {
-				if (j == i) {
-					continue;
-				}
-				List<GraphPath<String, DefaultEdge>> paths = ksp.getPaths(String.valueOf(j));
-				assertNull(paths);
-			}
-		}
-	}
-	
-	/**
-	 * Testing that using path validator that accepts all requests
-	 * finds full paths.
-	 */
-	public void testAllowAll() {
-		int size = 5;		
-		SimpleGraph<String, DefaultEdge> clique = buildCliqueGraph(size);
-		for (int i = 0; i < size; i++) {
-			KShortestPaths<String, DefaultEdge> ksp = new KShortestPaths<String, DefaultEdge>(
-					clique, String.valueOf(i), 30, Integer.MAX_VALUE, new PathValidator<String, DefaultEdge>() {
+                        @Override
+                        public boolean isValidPath(AbstractPathElement<String, DefaultEdge> prevPathElement,
+                                DefaultEdge edge) {
+                            // block all paths
+                            return false;
+                        }
+                    });
+            
+            for (int j = 0; j < size; j++) {
+                if (j == i) {
+                    continue;
+                }
+                List<GraphPath<String, DefaultEdge>> paths = ksp.getPaths(String.valueOf(j));
+                assertNull(paths);
+            }
+        }
+    }
+    
+    /**
+     * Testing that using path validator that accepts all requests
+     * finds full paths.
+     */
+    public void testAllowAll() {
+        int size = 5;        
+        SimpleGraph<String, DefaultEdge> clique = buildCliqueGraph(size);
+        for (int i = 0; i < size; i++) {
+            KShortestPaths<String, DefaultEdge> ksp = new KShortestPaths<String, DefaultEdge>(
+                    clique, String.valueOf(i), 30, Integer.MAX_VALUE, new PathValidator<String, DefaultEdge>() {
 
-						@Override
-						public boolean isValidPath(AbstractPathElement<String, DefaultEdge> prevPathElement,
-								DefaultEdge edge) {
-							// block all paths
-							return true;
-						}
-					});
-			
-			for (int j = 0; j < size; j++) {
-				if (j == i) {
-					continue;
-				}
-				List<GraphPath<String, DefaultEdge>> paths = ksp.getPaths(String.valueOf(j));
-				assertNotNull(paths);
-				assertEquals(16, paths.size());
-			}
-		}
-	}
-	
-	/**
-	 * Testing a ring with only single path allowed between two vertices.
-	 */
-	public void testRing() {
-		int size = 10;		
-		SimpleGraph<Integer, DefaultEdge> ring = buildRingGraph(size);
-		for (int i = 0; i < size; i++) {
-			KShortestPaths<Integer, DefaultEdge> ksp = new KShortestPaths<Integer, DefaultEdge>(
-					ring, i, 2, Integer.MAX_VALUE, new PathValidator<Integer, DefaultEdge>() {
+                        @Override
+                        public boolean isValidPath(AbstractPathElement<String, DefaultEdge> prevPathElement,
+                                DefaultEdge edge) {
+                            // block all paths
+                            return true;
+                        }
+                    });
+            
+            for (int j = 0; j < size; j++) {
+                if (j == i) {
+                    continue;
+                }
+                List<GraphPath<String, DefaultEdge>> paths = ksp.getPaths(String.valueOf(j));
+                assertNotNull(paths);
+                assertEquals(16, paths.size());
+            }
+        }
+    }
+    
+    /**
+     * Testing a ring with only single path allowed between two vertices.
+     */
+    public void testRing() {
+        int size = 10;        
+        SimpleGraph<Integer, DefaultEdge> ring = buildRingGraph(size);
+        for (int i = 0; i < size; i++) {
+            KShortestPaths<Integer, DefaultEdge> ksp = new KShortestPaths<Integer, DefaultEdge>(
+                    ring, i, 2, Integer.MAX_VALUE, new PathValidator<Integer, DefaultEdge>() {
 
-						@Override
-						public boolean isValidPath(AbstractPathElement<Integer, DefaultEdge> prevPathElement,
-								DefaultEdge edge) {
-							if (prevPathElement == null) {
-								return true;
-							}
-							return Math.abs(prevPathElement.getVertex() - 
-									Graphs.getOppositeVertex(ring, edge, prevPathElement.getVertex())) == 1;
-						}
-					});
-			
-			for (int j = 0; j < size; j++) {
-				if (j == i) {
-					continue;
-				}
-				List<GraphPath<Integer, DefaultEdge>> paths = ksp.getPaths(j);
-				assertNotNull(paths);
-				assertEquals(1, paths.size());
-			}
-		}
-	}
-	
-	/**
-	 * Testing a graph where the validator denies the request to go
-	 * on an edge which cutting it makes the graph disconnected
-	 */
-	public void testDisconnected() {
-		int cliqueSize = 5;		
-		//generate graph of two cliques connected by single edge
-		SimpleGraph<Integer, DefaultEdge> graph = buildGraphForTestDisconnected(cliqueSize);
-		for (int i = 0; i < graph.vertexSet().size(); i++) {
-			KShortestPaths<Integer, DefaultEdge> ksp = new KShortestPaths<Integer, DefaultEdge>(
-					graph, i, 100, Integer.MAX_VALUE, new PathValidator<Integer, DefaultEdge>() {
+                        @Override
+                        public boolean isValidPath(AbstractPathElement<Integer, DefaultEdge> prevPathElement,
+                                DefaultEdge edge) {
+                            if (prevPathElement == null) {
+                                return true;
+                            }
+                            return Math.abs(prevPathElement.getVertex() - 
+                                    Graphs.getOppositeVertex(ring, edge, prevPathElement.getVertex())) == 1;
+                        }
+                    });
+            
+            for (int j = 0; j < size; j++) {
+                if (j == i) {
+                    continue;
+                }
+                List<GraphPath<Integer, DefaultEdge>> paths = ksp.getPaths(j);
+                assertNotNull(paths);
+                assertEquals(1, paths.size());
+            }
+        }
+    }
+    
+    /**
+     * Testing a graph where the validator denies the request to go
+     * on an edge which cutting it makes the graph disconnected
+     */
+    public void testDisconnected() {
+        int cliqueSize = 5;        
+        //generate graph of two cliques connected by single edge
+        SimpleGraph<Integer, DefaultEdge> graph = buildGraphForTestDisconnected(cliqueSize);
+        for (int i = 0; i < graph.vertexSet().size(); i++) {
+            KShortestPaths<Integer, DefaultEdge> ksp = new KShortestPaths<Integer, DefaultEdge>(
+                    graph, i, 100, Integer.MAX_VALUE, new PathValidator<Integer, DefaultEdge>() {
 
-						@Override
-						public boolean isValidPath(AbstractPathElement<Integer, DefaultEdge> prevPathElement,
-								DefaultEdge edge) {
-							//accept all requests but the one to pass through the edge connecting
-							//the two cliques.
-							DefaultEdge connectingEdge = graph.getEdge(cliqueSize - 1, cliqueSize);
-							return connectingEdge != edge;
-						}
-					});
-			
-			for (int j = 0; j < graph.vertexSet().size(); j++) {
-				if (j == i) {
-					continue;
-				}
-				List<GraphPath<Integer, DefaultEdge>> paths = ksp.getPaths(j);
-				if ((i < cliqueSize && j < cliqueSize) || (i >= cliqueSize && j >= cliqueSize)) {
-					//within the clique - path should exist
-					assertNotNull(paths);
-					assertTrue(paths.size() > 0);
-				} else {
-					//else - should not
-					assertNull(paths);
-				}
-				
-			}
-		}
-	}
+                        @Override
+                        public boolean isValidPath(AbstractPathElement<Integer, DefaultEdge> prevPathElement,
+                                DefaultEdge edge) {
+                            //accept all requests but the one to pass through the edge connecting
+                            //the two cliques.
+                            DefaultEdge connectingEdge = graph.getEdge(cliqueSize - 1, cliqueSize);
+                            return connectingEdge != edge;
+                        }
+                    });
+            
+            for (int j = 0; j < graph.vertexSet().size(); j++) {
+                if (j == i) {
+                    continue;
+                }
+                List<GraphPath<Integer, DefaultEdge>> paths = ksp.getPaths(j);
+                if ((i < cliqueSize && j < cliqueSize) || (i >= cliqueSize && j >= cliqueSize)) {
+                    //within the clique - path should exist
+                    assertNotNull(paths);
+                    assertTrue(paths.size() > 0);
+                } else {
+                    //else - should not
+                    assertNull(paths);
+                }
+                
+            }
+        }
+    }
 
-	private SimpleGraph<String, DefaultEdge> buildCliqueGraph(int size) {
-		SimpleGraph<String, DefaultEdge> clique = new SimpleGraph<>(DefaultEdge.class);
-		CompleteGraphGenerator<String, DefaultEdge> graphGenerator = new CompleteGraphGenerator<>(size);
-		graphGenerator.generateGraph(clique, 
-				new VertexFactory<String>() {
+    private SimpleGraph<String, DefaultEdge> buildCliqueGraph(int size) {
+        SimpleGraph<String, DefaultEdge> clique = new SimpleGraph<>(DefaultEdge.class);
+        CompleteGraphGenerator<String, DefaultEdge> graphGenerator = new CompleteGraphGenerator<>(size);
+        graphGenerator.generateGraph(clique, 
+                new VertexFactory<String>() {
 
-			private int index = 0;
+            private int index = 0;
             @Override
             public String createVertex() {
                 return String.valueOf(index++);
             }
-		}, null);
-		
-		return clique;
-	}
-	
-	private SimpleGraph<Integer, DefaultEdge> buildGraphForTestDisconnected(int size) {
-		VertexFactory<Integer> vertexFactory = new VertexFactory<Integer>() {
-			
-			private int index = 0;
+        }, null);
+        
+        return clique;
+    }
+    
+    private SimpleGraph<Integer, DefaultEdge> buildGraphForTestDisconnected(int size) {
+        VertexFactory<Integer> vertexFactory = new VertexFactory<Integer>() {
+            
+            private int index = 0;
             @Override
             public Integer createVertex() {
                 return index++;
             }
-		};
-		SimpleGraph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
-		
-		CompleteGraphGenerator<Integer, DefaultEdge> completeGraphGenerator = new CompleteGraphGenerator<>(size);
-		//two complete graphs
-		SimpleGraph<Integer, DefaultEdge> east = new SimpleGraph<>(DefaultEdge.class);		
-		completeGraphGenerator.generateGraph(east, vertexFactory, null);
-		
-		SimpleGraph<Integer, DefaultEdge> west = new SimpleGraph<>(DefaultEdge.class);		
-		completeGraphGenerator.generateGraph(west, vertexFactory, null);
-		
-		Graphs.addGraph(graph, east);
-		Graphs.addGraph(graph, west);
-		//connected by single edge
-		graph.addEdge(size - 1, size);
-		
-		return graph;
-	}
-	
-	private SimpleGraph<Integer, DefaultEdge> buildRingGraph(int size) {
-		SimpleGraph<Integer, DefaultEdge> clique = new SimpleGraph<>(DefaultEdge.class);
-		RingGraphGenerator<Integer, DefaultEdge> graphGenerator = new RingGraphGenerator<>(size);
-		graphGenerator.generateGraph(clique, 
-				new VertexFactory<Integer>() {
+        };
+        SimpleGraph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
+        
+        CompleteGraphGenerator<Integer, DefaultEdge> completeGraphGenerator = new CompleteGraphGenerator<>(size);
+        //two complete graphs
+        SimpleGraph<Integer, DefaultEdge> east = new SimpleGraph<>(DefaultEdge.class);        
+        completeGraphGenerator.generateGraph(east, vertexFactory, null);
+        
+        SimpleGraph<Integer, DefaultEdge> west = new SimpleGraph<>(DefaultEdge.class);        
+        completeGraphGenerator.generateGraph(west, vertexFactory, null);
+        
+        Graphs.addGraph(graph, east);
+        Graphs.addGraph(graph, west);
+        //connected by single edge
+        graph.addEdge(size - 1, size);
+        
+        return graph;
+    }
+    
+    private SimpleGraph<Integer, DefaultEdge> buildRingGraph(int size) {
+        SimpleGraph<Integer, DefaultEdge> clique = new SimpleGraph<>(DefaultEdge.class);
+        RingGraphGenerator<Integer, DefaultEdge> graphGenerator = new RingGraphGenerator<>(size);
+        graphGenerator.generateGraph(clique, 
+                new VertexFactory<Integer>() {
 
-			private int index = 0;
+            private int index = 0;
             @Override
             public Integer createVertex() {
                 return index++;
             }
-		}, null);
-		
-		return clique;
-	}
+        }, null);
+        
+        return clique;
+    }
 }


### PR DESCRIPTION
Consider a case where we need to disqualify a valid path found by some shortest path algorithm. This disqualification is due to some external considerations and rules which one would like to apply. 

For example, in many applications, one would like to find a shortest path which is disjoint to another. For this he may manipulate the `Graph` structure to exclude the edges of the other path. But, in cases where the `Graph` instance is shared and used by many threads, it may be inefficient to manipulate it in such way nor to create copies of it in case it is very big. 
Another example, is in applications where each edge can be associated with a set of discrete resources which are checked to follow some rule(s): for example, a path is valid only when it is using exactly the same set of resource(s), all along the path (for this they must be available an every edge of the path). Currently, the shortest path algorithms are bounded to consider only the graph structure and edge weights for its operation so they cannot be used for purpose. To summarize, there exists many other such applications in the literature, and we can think of many others. 

Clearly, in the above cases and others, the disqualification of the path cannot be done after it was found by the algorithm, and needed to be done on-the-fly while searching for the path.

I have added an option for the `KShortestPaths` algorithm to be able to accept an external `PathValidator` (new `interface`). This validator is queried to accept/deny every new edge the algorithm wants to add to path. In order to do so, it is provided with the new edge as well as with the previous path element (which then can be traversed back to the source vertex). This way one may use it provide external consideration to the validity of the path and so to expand the use cases the algorithm can be used for. However, note that the external path validator is used _in addition_ to the basic validations already done by the algorithm - that the path is indeed from the source to target and that it is simple (contains no loops) - so one cannot end with an invalid path due to the usage of any implementation of `PathValidator`.