### PR TITLE
Make Eclipse happy.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -203,6 +203,37 @@
                     <windowtitle>JGraphT : a free Java graph library</windowtitle>
                   </configuration>
                 </plugin>
+                <!--This plugin's configuration is used to store Eclipse m2e settings only. It has no influence on the Maven build itself.-->
+                <plugin>
+                	<groupId>org.eclipse.m2e</groupId>
+                	<artifactId>lifecycle-mapping</artifactId>
+                	<version>1.0.0</version>
+                	<configuration>
+                		<lifecycleMappingMetadata>
+                			<pluginExecutions>
+                				<pluginExecution>
+                					<pluginExecutionFilter>
+                						<groupId>
+                							org.apache.felix
+                						</groupId>
+                						<artifactId>
+                							maven-bundle-plugin
+                						</artifactId>
+                						<versionRange>
+                							[3.0.1,)
+                						</versionRange>
+                						<goals>
+                							<goal>manifest</goal>
+                						</goals>
+                					</pluginExecutionFilter>
+                					<action>
+                						<ignore></ignore>
+                					</action>
+                				</pluginExecution>
+                			</pluginExecutions>
+                		</lifecycleMappingMetadata>
+                	</configuration>
+                </plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
I'm updating the setup instructions for Eclipse Neon, and everything worked fine out of the box, except that Eclipse wanted me to add this to get rid of little red errors for the jgrapht-core and jgrapht-ext poms by adding this to the root pom.

@jkinable can you merge this one if it's OK?  I'm going to try to get into the habit of using pull requests for my own changes now that I have someone else available as a reviewer.