### PR TITLE
Bug fixes

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/AStarShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/AStarShortestPath.java
@@ -148,7 +148,7 @@ public class AStarShortestPath<V, E>
             FibonacciHeapNode<V> currentNode = openList.removeMin();
 
             //Check whether we reached the target vertex
-            if (currentNode.getData() == targetVertex) {
+            if (currentNode.getData().equals(targetVertex)) {
                 //Build the path
                 return this.buildGraphPath(
                     sourceVertex,

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/MinSourceSinkCut.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/MinSourceSinkCut.java
@@ -37,7 +37,9 @@ package org.jgrapht.alg;
 import java.util.*;
 
 import org.jgrapht.*;
-import org.jgrapht.alg.flow.EdmondsKarpMaximumFlow;
+import org.jgrapht.alg.flow.MaximumFlowAlgorithmBase;
+import org.jgrapht.alg.flow.PushRelabelMaximumFlow;
+import org.jgrapht.alg.interfaces.MaximumFlowAlgorithm;
 import org.jgrapht.alg.interfaces.MaximumFlowAlgorithm.*;
 
 
@@ -53,23 +55,28 @@ import org.jgrapht.alg.interfaces.MaximumFlowAlgorithm.*;
  */
 public class MinSourceSinkCut<V, E>
 {
-    EdmondsKarpMaximumFlow<V, E> ekMaxFlow;
+    MaximumFlowAlgorithm<V, E> ekMaxFlow;
     Set<V> minCut = null;
     DirectedGraph<V, E> graph;
     double cutWeight;
     V source = null;
     V sink = null;
-    double epsilon = EdmondsKarpMaximumFlow.DEFAULT_EPSILON;
+    double epsilon = MaximumFlowAlgorithmBase.DEFAULT_EPSILON;
 
     public MinSourceSinkCut(DirectedGraph<V, E> graph)
     {
-        this.ekMaxFlow = new EdmondsKarpMaximumFlow<>(graph);
+        this.ekMaxFlow = new PushRelabelMaximumFlow<>(graph);
         this.graph = graph;
     }
 
     public MinSourceSinkCut(DirectedGraph<V, E> graph, double epsilon)
     {
-        this.ekMaxFlow = new EdmondsKarpMaximumFlow<>(graph);
+        this(graph, new PushRelabelMaximumFlow<>(graph), epsilon);
+    }
+
+    public MinSourceSinkCut(DirectedGraph<V, E> graph, MaximumFlowAlgorithm<V, E> maximumFlowAlgorithm, double epsilon)
+    {
+        this.ekMaxFlow = maximumFlowAlgorithm;
         this.graph = graph;
         this.epsilon = epsilon;
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/extension/ExtensionManager.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/extension/ExtensionManager.java
@@ -39,7 +39,7 @@ import java.util.Map;
 
 /**
  * Convenience class to manage extensions/encapsulations.
- * This class creates and manages object extensions and encapsulations. An object, from here on denoted as 'prototype',
+ * This class creates and manages object extensions and encapsulations. An object, from here on denoted as 'original',
  * can be encapsulated in or extended by another object. An example would be the relation between an edge (original) and an annotated edge. The
  * annotated edge encapsulates/extends an edge, thereby augmenting it with additional data.
  * In symbolic form, if b is the original class, than a(b) would be its extension. This concept is similar to java's extension where

--- a/jgrapht-core/src/main/java/org/jgrapht/experimental/dag/DirectedAcyclicGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/experimental/dag/DirectedAcyclicGraph.java
@@ -73,7 +73,7 @@ import org.jgrapht.traverse.DepthFirstIterator;
  * @author Peter Giles, gilesp@u.washington.edu
  */
 public class DirectedAcyclicGraph<V, E>
-    extends SimpleDirectedGraph<V, E>
+    extends SimpleDirectedGraph<V, E> implements Iterable<V>
 {
     private static final long serialVersionUID = 4522128427004938150L;
 
@@ -374,10 +374,6 @@ public class DirectedAcyclicGraph<V, E>
      * the Affected Region
      * @param visited a simple data structure that lets us know if we already
      * visited a node with a given topo index
-     * @param topoIndexMap for quick lookups, a map from vertex to topo index in
-     * the AR
-     * @param ub the topo index of the original fromVertex -- used for cycle
-     * detection
      *
      * @throws CycleFoundException if a cycle is discovered
      */
@@ -434,7 +430,6 @@ public class DirectedAcyclicGraph<V, E>
      * @param db the set we are populating with back-connected vertices in the
      * AR
      * @param visited
-     * @param topoIndexMap
      */
     private void dfsB(
         V vertex,
@@ -839,8 +834,6 @@ public class DirectedAcyclicGraph<V, E>
          * do it because we can make better use of space by only needing an
          * ArrayList of size |AR|.
          *
-         * @param unscaledIndex
-         *
          * @return the ArrayList index
          */
         private int translateIndex(int index)
@@ -936,8 +929,6 @@ public class DirectedAcyclicGraph<V, E>
          * do it because we can make better use of space by only needing an
          * ArrayList of size |AR|.
          *
-         * @param unscaledIndex
-         *
          * @return the ArrayList index
          */
         private int translateIndex(int index)
@@ -1003,8 +994,6 @@ public class DirectedAcyclicGraph<V, E>
          * do this because topological indices can be negative, and we want to
          * do it because we can make better use of space by only needing an
          * ArrayList of size |AR|.
-         *
-         * @param unscaledIndex
          *
          * @return the ArrayList index
          */


### PR DESCRIPTION
- Fixes: AStarShortestPath.getShortestPath will use equal to compare currentNode and targetVertex #236 as suggested by @Zgce
- Fixes: DirectedAcyclicGraph should extend Iterable<V> #201 as suggested by Andrew Pennebaker
- Fixes: Allow setting the max-flow implementation for min s-t cut #231 as suggested by Roman Pearah
  - Changed default max flow algorithm to PushRelabel
  - Added constructor to allow custom max flow algorithm