### PR TITLE
Common interface for graph importers and exporters

### DIFF
--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLExportDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLExportDemo.java
@@ -250,7 +250,7 @@ public final class GraphMLExportDemo
         try {
             Writer writer = new BufferedWriter(
                 new OutputStreamWriter(System.out));
-            exporter.export(g, writer);
+            exporter.exportGraph(g, writer);
             writer.flush();
         } catch (ExportException | IOException e) {
             System.err.println("Error: " + e.getMessage());

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLExportDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLExportDemo.java
@@ -250,7 +250,7 @@ public final class GraphMLExportDemo
         try {
             Writer writer = new BufferedWriter(
                 new OutputStreamWriter(System.out));
-            exporter.export(writer, g);
+            exporter.export(g, writer);
             writer.flush();
         } catch (ExportException | IOException e) {
             System.err.println("Error: " + e.getMessage());

--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -61,9 +61,6 @@
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>
-					<excludes>
-						<exclude>**/package.html</exclude>
-					</excludes>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -61,6 +61,9 @@
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>
+					<excludes>
+						<exclude>**/package.html</exclude>
+					</excludes>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/ComponentAttributeProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/ComponentAttributeProvider.java
@@ -26,8 +26,6 @@
  *
  * Original Author:  John Sichi
  *
- * $Id$
- *
  * Changes
  * -------
  * 12-Jun-2010 : Initial Version (JVS);
@@ -42,7 +40,6 @@ import java.util.*;
  * Provides display attributes for vertices and/or edges in a graph.
  *
  * @author John Sichi
- * @version $Id$
  */
 public interface ComponentAttributeProvider<T>
 {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
@@ -200,7 +200,7 @@ public class DIMACSImporter<V, E>
      *         error
      */
     @Override
-    public void read(Graph<V, E> graph, Reader input)
+    public void importGraph(Graph<V, E> graph, Reader input)
         throws ImportException
     {
         // convert to buffered

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
@@ -39,7 +39,10 @@ import org.jgrapht.WeightedGraph;
 
 import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -83,6 +86,7 @@ import java.util.Map;
  * @param <E> the graph edge type
  */
 public class DIMACSImporter<V, E>
+    implements GraphImporter<V, E>
 {
     private VertexProvider<V> vertexProvider;
     private EdgeProvider<V, E> edgeProvider;
@@ -179,6 +183,30 @@ public class DIMACSImporter<V, E>
         }
         this.edgeProvider = edgeProvider;
     }
+    
+    /**
+     * Import a graph.
+     * 
+     * <p>
+     * The provided graph must be able to support the features of the graph that
+     * is read. For example if the file contains self-loops then the graph
+     * provided must also support self-loops. The same for multiple edges.
+     * 
+     * <p>
+     * If the provided graph is a weighted graph, the importer also reads edge
+     * weights. Otherwise edge weights are ignored.
+     * 
+     * @param input the input stream
+     * @param graph the output graph
+     * @throws ImportException in case an error occurs, such as I/O or parse
+     *         error
+     */
+    @Override
+    public void read(InputStream input, Graph<V, E> graph)
+        throws ImportException
+    {
+        read(new InputStreamReader(input, StandardCharsets.UTF_8), graph);
+    }
 
     /**
      * Import a graph.
@@ -197,6 +225,7 @@ public class DIMACSImporter<V, E>
      * @throws ImportException in case an error occurs, such as I/O or parse
      *         error
      */
+    @Override
     public void read(Reader input, Graph<V, E> graph)
         throws ImportException
     {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
@@ -39,10 +39,8 @@ import org.jgrapht.WeightedGraph;
 
 import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -196,37 +194,13 @@ public class DIMACSImporter<V, E>
      * If the provided graph is a weighted graph, the importer also reads edge
      * weights. Otherwise edge weights are ignored.
      * 
-     * @param input the input stream
      * @param graph the output graph
-     * @throws ImportException in case an error occurs, such as I/O or parse
-     *         error
-     */
-    @Override
-    public void read(InputStream input, Graph<V, E> graph)
-        throws ImportException
-    {
-        read(new InputStreamReader(input, StandardCharsets.UTF_8), graph);
-    }
-
-    /**
-     * Import a graph.
-     * 
-     * <p>
-     * The provided graph must be able to support the features of the graph that
-     * is read. For example if the file contains self-loops then the graph
-     * provided must also support self-loops. The same for multiple edges.
-     * 
-     * <p>
-     * If the provided graph is a weighted graph, the importer also reads edge
-     * weights. Otherwise edge weights are ignored.
-     * 
      * @param input the input reader
-     * @param graph the output graph
      * @throws ImportException in case an error occurs, such as I/O or parse
      *         error
      */
     @Override
-    public void read(Reader input, Graph<V, E> graph)
+    public void read(Graph<V, E> graph, Reader input)
         throws ImportException
     {
         // convert to buffered
@@ -253,7 +227,8 @@ public class DIMACSImporter<V, E>
         while (cols != null) {
             if (cols[0].equals("e")) {
                 if (cols.length < 3) {
-                    throw new ImportException("Failed to parse edge");
+                    throw new ImportException(
+                        "Failed to parse edge:" + Arrays.toString(cols));
                 }
                 Integer source;
                 try {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DIMACSImporter.java
@@ -25,9 +25,7 @@
  * (C) Copyright 2010-2010, by Michael Behrisch and Contributors.
  *
  * Original Author:  Michael Behrisch
- * Contributor(s): Joris Kinable  -
- *
- * $Id$
+ * Contributor(s): Joris Kinable, Dimitrios Michail
  *
  * Changes
  * -------
@@ -37,9 +35,7 @@
 package org.jgrapht.ext;
 
 import org.jgrapht.Graph;
-import org.jgrapht.VertexFactory;
 import org.jgrapht.WeightedGraph;
-import org.jgrapht.generate.GraphGenerator;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -81,14 +77,15 @@ import java.util.Map;
  *
  * @author Michael Behrisch (adaptation of GraphReader class)
  * @author Joris Kinable
+ * @author Dimitrios Michail
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
  */
 public class DIMACSImporter<V, E>
-    implements GraphGenerator<V, E, V>
 {
-    private final BufferedReader input;
+    private VertexProvider<V> vertexProvider;
+    private EdgeProvider<V, E> edgeProvider;
     private final double defaultWeight;
 
     // ~ Constructors ----------------------------------------------------------
@@ -96,34 +93,194 @@ public class DIMACSImporter<V, E>
     /**
      * Construct a new DIMACSImporter
      * 
-     * @param input the input reader
+     * @param vertexProvider provider for the generation of vertices. Must not
+     *        be null.
+     * @param edgeProvider provider for the generation of edges. Must not be
+     *        null.
      * @param defaultWeight default edge weight
-     * @throws IOException in case an I/O error occurs
      */
-    public DIMACSImporter(Reader input, double defaultWeight)
-        throws IOException
+    public DIMACSImporter(
+        VertexProvider<V> vertexProvider,
+        EdgeProvider<V, E> edgeProvider,
+        double defaultWeight)
     {
-        if (input instanceof BufferedReader) {
-            this.input = (BufferedReader) input;
-        } else {
-            this.input = new BufferedReader(input);
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
         }
+        this.vertexProvider = vertexProvider;
+        if (edgeProvider == null) {
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
         this.defaultWeight = defaultWeight;
     }
 
     /**
      * Construct a new DIMACSImporter
      * 
-     * @param input the input reader
-     * @throws IOException in case an I/O error occurs
+     * @param vertexProvider provider for the generation of vertices. Must not
+     *        be null.
+     * @param edgeProvider provider for the generation of edges. Must not be
+     *        null.
      */
-    public DIMACSImporter(Reader input)
-        throws IOException
+    public DIMACSImporter(
+        VertexProvider<V> vertexProvider,
+        EdgeProvider<V, E> edgeProvider)
     {
-        this(input, 1);
+        this(vertexProvider, edgeProvider, WeightedGraph.DEFAULT_EDGE_WEIGHT);
     }
 
     // ~ Methods ---------------------------------------------------------------
+
+    /**
+     * Get the vertex provider
+     * 
+     * @return the vertex provider
+     */
+    public VertexProvider<V> getVertexProvider()
+    {
+        return vertexProvider;
+    }
+
+    /**
+     * Set the vertex provider
+     * 
+     * @param vertexProvider the new vertex provider. Must not be null.
+     */
+    public void setVertexProvider(VertexProvider<V> vertexProvider)
+    {
+        if (vertexProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex provider cannot be null");
+        }
+        this.vertexProvider = vertexProvider;
+    }
+
+    /**
+     * Get the edge provider
+     * 
+     * @return The edge provider
+     */
+    public EdgeProvider<V, E> getEdgeProvider()
+    {
+        return edgeProvider;
+    }
+
+    /**
+     * Set the edge provider.
+     * 
+     * @param edgeProvider the new edge provider. Must not be null.
+     */
+    public void setEdgeProvider(EdgeProvider<V, E> edgeProvider)
+    {
+        if (edgeProvider == null) {
+            throw new IllegalArgumentException("Edge provider cannot be null");
+        }
+        this.edgeProvider = edgeProvider;
+    }
+
+    /**
+     * Import a graph.
+     * 
+     * <p>
+     * The provided graph must be able to support the features of the graph that
+     * is read. For example if the file contains self-loops then the graph
+     * provided must also support self-loops. The same for multiple edges.
+     * 
+     * <p>
+     * If the provided graph is a weighted graph, the importer also reads edge
+     * weights. Otherwise edge weights are ignored.
+     * 
+     * @param input the input reader
+     * @param graph the output graph
+     * @throws ImportException in case an error occurs, such as I/O or parse
+     *         error
+     */
+    public void read(Reader input, Graph<V, E> graph)
+        throws ImportException
+    {
+        // convert to buffered
+        BufferedReader in;
+        if (input instanceof BufferedReader) {
+            in = (BufferedReader) input;
+        } else {
+            in = new BufferedReader(input);
+        }
+
+        // add nodes
+        final int size = readNodeCount(in);
+        Map<Integer, V> map = new HashMap<Integer, V>();
+        for (int i = 0; i < size; i++) {
+            Integer id = Integer.valueOf(i + 1);
+            V vertex = vertexProvider
+                .buildVertex(id.toString(), new HashMap<String, String>());
+            map.put(id, vertex);
+            graph.addVertex(vertex);
+        }
+
+        // add edges
+        String[] cols = skipComments(in);
+        while (cols != null) {
+            if (cols[0].equals("e")) {
+                if (cols.length < 3) {
+                    throw new ImportException("Failed to parse edge");
+                }
+                Integer source;
+                try {
+                    source = Integer.parseInt(cols[1]);
+                } catch (NumberFormatException e) {
+                    throw new ImportException(
+                        "Failed to parse edge source node:" + e.getMessage(),
+                        e);
+                }
+                Integer target;
+                try {
+                    target = Integer.parseInt(cols[2]);
+                } catch (NumberFormatException e) {
+                    throw new ImportException(
+                        "Failed to parse edge target node:" + e.getMessage(),
+                        e);
+                }
+
+                String label = "e_" + source + "_" + target;
+                V from = map.get(source);
+                if (from == null) {
+                    throw new ImportException(
+                        "Node " + source + " does not exist");
+                }
+                V to = map.get(target);
+                if (to == null) {
+                    throw new ImportException(
+                        "Node " + target + " does not exist");
+                }
+
+                try {
+
+                    E e = edgeProvider.buildEdge(
+                        from,
+                        to,
+                        label,
+                        new HashMap<String, String>());
+                    graph.addEdge(from, to, e);
+
+                    if (graph instanceof WeightedGraph<?, ?>) {
+                        double weight = defaultWeight;
+                        if (cols.length > 3) {
+                            weight = Double.parseDouble(cols[3]);
+                        }
+                        ((WeightedGraph<V, E>) graph).setEdgeWeight(e, weight);
+                    }
+                } catch (IllegalArgumentException e) {
+                    throw new ImportException(
+                        "Failed to import DIMACS graph:" + e.getMessage(),
+                        e);
+                }
+            }
+            cols = skipComments(in);
+        }
+
+    }
 
     private String[] split(final String src)
     {
@@ -133,7 +290,7 @@ public class DIMACSImporter<V, E>
         return src.split("\\s+");
     }
 
-    private String[] skipComments()
+    private String[] skipComments(BufferedReader input)
     {
         String[] cols = null;
         try {
@@ -144,52 +301,31 @@ public class DIMACSImporter<V, E>
                 cols = split(input.readLine());
             }
         } catch (IOException e) {
+            // ignore
         }
         return cols;
     }
 
-    private int readNodeCount()
+    private int readNodeCount(BufferedReader input)
+        throws ImportException
     {
-        final String[] cols = skipComments();
+        final String[] cols = skipComments(input);
         if (cols[0].equals("p")) {
-            return Integer.parseInt(cols[2]);
-        }
-        return -1;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void generateGraph(
-        Graph<V, E> target,
-        VertexFactory<V> vertexFactory,
-        Map<String, V> resultMap)
-    {
-        final int size = readNodeCount();
-        if (resultMap == null) {
-            resultMap = new HashMap<>();
-        }
-
-        for (int i = 0; i < size; i++) {
-            V newVertex = vertexFactory.createVertex();
-            target.addVertex(newVertex);
-            resultMap.put(Integer.toString(i + 1), newVertex);
-        }
-        String[] cols = skipComments();
-        while (cols != null) {
-            if (cols[0].equals("e")) {
-                E edge = target
-                    .addEdge(resultMap.get(cols[1]), resultMap.get(cols[2]));
-                if (target instanceof WeightedGraph && (edge != null)) {
-                    double weight = defaultWeight;
-                    if (cols.length > 3) {
-                        weight = Double.parseDouble(cols[3]);
-                    }
-                    ((WeightedGraph<V, E>) target).setEdgeWeight(edge, weight);
-                }
+            if (cols.length < 3) {
+                throw new ImportException("Failed to read number of vertices.");
             }
-            cols = skipComments();
+            Integer nodes;
+            try {
+                nodes = Integer.parseInt(cols[2]);
+            } catch (NumberFormatException e) {
+                throw new ImportException("Failed to read number of vertices.");
+            }
+            if (nodes < 0) {
+                throw new ImportException("Negative number of vertices.");
+            }
+            return nodes;
         }
+        throw new ImportException("Failed to read number of vertices.");
     }
+
 }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTExporter.java
@@ -125,7 +125,7 @@ public class DOTExporter<V, E>
      */
     @Deprecated
     public void export(Writer writer, Graph<V, E> g) { 
-        export(g, writer);
+        exportGraph(g, writer);
     }
     
     /**
@@ -135,7 +135,7 @@ public class DOTExporter<V, E>
      * @param writer the writer to which the graph to be exported
      */
     @Override
-    public void export(Graph<V, E> g, Writer writer)
+    public void exportGraph(Graph<V, E> g, Writer writer)
     {
         PrintWriter out = new PrintWriter(writer);
         String indent = "  ";

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTExporter.java
@@ -29,12 +29,15 @@
  */
 package org.jgrapht.ext;
 
-import java.io.*;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
-import java.util.*;
-
-import org.jgrapht.*;
-
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.Graph;
 
 /**
  * Exports a graph into a DOT file.
@@ -46,6 +49,7 @@ import org.jgrapht.*;
  * @author Trevor Harmon
  */
 public class DOTExporter<V, E>
+    implements GraphExporter<V, E>
 {
     private VertexNameProvider<V> vertexIDProvider;
     private VertexNameProvider<V> vertexLabelProvider;
@@ -116,6 +120,19 @@ public class DOTExporter<V, E>
         this.edgeAttributeProvider = edgeAttributeProvider;
     }
 
+    /**
+     * Exports an graph into a plain text in DOT format.
+     *
+     * @param out output stream to export the graph
+     * @param g the graph
+     * @throws ExportException in case any error occurs during export
+     */
+    @Override
+    public void export(OutputStream out, Graph<V, E> g)
+    {
+        export(new OutputStreamWriter(out, StandardCharsets.UTF_8), g);
+    }
+    
     /**
      * Exports a graph into a plain text file in DOT format.
      *

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTExporter.java
@@ -125,7 +125,6 @@ public class DOTExporter<V, E>
      *
      * @param out output stream to export the graph
      * @param g the graph
-     * @throws ExportException in case any error occurs during export
      */
     @Override
     public void export(OutputStream out, Graph<V, E> g)

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTExporter.java
@@ -29,11 +29,8 @@
  */
 package org.jgrapht.ext;
 
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import org.jgrapht.DirectedGraph;
@@ -121,24 +118,24 @@ public class DOTExporter<V, E>
     }
 
     /**
-     * Exports an graph into a plain text in DOT format.
-     *
-     * @param out output stream to export the graph
-     * @param g the graph
-     */
-    @Override
-    public void export(OutputStream out, Graph<V, E> g)
-    {
-        export(new OutputStreamWriter(out, StandardCharsets.UTF_8), g);
-    }
-    
-    /**
      * Exports a graph into a plain text file in DOT format.
      *
      * @param writer the writer to which the graph to be exported
      * @param g the graph to be exported
      */
-    public void export(Writer writer, Graph<V, E> g)
+    @Deprecated
+    public void export(Writer writer, Graph<V, E> g) { 
+        export(g, writer);
+    }
+    
+    /**
+     * Exports a graph into a plain text file in DOT format.
+     *
+     * @param g the graph to be exported
+     * @param writer the writer to which the graph to be exported
+     */
+    @Override
+    public void export(Graph<V, E> g, Writer writer)
     {
         PrintWriter out = new PrintWriter(writer);
         String indent = "  ";

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
@@ -31,10 +31,7 @@
 package org.jgrapht.ext;
 
 import java.io.BufferedReader;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -158,31 +155,13 @@ public class DOTImporter<V, E>
      * The current implementation reads the whole input as a string and then
      * parses the graph.
      *
-     * @param input the input stream
      * @param graph the graph to update
-     *
-     * @throws ImportException if there is a problem parsing the file.
-     */
-    @Override
-    public void read(InputStream input, Graph<V, E> graph)
-        throws ImportException
-    {
-        read(new InputStreamReader(input, StandardCharsets.UTF_8), graph);
-    }
-    
-    /**
-     * Read a dot formatted input and populate the provided graph.
-     * 
-     * The current implementation reads the whole input as a string and then
-     * parses the graph.
-     *
      * @param input the input reader
-     * @param graph the graph to update
      *
      * @throws ImportException if there is a problem parsing the file.
      */
     @Override
-    public void read(Reader input, Graph<V, E> graph)
+    public void read(Graph<V, E> graph, Reader input)
         throws ImportException
     {
         BufferedReader br;
@@ -197,8 +176,8 @@ public class DOTImporter<V, E>
     /**
      * Read a dot formatted string and populate the provided graph.
      *
-     * @param input the content of a dot file.
-     * @param graph the graph to update.
+     * @param input the content of a dot file as a string
+     * @param graph the graph to update
      *
      * @throws ImportException if there is a problem parsing the file.
      */
@@ -217,7 +196,7 @@ public class DOTImporter<V, E>
      *
      * @throws ImportException if there is a problem parsing the file.
      */
-    public void read(String input, Graph<V, E> graph)
+    private void read(String input, Graph<V, E> graph)
         throws ImportException
     {
         if ((input == null) || input.isEmpty()) {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
@@ -161,7 +161,7 @@ public class DOTImporter<V, E>
      * @throws ImportException if there is a problem parsing the file.
      */
     @Override
-    public void read(Graph<V, E> graph, Reader input)
+    public void importGraph(Graph<V, E> graph, Reader input)
         throws ImportException
     {
         BufferedReader br;

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTUtils.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTUtils.java
@@ -59,7 +59,7 @@ public class DOTUtils
             // vertex name provider
             new StringNameProvider<V>(),
             // edge label provider
-            null).export(graph, outputWriter);
+            null).exportGraph(graph, outputWriter);
 
         return outputWriter.toString();
     }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTUtils.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTUtils.java
@@ -26,8 +26,6 @@
  *
  * Original Author:  Christoph Zauner
  *
- * $Id$
- *
  * Changes
  * -------
  *
@@ -44,7 +42,12 @@ import org.jgrapht.Graph;
 public class DOTUtils
 {
     /**
-     * @return a {@link String} represenation in DOT format of the given graph.
+     * Convert a graph into a String in DOT format.
+     *  
+     * @param graph the input graph
+     * @param <V> the graph vertex type
+     * @param <E> the graph edge type
+     * @return a {@link String} representation in DOT format of the given graph.
      */
     public static <V, E> String convertGraphToDotString(
         Graph<V, E> graph)

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTUtils.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTUtils.java
@@ -59,7 +59,7 @@ public class DOTUtils
             // vertex name provider
             new StringNameProvider<V>(),
             // edge label provider
-            null).export(outputWriter, graph);
+            null).export(graph, outputWriter);
 
         return outputWriter.toString();
     }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/EdgeNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/EdgeNameProvider.java
@@ -20,7 +20,7 @@
  * the Eclipse Foundation.
  */
 /* ------------------
- * VertexNameProvider.java
+ * EdgeNameProvider.java
  * ------------------
  * (C) Copyright 2005-2008, by Trevor Harmon.
  *
@@ -30,7 +30,7 @@
 package org.jgrapht.ext;
 
 /**
- * Assigns a display name for each of the graph edes.
+ * Assigns a display name for each of the graph edges.
  */
 public interface EdgeNameProvider<E>
 {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/ExportException.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/ExportException.java
@@ -27,8 +27,6 @@
  * Original Author:  Dimitrios Michail
  * Contributor(s): 
  *
- * $Id$
- *
  * Changes
  * -------
  * 17-July-2016 : Initial revision (DM);

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
@@ -33,16 +33,14 @@
  */
 package org.jgrapht.ext;
 
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.Graph;
+import org.jgrapht.UndirectedGraph;
 import org.jgrapht.WeightedGraph;
 
 /**
@@ -220,24 +218,37 @@ public class GmlExporter<V, E>
     }
 
     /**
-     * Exports an graph into a plain text GML format.
+     * Exports an undirected graph into a plain text file in GML format.
      *
-     * @param out output stream to export the graph
-     * @param g the graph
+     * @param writer the writer to which the graph to be exported
+     * @param g the undirected graph to be exported
      */
-    @Override
-    public void export(OutputStream out, Graph<V, E> g)
+    @Deprecated
+    public void export(Writer writer, UndirectedGraph<V, E> g)
     {
-        export(new OutputStreamWriter(out, StandardCharsets.UTF_8), g);
+        export(g, writer);
     }
 
+    /**
+     * Exports a directed graph into a plain text file in GML format.
+     *
+     * @param writer the writer to which the graph to be exported
+     * @param g the directed graph to be exported
+     */
+    @Deprecated
+    public void export(Writer writer, DirectedGraph<V, E> g)
+    {
+        export(g, writer);
+    }
+    
     /**
      * Exports an graph into a plain text GML format.
      *
      * @param writer the writer
      * @param g the graph
      */
-    public void export(Writer writer, Graph<V, E> g)
+    @Override
+    public void export(Graph<V, E> g, Writer writer)
     {
         PrintWriter out = new PrintWriter(writer);
 

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
@@ -226,7 +226,7 @@ public class GmlExporter<V, E>
     @Deprecated
     public void export(Writer writer, UndirectedGraph<V, E> g)
     {
-        export(g, writer);
+        exportGraph(g, writer);
     }
 
     /**
@@ -238,7 +238,7 @@ public class GmlExporter<V, E>
     @Deprecated
     public void export(Writer writer, DirectedGraph<V, E> g)
     {
-        export(g, writer);
+        exportGraph(g, writer);
     }
     
     /**
@@ -248,7 +248,7 @@ public class GmlExporter<V, E>
      * @param g the graph
      */
     @Override
-    public void export(Graph<V, E> g, Writer writer)
+    public void exportGraph(Graph<V, E> g, Writer writer)
     {
         PrintWriter out = new PrintWriter(writer);
 

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
@@ -26,8 +26,6 @@
  *
  * Original Author:  Dimitrios Michail <dimitrios.michail@gmail.com>
  *
- * $Id$
- *
  * Changes
  * -------
  * 15-Dec-2006 : Initial Version (DM);
@@ -35,11 +33,14 @@
  */
 package org.jgrapht.ext;
 
-import java.io.*;
+import java.io.PrintWriter;
+import java.io.Writer;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.jgrapht.*;
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.Graph;
+import org.jgrapht.WeightedGraph;
 
 /**
  * Exports a graph into a GML file (Graph Modeling Language).

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
@@ -33,8 +33,11 @@
  */
 package org.jgrapht.ext;
 
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -60,6 +63,7 @@ import org.jgrapht.WeightedGraph;
  * @author Dimitrios Michail
  */
 public class GmlExporter<V, E>
+    implements GraphExporter<V, E>
 {
     private static final String CREATOR = "JGraphT GML Exporter";
     private static final String VERSION = "1";
@@ -213,6 +217,18 @@ public class GmlExporter<V, E>
             }
             out.println(TAB1 + "]");
         }
+    }
+
+    /**
+     * Exports an graph into a plain text GML format.
+     *
+     * @param out output stream to export the graph
+     * @param g the graph
+     */
+    @Override
+    public void export(OutputStream out, Graph<V, E> g)
+    {
+        export(new OutputStreamWriter(out, StandardCharsets.UTF_8), g);
     }
 
     /**

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
@@ -46,7 +46,10 @@ import org.jgrapht.WeightedGraph;
 import org.jgrapht.ext.GmlParser.GmlContext;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -97,6 +100,7 @@ import java.util.Set;
  * @param <E> the edge type
  */
 public class GmlImporter<V, E>
+    implements GraphImporter<V, E>
 {
     private VertexProvider<V> vertexProvider;
     private EdgeProvider<V, E> edgeProvider;
@@ -188,6 +192,31 @@ public class GmlImporter<V, E>
      * @throws ImportException in case an error occurs, such as I/O or parse
      *         error
      */
+    @Override
+    public void read(InputStream input, Graph<V, E> graph)
+        throws ImportException
+    {
+        read(new InputStreamReader(input, StandardCharsets.UTF_8), graph);
+    }
+
+    /**
+     * Import a graph.
+     * 
+     * <p>
+     * The provided graph must be able to support the features of the graph that
+     * is read. For example if the gml file contains self-loops then the graph
+     * provided must also support self-loops. The same for multiple edges.
+     * 
+     * <p>
+     * If the provided graph is a weighted graph, the importer also reads edge
+     * weights. Otherwise edge weights are ignored.
+     * 
+     * @param input the input reader
+     * @param graph the output graph
+     * @throws ImportException in case an error occurs, such as I/O or parse
+     *         error
+     */
+    @Override
     public void read(Reader input, Graph<V, E> graph)
         throws ImportException
     {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
@@ -190,7 +190,7 @@ public class GmlImporter<V, E>
      *         error
      */
     @Override
-    public void read(Graph<V, E> graph, Reader input)
+    public void importGraph(Graph<V, E> graph, Reader input)
         throws ImportException
     {
         try {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
@@ -46,10 +46,7 @@ import org.jgrapht.WeightedGraph;
 import org.jgrapht.ext.GmlParser.GmlContext;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.Reader;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -187,37 +184,13 @@ public class GmlImporter<V, E>
      * If the provided graph is a weighted graph, the importer also reads edge
      * weights. Otherwise edge weights are ignored.
      * 
-     * @param input the input stream
      * @param graph the output graph
-     * @throws ImportException in case an error occurs, such as I/O or parse
-     *         error
-     */
-    @Override
-    public void read(InputStream input, Graph<V, E> graph)
-        throws ImportException
-    {
-        read(new InputStreamReader(input, StandardCharsets.UTF_8), graph);
-    }
-
-    /**
-     * Import a graph.
-     * 
-     * <p>
-     * The provided graph must be able to support the features of the graph that
-     * is read. For example if the gml file contains self-loops then the graph
-     * provided must also support self-loops. The same for multiple edges.
-     * 
-     * <p>
-     * If the provided graph is a weighted graph, the importer also reads edge
-     * weights. Otherwise edge weights are ignored.
-     * 
      * @param input the input reader
-     * @param graph the output graph
      * @throws ImportException in case an error occurs, such as I/O or parse
      *         error
      */
     @Override
-    public void read(Reader input, Graph<V, E> graph)
+    public void read(Graph<V, E> graph, Reader input)
         throws ImportException
     {
         try {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphExporter.java
@@ -56,10 +56,10 @@ public interface GraphExporter<V, E>
      * @param out the output stream
      * @throws ExportException in case any error occurs
      */
-    default void export(Graph<V, E> g, OutputStream out)
+    default void exportGraph(Graph<V, E> g, OutputStream out)
         throws ExportException
     {
-        export(g, new OutputStreamWriter(out, StandardCharsets.UTF_8));
+        exportGraph(g, new OutputStreamWriter(out, StandardCharsets.UTF_8));
     }
 
     /**
@@ -69,7 +69,7 @@ public interface GraphExporter<V, E>
      * @param writer the output writer
      * @throws ExportException in case any error occurs
      */
-    void export(Graph<V, E> g, Writer writer)
+    void exportGraph(Graph<V, E> g, Writer writer)
         throws ExportException;
 
     /**
@@ -79,11 +79,11 @@ public interface GraphExporter<V, E>
      * @param file the file to write to
      * @throws ExportException in case any error occurs
      */
-    default void export(Graph<V, E> g, File file)
+    default void exportGraph(Graph<V, E> g, File file)
         throws ExportException
     {
         try {
-            export(g, new FileWriter(file));
+            exportGraph(g, new FileWriter(file));
         } catch (IOException e) {
             throw new ExportException(e);
         }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphExporter.java
@@ -33,7 +33,13 @@
  */
 package org.jgrapht.ext;
 
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 
 import org.jgrapht.Graph;
 
@@ -46,12 +52,42 @@ public interface GraphExporter<V, E>
     /**
      * Export a graph
      * 
-     * @param out the output stream
      * @param g the graph to export
+     * @param out the output stream
      * @throws ExportException in case any error occurs
      */
-    void export(OutputStream out, Graph<V, E> g)
+    default void export(Graph<V, E> g, OutputStream out)
+        throws ExportException
+    {
+        export(g, new OutputStreamWriter(out, StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Export a graph
+     * 
+     * @param g the graph to export
+     * @param writer the output writer
+     * @throws ExportException in case any error occurs
+     */
+    void export(Graph<V, E> g, Writer writer)
         throws ExportException;
+
+    /**
+     * Export a graph
+     * 
+     * @param g the graph to export
+     * @param file the file to write to
+     * @throws ExportException in case any error occurs
+     */
+    default void export(Graph<V, E> g, File file)
+        throws ExportException
+    {
+        try {
+            export(g, new FileWriter(file));
+        } catch (IOException e) {
+            throw new ExportException(e);
+        }
+    }
 
 }
 

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphExporter.java
@@ -20,38 +20,39 @@
  * the Eclipse Foundation.
  */
 /* ------------------
- * ComponentAttributeProvider.java
+ * GraphExporter.java
  * ------------------
- * (C) Copyright 2010-2010, by John Sichi and Contributors.
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
  *
- * Original Author:  John Sichi
+ * Original Author:  Dimitrios Michail
  *
  * Changes
  * -------
- * 12-Jun-2010 : Initial Version (JVS);
+ * 17-Aug-2016 : Initial Version (DM);
  *
  */
 package org.jgrapht.ext;
 
-import java.util.Map;
+import java.io.OutputStream;
+
+import org.jgrapht.Graph;
 
 /**
- * Provides display attributes for vertices and/or edges in a graph.
- *
- * @author John Sichi
+ * Interface for graph exporters
  */
-public interface ComponentAttributeProvider<T>
+public interface GraphExporter<V, E>
 {
+
     /**
-     * Returns a set of attribute key/value pairs for a vertex or edge. If order
-     * is important in the output, be sure to use an order-deterministic map
-     * implementation.
-     *
-     * @param component vertex or edge for which attributes are to be obtained
-     *
-     * @return key/value pairs, or null if no attributes should be supplied
+     * Export a graph
+     * 
+     * @param out the output stream
+     * @param g the graph to export
+     * @throws ExportException in case any error occurs
      */
-    public Map<String, String> getComponentAttributes(T component);
+    void export(OutputStream out, Graph<V, E> g)
+        throws ExportException;
+
 }
 
-// End ComponentAttributeProvider.java
+// End GraphExporter.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphImporter.java
@@ -34,7 +34,9 @@
 package org.jgrapht.ext;
 
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 import org.jgrapht.Graph;
 
@@ -47,21 +49,26 @@ public interface GraphImporter<V, E>
     /**
      * Import a graph
      * 
-     * @param in the input stream
      * @param g the graph
-     * @throws ImportException in case any error occurs
+     * @param in the input stream
+     * @throws ImportException in case any error occurs, such as I/O or parse
+     *         error
      */
-    void read(InputStream in, Graph<V, E> g)
-        throws ImportException;
+    default void read(Graph<V, E> g, InputStream in)
+        throws ImportException
+    {
+        read(g, new InputStreamReader(in, StandardCharsets.UTF_8));
+    }
 
     /**
      * Import a graph
      * 
-     * @param in the input reader
      * @param g the graph
-     * @throws ImportException in case any error occurs
+     * @param in the input reader
+     * @throws ImportException in case any error occurs, such as I/O or parse
+     *         error
      */
-    void read(Reader in, Graph<V, E> g)
+    void read(Graph<V, E> g, Reader in)
         throws ImportException;
 
 }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphImporter.java
@@ -1,0 +1,69 @@
+/* ==========================================
+ * JGraphT : a free Java graph-theory library
+ * ==========================================
+ *
+ * Project Info:  http://jgrapht.sourceforge.net/
+ * Project Creator:  Barak Naveh (http://sourceforge.net/users/barak_naveh)
+ *
+ * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+/* ------------------
+ * GraphImporter.java
+ * ------------------
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * Original Author:  Dimitrios Michail
+ *
+ * Changes
+ * -------
+ * 17-Aug-2016 : Initial Version (DM);
+ *
+ */
+package org.jgrapht.ext;
+
+import java.io.InputStream;
+import java.io.Reader;
+
+import org.jgrapht.Graph;
+
+/**
+ * Interface for graph importers
+ */
+public interface GraphImporter<V, E>
+{
+
+    /**
+     * Import a graph
+     * 
+     * @param in the input stream
+     * @param g the graph
+     * @throws ImportException in case any error occurs
+     */
+    void read(InputStream in, Graph<V, E> g)
+        throws ImportException;
+
+    /**
+     * Import a graph
+     * 
+     * @param in the input reader
+     * @param g the graph
+     * @throws ImportException in case any error occurs
+     */
+    void read(Reader in, Graph<V, E> g)
+        throws ImportException;
+
+}
+
+// End GraphImporter.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphImporter.java
@@ -33,6 +33,9 @@
  */
 package org.jgrapht.ext;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
@@ -54,10 +57,10 @@ public interface GraphImporter<V, E>
      * @throws ImportException in case any error occurs, such as I/O or parse
      *         error
      */
-    default void read(Graph<V, E> g, InputStream in)
+    default void importGraph(Graph<V, E> g, InputStream in)
         throws ImportException
     {
-        read(g, new InputStreamReader(in, StandardCharsets.UTF_8));
+        importGraph(g, new InputStreamReader(in, StandardCharsets.UTF_8));
     }
 
     /**
@@ -68,8 +71,30 @@ public interface GraphImporter<V, E>
      * @throws ImportException in case any error occurs, such as I/O or parse
      *         error
      */
-    void read(Graph<V, E> g, Reader in)
+    void importGraph(Graph<V, E> g, Reader in)
         throws ImportException;
+
+    /**
+     * Import a graph
+     * 
+     * @param g the graph
+     * @param file the file to read from
+     * @throws ImportException in case any error occurs, such as I/O or parse
+     *         error
+     */
+    default void importGraph(Graph<V, E> g, File file)
+        throws ImportException
+    {
+        try {
+            importGraph(
+                g,
+                new InputStreamReader(
+                    new FileInputStream(file),
+                    StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new ImportException(e);
+        }
+    }
 
 }
 

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -480,6 +480,10 @@ public class GraphMLExporter<V, E>
      *
      * @param writer the writer to which the graph to be exported
      * @param g the graph to be exported
+     * 
+     * @throws SAXException in case of a SAX error
+     * @throws TransformerConfigurationException in case of a configuration
+     *         error
      */
     @Deprecated
     public void export(Writer writer, Graph<V, E> g)

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -30,17 +30,15 @@
  */
 package org.jgrapht.ext;
 
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
 import javax.xml.transform.OutputKeys;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.sax.SAXTransformerFactory;
 import javax.xml.transform.sax.TransformerHandler;
 import javax.xml.transform.stream.StreamResult;
@@ -478,27 +476,31 @@ public class GraphMLExporter<V, E>
     }
 
     /**
-     * Exports a graph in GraphML format.
+     * Exports a graph into a plain text file in GraphML format.
      *
-     * @param out output stream to export the graph
-     * @param g the graph
-     * @throws ExportException in case any error occurs during export
+     * @param writer the writer to which the graph to be exported
+     * @param g the graph to be exported
      */
-    @Override
-    public void export(OutputStream out, Graph<V, E> g)
-        throws ExportException
+    @Deprecated
+    public void export(Writer writer, Graph<V, E> g)
+        throws SAXException, TransformerConfigurationException
     {
-        export(new OutputStreamWriter(out, StandardCharsets.UTF_8), g);
+        try {
+            export(g, writer);
+        } catch (ExportException e) {
+            throw new SAXException(e);
+        }
     }
-
+    
     /**
      * Exports a graph in GraphML format.
      *
-     * @param writer the writer to export the graph
      * @param g the graph
+     * @param writer the writer to export the graph
      * @throws ExportException in case any error occurs during export
      */
-    public void export(Writer writer, Graph<V, E> g)
+    @Override
+    public void export(Graph<V, E> g, Writer writer)
         throws ExportException
     {
         try {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -490,7 +490,7 @@ public class GraphMLExporter<V, E>
         throws SAXException, TransformerConfigurationException
     {
         try {
-            export(g, writer);
+            exportGraph(g, writer);
         } catch (ExportException e) {
             throw new SAXException(e);
         }
@@ -504,7 +504,7 @@ public class GraphMLExporter<V, E>
      * @throws ExportException in case any error occurs during export
      */
     @Override
-    public void export(Graph<V, E> g, Writer writer)
+    public void exportGraph(Graph<V, E> g, Writer writer)
         throws ExportException
     {
         try {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -30,8 +30,11 @@
  */
 package org.jgrapht.ext;
 
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -61,6 +64,7 @@ import org.xml.sax.helpers.AttributesImpl;
  * @author Dimitrios Michail
  */
 public class GraphMLExporter<V, E>
+    implements GraphExporter<V, E>
 {
     // providers
     private VertexNameProvider<V> vertexIDProvider;
@@ -476,6 +480,20 @@ public class GraphMLExporter<V, E>
     /**
      * Exports a graph in GraphML format.
      *
+     * @param out output stream to export the graph
+     * @param g the graph
+     * @throws ExportException in case any error occurs during export
+     */
+    @Override
+    public void export(OutputStream out, Graph<V, E> g)
+        throws ExportException
+    {
+        export(new OutputStreamWriter(out, StandardCharsets.UTF_8), g);
+    }
+
+    /**
+     * Exports a graph in GraphML format.
+     *
      * @param writer the writer to export the graph
      * @param g the graph
      * @throws ExportException in case any error occurs during export
@@ -739,7 +757,9 @@ public class GraphMLExporter<V, E>
 
             if (exportEdgeWeights) {
                 Double weight = g.getEdgeWeight(e);
-                if (!weight.equals(WeightedGraph.DEFAULT_EDGE_WEIGHT)) { // not default value
+                if (!weight.equals(WeightedGraph.DEFAULT_EDGE_WEIGHT)) { // not
+                                                                         // default
+                                                                         // value
                     writeData(
                         handler,
                         "edge_weight_key",

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
@@ -35,7 +35,6 @@
 package org.jgrapht.ext;
 
 import java.io.File;
-import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
 import java.util.ArrayDeque;
@@ -273,53 +272,13 @@ public class GraphMLImporter<V, E>
      * GraphML-Attributes Values are read as string key-value pairs and passed
      * on to the {@link VertexProvider} and {@link EdgeProvider} respectively.
      * 
+     * @param graph the output graph
      * @param input the input reader
-     * @param graph the output graph
      * @throws ImportException in case an error occurs, such as I/O or parse
      *         error
      */
     @Override
-    public void read(Reader input, Graph<V, E> graph)
-        throws ImportException
-    {
-        try {
-            // parse
-            XMLReader xmlReader = createXMLReader();
-            GraphMLHandler handler = new GraphMLHandler();
-            xmlReader.setContentHandler(handler);
-            xmlReader.setErrorHandler(handler);
-            xmlReader.parse(new InputSource(input));
-
-            // read result
-            handler.updateGraph(graph);
-        } catch (Exception se) {
-            throw new ImportException("Failed to parse GraphML", se);
-        }
-    }
-    
-    /**
-     * Import a graph.
-     * 
-     * <p>
-     * The provided graph must be able to support the features of the graph that
-     * is read. For example if the GraphML file contains self-loops then the
-     * graph provided must also support self-loops. The same for multiple edges.
-     * 
-     * <p>
-     * If the provided graph is a weighted graph, the importer also reads edge
-     * weights.
-     * 
-     * <p>
-     * GraphML-Attributes Values are read as string key-value pairs and passed
-     * on to the {@link VertexProvider} and {@link EdgeProvider} respectively.
-     * 
-     * @param input the input stream
-     * @param graph the output graph
-     * @throws ImportException in case an error occurs, such as I/O or parse
-     *         error
-     */
-    @Override
-    public void read(InputStream input, Graph<V, E> graph)
+    public void read(Graph<V, E> graph, Reader input)
         throws ImportException
     {
         try {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
@@ -35,6 +35,7 @@
 package org.jgrapht.ext;
 
 import java.io.File;
+import java.io.InputStream;
 import java.io.Reader;
 import java.net.URL;
 import java.util.ArrayDeque;
@@ -151,6 +152,7 @@ import org.xml.sax.helpers.DefaultHandler;
  * @since July 2016
  */
 public class GraphMLImporter<V, E>
+    implements GraphImporter<V, E>
 {
     private static final String GRAPHML_SCHEMA_FILENAME = "graphml.xsd";
 
@@ -271,12 +273,71 @@ public class GraphMLImporter<V, E>
      * GraphML-Attributes Values are read as string key-value pairs and passed
      * on to the {@link VertexProvider} and {@link EdgeProvider} respectively.
      * 
+     * @param input the input reader
+     * @param graph the output graph
+     * @throws ImportException in case an error occurs, such as I/O or parse
+     *         error
+     */
+    @Override
+    public void read(Reader input, Graph<V, E> graph)
+        throws ImportException
+    {
+        try {
+            // parse
+            XMLReader xmlReader = createXMLReader();
+            GraphMLHandler handler = new GraphMLHandler();
+            xmlReader.setContentHandler(handler);
+            xmlReader.setErrorHandler(handler);
+            xmlReader.parse(new InputSource(input));
+
+            // read result
+            handler.updateGraph(graph);
+        } catch (Exception se) {
+            throw new ImportException("Failed to parse GraphML", se);
+        }
+    }
+    
+    /**
+     * Import a graph.
+     * 
+     * <p>
+     * The provided graph must be able to support the features of the graph that
+     * is read. For example if the GraphML file contains self-loops then the
+     * graph provided must also support self-loops. The same for multiple edges.
+     * 
+     * <p>
+     * If the provided graph is a weighted graph, the importer also reads edge
+     * weights.
+     * 
+     * <p>
+     * GraphML-Attributes Values are read as string key-value pairs and passed
+     * on to the {@link VertexProvider} and {@link EdgeProvider} respectively.
+     * 
      * @param input the input stream
      * @param graph the output graph
      * @throws ImportException in case an error occurs, such as I/O or parse
      *         error
      */
-    public void read(Reader input, Graph<V, E> graph)
+    @Override
+    public void read(InputStream input, Graph<V, E> graph)
+        throws ImportException
+    {
+        try {
+            // parse
+            XMLReader xmlReader = createXMLReader();
+            GraphMLHandler handler = new GraphMLHandler();
+            xmlReader.setContentHandler(handler);
+            xmlReader.setErrorHandler(handler);
+            xmlReader.parse(new InputSource(input));
+
+            // read result
+            handler.updateGraph(graph);
+        } catch (Exception se) {
+            throw new ImportException("Failed to parse GraphML", se);
+        }
+    }
+
+    private XMLReader createXMLReader()
         throws ImportException
     {
         try {
@@ -298,15 +359,8 @@ public class GraphMLImporter<V, E>
             spf.setSchema(schema);
             SAXParser saxParser = spf.newSAXParser();
 
-            // parse
-            XMLReader xmlReader = saxParser.getXMLReader();
-            GraphMLHandler handler = new GraphMLHandler();
-            xmlReader.setContentHandler(handler);
-            xmlReader.setErrorHandler(handler);
-            xmlReader.parse(new InputSource(input));
-
-            // read result
-            handler.updateGraph(graph);
+            // create reader
+            return saxParser.getXMLReader();
         } catch (Exception se) {
             throw new ImportException("Failed to parse GraphML", se);
         }
@@ -374,9 +428,8 @@ public class GraphMLImporter<V, E>
                             validKey.attributeName,
                             collectedAttributes.get(validId));
                     } else if (validKey.defaultValue != null) {
-                        finalAttributes.put(
-                            validKey.attributeName,
-                            validKey.defaultValue);
+                        finalAttributes
+                            .put(validKey.attributeName, validKey.defaultValue);
                     }
                 }
 
@@ -508,14 +561,14 @@ public class GraphMLImporter<V, E>
                 String keyAttrName = findAttribute(KEY_ATTR_NAME, attributes);
                 currentKey = new Key(keyId, keyAttrName, null, null);
                 if (keyFor != null) {
-                    switch(keyFor) { 
-                    case EDGE: 
+                    switch (keyFor) {
+                    case EDGE:
                         currentKey.target = KeyTarget.EDGE;
                         break;
-                    case NODE: 
+                    case NODE:
                         currentKey.target = KeyTarget.NODE;
                         break;
-                    case ALL: 
+                    case ALL:
                         currentKey.target = KeyTarget.ALL;
                         break;
                     }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
@@ -278,7 +278,7 @@ public class GraphMLImporter<V, E>
      *         error
      */
     @Override
-    public void read(Graph<V, E> graph, Reader input)
+    public void importGraph(Graph<V, E> graph, Reader input)
         throws ImportException
     {
         try {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLImporter.java
@@ -27,8 +27,6 @@
  * Original Author:  Dimitrios Michail
  * Contributor(s): 
  *
- * $Id$
- *
  * Changes
  * -------
  * 17-July-2016 : Initial revision (DM);

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerEdgeNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerEdgeNameProvider.java
@@ -29,8 +29,8 @@
  */
 package org.jgrapht.ext;
 
-import java.util.*;
-
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Assigns a unique integer to represent each edge. Each instance of

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerNameProvider.java
@@ -26,8 +26,6 @@
  *
  * Original Author:  Charles Fry
  *
- * $Id$
- *
  * Changes
  * -------
  * 13-Dec-2005 : Initial Version (CF);
@@ -35,10 +33,11 @@
  */
 package org.jgrapht.ext;
 
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 
-import org.jgrapht.event.*;
-
+import org.jgrapht.event.GraphEdgeChangeEvent;
+import org.jgrapht.event.GraphListener;
 
 /**
  * Assigns a unique integer to represent each vertex. Each instance of

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/JGraphModelAdapter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/JGraphModelAdapter.java
@@ -218,7 +218,7 @@ public class JGraphModelAdapter<V, E>
      * @param cellFactory a {@link CellFactory} to be used to create the JGraph
      * cells. <code>null</code> is NOT permitted.
      *
-     * @throws IllegalArgumentException
+     * @throws IllegalArgumentException in case a parameter is not permitted
      */
     public JGraphModelAdapter(
         Graph<V, E> jGraphTGraph,
@@ -266,6 +266,8 @@ public class JGraphModelAdapter<V, E>
      *
      * @param jGraphTGraph the graph for which default edge attributes to be
      * created.
+     * @param <V> the graph vertex type
+     * @param <E> the graph edge type
      *
      * @return a map of attributes to be used as default for edge attributes.
      */

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/MatrixExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/MatrixExporter.java
@@ -154,7 +154,7 @@ public class MatrixExporter<V, E>
     }
 
     @Override
-    public void export(Graph<V, E> g, Writer writer)
+    public void exportGraph(Graph<V, E> g, Writer writer)
         throws ExportException
     {
         switch (format) {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/MatrixExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/MatrixExporter.java
@@ -26,8 +26,6 @@
  *
  * Original Author:  Charles Fry
  *
- * $Id$
- *
  * Changes
  * -------
  * 13-Dec-2005 : Initial Version (CF);
@@ -35,13 +33,18 @@
  */
 package org.jgrapht.ext;
 
-import java.io.*;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import java.util.*;
-
-import org.jgrapht.*;
-import org.jgrapht.util.*;
-
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.Graphs;
+import org.jgrapht.UndirectedGraph;
+import org.jgrapht.util.ModifiableInteger;
 
 /**
  * Exports a graph to a plain text matrix format, which can be processed by

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/MatrixExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/MatrixExporter.java
@@ -22,13 +22,15 @@
 /* ------------------
  * MatrixExporter.java
  * ------------------
- * (C) Copyright 2005-2008, by Charles Fry and Contributors.
+ * (C) Copyright 2005-2016, by Charles Fry and Contributors.
  *
  * Original Author:  Charles Fry
+ * Contributor(s): Dimitrios Michail
  *
  * Changes
  * -------
  * 13-Dec-2005 : Initial Version (CF);
+ * 19-Aug-2016 : Common interface with all other exporters (DM)
  *
  */
 package org.jgrapht.ext;
@@ -42,70 +44,157 @@ import java.util.Map;
 import java.util.Set;
 
 import org.jgrapht.DirectedGraph;
+import org.jgrapht.Graph;
 import org.jgrapht.Graphs;
 import org.jgrapht.UndirectedGraph;
 import org.jgrapht.util.ModifiableInteger;
 
 /**
  * Exports a graph to a plain text matrix format, which can be processed by
- * matrix manipulation software, such as <a href="http://rs.cipr.uib.no/mtj/">
- * MTJ</a> or <a href="http://www.mathworks.com/products/matlab/">MATLAB</a>.
- *
+ * matrix manipulation software, such as
+ * <a href="http://rs.cipr.uib.no/mtj/"> MTJ</a> or
+ * <a href="http://www.mathworks.com/products/matlab/">MATLAB</a>.
+ * 
+ * <p>
+ * The exporter supports three different formats, see {@link Format}.
+ * </p>
+ * 
+ * @see Format
+ * 
  * @author Charles Fry
+ * @author Dimitrios Michail
  */
 public class MatrixExporter<V, E>
+    implements GraphExporter<V, E>
 {
-    private String delimiter = " ";
-    private String prefix = "";
-    private String suffix = "";
+    private final String delimiter = " ";
+    private Format format;
+    private VertexNameProvider<V> vertexIDProvider;
 
     /**
-     * Creates a new MatrixExporter object.
+     * Formats supported by the exporter.
+     */
+    public enum Format
+    {
+        /**
+         * A sparse representation of the adjacency matrix. This is the default.
+         * Exports the specified graph into a plain text file format containing
+         * a sparse representation of the graph's adjacency matrix. The value
+         * stored in each position of the matrix indicates the number of edges
+         * between two vertices. With an undirected graph, the adjacency matrix
+         * is symmetric.
+         */
+        SPARSE_ADJACENCY_MATRIX,
+        /**
+         * A sparse representation of the Laplacian.
+         */
+        SPARSE_LAPLACIAN_MATRIX,
+        /**
+         * A sparse representation of the normalized Laplacian.
+         */
+        SPARSE_NORMALIZED_LAPLACIAN_MATRIX,
+    }
+
+    /**
+     * Creates a new MatrixExporter with integer name provider for the vertex
+     * identifiers and {@link Format#SPARSE_ADJACENCY_MATRIX} as the default
+     * format.
      */
     public MatrixExporter()
     {
+        this(Format.SPARSE_ADJACENCY_MATRIX, new IntegerNameProvider<>());
     }
 
-    private void println(
-        PrintWriter out,
-        String fromName,
-        String toName,
-        String value)
+    /**
+     * Creates a new MatrixExporter with integer name provider for the vertex
+     * identifiers.
+     * 
+     * @param format format to use
+     */
+    public MatrixExporter(Format format)
     {
-        out.println(
-            prefix + fromName + suffix + delimiter
-            + prefix + toName + suffix + delimiter
-            + prefix + value + suffix);
+        this(format, new IntegerNameProvider<>());
+    }
+
+    /**
+     * Creates a new MatrixExporter.
+     * 
+     * @param format format to use
+     * @param vertexIDProvider for generating vertex identifiers. Must not be
+     *        null.
+     */
+    public MatrixExporter(Format format, VertexNameProvider<V> vertexIDProvider)
+    {
+        this.format = format;
+        if (vertexIDProvider == null) {
+            throw new IllegalArgumentException(
+                "Vertex ID provider must not be null");
+        }
+        this.vertexIDProvider = vertexIDProvider;
+    }
+
+    /**
+     * Get the format that the exporter is using.
+     * 
+     * @return the output format
+     */
+    public Format getFormat()
+    {
+        return format;
+    }
+
+    /**
+     * Set the output format of the exporter
+     * 
+     * @param format the format to use
+     */
+    public void setFormat(Format format)
+    {
+        this.format = format;
+    }
+
+    @Override
+    public void export(Graph<V, E> g, Writer writer)
+        throws ExportException
+    {
+        switch (format) {
+        case SPARSE_ADJACENCY_MATRIX:
+            exportAdjacencyMatrix(g, writer);
+            break;
+        case SPARSE_LAPLACIAN_MATRIX:
+            if (g instanceof UndirectedGraph<?, ?>) {
+                exportLaplacianMatrix((UndirectedGraph<V, E>) g, writer);
+            } else {
+                throw new ExportException(
+                    "Exporter can only export undirected graphs in this format");
+            }
+            break;
+        case SPARSE_NORMALIZED_LAPLACIAN_MATRIX:
+            if (g instanceof UndirectedGraph<?, ?>) {
+                exportNormalizedLaplacianMatrix(
+                    (UndirectedGraph<V, E>) g,
+                    writer);
+            } else {
+                throw new ExportException(
+                    "Exporter can only export undirected graphs in this format");
+            }
+            break;
+        }
     }
 
     /**
      * Exports the specified graph into a plain text file format containing a
      * sparse representation of the graph's adjacency matrix. The value stored
      * in each position of the matrix indicates the number of edges between two
-     * vertices. With an undirected graph, the adjacency matrix is symetric.
+     * vertices. With an undirected graph, the adjacency matrix is symmetric.
      *
      * @param output the writer to which the graph to be exported.
      * @param g the graph to be exported.
      */
+    @Deprecated
     public void exportAdjacencyMatrix(Writer output, UndirectedGraph<V, E> g)
     {
-        PrintWriter out = new PrintWriter(output);
-
-        VertexNameProvider<V> nameProvider = new IntegerNameProvider<V>();
-        for (V from : g.vertexSet()) {
-            // assign ids in vertex set iteration order
-            nameProvider.getVertexName(from);
-        }
-
-        for (V from : g.vertexSet()) {
-            exportAdjacencyMatrixVertex(
-                out,
-                nameProvider,
-                from,
-                Graphs.neighborListOf(g, from));
-        }
-
-        out.flush();
+        exportAdjacencyMatrix(g, output);
     }
 
     /**
@@ -117,38 +206,87 @@ public class MatrixExporter<V, E>
      * @param output the writer to which the graph to be exported.
      * @param g the graph to be exported.
      */
+    @Deprecated
     public void exportAdjacencyMatrix(Writer output, DirectedGraph<V, E> g)
     {
-        PrintWriter out = new PrintWriter(output);
+        exportAdjacencyMatrix(g, output);
+    }
 
-        VertexNameProvider<V> nameProvider = new IntegerNameProvider<>();
+    /**
+     * Exports the specified graph into a plain text file format containing a
+     * sparse representation of the graph's Laplacian matrix. Laplacian matrices
+     * are only defined for simple graphs, so edge direction, multiple edges,
+     * loops, and weights are all ignored when creating the Laplacian matrix. If
+     * you're unsure about Laplacian matrices, see:
+     * <a href="http://mathworld.wolfram.com/LaplacianMatrix.html"> http://
+     * mathworld.wolfram.com/LaplacianMatrix.html</a>.
+     *
+     * @param output the writer to which the graph is to be exported.
+     * @param g the graph to be exported.
+     */
+    @Deprecated
+    public void exportLaplacianMatrix(Writer output, UndirectedGraph<V, E> g)
+    {
+        exportLaplacianMatrix(g, output);
+    }
+
+    /**
+     * Exports the specified graph into a plain text file format containing a
+     * sparse representation of the graph's normalized Laplacian matrix.
+     * Laplacian matrices are only defined for simple graphs, so edge direction,
+     * multiple edges, loops, and weights are all ignored when creating the
+     * Laplacian matrix. If you're unsure about normalized Laplacian matrices,
+     * see: <a href="http://mathworld.wolfram.com/LaplacianMatrix.html"> http://
+     * mathworld.wolfram.com/LaplacianMatrix.html</a>.
+     *
+     * @param output the writer to which the graph is to be exported.
+     * @param g the graph to be exported.
+     */
+    @Deprecated
+    public void exportNormalizedLaplacianMatrix(
+        Writer output,
+        UndirectedGraph<V, E> g)
+    {
+        exportNormalizedLaplacianMatrix(g, output);
+    }
+
+    private void exportAdjacencyMatrix(Graph<V, E> g, Writer writer)
+    {
         for (V from : g.vertexSet()) {
             // assign ids in vertex set iteration order
-            nameProvider.getVertexName(from);
+            vertexIDProvider.getVertexName(from);
         }
 
-        for (V from : g.vertexSet()) {
-            exportAdjacencyMatrixVertex(
-                out,
-                nameProvider,
-                from,
-                Graphs.successorListOf(g, from));
+        PrintWriter out = new PrintWriter(writer);
+
+        if (g instanceof DirectedGraph<?, ?>) {
+            for (V from : g.vertexSet()) {
+                exportAdjacencyMatrixVertex(
+                    out,
+                    from,
+                    Graphs.successorListOf((DirectedGraph<V, E>) g, from));
+            }
+        } else {
+            for (V from : g.vertexSet()) {
+                exportAdjacencyMatrixVertex(
+                    out,
+                    from,
+                    Graphs.neighborListOf(g, from));
+            }
         }
 
         out.flush();
     }
 
     private void exportAdjacencyMatrixVertex(
-        PrintWriter out,
-        VertexNameProvider<V> nameProvider,
+        PrintWriter writer,
         V from,
         List<V> neighbors)
     {
-        String fromName = nameProvider.getVertexName(from);
-        Map<String, ModifiableInteger> counts =
-                new LinkedHashMap<>();
+        String fromName = vertexIDProvider.getVertexName(from);
+        Map<String, ModifiableInteger> counts = new LinkedHashMap<>();
         for (V to : neighbors) {
-            String toName = nameProvider.getVertexName(to);
+            String toName = vertexIDProvider.getVertexName(to);
             ModifiableInteger count = counts.get(toName);
             if (count == null) {
                 count = new ModifiableInteger(0);
@@ -164,25 +302,22 @@ public class MatrixExporter<V, E>
         for (Map.Entry<String, ModifiableInteger> entry : counts.entrySet()) {
             String toName = entry.getKey();
             ModifiableInteger count = entry.getValue();
-            println(out, fromName, toName, count.toString());
+            exportEntry(writer, fromName, toName, count.toString());
         }
     }
 
-    /**
-     * Exports the specified graph into a plain text file format containing a
-     * sparse representation of the graph's Laplacian matrix. Laplacian matrices
-     * are only defined for simple graphs, so edge direction, multiple edges,
-     * loops, and weights are all ignored when creating the Laplacian matrix. If
-     * you're unsure about Laplacian matrices, see: <a
-     * href="http://mathworld.wolfram.com/LaplacianMatrix.html">
-     * http://mathworld.wolfram.com/LaplacianMatrix.html</a>.
-     *
-     * @param output the writer to which the graph is to be exported.
-     * @param g the graph to be exported.
-     */
-    public void exportLaplacianMatrix(Writer output, UndirectedGraph<V, E> g)
+    private void exportEntry(
+        PrintWriter writer,
+        String from,
+        String to,
+        String value)
     {
-        PrintWriter out = new PrintWriter(output);
+        writer.println(from + delimiter + to + delimiter + value);
+    }
+
+    private void exportLaplacianMatrix(UndirectedGraph<V, E> g, Writer writer)
+    {
+        PrintWriter out = new PrintWriter(writer);
 
         VertexNameProvider<V> nameProvider = new IntegerNameProvider<>();
         for (V from : g.vertexSet()) {
@@ -193,39 +328,26 @@ public class MatrixExporter<V, E>
         for (V from : g.vertexSet()) {
             String fromName = nameProvider.getVertexName(from);
 
-            // TODO modify Graphs to return neighbor sets
             List<V> neighbors = Graphs.neighborListOf(g, from);
-            println(
+            exportEntry(
                 out,
                 fromName,
                 fromName,
                 Integer.toString(neighbors.size()));
             for (V to : neighbors) {
                 String toName = nameProvider.getVertexName(to);
-                println(out, fromName, toName, "-1");
+                exportEntry(out, fromName, toName, "-1");
             }
         }
 
         out.flush();
     }
 
-    /**
-     * Exports the specified graph into a plain text file format containing a
-     * sparse representation of the graph's normalized Laplacian matrix.
-     * Laplacian matrices are only defined for simple graphs, so edge direction,
-     * multiple edges, loops, and weights are all ignored when creating the
-     * Laplacian matrix. If you're unsure about normalized Laplacian matrices,
-     * see: <a href="http://mathworld.wolfram.com/LaplacianMatrix.html">
-     * http://mathworld.wolfram.com/LaplacianMatrix.html</a>.
-     *
-     * @param output the writer to which the graph is to be exported.
-     * @param g the graph to be exported.
-     */
-    public void exportNormalizedLaplacianMatrix(
-        Writer output,
-        UndirectedGraph<V, E> g)
+    private void exportNormalizedLaplacianMatrix(
+        UndirectedGraph<V, E> g,
+        Writer writer)
     {
-        PrintWriter out = new PrintWriter(output);
+        PrintWriter out = new PrintWriter(writer);
 
         VertexNameProvider<V> nameProvider = new IntegerNameProvider<>();
         for (V from : g.vertexSet()) {
@@ -235,24 +357,25 @@ public class MatrixExporter<V, E>
 
         for (V from : g.vertexSet()) {
             String fromName = nameProvider.getVertexName(from);
-            Set<V> neighbors =
-                new LinkedHashSet<>(Graphs.neighborListOf(g, from));
+            Set<V> neighbors = new LinkedHashSet<>(
+                Graphs.neighborListOf(g, from));
             if (neighbors.isEmpty()) {
-                println(out, fromName, fromName, "0");
+                exportEntry(out, fromName, fromName, "0");
             } else {
-                println(out, fromName, fromName, "1");
+                exportEntry(out, fromName, fromName, "1");
 
                 for (V to : neighbors) {
                     String toName = nameProvider.getVertexName(to);
-                    double value =
-                        -1 / Math.sqrt(g.degreeOf(from) * g.degreeOf(to));
-                    println(out, fromName, toName, Double.toString(value));
+                    double value = -1
+                        / Math.sqrt(g.degreeOf(from) * g.degreeOf(to));
+                    exportEntry(out, fromName, toName, Double.toString(value));
                 }
             }
         }
 
         out.flush();
     }
+
 }
 
 // End MatrixExporter.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/StringEdgeNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/StringEdgeNameProvider.java
@@ -44,6 +44,7 @@ public class StringEdgeNameProvider<E>
      * Returns the String representation an edge.
      *
      * @param edge the edge to be named
+     * @return a unique String edge representation
      */
     @Override public String getEdgeName(E edge)
     {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/StringNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/StringNameProvider.java
@@ -26,17 +26,12 @@
  *
  * Original Author:  Charles Fry
  *
- * $Id$
- *
  * Changes
  * -------
  * 13-Dec-2005 : Initial Version (CF);
  *
  */
 package org.jgrapht.ext;
-
-import org.jgrapht.event.*;
-
 
 /**
  * Generates vertex names by invoking {@link #toString()} on them. This assumes
@@ -59,8 +54,6 @@ public class StringNameProvider<V>
      * @param vertex the vertex to be named
      *
      * @return the name of
-     *
-     * @see GraphListener#edgeAdded(GraphEdgeChangeEvent)
      */
     @Override public String getVertexName(V vertex)
     {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/VertexNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/VertexNameProvider.java
@@ -26,8 +26,6 @@
  *
  * Original Author:  Avner Linder
  *
- * $Id$
- *
  * Changes
  * -------
  * 27-May-2004 : Initial Version (AL);

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/VertexProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/VertexProvider.java
@@ -29,8 +29,7 @@
  */
 package org.jgrapht.ext;
 
-import java.util.*;
-
+import java.util.Map;
 
 /**
  * Creates a Vertex of type V
@@ -45,7 +44,7 @@ public interface VertexProvider<V>
      * @param label the label of the vertex
      * @param attributes any other attributes of the vertex
      *
-     * @return the vertex.
+     * @return the vertex
      */
     V buildVertex(String label, Map<String, String> attributes);
 }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/VertexUpdater.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/VertexUpdater.java
@@ -29,14 +29,13 @@
  */
 package org.jgrapht.ext;
 
-import java.util.*;
-
+import java.util.Map;
 
 /**
  * Type to handle updates to a vertex when an import gets more information about
  * a vertex after it has been created.
  *
- * @param <V>
+ * @param <V> the vertex type
  */
 public interface VertexUpdater<V>
 {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/VisioExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/VisioExporter.java
@@ -59,6 +59,7 @@ import java.io.PrintStream;
  * @author Avner Linder
  */
 public class VisioExporter<V, E>
+    implements GraphExporter<V, E>
 {
     private VertexNameProvider<V> vertexNameProvider;
 
@@ -87,6 +88,7 @@ public class VisioExporter<V, E>
      * @param output the print stream to which the graph to be exported.
      * @param g the graph to be exported.
      */
+    @Override
     public void export(OutputStream output, Graph<V, E> g)
     {
         PrintStream out = new PrintStream(output);

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/VisioExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/VisioExporter.java
@@ -27,8 +27,6 @@
  * Original Author:  Avner Linder
  * Contributor(s):   Barak Naveh
  *
- * $Id$
- *
  * Changes
  * -------
  * 27-May-2004 : Initial Version (AL);
@@ -54,6 +52,9 @@ import java.io.PrintStream;
  * <li>Format/Line...</li>
  * <li>Line ends: End: (choose an arrow)</li>
  * </ol>
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
  *
  * @author Avner Linder
  */

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/VisioExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/VisioExporter.java
@@ -22,10 +22,10 @@
 /* ------------------
  * VisioExporter.java
  * ------------------
- * (C) Copyright 2003-2008, by Avner Linder and Contributors.
+ * (C) Copyright 2003-2016, by Avner Linder and Contributors.
  *
  * Original Author:  Avner Linder
- * Contributor(s):   Barak Naveh
+ * Contributor(s):   Barak Naveh, Dimitrios Michail
  *
  * Changes
  * -------
@@ -37,11 +37,12 @@ package org.jgrapht.ext;
 import org.jgrapht.Graph;
 
 import java.io.OutputStream;
-import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.io.Writer;
 
 
 /**
- * Exports a graph to a csv format that can be imported into MS Visio.
+ * Exports a graph to a CSV format that can be imported into MS Visio.
  *
  * <p><b>Tip:</b> By default, the exported graph doesn't show link directions.
  * To show link directions:<br>
@@ -64,7 +65,7 @@ public class VisioExporter<V, E>
     private VertexNameProvider<V> vertexNameProvider;
 
     /**
-     * Creates a new VisioExporter object with the specified naming policy.
+     * Creates a new VisioExporter with the specified naming policy.
      *
      * @param vertexNameProvider the vertex name provider to be used for naming
      * the Visio shapes.
@@ -75,7 +76,7 @@ public class VisioExporter<V, E>
     }
 
     /**
-     * Creates a new VisioExporter object.
+     * Creates a new VisioExporter.
      */
     public VisioExporter()
     {
@@ -83,16 +84,32 @@ public class VisioExporter<V, E>
     }
 
     /**
-     * Exports the specified graph into a Visio csv file format.
+     * Exports the specified graph into a Visio CSV file format.
      *
      * @param output the print stream to which the graph to be exported.
      * @param g the graph to be exported.
      */
-    @Override
+    @Deprecated
     public void export(OutputStream output, Graph<V, E> g)
     {
-        PrintStream out = new PrintStream(output);
-
+        try {
+            export(g, output);
+        } catch (ExportException e) {
+            // ignore
+        }
+    }
+    
+    /**
+     * Exports the specified graph into a Visio CSV file format.
+     *
+     * @param g the graph to be exported.
+     * @param writer the writer to which the graph to be exported.
+     */
+    @Override
+    public void export(Graph<V, E> g, Writer writer)
+    {
+        PrintWriter out = new PrintWriter(writer);
+        
         for (V v : g.vertexSet()) {
             exportVertex(out, v);
         }
@@ -104,7 +121,7 @@ public class VisioExporter<V, E>
         out.flush();
     }
 
-    private void exportEdge(PrintStream out, E edge, Graph<V, E> g)
+    private void exportEdge(PrintWriter out, E edge, Graph<V, E> g)
     {
         String sourceName =
             vertexNameProvider.getVertexName(g.getEdgeSource(edge));
@@ -126,7 +143,7 @@ public class VisioExporter<V, E>
         out.print("\n");
     }
 
-    private void exportVertex(PrintStream out, V vertex)
+    private void exportVertex(PrintWriter out, V vertex)
     {
         String name = vertexNameProvider.getVertexName(vertex);
 

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/VisioExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/VisioExporter.java
@@ -93,7 +93,7 @@ public class VisioExporter<V, E>
     public void export(OutputStream output, Graph<V, E> g)
     {
         try {
-            export(g, output);
+            exportGraph(g, output);
         } catch (ExportException e) {
             // ignore
         }
@@ -106,7 +106,7 @@ public class VisioExporter<V, E>
      * @param writer the writer to which the graph to be exported.
      */
     @Override
-    public void export(Graph<V, E> g, Writer writer)
+    public void exportGraph(Graph<V, E> g, Writer writer)
     {
         PrintWriter out = new PrintWriter(writer);
         

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DIMACSImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DIMACSImporterTest.java
@@ -96,7 +96,7 @@ public class DIMACSImporterTest
 
         DIMACSImporter<Integer, E> importer = new DIMACSImporter<>(vp, ep);
         try {
-            importer.read(g, new InputStreamReader(in, "UTF-8"));
+            importer.importGraph(g, new InputStreamReader(in, "UTF-8"));
         } catch (UnsupportedEncodingException e) {
             // cannot happen
         }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DIMACSImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DIMACSImporterTest.java
@@ -25,9 +25,7 @@
  * (C) Copyright 2016-2016, by Joris Kinable and Contributors.
  *
  * Original Author:  Joris Kinable
- * Contributor(s):
- *
- * $Id$
+ * Contributor(s): Dimitrios Michail
  *
  * Changes
  * -------
@@ -38,80 +36,238 @@ package org.jgrapht.ext;
 
 import junit.framework.TestCase;
 import org.jgrapht.Graph;
-import org.jgrapht.VertexFactory;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.DefaultWeightedEdge;
-import org.jgrapht.graph.SimpleGraph;
-import org.jgrapht.graph.SimpleWeightedGraph;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.DirectedWeightedPseudograph;
 
 import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 /**
  * .
  *
  * @author Joris Kinable
+ * @author Dimitrios Michail
  */
-public class DIMACSImporterTest extends TestCase {
+public class DIMACSImporterTest
+    extends TestCase
+{
+
+    public <E> Graph<Integer, E> readGraph(
+        InputStream in,
+        Class<? extends E> edgeClass,
+        boolean weighted)
+        throws ImportException
+    {
+        Graph<Integer, E> g;
+        if (weighted) {
+            g = new DirectedWeightedPseudograph<Integer, E>(edgeClass);
+        } else {
+            g = new DirectedPseudograph<Integer, E>(edgeClass);
+        }
+
+        VertexProvider<Integer> vp = new VertexProvider<Integer>()
+        {
+            @Override
+            public Integer buildVertex(
+                String label,
+                Map<String, String> attributes)
+            {
+                return Integer.parseInt(label);
+            }
+        };
+
+        EdgeProvider<Integer, E> ep = new EdgeProvider<Integer, E>()
+        {
+
+            @Override
+            public E buildEdge(
+                Integer from,
+                Integer to,
+                String label,
+                Map<String, String> attributes)
+            {
+                return g.getEdgeFactory().createEdge(from, to);
+            }
+
+        };
+
+        DIMACSImporter<Integer, E> importer = new DIMACSImporter<>(vp, ep);
+        try {
+            importer.read(new InputStreamReader(in, "UTF-8"), g);
+        } catch (UnsupportedEncodingException e) {
+            // cannot happen
+        }
+
+        return g;
+    }
+
     /**
      * Read and parse an actual instance
      */
-    public void testReadDIMACSInstance(){
-        InputStream fstream = getClass().getClassLoader().getResourceAsStream("myciel3.col");
-        BufferedReader in = new BufferedReader(new InputStreamReader(fstream));
-        try {
-            DIMACSImporter<Integer, DefaultEdge> reader=new DIMACSImporter<>(in);
-            VertexFactory<Integer> vf = new IntVertexFactory();
-            Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
-            reader.generateGraph(graph, vf, null);
+    public void testReadDIMACSInstance()
+        throws ImportException
+    {
+        InputStream fstream = getClass().getClassLoader()
+            .getResourceAsStream("myciel3.col");
+        Graph<Integer, DefaultEdge> graph = readGraph(
+            fstream,
+            DefaultEdge.class,
+            false);
 
-            assertEquals(graph.vertexSet().size(), 11);
-            assertEquals(graph.edgeSet().size(), 20);
+        assertEquals(graph.vertexSet().size(), 11);
+        assertEquals(graph.edgeSet().size(), 20);
 
-            int[][] edges={{1, 2}, {1, 4}, {1, 7}, {1, 9}, {2, 3}, {2, 6}, {2, 8}, {3, 5}, {3, 7}, {3, 10}, {4, 5}, {4, 6}, {4, 10}, {5, 8}, {5, 9}, {6, 11}, {7, 11}, {8, 11}, {9, 11}, {10, 11}};
-            for(int[] edge: edges)
-                assertTrue(graph.containsEdge(edge[0],edge[1]));
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
+        int[][] edges = {
+            { 1, 2 },
+            { 1, 4 },
+            { 1, 7 },
+            { 1, 9 },
+            { 2, 3 },
+            { 2, 6 },
+            { 2, 8 },
+            { 3, 5 },
+            { 3, 7 },
+            { 3, 10 },
+            { 4, 5 },
+            { 4, 6 },
+            { 4, 10 },
+            { 5, 8 },
+            { 5, 9 },
+            { 6, 11 },
+            { 7, 11 },
+            { 8, 11 },
+            { 9, 11 },
+            { 10, 11 } };
+        for (int[] edge : edges)
+            assertTrue(graph.containsEdge(edge[0], edge[1]));
     }
 
     /**
      * Read and parse an weighted instance
      */
-    public void testReadWeightedDIMACSInstance(){
-        InputStream fstream = getClass().getClassLoader().getResourceAsStream("myciel3_weighted.col");
-        BufferedReader in = new BufferedReader(new InputStreamReader(fstream));
-        try {
-            DIMACSImporter<Integer, DefaultWeightedEdge> reader=new DIMACSImporter<>(in);
-            VertexFactory<Integer> vf = new IntVertexFactory();
-            Graph<Integer, DefaultWeightedEdge> graph = new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
-            reader.generateGraph(graph, vf, null);
-
-            assertEquals(graph.vertexSet().size(), 11);
-            assertEquals(graph.edgeSet().size(), 20);
-
-            int[][] edges={{1, 2, 1}, {1, 4, 2}, {1, 7, 3}, {1, 9, 4}, {2, 3, 5}, {2, 6, 6}, {2, 8, 7}, {3, 5, 8}, {3, 7, 9}, {3, 10, 10}, {4, 5, 11}, {4, 6, 12}, {4, 10, 13}, {5, 8, 14}, {5, 9, 15}, {6, 11, 16}, {7, 11, 17}, {8, 11, 18}, {9, 11, 19}, {10, 11, 20}};
-            for(int[] edge: edges) {
-                assertTrue(graph.containsEdge(edge[0], edge[1]));
-                DefaultWeightedEdge e=graph.getEdge(edge[0], edge[1]);
-                assertEquals((int)graph.getEdgeWeight(e), edge[2]);
-            }
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-    }
-
-    //~ Inner Classes ----------------------------------------------------------
-
-    private static final class IntVertexFactory
-            implements VertexFactory<Integer>
+    public void testReadWeightedDIMACSInstance()
+        throws ImportException
     {
-        int last = 1;
+        InputStream fstream = getClass().getClassLoader()
+            .getResourceAsStream("myciel3_weighted.col");
+        Graph<Integer, DefaultWeightedEdge> graph = readGraph(
+            fstream,
+            DefaultWeightedEdge.class,
+            true);
 
-        @Override
-        public Integer createVertex()
-        {
-            return last++;
+        assertEquals(graph.vertexSet().size(), 11);
+        assertEquals(graph.edgeSet().size(), 20);
+
+        int[][] edges = {
+            { 1, 2, 1 },
+            { 1, 4, 2 },
+            { 1, 7, 3 },
+            { 1, 9, 4 },
+            { 2, 3, 5 },
+            { 2, 6, 6 },
+            { 2, 8, 7 },
+            { 3, 5, 8 },
+            { 3, 7, 9 },
+            { 3, 10, 10 },
+            { 4, 5, 11 },
+            { 4, 6, 12 },
+            { 4, 10, 13 },
+            { 5, 8, 14 },
+            { 5, 9, 15 },
+            { 6, 11, 16 },
+            { 7, 11, 17 },
+            { 8, 11, 18 },
+            { 9, 11, 19 },
+            { 10, 11, 20 } };
+
+        for (int[] edge : edges) {
+            assertTrue(graph.containsEdge(edge[0], edge[1]));
+            DefaultWeightedEdge e = graph.getEdge(edge[0], edge[1]);
+            assertEquals((int) graph.getEdgeWeight(e), edge[2]);
         }
     }
+
+    public void testWrongDIMACSInstance1()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "p edge ERROR 5\n"
+                     + "e 1 2\n"
+                     + "e 1 4\n";
+        // @formatter:on
+
+        try {
+            readGraph(
+                new ByteArrayInputStream(
+                    input.getBytes(StandardCharsets.UTF_8)),
+                DefaultEdge.class,
+                false);
+            fail("No!");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testWrongDIMACSInstance2()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "p edge -10 5\n"
+                     + "e 1 2\n"
+                     + "e 1 4\n";
+        // @formatter:on
+
+        try {
+            readGraph(
+                new ByteArrayInputStream(
+                    input.getBytes(StandardCharsets.UTF_8)),
+                DefaultEdge.class,
+                false);
+            fail("No!");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testWrongDIMACSInstance3()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "p edge 2 5\n"
+                     + "e 1 2\n"
+                     + "e 1 4\n";
+        // @formatter:on
+
+        try {
+            readGraph(
+                new ByteArrayInputStream(
+                    input.getBytes(StandardCharsets.UTF_8)),
+                DefaultEdge.class,
+                false);
+            fail("No!");
+        } catch (ImportException e) {
+        }
+    }
+
+    public void testWrongDIMACSInstance4()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "p edge 2 2\n"
+                     + "e 2\n"
+                     + "e 1 2\n";
+        // @formatter:on
+
+        try {
+            readGraph(
+                new ByteArrayInputStream(
+                    input.getBytes(StandardCharsets.UTF_8)),
+                DefaultEdge.class,
+                false);
+            fail("No!");
+        } catch (ImportException e) {
+        }
+    }
+
 }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DIMACSImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DIMACSImporterTest.java
@@ -96,7 +96,7 @@ public class DIMACSImporterTest
 
         DIMACSImporter<Integer, E> importer = new DIMACSImporter<>(vp, ep);
         try {
-            importer.read(new InputStreamReader(in, "UTF-8"), g);
+            importer.read(g, new InputStreamReader(in, "UTF-8"));
         } catch (UnsupportedEncodingException e) {
             // cannot happen
         }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
@@ -109,7 +109,7 @@ public class DOTExporterTest
                 vertexAttributeProvider,
                 null);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED, res);
     }
@@ -137,7 +137,7 @@ public class DOTExporterTest
                     new DefaultDirectedGraph<>(
                             DefaultEdge.class);
             graph.addVertex(vertex);
-            exporter.export(graph, new ByteArrayOutputStream());
+            exporter.exportGraph(graph, new ByteArrayOutputStream());
         }
 
         List<String> invalidVertices =
@@ -149,7 +149,7 @@ public class DOTExporterTest
             graph.addVertex(vertex);
 
             try {
-                exporter.export(graph, new ByteArrayOutputStream());
+                exporter.exportGraph(graph, new ByteArrayOutputStream());
                 Assert.fail(vertex);
             } catch (RuntimeException re) {
                 // this is a negative test so exception is expected

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
@@ -68,7 +68,8 @@ public class DOTExporterTest
 
     //~ Methods ----------------------------------------------------------------
 
-    public void testUndirected()
+    public void testUndirected() 
+        throws UnsupportedEncodingException
     {
         UndirectedGraph<String, DefaultEdge> g =
                 new SimpleGraph<>(DefaultEdge.class);
@@ -78,7 +79,6 @@ public class DOTExporterTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
-        StringWriter w = new StringWriter();
         ComponentAttributeProvider<String> vertexAttributeProvider =
             new ComponentAttributeProvider<String>() {
                 @Override
@@ -108,8 +108,10 @@ public class DOTExporterTest
                 null,
                 vertexAttributeProvider,
                 null);
-        exporter.export(w, g);
-        assertEquals(UNDIRECTED, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(UNDIRECTED, res);
     }
 
     public void testValidNodeIDs()
@@ -134,8 +136,7 @@ public class DOTExporterTest
                     new DefaultDirectedGraph<>(
                             DefaultEdge.class);
             graph.addVertex(vertex);
-
-            exporter.export(new StringWriter(), graph);
+            exporter.export(new ByteArrayOutputStream(), graph);
         }
 
         List<String> invalidVertices =
@@ -147,7 +148,7 @@ public class DOTExporterTest
             graph.addVertex(vertex);
 
             try {
-                exporter.export(new StringWriter(), graph);
+                exporter.export(new ByteArrayOutputStream(), graph);
                 Assert.fail(vertex);
             } catch (RuntimeException re) {
                 // this is a negative test so exception is expected

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
@@ -68,8 +68,8 @@ public class DOTExporterTest
 
     //~ Methods ----------------------------------------------------------------
 
-    public void testUndirected() 
-        throws UnsupportedEncodingException
+    public void testUndirected()
+        throws UnsupportedEncodingException, ExportException
     {
         UndirectedGraph<String, DefaultEdge> g =
                 new SimpleGraph<>(DefaultEdge.class);
@@ -109,12 +109,13 @@ public class DOTExporterTest
                 vertexAttributeProvider,
                 null);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED, res);
     }
 
     public void testValidNodeIDs()
+        throws ExportException
     {
         DOTExporter<String, DefaultEdge> exporter =
             new DOTExporter<>(
@@ -136,7 +137,7 @@ public class DOTExporterTest
                     new DefaultDirectedGraph<>(
                             DefaultEdge.class);
             graph.addVertex(vertex);
-            exporter.export(new ByteArrayOutputStream(), graph);
+            exporter.export(graph, new ByteArrayOutputStream());
         }
 
         List<String> invalidVertices =
@@ -148,7 +149,7 @@ public class DOTExporterTest
             graph.addVertex(vertex);
 
             try {
-                exporter.export(new ByteArrayOutputStream(), graph);
+                exporter.export(graph, new ByteArrayOutputStream());
                 Assert.fail(vertex);
             } catch (RuntimeException re) {
                 // this is a negative test so exception is expected

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
@@ -29,7 +29,8 @@
  */
 package org.jgrapht.ext;
 
-import java.io.StringWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 import junit.framework.*;
@@ -124,7 +125,8 @@ public class DOTImporterTest extends TestCase
       Assert.assertEquals(2, result.edgeSet().size());
    }
 
-   public void testExportImportLoop() throws ImportException {
+   public void testExportImportLoop() 
+       throws ImportException, UnsupportedEncodingException {
       DirectedMultigraph<String, DefaultEdge> start
             = new DirectedMultigraph<String, DefaultEdge>(DefaultEdge.class);
       start.addVertex("a");
@@ -144,14 +146,15 @@ public class DOTImporterTest extends TestCase
       }, null, new IntegerEdgeNameProvider<DefaultEdge>());
 
       DOTImporter<String, DefaultEdge> importer = buildImporter();
-      StringWriter writer = new StringWriter();
 
-      exporter.export(writer, start);
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      exporter.export(os, start);
+      String output = new String(os.toByteArray(), "UTF-8");
 
       DirectedMultigraph<String, DefaultEdge> result
             = new DirectedMultigraph<String, DefaultEdge>(DefaultEdge.class);
 
-      importer.read(writer.toString(), result);
+      importer.read(output, result);
 
       Assert.assertEquals(start.toString(), result.toString());
 

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
@@ -30,10 +30,13 @@
 package org.jgrapht.ext;
 
 import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 import junit.framework.*;
+
+import org.jgrapht.Graph;
 import org.jgrapht.graph.*;
 
 public class DOTImporterTest extends TestCase
@@ -528,6 +531,32 @@ public class DOTImporterTest extends TestCase
       }
 
    }
+   
+   public void testWithReader() throws ImportException {
+       String input = "graph G {\n"
+                      + "  1 [ \"label\"=\"abc123\" ];\n"
+                      + "  2 [ label=\"fred\" ];\n"
+                      + "  1 -- 2;\n"
+                      + "}";
+
+       Multigraph<String, DefaultEdge> expected
+             = new Multigraph<String, DefaultEdge>(DefaultEdge.class);
+       expected.addVertex("abc123");
+       expected.addVertex("fred");
+       expected.addEdge("abc123", "fred");
+
+       DOTImporter<String, DefaultEdge> importer = buildImporter();
+
+       Graph<String, DefaultEdge> result
+             = new Multigraph<String, DefaultEdge>(DefaultEdge.class);
+       importer.read(new StringReader(input), result);
+
+       Assert.assertEquals(expected.toString(), result.toString());
+
+       Assert.assertEquals(2, result.vertexSet().size());
+       Assert.assertEquals(1, result.edgeSet().size());
+
+    }
 
    private void testGarbage(String input, String expected) {
       DirectedMultigraph<String, DefaultEdge> result

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
@@ -60,7 +60,7 @@ public class DOTImporterTest extends TestCase
 
       Multigraph<String, DefaultEdge> result
             = new Multigraph<String, DefaultEdge>(DefaultEdge.class);
-      importer.read(result, new StringReader(input));
+      importer.importGraph(result, new StringReader(input));
 
       Assert.assertEquals(expected.toString(), result.toString());
 
@@ -90,7 +90,7 @@ public class DOTImporterTest extends TestCase
 
       DirectedMultigraph<String, DefaultEdge> result
             = new DirectedMultigraph<String, DefaultEdge>(DefaultEdge.class);
-      importer.read(result, new StringReader(input));
+      importer.importGraph(result, new StringReader(input));
 
       Assert.assertEquals(expected.toString(), result.toString());
 
@@ -120,7 +120,7 @@ public class DOTImporterTest extends TestCase
 
       Multigraph<String, DefaultEdge> result
             = new Multigraph<String, DefaultEdge>(DefaultEdge.class);
-      importer.read(result, new StringReader(input));
+      importer.importGraph(result, new StringReader(input));
 
       Assert.assertEquals(expected.toString(), result.toString());
 
@@ -151,13 +151,13 @@ public class DOTImporterTest extends TestCase
       DOTImporter<String, DefaultEdge> importer = buildImporter();
 
       ByteArrayOutputStream os = new ByteArrayOutputStream();
-      exporter.export(start, os);
+      exporter.exportGraph(start, os);
       String output = new String(os.toByteArray(), "UTF-8");
 
       DirectedMultigraph<String, DefaultEdge> result
             = new DirectedMultigraph<String, DefaultEdge>(DefaultEdge.class);
 
-      importer.read(result, new StringReader(output));
+      importer.importGraph(result, new StringReader(output));
 
       Assert.assertEquals(start.toString(), result.toString());
 
@@ -196,7 +196,7 @@ public class DOTImporterTest extends TestCase
             }
       );
 
-      importer.read(result, new StringReader(input));
+      importer.importGraph(result, new StringReader(input));
 
       Assert.assertEquals(1, result.vertexSet().size());
       Assert.assertTrue(result.vertexSet().contains("------this------contains-------dashes------"));
@@ -234,7 +234,7 @@ public class DOTImporterTest extends TestCase
       );
 
 
-      importer.read(result, new StringReader(input));
+      importer.importGraph(result, new StringReader(input));
       Assert.assertEquals("wrong size of vertexSet", 2, result.vertexSet().size());
       Assert.assertEquals("wrong size of edgeSet", 1, result.edgeSet().size());
 
@@ -349,7 +349,7 @@ public class DOTImporterTest extends TestCase
       );
 
       try {
-         importer.read(graph, new StringReader(input));
+         importer.importGraph(graph, new StringReader(input));
          Assert.fail("Should not get here");
       } catch (ImportException e) {
          Assert.assertEquals("Invalid attributes", e.getMessage());
@@ -386,7 +386,7 @@ public class DOTImporterTest extends TestCase
             }
       );
 
-      importer.read(result, new StringReader(input));
+      importer.importGraph(result, new StringReader(input));
 
       Assert.assertEquals("wrong size of vertexSet", 2, result.vertexSet().size());
       Assert.assertEquals("wrong size of edgeSet", 1, result.edgeSet().size());
@@ -425,7 +425,7 @@ public class DOTImporterTest extends TestCase
       );
 
 
-      importer.read(result, new StringReader(input));
+      importer.importGraph(result, new StringReader(input));
       Assert.assertEquals("wrong size of vertexSet", 1, result.vertexSet().size());
       Assert.assertEquals("wrong size of edgeSet", 0, result.edgeSet().size());
    }
@@ -456,7 +456,7 @@ public class DOTImporterTest extends TestCase
       );
 
 
-      importer.read(result, new StringReader(input));
+      importer.importGraph(result, new StringReader(input));
       Assert.assertEquals("wrong size of vertexSet", 1, result.vertexSet().size());
       Assert.assertEquals("wrong size of edgeSet", 0, result.edgeSet().size());
       Assert.assertEquals("wrong parsing", escapedLabel, ((TestVertex) result.vertexSet().toArray()[0]).getId());
@@ -487,7 +487,7 @@ public class DOTImporterTest extends TestCase
       );
 
 
-      importer.read(result, new StringReader(input));
+      importer.importGraph(result, new StringReader(input));
       Assert.assertEquals("wrong size of vertexSet", 2, result.vertexSet().size());
       Assert.assertEquals("wrong size of edgeSet", 0, result.edgeSet().size());
    }
@@ -520,7 +520,7 @@ public class DOTImporterTest extends TestCase
       );
 
       try {
-         importer.read(result, new StringReader(input));
+         importer.importGraph(result, new StringReader(input));
          Assert.fail("should not get here");
       } catch (ImportException e) {
          Assert.assertEquals(
@@ -549,7 +549,7 @@ public class DOTImporterTest extends TestCase
 
        Graph<String, DefaultEdge> result
              = new Multigraph<String, DefaultEdge>(DefaultEdge.class);
-       importer.read(result, new StringReader(input));
+       importer.importGraph(result, new StringReader(input));
 
        Assert.assertEquals(expected.toString(), result.toString());
 
@@ -567,7 +567,7 @@ public class DOTImporterTest extends TestCase
    private void testGarbageGraph(String input, String expected, AbstractBaseGraph<String, DefaultEdge> graph) {
       DOTImporter<String, DefaultEdge> importer = buildImporter();
       try {
-         importer.read(graph, new StringReader(input));
+         importer.importGraph(graph, new StringReader(input));
          Assert.fail("Should not get here");
       } catch (ImportException e) {
          Assert.assertEquals(expected, e.getMessage());

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
@@ -60,7 +60,7 @@ public class DOTImporterTest extends TestCase
 
       Multigraph<String, DefaultEdge> result
             = new Multigraph<String, DefaultEdge>(DefaultEdge.class);
-      importer.read(input, result);
+      importer.read(result, new StringReader(input));
 
       Assert.assertEquals(expected.toString(), result.toString());
 
@@ -90,7 +90,7 @@ public class DOTImporterTest extends TestCase
 
       DirectedMultigraph<String, DefaultEdge> result
             = new DirectedMultigraph<String, DefaultEdge>(DefaultEdge.class);
-      importer.read(input, result);
+      importer.read(result, new StringReader(input));
 
       Assert.assertEquals(expected.toString(), result.toString());
 
@@ -120,7 +120,7 @@ public class DOTImporterTest extends TestCase
 
       Multigraph<String, DefaultEdge> result
             = new Multigraph<String, DefaultEdge>(DefaultEdge.class);
-      importer.read(input, result);
+      importer.read(result, new StringReader(input));
 
       Assert.assertEquals(expected.toString(), result.toString());
 
@@ -129,7 +129,7 @@ public class DOTImporterTest extends TestCase
    }
 
    public void testExportImportLoop() 
-       throws ImportException, UnsupportedEncodingException {
+       throws ImportException, ExportException, UnsupportedEncodingException {
       DirectedMultigraph<String, DefaultEdge> start
             = new DirectedMultigraph<String, DefaultEdge>(DefaultEdge.class);
       start.addVertex("a");
@@ -151,13 +151,13 @@ public class DOTImporterTest extends TestCase
       DOTImporter<String, DefaultEdge> importer = buildImporter();
 
       ByteArrayOutputStream os = new ByteArrayOutputStream();
-      exporter.export(os, start);
+      exporter.export(start, os);
       String output = new String(os.toByteArray(), "UTF-8");
 
       DirectedMultigraph<String, DefaultEdge> result
             = new DirectedMultigraph<String, DefaultEdge>(DefaultEdge.class);
 
-      importer.read(output, result);
+      importer.read(result, new StringReader(output));
 
       Assert.assertEquals(start.toString(), result.toString());
 
@@ -196,7 +196,7 @@ public class DOTImporterTest extends TestCase
             }
       );
 
-      importer.read(input, result);
+      importer.read(result, new StringReader(input));
 
       Assert.assertEquals(1, result.vertexSet().size());
       Assert.assertTrue(result.vertexSet().contains("------this------contains-------dashes------"));
@@ -234,7 +234,7 @@ public class DOTImporterTest extends TestCase
       );
 
 
-      importer.read(input, result);
+      importer.read(result, new StringReader(input));
       Assert.assertEquals("wrong size of vertexSet", 2, result.vertexSet().size());
       Assert.assertEquals("wrong size of edgeSet", 1, result.edgeSet().size());
 
@@ -349,7 +349,7 @@ public class DOTImporterTest extends TestCase
       );
 
       try {
-         importer.read(input, graph);
+         importer.read(graph, new StringReader(input));
          Assert.fail("Should not get here");
       } catch (ImportException e) {
          Assert.assertEquals("Invalid attributes", e.getMessage());
@@ -386,7 +386,7 @@ public class DOTImporterTest extends TestCase
             }
       );
 
-      importer.read(input, result);
+      importer.read(result, new StringReader(input));
 
       Assert.assertEquals("wrong size of vertexSet", 2, result.vertexSet().size());
       Assert.assertEquals("wrong size of edgeSet", 1, result.edgeSet().size());
@@ -425,7 +425,7 @@ public class DOTImporterTest extends TestCase
       );
 
 
-      importer.read(input, result);
+      importer.read(result, new StringReader(input));
       Assert.assertEquals("wrong size of vertexSet", 1, result.vertexSet().size());
       Assert.assertEquals("wrong size of edgeSet", 0, result.edgeSet().size());
    }
@@ -456,7 +456,7 @@ public class DOTImporterTest extends TestCase
       );
 
 
-      importer.read(input, result);
+      importer.read(result, new StringReader(input));
       Assert.assertEquals("wrong size of vertexSet", 1, result.vertexSet().size());
       Assert.assertEquals("wrong size of edgeSet", 0, result.edgeSet().size());
       Assert.assertEquals("wrong parsing", escapedLabel, ((TestVertex) result.vertexSet().toArray()[0]).getId());
@@ -487,7 +487,7 @@ public class DOTImporterTest extends TestCase
       );
 
 
-      importer.read(input, result);
+      importer.read(result, new StringReader(input));
       Assert.assertEquals("wrong size of vertexSet", 2, result.vertexSet().size());
       Assert.assertEquals("wrong size of edgeSet", 0, result.edgeSet().size());
    }
@@ -520,7 +520,7 @@ public class DOTImporterTest extends TestCase
       );
 
       try {
-         importer.read(input, result);
+         importer.read(result, new StringReader(input));
          Assert.fail("should not get here");
       } catch (ImportException e) {
          Assert.assertEquals(
@@ -549,7 +549,7 @@ public class DOTImporterTest extends TestCase
 
        Graph<String, DefaultEdge> result
              = new Multigraph<String, DefaultEdge>(DefaultEdge.class);
-       importer.read(new StringReader(input), result);
+       importer.read(result, new StringReader(input));
 
        Assert.assertEquals(expected.toString(), result.toString());
 
@@ -567,7 +567,7 @@ public class DOTImporterTest extends TestCase
    private void testGarbageGraph(String input, String expected, AbstractBaseGraph<String, DefaultEdge> graph) {
       DOTImporter<String, DefaultEdge> importer = buildImporter();
       try {
-         importer.read(input, graph);
+         importer.read(graph, new StringReader(input));
          Assert.fail("Should not get here");
       } catch (ImportException e) {
          Assert.assertEquals(expected, e.getMessage());

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlExporterTest.java
@@ -22,11 +22,10 @@
 /* ------------------------------
  * GmlExporterTest.java
  * ------------------------------
- * (C) Copyright 2003-2008, by Barak Naveh and Contributors.
+ * (C) Copyright 2006-2016, by John V. Sichi and Contributors. 
  *
  * Original Author:  John V. Sichi
- *
- * $Id$
+ * Contributors: Dimitrios Michail
  *
  * Changes
  * -------
@@ -35,17 +34,22 @@
  */
 package org.jgrapht.ext;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
 
-import junit.framework.*;
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.UndirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleDirectedGraph;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.SimpleWeightedGraph;
 
-import org.jgrapht.*;
-import org.jgrapht.graph.*;
+import junit.framework.TestCase;
 
 /**
- * .
- *
  * @author John V. Sichi
+ * @author Dimitrios Michail
  */
 public class GmlExporterTest
     extends TestCase
@@ -267,6 +271,7 @@ public class GmlExporterTest
     // ----------------------------------------------------------------
 
     public void testUndirected()
+        throws UnsupportedEncodingException
     {
         UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
             DefaultEdge.class);
@@ -276,15 +281,17 @@ public class GmlExporterTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
-        StringWriter w = new StringWriter();
         GmlExporter<String, DefaultEdge> exporter = new GmlExporter<String, DefaultEdge>();
-        exporter.export(w, g);
-        assertEquals(UNDIRECTED, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(UNDIRECTED, res);
     }
 
     public void testUnweightedUndirected()
+        throws UnsupportedEncodingException
     {
-        UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
+        UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<>(
             DefaultEdge.class);
         g.addVertex(V1);
         g.addVertex(V2);
@@ -292,16 +299,18 @@ public class GmlExporterTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
-        StringWriter w = new StringWriter();
-        GmlExporter<String, DefaultEdge> exporter = new GmlExporter<String, DefaultEdge>();
+        GmlExporter<String, DefaultEdge> exporter = new GmlExporter<>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
-        exporter.export(w, g);
-        assertEquals(UNDIRECTED, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(UNDIRECTED, res);
     }
 
     public void testDirected()
+        throws UnsupportedEncodingException
     {
-        DirectedGraph<String, DefaultEdge> g = new SimpleDirectedGraph<String, DefaultEdge>(
+        DirectedGraph<String, DefaultEdge> g = new SimpleDirectedGraph<>(
             DefaultEdge.class);
         g.addVertex(V1);
         g.addVertex(V2);
@@ -314,13 +323,15 @@ public class GmlExporterTest
         g.addEdge(V3, V4);
         g.addEdge(V4, V5);
 
-        StringWriter w = new StringWriter();
-        GmlExporter<String, DefaultEdge> exporter = new GmlExporter<String, DefaultEdge>();
-        exporter.export(w, g);
-        assertEquals(DIRECTED, w.toString());
+        GmlExporter<String, DefaultEdge> exporter = new GmlExporter<>();
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(DIRECTED, res);
     }
 
     public void testWeightedUndirected()
+        throws UnsupportedEncodingException
     {
         SimpleGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
             DefaultWeightedEdge.class);
@@ -332,17 +343,18 @@ public class GmlExporterTest
         DefaultWeightedEdge e2 = g.addEdge(V3, V1);
         g.setEdgeWeight(e2, 5.0);
 
-        StringWriter w = new StringWriter();
-
-        GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<String, DefaultWeightedEdge>();
+        GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
-        exporter.export(w, g);
-        assertEquals(UNDIRECTED_WEIGHTED, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(UNDIRECTED_WEIGHTED, res);
     }
 
     public void testWeightedUndirectedWithEdgeLabels()
+        throws UnsupportedEncodingException
     {
-        SimpleGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
+        SimpleGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<>(
             DefaultWeightedEdge.class);
         g.addVertex(V1);
         g.addVertex(V2);
@@ -352,18 +364,19 @@ public class GmlExporterTest
         DefaultWeightedEdge e2 = g.addEdge(V3, V1);
         g.setEdgeWeight(e2, 5.0);
 
-        StringWriter w = new StringWriter();
-
-        GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<String, DefaultWeightedEdge>();
+        GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_LABELS, true);
-        exporter.export(w, g);
-        assertEquals(UNDIRECTED_WEIGHTED_WITH_EDGE_LABELS, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(UNDIRECTED_WEIGHTED_WITH_EDGE_LABELS, res);
     }
 
     public void testUndirectedWithVertexLabels()
+        throws UnsupportedEncodingException
     {
-        SimpleGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
+        SimpleGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<>(
             DefaultWeightedEdge.class);
         g.addVertex(V1);
         g.addVertex(V2);
@@ -373,12 +386,12 @@ public class GmlExporterTest
         DefaultWeightedEdge e2 = g.addEdge(V3, V1);
         g.setEdgeWeight(e2, 5.0);
 
-        StringWriter w = new StringWriter();
-
-        GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<String, DefaultWeightedEdge>();
+        GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_VERTEX_LABELS, true);
-        exporter.export(w, g);
-        assertEquals(UNDIRECTED_WITH_VERTEX_LABELS, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(UNDIRECTED_WITH_VERTEX_LABELS, res);
     }
 
     public void testParameters()

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlExporterTest.java
@@ -271,7 +271,7 @@ public class GmlExporterTest
     // ----------------------------------------------------------------
 
     public void testUndirected()
-        throws UnsupportedEncodingException
+        throws UnsupportedEncodingException, ExportException
     {
         UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(
             DefaultEdge.class);
@@ -283,13 +283,13 @@ public class GmlExporterTest
 
         GmlExporter<String, DefaultEdge> exporter = new GmlExporter<String, DefaultEdge>();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED, res);
     }
 
     public void testUnweightedUndirected()
-        throws UnsupportedEncodingException
+        throws UnsupportedEncodingException, ExportException
     {
         UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<>(
             DefaultEdge.class);
@@ -302,13 +302,13 @@ public class GmlExporterTest
         GmlExporter<String, DefaultEdge> exporter = new GmlExporter<>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED, res);
     }
 
     public void testDirected()
-        throws UnsupportedEncodingException
+        throws UnsupportedEncodingException, ExportException
     {
         DirectedGraph<String, DefaultEdge> g = new SimpleDirectedGraph<>(
             DefaultEdge.class);
@@ -325,13 +325,13 @@ public class GmlExporterTest
 
         GmlExporter<String, DefaultEdge> exporter = new GmlExporter<>();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(DIRECTED, res);
     }
 
     public void testWeightedUndirected()
-        throws UnsupportedEncodingException
+        throws UnsupportedEncodingException, ExportException
     {
         SimpleGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
             DefaultWeightedEdge.class);
@@ -346,13 +346,13 @@ public class GmlExporterTest
         GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED_WEIGHTED, res);
     }
 
     public void testWeightedUndirectedWithEdgeLabels()
-        throws UnsupportedEncodingException
+        throws UnsupportedEncodingException, ExportException
     {
         SimpleGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<>(
             DefaultWeightedEdge.class);
@@ -368,13 +368,13 @@ public class GmlExporterTest
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_LABELS, true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED_WEIGHTED_WITH_EDGE_LABELS, res);
     }
 
     public void testUndirectedWithVertexLabels()
-        throws UnsupportedEncodingException
+        throws UnsupportedEncodingException, ExportException
     {
         SimpleGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<>(
             DefaultWeightedEdge.class);
@@ -389,7 +389,7 @@ public class GmlExporterTest
         GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_VERTEX_LABELS, true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED_WITH_VERTEX_LABELS, res);
     }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlExporterTest.java
@@ -283,7 +283,7 @@ public class GmlExporterTest
 
         GmlExporter<String, DefaultEdge> exporter = new GmlExporter<String, DefaultEdge>();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED, res);
     }
@@ -302,7 +302,7 @@ public class GmlExporterTest
         GmlExporter<String, DefaultEdge> exporter = new GmlExporter<>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED, res);
     }
@@ -325,7 +325,7 @@ public class GmlExporterTest
 
         GmlExporter<String, DefaultEdge> exporter = new GmlExporter<>();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(DIRECTED, res);
     }
@@ -346,7 +346,7 @@ public class GmlExporterTest
         GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED_WEIGHTED, res);
     }
@@ -368,7 +368,7 @@ public class GmlExporterTest
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_LABELS, true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED_WEIGHTED_WITH_EDGE_LABELS, res);
     }
@@ -389,7 +389,7 @@ public class GmlExporterTest
         GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_VERTEX_LABELS, true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED_WITH_VERTEX_LABELS, res);
     }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
@@ -33,8 +33,9 @@
  */
 package org.jgrapht.ext;
 
+import java.io.ByteArrayOutputStream;
 import java.io.StringReader;
-import java.io.StringWriter;
+import java.io.UnsupportedEncodingException;
 import java.util.Map;
 
 import org.jgrapht.Graph;
@@ -544,7 +545,7 @@ public class GmlImporterTest
     }
 
     public void testExportImport()
-        throws ImportException
+        throws ImportException, UnsupportedEncodingException
     {
         DirectedWeightedPseudograph<String, DefaultWeightedEdge> g1 = new DirectedWeightedPseudograph<String, DefaultWeightedEdge>(
             DefaultWeightedEdge.class);
@@ -555,11 +556,11 @@ public class GmlImporterTest
         g1.setEdgeWeight(g1.addEdge("2", "3"), 3.0);
         g1.setEdgeWeight(g1.addEdge("3", "3"), 5.0);
 
-        StringWriter sw = new StringWriter();
         GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<String, DefaultWeightedEdge>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
-        exporter.export(sw, g1);
-        String output = sw.toString();
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g1);
+        String output = new String(os.toByteArray(), "UTF-8");
 
         Graph<String, DefaultWeightedEdge> g2 = readGraph(
             output,

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
@@ -50,7 +50,7 @@ import org.jgrapht.graph.WeightedPseudograph;
 import junit.framework.TestCase;
 
 /**
- * 
+ * .
  * @author Dimitrios Michail
  */
 public class GmlImporterTest
@@ -106,7 +106,7 @@ public class GmlImporterTest
         };
 
         GmlImporter<String, E> importer = new GmlImporter<String, E>(vp, ep);
-        importer.read(new StringReader(input), g);
+        importer.read(g, new StringReader(input));
 
         return g;
     }
@@ -545,7 +545,7 @@ public class GmlImporterTest
     }
 
     public void testExportImport()
-        throws ImportException, UnsupportedEncodingException
+        throws ImportException, ExportException, UnsupportedEncodingException
     {
         DirectedWeightedPseudograph<String, DefaultWeightedEdge> g1 = new DirectedWeightedPseudograph<String, DefaultWeightedEdge>(
             DefaultWeightedEdge.class);
@@ -559,7 +559,7 @@ public class GmlImporterTest
         GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<String, DefaultWeightedEdge>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g1);
+        exporter.export(g1, os);
         String output = new String(os.toByteArray(), "UTF-8");
 
         Graph<String, DefaultWeightedEdge> g2 = readGraph(
@@ -617,7 +617,7 @@ public class GmlImporterTest
             GmlImporter<String, DefaultEdge> importer = new GmlImporter<String, DefaultEdge>(
                 vp,
                 ep);
-            importer.read(new StringReader(input), g);
+            importer.read(g, new StringReader(input));
             fail("No!");
         } catch (ImportException e) {
         }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GmlImporterTest.java
@@ -106,7 +106,7 @@ public class GmlImporterTest
         };
 
         GmlImporter<String, E> importer = new GmlImporter<String, E>(vp, ep);
-        importer.read(g, new StringReader(input));
+        importer.importGraph(g, new StringReader(input));
 
         return g;
     }
@@ -559,7 +559,7 @@ public class GmlImporterTest
         GmlExporter<String, DefaultWeightedEdge> exporter = new GmlExporter<String, DefaultWeightedEdge>();
         exporter.setParameter(GmlExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g1, os);
+        exporter.exportGraph(g1, os);
         String output = new String(os.toByteArray(), "UTF-8");
 
         Graph<String, DefaultWeightedEdge> g2 = readGraph(
@@ -617,7 +617,7 @@ public class GmlImporterTest
             GmlImporter<String, DefaultEdge> importer = new GmlImporter<String, DefaultEdge>(
                 vp,
                 ep);
-            importer.read(g, new StringReader(input));
+            importer.importGraph(g, new StringReader(input));
             fail("No!");
         } catch (ImportException e) {
         }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
@@ -96,7 +96,7 @@ public class GraphMLExporterTest
 
         GraphExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
 
@@ -136,7 +136,7 @@ public class GraphMLExporterTest
         GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
         exporter.setExportEdgeWeights(true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -171,7 +171,7 @@ public class GraphMLExporterTest
 
         GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -210,7 +210,7 @@ public class GraphMLExporterTest
         GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
         exporter.setExportEdgeWeights(true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -251,7 +251,7 @@ public class GraphMLExporterTest
         GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<>();
         exporter.setExportEdgeWeights(true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -294,7 +294,7 @@ public class GraphMLExporterTest
         exporter.setExportEdgeWeights(true);
         exporter.setEdgeWeightAttributeName("value");
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -412,7 +412,7 @@ public class GraphMLExporterTest
             });
         exporter.setExportEdgeWeights(true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -487,7 +487,7 @@ public class GraphMLExporterTest
         exporter.setEdgeLabelAttributeName("custom_edge_label");
         exporter.setExportEdgeWeights(true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
 
@@ -605,7 +605,7 @@ public class GraphMLExporterTest
             GraphMLExporter.AttributeType.STRING,
             "johndoe");
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -688,7 +688,7 @@ public class GraphMLExporterTest
             GraphMLExporter.AttributeType.STRING,
             "johndoe");
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g);
+        exporter.export(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
@@ -96,7 +96,7 @@ public class GraphMLExporterTest
 
         GraphExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
 
@@ -136,7 +136,7 @@ public class GraphMLExporterTest
         GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
         exporter.setExportEdgeWeights(true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -171,7 +171,7 @@ public class GraphMLExporterTest
 
         GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -210,7 +210,7 @@ public class GraphMLExporterTest
         GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
         exporter.setExportEdgeWeights(true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -251,7 +251,7 @@ public class GraphMLExporterTest
         GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<>();
         exporter.setExportEdgeWeights(true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -294,7 +294,7 @@ public class GraphMLExporterTest
         exporter.setExportEdgeWeights(true);
         exporter.setEdgeWeightAttributeName("value");
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -412,7 +412,7 @@ public class GraphMLExporterTest
             });
         exporter.setExportEdgeWeights(true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -487,7 +487,7 @@ public class GraphMLExporterTest
         exporter.setEdgeLabelAttributeName("custom_edge_label");
         exporter.setExportEdgeWeights(true);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
 
@@ -605,7 +605,7 @@ public class GraphMLExporterTest
             GraphMLExporter.AttributeType.STRING,
             "johndoe");
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }
@@ -688,7 +688,7 @@ public class GraphMLExporterTest
             GraphMLExporter.AttributeType.STRING,
             "johndoe");
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g, os);
+        exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         XMLAssert.assertXMLEqual(output, res);
     }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
@@ -30,18 +30,22 @@
  */
 package org.jgrapht.ext;
 
-import java.io.*;
+import java.io.ByteArrayOutputStream;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import junit.framework.*;
-
-import org.custommonkey.xmlunit.*;
-
-import org.jgrapht.*;
+import org.custommonkey.xmlunit.XMLAssert;
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.UndirectedGraph;
 import org.jgrapht.ext.GraphMLExporter.AttributeCategory;
 import org.jgrapht.ext.GraphMLExporter.AttributeType;
-import org.jgrapht.graph.*;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleDirectedGraph;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.SimpleWeightedGraph;
+
+import junit.framework.TestCase;
 
 /**
  * @author Trevor Harmon
@@ -90,11 +94,12 @@ public class GraphMLExporterTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
-        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
-        StringWriter w = new StringWriter();
-        exporter.export(w, g);
+        GraphExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        XMLAssert.assertXMLEqual(output, res);
 
-        XMLAssert.assertXMLEqual(output, w.toString());
     }
 
     public void testUndirectedWeighted()
@@ -128,12 +133,12 @@ public class GraphMLExporterTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
-        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
-        StringWriter w = new StringWriter();
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
         exporter.setExportEdgeWeights(true);
-        exporter.export(w, g);
-
-        XMLAssert.assertXMLEqual(output, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        XMLAssert.assertXMLEqual(output, res);
     }
 
     public void testDirected()
@@ -164,11 +169,11 @@ public class GraphMLExporterTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
-        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
-        StringWriter w = new StringWriter();
-        exporter.export(w, g);
-
-        XMLAssert.assertXMLEqual(output, w.toString());
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        XMLAssert.assertXMLEqual(output, res);
     }
 
     public void testUndirectedUnweightedWithWeights()
@@ -202,12 +207,12 @@ public class GraphMLExporterTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
-        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
-        StringWriter w = new StringWriter();
+        GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<>();
         exporter.setExportEdgeWeights(true);
-        exporter.export(w, g);
-
-        XMLAssert.assertXMLEqual(output, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        XMLAssert.assertXMLEqual(output, res);
     }
 
     public void testUndirectedWeightedWithWeights()
@@ -243,12 +248,12 @@ public class GraphMLExporterTest
         g.addEdge(V3, V1);
         g.setEdgeWeight(g.getEdge(V1, V2), 3.0);
 
-        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<String, DefaultWeightedEdge>();
-        StringWriter w = new StringWriter();
+        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<>();
         exporter.setExportEdgeWeights(true);
-        exporter.export(w, g);
-
-        XMLAssert.assertXMLEqual(output, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        XMLAssert.assertXMLEqual(output, res);
     }
 
     public void testUndirectedWeightedWithCustomNameWeights()
@@ -285,13 +290,13 @@ public class GraphMLExporterTest
         g.addEdge(V3, V1);
         g.setEdgeWeight(g.getEdge(V1, V2), 3.0);
 
-        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<String, DefaultWeightedEdge>();
-        StringWriter w = new StringWriter();
+        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<>();
         exporter.setExportEdgeWeights(true);
         exporter.setEdgeWeightAttributeName("value");
-        exporter.export(w, g);
-
-        XMLAssert.assertXMLEqual(output, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        XMLAssert.assertXMLEqual(output, res);
     }
 
     public void testNoRegisterWeightAttribute()
@@ -385,7 +390,7 @@ public class GraphMLExporterTest
         g.setEdgeWeight(g.getEdge(V1, V2), 3.0);
         g.setEdgeWeight(g.getEdge(V3, V1), 15.0);
 
-        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<String, DefaultWeightedEdge>(
+        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<>(
             new IntegerNameProvider<String>(),
             new VertexNameProvider<String>()
             {
@@ -405,11 +410,11 @@ public class GraphMLExporterTest
                 }
 
             });
-        StringWriter w = new StringWriter();
         exporter.setExportEdgeWeights(true);
-        exporter.export(w, g);
-
-        XMLAssert.assertXMLEqual(output, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        XMLAssert.assertXMLEqual(output, res);
     }
 
     public void testUndirectedWeightedWithWeightsAndLabelsAndCustomNames()
@@ -449,7 +454,7 @@ public class GraphMLExporterTest
                 + "</graphml>" + NL;
             // @formatter:on
 
-        SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
+        SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<>(
             DefaultWeightedEdge.class);
         g.addVertex(V1);
         g.addVertex(V2);
@@ -459,7 +464,7 @@ public class GraphMLExporterTest
         g.setEdgeWeight(g.getEdge(V1, V2), 3.0);
         g.setEdgeWeight(g.getEdge(V3, V1), 15.0);
 
-        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<String, DefaultWeightedEdge>();
+        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<>();
         exporter.setVertexLabelProvider(new VertexNameProvider<String>()
         {
             @Override
@@ -480,12 +485,12 @@ public class GraphMLExporterTest
 
             });
         exporter.setEdgeLabelAttributeName("custom_edge_label");
-
-        StringWriter w = new StringWriter();
         exporter.setExportEdgeWeights(true);
-        exporter.export(w, g);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        XMLAssert.assertXMLEqual(output, res);
 
-        XMLAssert.assertXMLEqual(output, w.toString());
     }
 
     public void testUndirectedWeightedWithWeightsAndColor()
@@ -529,7 +534,7 @@ public class GraphMLExporterTest
 				+ "</graphml>" + NL;
 		    // @formatter:on
 
-        SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
+        SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<>(
             DefaultWeightedEdge.class);
         g.addVertex(V1);
         g.addVertex(V2);
@@ -581,14 +586,13 @@ public class GraphMLExporterTest
             }
         };
 
-        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<String, DefaultWeightedEdge>(
+        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<>(
             new IntegerNameProvider<>(),
             null,
             vertexAttributeProvider,
             new IntegerEdgeNameProvider<>(),
             null,
             edgeAttributeProvider);
-        StringWriter w = new StringWriter();
         exporter.setExportEdgeWeights(true);
         exporter.registerAttribute(
             "color",
@@ -600,11 +604,12 @@ public class GraphMLExporterTest
             GraphMLExporter.AttributeCategory.ALL,
             GraphMLExporter.AttributeType.STRING,
             "johndoe");
-        exporter.export(w, g);
-
-        XMLAssert.assertXMLEqual(output, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        XMLAssert.assertXMLEqual(output, res);
     }
-    
+
     public void testUndirectedWeightedWithNullComponentProvider()
         throws Exception
     {
@@ -636,7 +641,7 @@ public class GraphMLExporterTest
                 + "</graphml>" + NL;
             // @formatter:on
 
-        SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<String, DefaultWeightedEdge>(
+        SimpleWeightedGraph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<>(
             DefaultWeightedEdge.class);
         g.addVertex(V1);
         g.addVertex(V2);
@@ -664,14 +669,13 @@ public class GraphMLExporterTest
             }
         };
 
-        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<String, DefaultWeightedEdge>(
+        GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<>(
             new IntegerNameProvider<>(),
             null,
             vertexAttributeProvider,
             new IntegerEdgeNameProvider<>(),
             null,
             edgeAttributeProvider);
-        StringWriter w = new StringWriter();
         exporter.setExportEdgeWeights(true);
         exporter.registerAttribute(
             "color",
@@ -683,9 +687,10 @@ public class GraphMLExporterTest
             GraphMLExporter.AttributeCategory.ALL,
             GraphMLExporter.AttributeType.STRING,
             "johndoe");
-        exporter.export(w, g);
-
-        XMLAssert.assertXMLEqual(output, w.toString());
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g);
+        String res = new String(os.toByteArray(), "UTF-8");
+        XMLAssert.assertXMLEqual(output, res);
     }
 
 }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
@@ -35,8 +35,8 @@
  */
 package org.jgrapht.ext;
 
+import java.io.ByteArrayOutputStream;
 import java.io.StringReader;
-import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -724,11 +724,11 @@ public class GraphMLImporterTest
         g1.addEdge("2", "3");
         g1.addEdge("3", "3");
 
-        StringWriter sw = new StringWriter();
         GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
-        exporter.export(sw, g1);
-        String output = sw.toString();
-
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.export(os, g1);
+        String output = new String(os.toByteArray(), "UTF-8");
+        
         Graph<String, DefaultEdge> g2 = readGraph(
             output,
             DefaultEdge.class,

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
@@ -542,7 +542,7 @@ public class GraphMLImporterTest
             vAttributes,
             eAttributes);
         importer.setEdgeWeightAttributeName("myvalue");
-        importer.read(new StringReader(input), g);
+        importer.read(g, new StringReader(input));
 
         assertEquals(3, g.vertexSet().size());
         assertEquals(3, g.edgeSet().size());
@@ -605,7 +605,7 @@ public class GraphMLImporterTest
             vAttributes,
             eAttributes);
         importer.setEdgeWeightAttributeName("myvalue");
-        importer.read(new StringReader(input), g);
+        importer.read(g, new StringReader(input));
 
         assertEquals(3, g.vertexSet().size());
         assertEquals(3, g.edgeSet().size());
@@ -766,7 +766,7 @@ public class GraphMLImporterTest
 
         GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(os, g1);
+        exporter.export(g1, os);
         String output = new String(os.toByteArray(), "UTF-8");
 
         Graph<String, DefaultEdge> g2 = readGraph(
@@ -838,7 +838,7 @@ public class GraphMLImporterTest
             GraphMLImporter<String, DefaultEdge> importer = new GraphMLImporter<String, DefaultEdge>(
                 vp,
                 ep);
-            importer.read(new StringReader(input), g);
+            importer.read(g, new StringReader(input));
             fail("No!");
         } catch (Exception e) {
             // nothing
@@ -885,7 +885,7 @@ public class GraphMLImporterTest
         throws ImportException
     {
         GraphMLImporter<String, E> importer = createGraphImporter(g, vp, ep);
-        importer.read(new StringReader(input), g);
+        importer.read(g, new StringReader(input));
         return g;
     }
 
@@ -897,7 +897,7 @@ public class GraphMLImporterTest
         throws ImportException
     {
         GraphMLImporter<String, E> importer = createGraphImporter(g, vp, ep);
-        importer.read(input, g);
+        importer.read(g, input);
         return g;
     }
 
@@ -978,7 +978,7 @@ public class GraphMLImporterTest
             g,
             vertexAttributes,
             edgeAttributes);
-        importer.read(new StringReader(input), g);
+        importer.read(g, new StringReader(input));
         return g;
     }
 
@@ -1010,7 +1010,7 @@ public class GraphMLImporterTest
             g,
             vertexAttributes,
             edgeAttributes);
-        importer.read(input, g);
+        importer.read(g, input);
         return g;
     }
 

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLImporterTest.java
@@ -542,7 +542,7 @@ public class GraphMLImporterTest
             vAttributes,
             eAttributes);
         importer.setEdgeWeightAttributeName("myvalue");
-        importer.read(g, new StringReader(input));
+        importer.importGraph(g, new StringReader(input));
 
         assertEquals(3, g.vertexSet().size());
         assertEquals(3, g.edgeSet().size());
@@ -605,7 +605,7 @@ public class GraphMLImporterTest
             vAttributes,
             eAttributes);
         importer.setEdgeWeightAttributeName("myvalue");
-        importer.read(g, new StringReader(input));
+        importer.importGraph(g, new StringReader(input));
 
         assertEquals(3, g.vertexSet().size());
         assertEquals(3, g.edgeSet().size());
@@ -766,7 +766,7 @@ public class GraphMLImporterTest
 
         GraphMLExporter<String, DefaultEdge> exporter = new GraphMLExporter<String, DefaultEdge>();
         ByteArrayOutputStream os = new ByteArrayOutputStream();
-        exporter.export(g1, os);
+        exporter.exportGraph(g1, os);
         String output = new String(os.toByteArray(), "UTF-8");
 
         Graph<String, DefaultEdge> g2 = readGraph(
@@ -838,7 +838,7 @@ public class GraphMLImporterTest
             GraphMLImporter<String, DefaultEdge> importer = new GraphMLImporter<String, DefaultEdge>(
                 vp,
                 ep);
-            importer.read(g, new StringReader(input));
+            importer.importGraph(g, new StringReader(input));
             fail("No!");
         } catch (Exception e) {
             // nothing
@@ -885,7 +885,7 @@ public class GraphMLImporterTest
         throws ImportException
     {
         GraphMLImporter<String, E> importer = createGraphImporter(g, vp, ep);
-        importer.read(g, new StringReader(input));
+        importer.importGraph(g, new StringReader(input));
         return g;
     }
 
@@ -897,7 +897,7 @@ public class GraphMLImporterTest
         throws ImportException
     {
         GraphMLImporter<String, E> importer = createGraphImporter(g, vp, ep);
-        importer.read(g, input);
+        importer.importGraph(g, input);
         return g;
     }
 
@@ -978,7 +978,7 @@ public class GraphMLImporterTest
             g,
             vertexAttributes,
             edgeAttributes);
-        importer.read(g, new StringReader(input));
+        importer.importGraph(g, new StringReader(input));
         return g;
     }
 
@@ -1010,7 +1010,7 @@ public class GraphMLImporterTest
             g,
             vertexAttributes,
             edgeAttributes);
-        importer.read(g, input);
+        importer.importGraph(g, input);
         return g;
     }
 

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/MatrixExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/MatrixExporterTest.java
@@ -106,13 +106,13 @@ public class MatrixExporterTest
         GraphExporter<String, DefaultEdge> exporter1 = new MatrixExporter<>(
             MatrixExporter.Format.SPARSE_LAPLACIAN_MATRIX);
         StringWriter w1 = new StringWriter();
-        exporter1.export(g, w1);
+        exporter1.exportGraph(g, w1);
         assertEquals(LAPLACIAN, w1.toString());
 
         GraphExporter<String, DefaultEdge> exporter2 = new MatrixExporter<>(
             MatrixExporter.Format.SPARSE_NORMALIZED_LAPLACIAN_MATRIX);
         StringWriter w2 = new StringWriter();
-        exporter2.export(g, w2);
+        exporter2.exportGraph(g, w2);
         assertEquals(NORMALIZED_LAPLACIAN, w2.toString());
     }
 
@@ -130,7 +130,7 @@ public class MatrixExporterTest
         
         GraphExporter<String, DefaultEdge> exporter = new MatrixExporter<>();
         StringWriter w = new StringWriter();
-        exporter.export(g, w);
+        exporter.exportGraph(g, w);
         assertEquals(UNDIRECTED_ADJACENCY, w.toString());
     }
 
@@ -148,7 +148,7 @@ public class MatrixExporterTest
         
         GraphExporter<String, DefaultEdge> exporter = new MatrixExporter<>();
         Writer w = new StringWriter();
-        exporter.export(g, w);
+        exporter.exportGraph(g, w);
         assertEquals(DIRECTED_ADJACENCY, w.toString());
     }
 }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/MatrixExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/MatrixExporterTest.java
@@ -59,8 +59,6 @@ public class MatrixExporterTest
 
     private static final String NL = System.getProperty("line.separator");
 
-    // TODO jvs 23-Dec-2006:  externalized diff-based testing framework
-
     private static final String LAPLACIAN =
         "1 1 2" + NL
         + "1 2 -1" + NL
@@ -90,12 +88,12 @@ public class MatrixExporterTest
         "1 2 1" + NL
         + "3 1 2" + NL;
 
-    private static final MatrixExporter<String, DefaultEdge> exporter =
-        new MatrixExporter<String, DefaultEdge>();
+    
 
     //~ Methods ----------------------------------------------------------------
 
     public void testLaplacian()
+        throws ExportException
     {
         UndirectedGraph<String, DefaultEdge> g =
             new SimpleGraph<String, DefaultEdge>(DefaultEdge.class);
@@ -105,16 +103,21 @@ public class MatrixExporterTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
-        StringWriter w = new StringWriter();
-        exporter.exportLaplacianMatrix(w, g);
-        assertEquals(LAPLACIAN, w.toString());
+        GraphExporter<String, DefaultEdge> exporter1 = new MatrixExporter<>(
+            MatrixExporter.Format.SPARSE_LAPLACIAN_MATRIX);
+        StringWriter w1 = new StringWriter();
+        exporter1.export(g, w1);
+        assertEquals(LAPLACIAN, w1.toString());
 
-        w = new StringWriter();
-        exporter.exportNormalizedLaplacianMatrix(w, g);
-        assertEquals(NORMALIZED_LAPLACIAN, w.toString());
+        GraphExporter<String, DefaultEdge> exporter2 = new MatrixExporter<>(
+            MatrixExporter.Format.SPARSE_NORMALIZED_LAPLACIAN_MATRIX);
+        StringWriter w2 = new StringWriter();
+        exporter2.export(g, w2);
+        assertEquals(NORMALIZED_LAPLACIAN, w2.toString());
     }
 
     public void testAdjacencyUndirected()
+        throws ExportException
     {
         UndirectedGraph<String, DefaultEdge> g =
             new Pseudograph<String, DefaultEdge>(DefaultEdge.class);
@@ -124,13 +127,15 @@ public class MatrixExporterTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
         g.addEdge(V1, V1);
-
+        
+        GraphExporter<String, DefaultEdge> exporter = new MatrixExporter<>();
         StringWriter w = new StringWriter();
-        exporter.exportAdjacencyMatrix(w, g);
+        exporter.export(g, w);
         assertEquals(UNDIRECTED_ADJACENCY, w.toString());
     }
 
     public void testAdjacencyDirected()
+        throws ExportException
     {
         DirectedGraph<String, DefaultEdge> g =
             new DirectedMultigraph<String, DefaultEdge>(DefaultEdge.class);
@@ -140,9 +145,10 @@ public class MatrixExporterTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
         g.addEdge(V3, V1);
-
+        
+        GraphExporter<String, DefaultEdge> exporter = new MatrixExporter<>();
         Writer w = new StringWriter();
-        exporter.exportAdjacencyMatrix(w, g);
+        exporter.export(g, w);
         assertEquals(DIRECTED_ADJACENCY, w.toString());
     }
 }


### PR DESCRIPTION
In this proposed pull request, I unified the interface of the graph importers and exporters. 

Main changes
- Added two interfaces: GraphImporter and GraphExporter in order to unify how importers and exporters work.
- DIMACSImporter: changed the implementation and the interface to follow the interface of all the remaining importers and improved the parser's error handling. This is not a breaking change as the class DIMACSImporter was not in the previous release. The details of the implementation are the same, however we now use the VertexProvider and EdgeProvider interfaces as done by all the other importers.
- DOTExporter: now implements the GraphExporter interface
- DOTImporter 
   - changed the implementation to use a Graph (instead of forcing an AbstractBaseGraph) as the other importers (deprecated the old method)
   - now implements the GraphImporter interface
- GmlExporter: now implements the GraphExporter interface
- GmlImporter: now implements the GraphImporter interface
- GraphMLExporter: now implements the GraphExporter interface
- GraphMLImporter: now implements the GraphExporter interface
- VisioExporter: now implements the GraphExporter interface

Also updated the test cases as appropriate. The DIMACSImporter class was augmented with a few more tests containing wrong input. All the above changes do not break compatibility with previous releases.

Other less important changes which also do not break anything.
- DotUtils: added missing javadoc
- ComponentAttributeProvider.java: code cleanups, removed CVS style $Id$
- EdgeNameProvider: fixed javadoc typo and wrong header
- IntegerEdgeNameProvider and IntegerNameProvider: code cleanup
- JGraphModelAdapter: added missing javadoc comment
- StringEdgeNameProvider: added missing javadoc comment
- StringNameProvider: code cleanups
- MatrixExporter: code cleanup
- VertexNameProvider, VertexProvider, VertexUpdater: code cleanup
- pom.xml: Exclude package.html from packaging in the final jar

The only exporter which currently does not follow the GraphExporter interface is the MatrixExporter. This is because the MatrixExporter can export in 3 different formats and needs significant changes, best done in a different pull request.