### PR TITLE
Eclipse formatter disable/enable tags

### DIFF
--- a/etc/eclipse-formatter-settings.xml
+++ b/etc/eclipse-formatter-settings.xml
@@ -242,5 +242,8 @@
 <setting id="org.eclipse.jdt.core.formatter.tabulation.char" value="space"/>
 <setting id="org.eclipse.jdt.core.formatter.tabulation.size" value="4"/>
 <setting id="org.eclipse.jdt.core.formatter.use_tabs_only_for_leading_indentations" value="false"/>
+<setting id="org.eclipse.jdt.core.formatter.use_on_off_tags" value="true"/>
+<setting id="org.eclipse.jdt.core.formatter.disabling_tag" value="@formatter:off"/>
+<setting id="org.eclipse.jdt.core.formatter.enabling_tag" value="@formatter:on"/>
 </profile>
 </profiles>


### PR DESCRIPTION
Enabled the eclipse formatter tags that disable and enable the formatter for a while. 

This allows the formatter to stop working if someone uses for example:
```
        // @formatter:off
        String input = "graph [\n"
                     + "  comment \"Sample Graph\"\n"
                     + "  directed 1\n"
                     + "  node [\n"
                     + "    id 1\n"
                     + "  ]\n"
                     + "  node [\n"
                     + "    id 2\n"
                     + "  ]\n"
                     + "  edge [\n"
                     + "    source 1\n"
                     + "    target 2\n"
                     + "  ]\n"
                     + "]";
        // @formatter:on
```

I am using this in test cases, where the formatter breaks the formatting.