### PR TITLE
Capture trivial paths in AllDirectedPaths

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/AllDirectedPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/AllDirectedPaths.java
@@ -23,7 +23,7 @@
 /* -------------------------
  * AllDirectedPaths.java
  * -------------------------
- * (C) Copyright 2015-2015, Vera-Licona Research Group and Contributors.
+ * (C) Copyright 2015-2016, Vera-Licona Research Group and Contributors.
  *
  * Original Author:  Andrew Gainer-Dewar, Ph.D. (Vera-Licona Research Group)
  * Contributor(s):
@@ -259,8 +259,17 @@ public class AllDirectedPaths<V, E>
 
         // Bootstrap the search with the source vertices
         for (V source : sourceVertices) {
+            if (targetVertices.contains(source)) {
+                completePaths.add(new GraphWalk<>(graph, source, source,
+                                                  new ArrayList<>(), 0));
+            }
+
             for (E edge : graph.outgoingEdgesOf(source)) {
                 assert graph.getEdgeSource(edge).equals(source);
+
+                if (targetVertices.contains(graph.getEdgeTarget(edge))) {
+                    completePaths.add(makePath(Collections.singletonList(edge)));
+                }
 
                 if (edgeMinDistancesFromTargets.containsKey(edge)) {
                     List<E> path = Collections.singletonList(edge);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/AllDirectedPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/AllDirectedPathsTest.java
@@ -78,6 +78,24 @@ public class AllDirectedPathsTest
         assertEquals("Toy network should have correct number of simple paths", 7, allPaths.size());
     }
 
+    public void testTrivialPaths () {
+        AllDirectedPaths<String, DefaultEdge> pathFindingAlg =
+            new AllDirectedPaths<>(toyGraph());
+
+        Set<String> sources = new HashSet<>();
+        sources.add(I1);
+
+        Set<String> targets = new HashSet<>();
+        targets.add(I1);
+        targets.add(A);
+
+        List<GraphPath<String, DefaultEdge>> allPaths =
+            pathFindingAlg.getAllPaths(sources, targets, true, null);
+
+        assertEquals("Toy network should have correct number of trivial simple paths", 2, allPaths.size());
+    }
+
+
     public void testCycleBehavior () {
         DirectedGraph<String, DefaultEdge> toyGraph = toyGraph();
         toyGraph.addEdge(D, A);


### PR DESCRIPTION
Correctly handle paths of length 0 and 1 in AllDirectedPaths algorithm. Fixes #198 and #234.