### PR TITLE
Streamlined function names in flow interface

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/MinSourceSinkCut.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/MinSourceSinkCut.java
@@ -36,10 +36,8 @@
 package org.jgrapht.alg;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import org.jgrapht.*;
-import org.jgrapht.alg.flow.EdmondsKarpMFImpl;
 import org.jgrapht.alg.flow.MaximumFlowAlgorithmBase;
 import org.jgrapht.alg.flow.PushRelabelMFImpl;
 import org.jgrapht.alg.interfaces.MaximumFlowAlgorithm;
@@ -104,7 +102,7 @@ public class MinSourceSinkCut<V, E>
         minCut = new HashSet<>();
 
         //First compute a maxFlow from source to sink
-        MaximumFlow<E> maxFlow = ekMaxFlow.buildMaximumFlow(source, sink);
+        MaximumFlow<E> maxFlow = ekMaxFlow.getMaximumFlow(source, sink);
 
         this.cutWeight = maxFlow.getValue();
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
@@ -139,7 +139,7 @@ public final class EdmondsKarpMFImpl<V, E>
      * @param source source vertex
      * @param sink sink vertex
      */
-    public MaximumFlow<E> buildMaximumFlow(V source, V sink)
+    public MaximumFlow<E> getMaximumFlow(V source, V sink)
     {
         this.calculateMaximumFlow(source, sink);
         maxFlow = composeFlow();

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
@@ -362,7 +362,7 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
      *
      * @return <i>read-only</i> mapping from edges to doubles - flow values
      */
-    public Map<E, Double> getMaximumFlow(){
+    public Map<E, Double> getFlowMap(){
         if(maxFlow == null) //Lazily calculate the max flow map
             maxFlow=composeFlow();
         return maxFlow;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -166,7 +166,7 @@ public class PushRelabelMFImpl<V, E>
         }
     }
 
-    @Override public MaximumFlow<E> buildMaximumFlow(V source, V sink)
+    @Override public MaximumFlow<E> getMaximumFlow(V source, V sink)
     {
         this.calculateMaximumFlow(source, sink);
         maxFlow = composeFlow();

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MaximumFlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MaximumFlowAlgorithm.java
@@ -61,7 +61,7 @@ public interface MaximumFlowAlgorithm<V, E>
      *
      * @return maximum flow
      */
-    MaximumFlow<E> buildMaximumFlow(V source, V sink);
+    MaximumFlow<E> getMaximumFlow(V source, V sink);
 
     /**
      * Sets current source to <tt>source</tt>, current sink to <tt>sink</tt>,
@@ -73,7 +73,7 @@ public interface MaximumFlowAlgorithm<V, E>
      * @param sink sink vertex
      */
     default double calculateMaximumFlow(V source,V sink){
-        return buildMaximumFlow(source, sink).getValue();
+        return getMaximumFlow(source, sink).getValue();
     }
 
 
@@ -100,7 +100,7 @@ public interface MaximumFlowAlgorithm<V, E>
      *
      * @return <i>read-only</i> mapping from edges to doubles - flow values
      */
-    default Map<E, Double> getMaximumFlow(){
+    default Map<E, Double> getFlowMap(){
         throw new UnsupportedOperationException("Function not implemented");
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/EdmondsKarpMFImplTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/EdmondsKarpMFImplTest.java
@@ -82,7 +82,7 @@ public class EdmondsKarpMFImplTest extends MaximumFlowAlgorithmTest
             MaximumFlowAlgorithm<Integer, DefaultWeightedEdge> solver =
                 new EdmondsKarpMFImpl<>(
                     simple);
-            Map<DefaultWeightedEdge, Double> flow = solver.buildMaximumFlow(0, 1).getFlow();
+            Map<DefaultWeightedEdge, Double> flow = solver.getMaximumFlow(0, 1).getFlow();
             flow.put(e, 25.0);
             fail();
         } catch (UnsupportedOperationException ex) {
@@ -91,7 +91,7 @@ public class EdmondsKarpMFImplTest extends MaximumFlowAlgorithmTest
             MaximumFlowAlgorithm<Integer, DefaultWeightedEdge> solver =
                 new EdmondsKarpMFImpl<>(
                     simple);
-            solver.buildMaximumFlow(2, 0);
+            solver.getMaximumFlow(2, 0);
             fail();
         } catch (IllegalArgumentException ex) {
         }
@@ -99,7 +99,7 @@ public class EdmondsKarpMFImplTest extends MaximumFlowAlgorithmTest
             MaximumFlowAlgorithm<Integer, DefaultWeightedEdge> solver =
                     new EdmondsKarpMFImpl<>(
                             simple);
-            solver.buildMaximumFlow(1, 2);
+            solver.getMaximumFlow(1, 2);
             fail();
         } catch (IllegalArgumentException ex) {
         }
@@ -107,7 +107,7 @@ public class EdmondsKarpMFImplTest extends MaximumFlowAlgorithmTest
             MaximumFlowAlgorithm<Integer, DefaultWeightedEdge> solver =
                     new EdmondsKarpMFImpl<>(
                             simple);
-            solver.buildMaximumFlow(0, 0);
+            solver.getMaximumFlow(0, 0);
             fail();
         } catch (IllegalArgumentException ex) {
         }
@@ -115,7 +115,7 @@ public class EdmondsKarpMFImplTest extends MaximumFlowAlgorithmTest
             MaximumFlowAlgorithm<Integer, DefaultWeightedEdge> solver =
                     new EdmondsKarpMFImpl<>(
                             simple);
-            solver.buildMaximumFlow(null, 0);
+            solver.getMaximumFlow(null, 0);
             fail();
         } catch (IllegalArgumentException ex) {
         }
@@ -123,7 +123,7 @@ public class EdmondsKarpMFImplTest extends MaximumFlowAlgorithmTest
             MaximumFlowAlgorithm<Integer, DefaultWeightedEdge> solver =
                     new EdmondsKarpMFImpl<>(
                             simple);
-            solver.buildMaximumFlow(0, null);
+            solver.getMaximumFlow(0, null);
             fail();
         } catch (IllegalArgumentException ex) {
         }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmTest.java
@@ -37,12 +37,9 @@ package org.jgrapht.alg.flow;
 
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.Graph;
-import org.jgrapht.Graphs;
 import org.jgrapht.UndirectedGraph;
 import org.jgrapht.alg.interfaces.MaximumFlowAlgorithm;
 import org.jgrapht.graph.DefaultWeightedEdge;
-import org.jgrapht.graph.DirectedWeightedMultigraph;
-import org.jgrapht.graph.SimpleWeightedGraph;
 
 import java.util.Map;
 
@@ -65,7 +62,7 @@ public abstract class MaximumFlowAlgorithmTest extends MaximumFlowMinimumCutAlgo
 
         //Calculate the max flow for each source/sink pair
         for (int i = 0; i < sources.length; i++) {
-            verifyDirected(sources[i], sinks[i], expectedResults[i], network, solver.buildMaximumFlow(sources[i], sinks[i]));
+            verifyDirected(sources[i], sinks[i], expectedResults[i], network, solver.getMaximumFlow(sources[i], sinks[i]));
         }
     }
 
@@ -134,7 +131,7 @@ public abstract class MaximumFlowAlgorithmTest extends MaximumFlowMinimumCutAlgo
     }
 
     static void verifyUndirected(UndirectedGraph<Integer, DefaultWeightedEdge> graph, int source, int sink, int expectedResult, MaximumFlowAlgorithm<Integer, DefaultWeightedEdge> solver) {
-        MaximumFlowAlgorithm.MaximumFlow<DefaultWeightedEdge> maxFlow=solver.buildMaximumFlow(source, sink);
+        MaximumFlowAlgorithm.MaximumFlow<DefaultWeightedEdge> maxFlow=solver.getMaximumFlow(source, sink);
         Double flowValue = maxFlow.getValue();
         Map<DefaultWeightedEdge, Double> flow = maxFlow.getFlow();
 

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/flow/MaximumFlowAlgorithmPerformanceTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/flow/MaximumFlowAlgorithmPerformanceTest.java
@@ -102,7 +102,7 @@ public class MaximumFlowAlgorithmPerformanceTest extends TestCase {
 
         @Benchmark
         public void run() {
-            solver.buildMaximumFlow(source, sink);
+            solver.getMaximumFlow(source, sink);
         }
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/graph/GraphPerformanceTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/graph/GraphPerformanceTest.java
@@ -136,7 +136,7 @@ public class GraphPerformanceTest extends TestCase{
 
         private double calculateMaxFlow(SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph, Integer source, Integer sink){
             EdmondsKarpMFImpl<Integer, DefaultWeightedEdge> maximumFlowAlg= new EdmondsKarpMFImpl<>(graph);
-            return maximumFlowAlg.buildMaximumFlow(source, sink).getValue();
+            return maximumFlowAlg.getMaximumFlow(source, sink).getValue();
         }
 
         private boolean isStronglyConnected(SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph){


### PR DESCRIPTION
To improve consistency within the algorithm interfaces, I propose to rename 2 functions within the flow interface:

1. buildMaximumFlow -> getMaximumFlow. This function, as the name now suggests, returns a MaximumFlow object
2. getMaximumFlow -> getFlowMap. This function returns a Map with flow values for each edge.

Unfortunately this change violates backward compatibility, as the flow interface was introduced in the previous release. Three solutions:

1. We accept this one-time change since the flow interface was introduced only a few months ago.
2. We ignore the change and accept the inconsistency.
3. We change the naming over the next 2 versions (making the names deprecated in the first, and changing them in the second).