### PR TITLE
DOT importer id fix

### DIFF
--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
@@ -580,14 +580,9 @@ public class DOTImporter<V, E>
             id = node.substring(0, node.indexOf('[')).trim();
         }
 
-        String label = attributes.get("label");
-        if (label == null) {
-            label = id;
-        }
-
         V existing = vertexes.get(id);
         if (existing == null) {
-            V vertex = vertexProvider.buildVertex(label, attributes);
+            V vertex = vertexProvider.buildVertex(id, attributes);
             graph.addVertex(vertex);
             vertexes.put(id, vertex);
         } else {
@@ -596,7 +591,7 @@ public class DOTImporter<V, E>
             } else {
                 throw new ImportException(
                     "Update required for vertex "
-                    + label
+                    + id
                     + " but no vertexUpdater provided");
             }
         }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
@@ -22,9 +22,15 @@
 /* ------------------
  * DOTImporter.java
  * ------------------
- * (C) Copyright 2015, by  Wil Selwood.
+ * (C) Copyright 2015-2016, by  Wil Selwood and Contributors.
  *
  * Original Author:  Wil Selwood <wselwood@ijento.com>
+ * Contributor(s): Dimitrios Michail
+ * 
+ * Changes
+ * -------
+ * 2015 : Initial revision (WS);
+ * 19-Aug-2016: Always provide id to vertex providers (DM);
  *
  */
 package org.jgrapht.ext;

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
@@ -22,10 +22,16 @@
 /* ------------------
  * DOTImporterTest.java
  * ------------------
- * (C) Copyright 2015, by  Wil Selwood.
+ * (C) Copyright 2015-2016, by  Wil Selwood and Contributors.
  *
  * Original Author:  Wil Selwood <wselwood@ijento.com>
+ * Contributor(s): Dimitrios Michail
  *
+ * Changes
+ * -------
+ * 2015 : Initial revision (WS);
+ * 19-Aug-2016: Always provide id to vertex providers (DM);
+ * 
  */
 package org.jgrapht.ext;
 

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
@@ -156,9 +156,6 @@ public class DOTImporterTest extends TestCase
        importer.read(input, result);
 
        Assert.assertEquals(expected.toString(), result.toString());
-
-       Assert.assertEquals(3, result.vertexSet().size());
-       Assert.assertEquals(2, result.edgeSet().size());
     }
 
    public void testMultiLinksUndirected() throws ImportException {


### PR DESCRIPTION
This pull requests fixes the issue #204. 

The previous implementation did the following: 
 - If a vertex had no "label" the id of the vertex was given to the vertex provider
 - If a vertex had a "label" then the label was given to the vertex provider. Additionally 
   the label was provided to the vertex provider inside the attributes map.

The following example from issue #204 shows such a case.
```
vertex0 [label= "Test"];
vertex1 [label= "Test"];
```

Since labels are not necessarily unique, we now provide the id in both cases to the vertex provider. If there is also a label attached, it is provided inside the attributes map.