### PR TITLE
Fixed overflow bug in RandomGraphGenerator

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/generate/RandomGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/RandomGraphGenerator.java
@@ -22,15 +22,14 @@
 /* -----------------
  * RandomGraphGenerator.java
  * -----------------
- * (C) Copyright 2005-2008, by Assaf Lehr and Contributors.
+ * (C) Copyright 2005-2016, by Assaf Lehr and Contributors.
  *
  * Original Author:  Assaf Lehr
- * Contributor(s):   -
- *
- * $Id$
+ * Contributor(s):   Dimitrios Michail
  *
  * Changes
  * -------
+ * 5-Sep-2016: Fixed overflow issue (DM)
  */
 package org.jgrapht.generate;
 
@@ -359,11 +358,33 @@ public class RandomGraphGenerator<V, E>
         {
             int maxAllowedEdges;
             if (targetGraph instanceof SimpleGraph<?, ?>) {
-                maxAllowedEdges = numOfVertexes * (numOfVertexes - 1) / 2;
+                try {
+                    if (numOfVertexes % 2 == 0) {
+                        maxAllowedEdges = Math.multiplyExact(
+                            numOfVertexes / 2,
+                            numOfVertexes - 1);
+                    } else {
+                        maxAllowedEdges = Math.multiplyExact(
+                            numOfVertexes,
+                            (numOfVertexes - 1) / 2);
+                    }
+                } catch (ArithmeticException e) {
+                    maxAllowedEdges = Integer.MAX_VALUE;
+                }
             } else if (targetGraph instanceof SimpleDirectedGraph<?, ?>) {
-                maxAllowedEdges = numOfVertexes * (numOfVertexes - 1);
+                try {
+                    maxAllowedEdges = Math
+                        .multiplyExact(numOfVertexes, (numOfVertexes - 1));
+                } catch (ArithmeticException e) {
+                    maxAllowedEdges = Integer.MAX_VALUE;
+                }
             } else if (targetGraph instanceof DefaultDirectedGraph<?, ?>) {
-                maxAllowedEdges = numOfVertexes * numOfVertexes;
+                try {
+                    maxAllowedEdges = Math
+                        .multiplyExact(numOfVertexes, numOfVertexes);
+                } catch (ArithmeticException e) {
+                    maxAllowedEdges = Integer.MAX_VALUE;
+                }
             } else {
                 // This may be overly liberal in the case of something
                 // like a simple graph which has been wrapped with

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/RandomGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/RandomGraphGenerator.java
@@ -228,7 +228,7 @@ public class RandomGraphGenerator<V, E>
      *
      * <ol>
      * <li>when the number of possible edges becomes slim , this class will have
-     * a very poor performance , cause it will not use gready methods to choose
+     * a very poor performance , cause it will not use greedy methods to choose
      * them. for example : In simple graph , if #V = N (#x = number Of x) and we
      * want full mesh #edges= N*(N-1)/2 , the first added edges will do so
      * quickly (O(1) , the last will take O(N^2). So , do not use it in this
@@ -357,8 +357,8 @@ public class RandomGraphGenerator<V, E>
         public int getMaxEdgesForVertexNum(Graph<VV, EE> targetGraph)
         {
             int maxAllowedEdges;
-            if (targetGraph instanceof SimpleGraph<?, ?>) {
-                try {
+            try {
+                if (targetGraph instanceof SimpleGraph<?, ?>) {
                     if (numOfVertexes % 2 == 0) {
                         maxAllowedEdges = Math.multiplyExact(
                             numOfVertexes / 2,
@@ -368,28 +368,20 @@ public class RandomGraphGenerator<V, E>
                             numOfVertexes,
                             (numOfVertexes - 1) / 2);
                     }
-                } catch (ArithmeticException e) {
-                    maxAllowedEdges = Integer.MAX_VALUE;
-                }
-            } else if (targetGraph instanceof SimpleDirectedGraph<?, ?>) {
-                try {
+                } else if (targetGraph instanceof SimpleDirectedGraph<?, ?>) {
                     maxAllowedEdges = Math
                         .multiplyExact(numOfVertexes, (numOfVertexes - 1));
-                } catch (ArithmeticException e) {
-                    maxAllowedEdges = Integer.MAX_VALUE;
-                }
-            } else if (targetGraph instanceof DefaultDirectedGraph<?, ?>) {
-                try {
+                } else if (targetGraph instanceof DefaultDirectedGraph<?, ?>) {
                     maxAllowedEdges = Math
                         .multiplyExact(numOfVertexes, numOfVertexes);
-                } catch (ArithmeticException e) {
-                    maxAllowedEdges = Integer.MAX_VALUE;
+                } else {
+                    // This may be overly liberal in the case of something
+                    // like a simple graph which has been wrapped with
+                    // a graph adapter or view.
+                    maxAllowedEdges = -1; // infinite
                 }
-            } else {
-                // This may be overly liberal in the case of something
-                // like a simple graph which has been wrapped with
-                // a graph adapter or view.
-                maxAllowedEdges = -1; // infinite
+            } catch (ArithmeticException e) {
+                maxAllowedEdges = Integer.MAX_VALUE;
             }
             return maxAllowedEdges;
         }


### PR DESCRIPTION
This pull request closes issue #60. 

The problem was that the computation of the allowed maximum edges in a graph overflowed. The proposed fix uses Java 8 method Math.multiplyExact and checks for ArithmeticException(s).

The test suite was augmented to test for the border cases.
