### PR TITLE
Refactored test classes to use generics

### DIFF
--- a/jgrapht-core/src/test/java/org/jgrapht/alg/BellmanFordShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/BellmanFordShortestPathTest.java
@@ -100,7 +100,7 @@ public class BellmanFordShortestPathTest
     }
 
     @Override
-    protected List findPathBetween(
+    protected List<DefaultWeightedEdge> findPathBetween(
         Graph<String, DefaultWeightedEdge> g,
         String src,
         String dest)
@@ -112,7 +112,7 @@ public class BellmanFordShortestPathTest
     {
         Graph<String, DefaultWeightedEdge> g = createWithBias(true);
 
-        List path;
+        List<DefaultWeightedEdge> path;
 
         path = findPathBetween(g, V1, V4);
         assertEquals(Arrays.asList(

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/BiconnectedGraph.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/BiconnectedGraph.java
@@ -42,9 +42,8 @@ import org.jgrapht.graph.*;
  * @author Guillaume Boulmier
  * @since July 5, 2007
  */
-@SuppressWarnings("unchecked")
 public class BiconnectedGraph
-    extends SimpleGraph
+    extends SimpleGraph<String, DefaultEdge>
 {
     //~ Static fields/initializers ---------------------------------------------
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/BiconnectivityInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/BiconnectivityInspectorTest.java
@@ -46,7 +46,6 @@ import org.jgrapht.graph.*;
  * @author Guillaume Boulmier
  * @since July 5, 2007
  */
-@SuppressWarnings("unchecked")
 public class BiconnectivityInspectorTest
     extends TestCase
 {
@@ -56,7 +55,8 @@ public class BiconnectivityInspectorTest
     {
         BiconnectedGraph graph = new BiconnectedGraph();
 
-        BiconnectivityInspector inspector = new BiconnectivityInspector(graph);
+        BiconnectivityInspector<String, DefaultEdge> inspector =
+            new BiconnectivityInspector<>(graph);
 
         assertTrue(inspector.isBiconnected());
         assertEquals(0, inspector.getCutpoints().size());
@@ -71,16 +71,18 @@ public class BiconnectivityInspectorTest
 
     public void testLinearGraph(int nbVertices)
     {
-        UndirectedGraph graph = new SimpleGraph(DefaultEdge.class);
+        UndirectedGraph<Object, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
 
-        LinearGraphGenerator generator = new LinearGraphGenerator(nbVertices);
+        LinearGraphGenerator<Object, DefaultEdge> generator =
+            new LinearGraphGenerator<>(nbVertices);
         generator.generateGraph(
             graph,
                 new ClassBasedVertexFactory<>(
                         Object.class),
             null);
 
-        BiconnectivityInspector inspector = new BiconnectivityInspector(graph);
+        BiconnectivityInspector<Object, DefaultEdge> inspector =
+            new BiconnectivityInspector<>(graph);
 
         assertEquals(nbVertices - 2, inspector.getCutpoints().size());
         assertEquals(
@@ -92,7 +94,8 @@ public class BiconnectivityInspectorTest
     {
         NotBiconnectedGraph graph = new NotBiconnectedGraph();
 
-        BiconnectivityInspector inspector = new BiconnectivityInspector(graph);
+        BiconnectivityInspector<String, DefaultEdge> inspector =
+            new BiconnectivityInspector<>(graph);
 
         assertEquals(2, inspector.getCutpoints().size());
         assertEquals(3, inspector.getBiconnectedVertexComponents().size());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/BlockCutpointGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/BlockCutpointGraphTest.java
@@ -47,7 +47,6 @@ import org.jgrapht.graph.SimpleGraph;
  * @author Guillaume Boulmier
  * @since July 5, 2007
  */
-@SuppressWarnings("unchecked")
 public class BlockCutpointGraphTest
     extends TestCase
 {
@@ -57,7 +56,8 @@ public class BlockCutpointGraphTest
     {
         BiconnectedGraph graph = new BiconnectedGraph();
 
-        BlockCutpointGraph blockCutpointGraph = new BlockCutpointGraph(graph);
+        BlockCutpointGraph<String, DefaultEdge> blockCutpointGraph =
+            new BlockCutpointGraph<>(graph);
         testGetBlock(blockCutpointGraph);
 
         assertEquals(0, blockCutpointGraph.getCutpoints().size());
@@ -67,22 +67,19 @@ public class BlockCutpointGraphTest
         assertEquals(1, nbBiconnectedComponents);
     }
 
-    public void testGetBlock(BlockCutpointGraph blockCutpointGraph)
+    public <V> void testGetBlock(BlockCutpointGraph<V, DefaultEdge> blockCutpointGraph)
     {
-        for (Object o : blockCutpointGraph.vertexSet()) {
-            UndirectedGraph component = (UndirectedGraph) o;
+        for (UndirectedGraph<V, DefaultEdge> component : blockCutpointGraph.vertexSet()) {
             if (!component.edgeSet().isEmpty()) {
-                for (Object vertex : component.vertexSet()) {
+                for (V vertex : component.vertexSet()) {
                     if (!blockCutpointGraph.getCutpoints().contains(vertex)) {
-                        assertEquals(
-                                component,
-                                blockCutpointGraph.getBlock(vertex));
+                        assertEquals(component, blockCutpointGraph.getBlock(vertex));
                     }
                 }
             } else {
                 assertTrue(
-                        blockCutpointGraph.getCutpoints().contains(
-                                component.vertexSet().iterator().next()));
+                    blockCutpointGraph
+                        .getCutpoints().contains(component.vertexSet().iterator().next()));
             }
         }
     }
@@ -95,16 +92,17 @@ public class BlockCutpointGraphTest
 
     public void testLinearGraph(int nbVertices)
     {
-        UndirectedGraph graph = new SimpleGraph(DefaultEdge.class);
+        UndirectedGraph<Object, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
 
-        LinearGraphGenerator generator = new LinearGraphGenerator(nbVertices);
+        LinearGraphGenerator<Object, DefaultEdge> generator =
+            new LinearGraphGenerator<>(nbVertices);
         generator.generateGraph(
             graph,
                 new ClassBasedVertexFactory<>(
                         Object.class),
             null);
 
-        BlockCutpointGraph blockCutpointGraph = new BlockCutpointGraph(graph);
+        BlockCutpointGraph<Object, DefaultEdge> blockCutpointGraph = new BlockCutpointGraph<>(graph);
         testGetBlock(blockCutpointGraph);
 
         assertEquals(nbVertices - 2, blockCutpointGraph.getCutpoints().size());
@@ -116,9 +114,10 @@ public class BlockCutpointGraphTest
 
     public void testNotBiconnected()
     {
-        UndirectedGraph graph = new NotBiconnectedGraph();
+        UndirectedGraph<String, DefaultEdge> graph = new NotBiconnectedGraph();
 
-        BlockCutpointGraph blockCutpointGraph = new BlockCutpointGraph(graph);
+        BlockCutpointGraph<String, DefaultEdge> blockCutpointGraph =
+            new BlockCutpointGraph<>(graph);
         testGetBlock(blockCutpointGraph);
 
         assertEquals(2, blockCutpointGraph.getCutpoints().size());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/CycleDetectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/CycleDetectorTest.java
@@ -174,7 +174,7 @@ public class CycleDetectorTest
         CycleDetector<String, DefaultEdge> detector =
                 new CycleDetector<>(g);
 
-        Set emptySet = Collections.EMPTY_SET;
+        Set<String> emptySet = Collections.emptySet();
 
         assertEquals(!cyclicSet.isEmpty(), detector.detectCycles());
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/DijkstraShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/DijkstraShortestPathTest.java
@@ -88,7 +88,7 @@ public class DijkstraShortestPathTest
     }
 
     @Override
-    protected List findPathBetween(
+    protected List<DefaultWeightedEdge> findPathBetween(
         Graph<String, DefaultWeightedEdge> g,
         String src,
         String dest)

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/FloydWarshallShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/FloydWarshallShortestPathsTest.java
@@ -115,7 +115,7 @@ public class FloydWarshallShortestPathsTest
                     GraphPath<Integer, DefaultWeightedEdge> path=fw.getShortestPath(v1, v2);
                     if(path != null) {
                         this.verifyPath(undirected, path, fw.shortestDistance(v1, v2));
-                        List<Integer> vertexPath=Graphs.getPathVertexList(path);
+                        List<Integer> vertexPath= path.getVertexList();
                         assertEquals(fw.getFirstHop(v1, v2), vertexPath.get(1));
                         assertEquals(fw.getLastHop(v1, v2), vertexPath.get(vertexPath.size()-2));
                     }
@@ -224,7 +224,7 @@ public class FloydWarshallShortestPathsTest
         assertEquals(5.0, path.getWeight());
         assertEquals(weighted, path.getGraph());
         assertNull(fw.getShortestPath("b", "a"));
-        List<String> vertexPath=Graphs.getPathVertexList(path);
+        List<String> vertexPath=path.getVertexList();
         assertEquals(fw.getFirstHop("a", "b"), vertexPath.get(1));
         assertEquals(fw.getLastHop("a", "b"), vertexPath.get(vertexPath.size()-2));
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KSPDiscardsValidPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KSPDiscardsValidPathsTest.java
@@ -40,7 +40,6 @@ import junit.framework.*;
 import org.jgrapht.graph.*;
 
 
-@SuppressWarnings("unchecked")
 public class KSPDiscardsValidPathsTest
     extends TestCase
 {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KSPExampleGraph.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KSPExampleGraph.java
@@ -41,9 +41,8 @@ import org.jgrapht.graph.*;
 /**
  * <img src="./KSPExample.png">
  */
-@SuppressWarnings("unchecked")
 public class KSPExampleGraph
-    extends SimpleWeightedGraph
+    extends SimpleWeightedGraph<String, DefaultWeightedEdge>
 {
     //~ Static fields/initializers ---------------------------------------------
 
@@ -53,21 +52,21 @@ public class KSPExampleGraph
 
     //~ Instance fields --------------------------------------------------------
 
-    public Object edgeAD;
+    public DefaultWeightedEdge edgeAD;
 
-    public Object edgeBT;
+    public DefaultWeightedEdge edgeBT;
 
-    public Object edgeCB;
+    public DefaultWeightedEdge edgeCB;
 
-    public Object edgeCT;
+    public DefaultWeightedEdge edgeCT;
 
-    public Object edgeDE;
+    public DefaultWeightedEdge edgeDE;
 
-    public Object edgeEC;
+    public DefaultWeightedEdge edgeEC;
 
-    public Object edgeSA;
+    public DefaultWeightedEdge edgeSA;
 
-    public Object edgeST;
+    public DefaultWeightedEdge edgeST;
 
     //~ Constructors -----------------------------------------------------------
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KSPExampleTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KSPExampleTest.java
@@ -40,7 +40,6 @@ import junit.framework.*;
 import org.jgrapht.graph.*;
 
 
-@SuppressWarnings("unchecked")
 public class KSPExampleTest
     extends TestCase
 {
@@ -48,36 +47,39 @@ public class KSPExampleTest
 
     public void testFourReturnedPathsJGraphT()
     {
-        SimpleWeightedGraph graph = new KSPExampleGraph();
+        SimpleWeightedGraph<String, DefaultWeightedEdge> graph = new KSPExampleGraph();
 
-        Object sourceVertex = "S";
-        KShortestPaths ksp = new KShortestPaths(graph, sourceVertex, 4);
+        String sourceVertex = "S";
+        KShortestPaths<String, DefaultWeightedEdge> ksp =
+            new KShortestPaths<>(graph, sourceVertex, 4);
 
-        Object targetVertex = "T";
+        String targetVertex = "T";
         assertEquals(3, ksp.getPaths(targetVertex).size());
     }
 
     public void testThreeReturnedPathsJGraphT()
     {
-        SimpleWeightedGraph graph = new KSPExampleGraph();
+        SimpleWeightedGraph<String, DefaultWeightedEdge> graph = new KSPExampleGraph();
 
-        Object sourceVertex = "S";
+        String sourceVertex = "S";
         int nbPaths = 3;
-        KShortestPaths ksp = new KShortestPaths(graph, sourceVertex, nbPaths);
+        KShortestPaths<String, DefaultWeightedEdge> ksp =
+            new KShortestPaths<>(graph, sourceVertex, nbPaths);
 
-        Object targetVertex = "T";
+        String targetVertex = "T";
         assertEquals(nbPaths, ksp.getPaths(targetVertex).size());
     }
 
     public void testTwoReturnedPathsJGraphT()
     {
-        SimpleWeightedGraph graph = new KSPExampleGraph();
+        SimpleWeightedGraph<String, DefaultWeightedEdge> graph = new KSPExampleGraph();
 
-        Object sourceVertex = "S";
+        String sourceVertex = "S";
         int nbPaths = 2;
-        KShortestPaths ksp = new KShortestPaths(graph, sourceVertex, nbPaths);
+        KShortestPaths<String, DefaultWeightedEdge> ksp =
+            new KShortestPaths<>(graph, sourceVertex, nbPaths);
 
-        Object targetVertex = "T";
+        String targetVertex = "T";
         assertEquals(nbPaths, ksp.getPaths(targetVertex).size());
     }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathCompleteGraph4.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathCompleteGraph4.java
@@ -42,9 +42,8 @@ import org.jgrapht.graph.*;
  * @author Guillaume Boulmier
  * @since July 5, 2007
  */
-@SuppressWarnings("unchecked")
 public class KShortestPathCompleteGraph4
-    extends SimpleWeightedGraph
+    extends SimpleWeightedGraph<String, DefaultWeightedEdge>
 {
     //~ Static fields/initializers ---------------------------------------------
 
@@ -54,17 +53,17 @@ public class KShortestPathCompleteGraph4
 
     //~ Instance fields --------------------------------------------------------
 
-    public Object e12;
+    public DefaultWeightedEdge e12;
 
-    public Object e13;
+    public DefaultWeightedEdge e13;
 
-    public Object e23;
+    public DefaultWeightedEdge e23;
 
-    public Object eS1;
+    public DefaultWeightedEdge eS1;
 
-    public Object eS2;
+    public DefaultWeightedEdge eS2;
 
-    public Object eS3;
+    public DefaultWeightedEdge eS3;
 
     //~ Constructors -----------------------------------------------------------
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathCompleteGraph5.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathCompleteGraph5.java
@@ -42,9 +42,8 @@ import org.jgrapht.graph.*;
  * @author Guillaume Boulmier
  * @since July 5, 2007
  */
-@SuppressWarnings("unchecked")
 public class KShortestPathCompleteGraph5
-    extends SimpleWeightedGraph
+    extends SimpleWeightedGraph<String, DefaultWeightedEdge>
 {
     //~ Static fields/initializers ---------------------------------------------
 
@@ -54,25 +53,25 @@ public class KShortestPathCompleteGraph5
 
     //~ Instance fields --------------------------------------------------------
 
-    public Object e12;
+    public DefaultWeightedEdge e12;
 
-    public Object e13;
+    public DefaultWeightedEdge e13;
 
-    public Object e14;
+    public DefaultWeightedEdge e14;
 
-    public Object e23;
+    public DefaultWeightedEdge e23;
 
-    public Object e24;
+    public DefaultWeightedEdge e24;
 
-    public Object e34;
+    public DefaultWeightedEdge e34;
 
-    public Object eS1;
+    public DefaultWeightedEdge eS1;
 
-    public Object eS2;
+    public DefaultWeightedEdge eS2;
 
-    public Object eS3;
+    public DefaultWeightedEdge eS3;
 
-    public Object eS4;
+    public DefaultWeightedEdge eS4;
 
     //~ Constructors -----------------------------------------------------------
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathCompleteGraph6.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathCompleteGraph6.java
@@ -42,9 +42,8 @@ import org.jgrapht.graph.*;
  * @author Guillaume Boulmier
  * @since July 5, 2007
  */
-@SuppressWarnings("unchecked")
 public class KShortestPathCompleteGraph6
-    extends SimpleWeightedGraph
+    extends SimpleWeightedGraph<String, DefaultWeightedEdge>
 {
     //~ Static fields/initializers ---------------------------------------------
 
@@ -54,35 +53,35 @@ public class KShortestPathCompleteGraph6
 
     //~ Instance fields --------------------------------------------------------
 
-    public Object e12;
+    public DefaultWeightedEdge e12;
 
-    public Object e13;
+    public DefaultWeightedEdge e13;
 
-    public Object e14;
+    public DefaultWeightedEdge e14;
 
-    public Object e23;
+    public DefaultWeightedEdge e23;
 
-    public Object e24;
+    public DefaultWeightedEdge e24;
 
-    public Object e34;
+    public DefaultWeightedEdge e34;
 
-    public Object eS1;
+    public DefaultWeightedEdge eS1;
 
-    public Object eS2;
+    public DefaultWeightedEdge eS2;
 
-    public Object eS3;
+    public DefaultWeightedEdge eS3;
 
-    public Object eS4;
+    public DefaultWeightedEdge eS4;
 
-    private Object e15;
+    private DefaultWeightedEdge e15;
 
-    private Object e25;
+    private DefaultWeightedEdge e25;
 
-    private Object e35;
+    private DefaultWeightedEdge e35;
 
-    private Object e45;
+    private DefaultWeightedEdge e45;
 
-    private Object eS5;
+    private DefaultWeightedEdge eS5;
 
     //~ Constructors -----------------------------------------------------------
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathCostTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathCostTest.java
@@ -49,7 +49,6 @@ import org.jgrapht.graph.*;
  * @author Guillaume Boulmier
  * @since July 5, 2007
  */
-@SuppressWarnings("unchecked")
 public class KShortestPathCostTest
     extends TestCase
 {
@@ -61,8 +60,9 @@ public class KShortestPathCostTest
 
         KShortestPathCompleteGraph4 graph = new KShortestPathCompleteGraph4();
 
-        KShortestPaths pathFinder = new KShortestPaths(graph, "vS", nbPaths);
-        List pathElements = pathFinder.getPaths("v3");
+        KShortestPaths<String, DefaultWeightedEdge> pathFinder =
+            new KShortestPaths<>(graph, "vS", nbPaths);
+        List<GraphPath<String, DefaultWeightedEdge>> pathElements = pathFinder.getPaths("v3");
 
         assertEquals(
             "[[(vS : v1), (v1 : v3)], [(vS : v2), (v2 : v3)],"
@@ -71,7 +71,7 @@ public class KShortestPathCostTest
             pathElements.toString());
 
         assertEquals(5, pathElements.size(), 0);
-        GraphPath pathElement = (GraphPath) pathElements.get(0);
+        GraphPath<String, DefaultWeightedEdge> pathElement = pathElements.get(0);
         assertEquals(2, pathElement.getWeight(), 0);
 
         assertEquals(
@@ -85,14 +85,14 @@ public class KShortestPathCostTest
 
         int maxSize = 10;
 
-        KShortestPaths pathFinder =
-            new KShortestPaths(picture1Graph, "vS",
+        KShortestPaths<String, DefaultWeightedEdge> pathFinder =
+            new KShortestPaths<>(picture1Graph, "vS",
                 maxSize);
 
         //      assertEquals(2, pathFinder.getPaths("v5").size());
 
-        List pathElements = pathFinder.getPaths("v5");
-        GraphPath pathElement = (GraphPath) pathElements.get(0);
+        List<GraphPath<String, DefaultWeightedEdge>> pathElements = pathFinder.getPaths("v5");
+        GraphPath<String, DefaultWeightedEdge> pathElement = pathElements.get(0);
         assertEquals(
             Arrays.asList(
                 new Object[] {
@@ -101,12 +101,12 @@ public class KShortestPathCostTest
                 }),
             pathElement.getEdgeList());
 
-        List vertices = pathElement.getVertexList();
+        List<String> vertices = pathElement.getVertexList();
         assertEquals(
             Arrays.asList(new Object[] { "vS", "v1", "v5" }),
             vertices);
 
-        pathElement = (GraphPath) pathElements.get(1);
+        pathElement = pathElements.get(1);
         assertEquals(
             Arrays.asList(
                 new Object[] {
@@ -121,10 +121,10 @@ public class KShortestPathCostTest
             vertices);
 
         pathElements = pathFinder.getPaths("v7");
-        pathElement = (GraphPath) pathElements.get(0);
+        pathElement = pathElements.get(0);
         double lastCost = pathElement.getWeight();
         for (int i = 0; i < pathElements.size(); i++) {
-            pathElement = (GraphPath) pathElements.get(i);
+            pathElement = pathElements.get(i);
             double cost = pathElement.getWeight();
 
             assertTrue(lastCost <= cost);
@@ -186,27 +186,28 @@ public class KShortestPathCostTest
         verifyShortestPathsWeightsWithMaxSizeIncreases(picture1Graph);
     }
 
-    private void verifyShortestPathsInIncreasingOrderOfWeight(Graph graph)
+    private <E extends DefaultEdge> void verifyShortestPathsInIncreasingOrderOfWeight(
+        Graph<String, E> graph)
     {
         int maxSize = 20;
 
-        for (Object sourceVertex : graph.vertexSet()) {
-            for (Object targetVertex : graph.vertexSet()) {
+        for (String sourceVertex : graph.vertexSet()) {
+            for (String targetVertex : graph.vertexSet()) {
                 if (targetVertex != sourceVertex) {
-                    KShortestPaths pathFinder =
-                            new KShortestPaths(graph,
+                    KShortestPaths<String, E> pathFinder =
+                            new KShortestPaths<>(graph,
                                     sourceVertex, maxSize);
 
-                    List pathElements = pathFinder.getPaths(targetVertex);
+                    List<GraphPath<String, E>> pathElements = pathFinder.getPaths(targetVertex);
                     if (pathElements == null) {
                         // no path exists between the start vertex and the end
                         // vertex
                         continue;
                     }
-                    GraphPath pathElement = (GraphPath) pathElements.get(0);
+                    GraphPath<String, E> pathElement = pathElements.get(0);
                     double lastWeight = pathElement.getWeight();
                     for (int i = 0; i < pathElements.size(); i++) {
-                        pathElement = (GraphPath) pathElements.get(i);
+                        pathElement = pathElements.get(i);
                         double weight = pathElement.getWeight();
                         assertTrue(lastWeight <= weight);
                         lastWeight = weight;
@@ -217,17 +218,18 @@ public class KShortestPathCostTest
         }
     }
 
-    private void verifyShortestPathsWeightsWithMaxSizeIncreases(Graph graph)
+    private <E extends DefaultEdge> void verifyShortestPathsWeightsWithMaxSizeIncreases(
+        Graph<String, E> graph)
     {
         int maxSizeLimit = 10;
 
-        for (Object sourceVertex : graph.vertexSet()) {
-            for (Object targetVertex : graph.vertexSet()) {
+        for (String sourceVertex : graph.vertexSet()) {
+            for (String targetVertex : graph.vertexSet()) {
                 if (targetVertex != sourceVertex) {
-                    KShortestPaths pathFinder =
-                            new KShortestPaths(graph,
+                    KShortestPaths<String, E> pathFinder =
+                            new KShortestPaths<>(graph,
                                     sourceVertex, 1);
-                    List<GraphPath> prevPathElementsResults =
+                    List<GraphPath<String, E>> prevPathElementsResults =
                             pathFinder.getPaths(targetVertex);
 
                     if (prevPathElementsResults == null) {
@@ -238,9 +240,9 @@ public class KShortestPathCostTest
 
                     for (int maxSize = 2; maxSize < maxSizeLimit; maxSize++) {
                         pathFinder =
-                                new KShortestPaths(graph, sourceVertex,
+                                new KShortestPaths<>(graph, sourceVertex,
                                         maxSize);
-                        List<GraphPath> pathElementsResults =
+                        List<GraphPath<String, E>> pathElementsResults =
                                 pathFinder.getPaths(targetVertex);
 
                         verifyWeightsConsistency(
@@ -261,14 +263,14 @@ public class KShortestPathCostTest
      * @param pathElementsResults results obtained with a max-size argument
      * equal to <code>k+1</code>
      */
-    private void verifyWeightsConsistency(
-        List<GraphPath> prevPathElementsResults,
-        List<GraphPath> pathElementsResults)
+    private <E> void verifyWeightsConsistency(
+        List<GraphPath<String, E>> prevPathElementsResults,
+        List<GraphPath<String, E>> pathElementsResults)
     {
         for (int i = 0; i < prevPathElementsResults.size(); i++) {
-            GraphPath pathElementResult =
+            GraphPath<String, E> pathElementResult =
                     pathElementsResults.get(i);
-            GraphPath prevPathElementResult =
+            GraphPath<String, E> prevPathElementResult =
                     prevPathElementsResults.get(i);
             assertTrue(
                 pathElementResult.getWeight()

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathKValuesTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KShortestPathKValuesTest.java
@@ -38,6 +38,7 @@ package org.jgrapht.alg;
 
 import junit.framework.TestCase;
 import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.util.MathUtil;
 
 
@@ -45,7 +46,6 @@ import org.jgrapht.util.MathUtil;
  * @author Guillaume Boulmier
  * @since July 5, 2007
  */
-@SuppressWarnings("unchecked")
 public class KShortestPathKValuesTest
     extends TestCase
 {
@@ -75,7 +75,8 @@ public class KShortestPathKValuesTest
             maxSize <= calculateNbElementaryPathsForCompleteGraph(6);
             maxSize++)
         {
-            KShortestPaths finder = new KShortestPaths(graph, "vS", maxSize);
+            KShortestPaths<String, DefaultWeightedEdge> finder =
+                new KShortestPaths<>(graph, "vS", maxSize);
 
             assertEquals(finder.getPaths("v1").size(), maxSize);
             assertEquals(finder.getPaths("v2").size(), maxSize);
@@ -117,18 +118,18 @@ public class KShortestPathKValuesTest
         return nbPaths;
     }
 
-    private void verifyNbPathsForAllPairsOfVertices(Graph graph)
+    private void verifyNbPathsForAllPairsOfVertices(Graph<String, DefaultWeightedEdge> graph)
     {
         long nbPaths =
             calculateNbElementaryPathsForCompleteGraph(
                 graph.vertexSet().size());
         int maxSize = Integer.MAX_VALUE;
 
-        for (Object sourceVertex : graph.vertexSet()) {
-            KShortestPaths finder =
-                    new KShortestPaths(graph, sourceVertex,
+        for (String sourceVertex : graph.vertexSet()) {
+            KShortestPaths<String, DefaultWeightedEdge> finder =
+                    new KShortestPaths<>(graph, sourceVertex,
                             maxSize);
-            for (Object targetVertex : graph.vertexSet()) {
+            for (String targetVertex : graph.vertexSet()) {
                 if (targetVertex != sourceVertex) {
                     assertEquals(finder.getPaths(targetVertex).size(), nbPaths);
                 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KuhnMunkresMinimalWeightBipartitePerfectMatchingTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KuhnMunkresMinimalWeightBipartitePerfectMatchingTest.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 
 
-@SuppressWarnings("unchecked")
 public class KuhnMunkresMinimalWeightBipartitePerfectMatchingTest extends TestCase {
 
     interface V {}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/MinimumSpanningTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/MinimumSpanningTreeTest.java
@@ -63,11 +63,8 @@ public class MinimumSpanningTreeTest
 
     private DefaultWeightedEdge AB;
     private DefaultWeightedEdge AC;
-    private DefaultWeightedEdge AE;
     private DefaultWeightedEdge BD;
-    private DefaultWeightedEdge CD;
     private DefaultWeightedEdge DE;
-    private DefaultWeightedEdge EF;
     private DefaultWeightedEdge EG;
     private DefaultWeightedEdge GH;
     private DefaultWeightedEdge FH;
@@ -129,8 +126,8 @@ public class MinimumSpanningTreeTest
             final Collection<E> edgeSet,
             final double weight) {
 
-        assertEquals(weight, mst.getSpanningTreeCost());
-        assertTrue(mst.getEdgeSet().containsAll(edgeSet));
+        assertEquals(weight, mst.getMinimumSpanningTreeTotalWeight());
+        assertTrue(mst.getMinimumSpanningTreeEdgeSet().containsAll(edgeSet));
 
     }
 
@@ -155,14 +152,14 @@ public class MinimumSpanningTreeTest
         AB = Graphs.addEdge(g, A, B, 5);
         AC = Graphs.addEdge(g, A, C, 10);
         BD = Graphs.addEdge(g, B, D, 15);
-        CD = Graphs.addEdge(g, C, D, 20);
+        Graphs.addEdge(g, C, D, 20);
 
         g.addVertex(E);
         g.addVertex(F);
         g.addVertex(G);
         g.addVertex(H);
 
-        EF = Graphs.addEdge(g, E, F, 20);
+        Graphs.addEdge(g, E, F, 20);
         EG = Graphs.addEdge(g, E, G, 15);
         GH = Graphs.addEdge(g, G, H, 10);
         FH = Graphs.addEdge(g, F, H, 5);
@@ -186,9 +183,9 @@ public class MinimumSpanningTreeTest
         AB = Graphs.addEdge(g, A, B, bias * 2);
         AC = Graphs.addEdge(g, A, C, bias * 3);
         BD = Graphs.addEdge(g, B, D, bias * 5);
-        CD = Graphs.addEdge(g, C, D, bias * 20);
+        Graphs.addEdge(g, C, D, bias * 20);
         DE = Graphs.addEdge(g, D, E, bias * 5);
-        AE = Graphs.addEdge(g, A, E, bias * 100);
+        Graphs.addEdge(g, A, E, bias * 100);
 
         return g;
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/NeighborIndexTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/NeighborIndexTest.java
@@ -75,7 +75,7 @@ public class NeighborIndexTest
                 new NeighborIndex<>(g);
         g.addGraphListener(index);
 
-        Set neighbors1 = index.neighborsOf(V1);
+        Set<String> neighbors1 = index.neighborsOf(V1);
 
         assertEquals(1, neighbors1.size());
         assertEquals(true, neighbors1.contains(V2));
@@ -83,7 +83,7 @@ public class NeighborIndexTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
-        Set neighbors3 = index.neighborsOf(V3);
+        Set<String> neighbors3 = index.neighborsOf(V3);
 
         assertEquals(2, neighbors1.size());
         assertEquals(true, neighbors1.contains(V3));
@@ -117,8 +117,8 @@ public class NeighborIndexTest
                 new DirectedNeighborIndex<>(g);
         g.addGraphListener(index);
 
-        Set p = index.predecessorsOf(V1);
-        Set s = index.successorsOf(V1);
+        Set<String> p = index.predecessorsOf(V1);
+        Set<String> s = index.successorsOf(V1);
 
         assertEquals(0, p.size());
         assertEquals(1, s.size());
@@ -127,7 +127,7 @@ public class NeighborIndexTest
         g.addVertex(V3);
         g.addEdge(V3, V1);
 
-        Set q = index.successorsOf(V3);
+        Set<String> q = index.successorsOf(V3);
 
         assertEquals(1, p.size());
         assertEquals(1, s.size());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/NotBiconnectedGraph.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/NotBiconnectedGraph.java
@@ -42,9 +42,8 @@ import org.jgrapht.graph.*;
  * @author Guillaume Boulmier
  * @since July 5, 2007
  */
-@SuppressWarnings("unchecked")
 public class NotBiconnectedGraph
-    extends SimpleGraph
+    extends SimpleGraph<String, DefaultEdge>
 {
     //~ Static fields/initializers ---------------------------------------------
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/Picture1Graph.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/Picture1Graph.java
@@ -44,9 +44,8 @@ import org.jgrapht.graph.*;
  * @author Guillaume Boulmier
  * @since July 5, 2007
  */
-@SuppressWarnings("unchecked")
 public class Picture1Graph
-    extends SimpleDirectedWeightedGraph
+    extends SimpleDirectedWeightedGraph<String, DefaultWeightedEdge>
 {
     //~ Static fields/initializers ---------------------------------------------
 
@@ -56,31 +55,31 @@ public class Picture1Graph
 
     //~ Instance fields --------------------------------------------------------
 
-    public Object e15;
+    public DefaultWeightedEdge e15;
 
-    public Object e25;
+    public DefaultWeightedEdge e25;
 
-    public Object e27;
+    public DefaultWeightedEdge e27;
 
-    public Object e37;
+    public DefaultWeightedEdge e37;
 
-    public Object e47;
+    public DefaultWeightedEdge e47;
 
-    public Object e56;
+    public DefaultWeightedEdge e56;
 
-    public Object e57;
+    public DefaultWeightedEdge e57;
 
-    public Object e67;
+    public DefaultWeightedEdge e67;
 
-    public Object eS1;
+    public DefaultWeightedEdge eS1;
 
-    public Object eS2;
+    public DefaultWeightedEdge eS2;
 
-    public Object eS3;
+    public DefaultWeightedEdge eS3;
 
-    public Object eS4;
+    public DefaultWeightedEdge eS4;
 
-    public Object eS7;
+    public DefaultWeightedEdge eS7;
 
     //~ Constructors -----------------------------------------------------------
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/ShortestPathTestCase.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/ShortestPathTestCase.java
@@ -76,7 +76,7 @@ public abstract class ShortestPathTestCase
      */
     public void testPathBetween()
     {
-        List path;
+        List<DefaultWeightedEdge> path;
         Graph<String, DefaultWeightedEdge> g = create();
 
         path = findPathBetween(g, V1, V2);
@@ -106,7 +106,7 @@ public abstract class ShortestPathTestCase
                 }), path);
     }
 
-    protected abstract List findPathBetween(
+    protected abstract List<DefaultWeightedEdge> findPathBetween(
         Graph<String, DefaultWeightedEdge> g,
         String src,
         String dest);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/StrongConnectivityAlgorithmTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/StrongConnectivityAlgorithmTest.java
@@ -73,11 +73,11 @@ public class StrongConnectivityAlgorithmTest
 
     //
     public void testStrongConnectivityClasses(){
-        Class[] strongConnectivityAlgorithmClasses= {
+        Class<?>[] strongConnectivityAlgorithmClasses= {
                 GabowStrongConnectivityInspector.class,
                 KosarajuStrongConnectivityInspector.class
         };
-        for(Class strongConnectivityAlgorithm : strongConnectivityAlgorithmClasses){
+        for(Class<?> strongConnectivityAlgorithm : strongConnectivityAlgorithmClasses){
             this.testStronglyConnected1(strongConnectivityAlgorithm);
             this.testStronglyConnected2(strongConnectivityAlgorithm);
             this.testStronglyConnected3(strongConnectivityAlgorithm);
@@ -88,7 +88,7 @@ public class StrongConnectivityAlgorithmTest
     /**
      * .
      */
-    public void testStronglyConnected1(Class strongConnectivityAlgorithm)
+    public void testStronglyConnected1(Class<?> strongConnectivityAlgorithm)
     {
         DirectedGraph<String, DefaultEdge> g =
                 new DefaultDirectedGraph<>(
@@ -141,7 +141,7 @@ public class StrongConnectivityAlgorithmTest
     /**
      * .
      */
-    public void testStronglyConnected2(Class strongConnectivityAlgorithm)
+    public void testStronglyConnected2(Class<?> strongConnectivityAlgorithm)
     {
         DirectedGraph<String, DefaultEdge> g =
                 new DefaultDirectedGraph<>(
@@ -195,7 +195,7 @@ public class StrongConnectivityAlgorithmTest
     /**
      * .
      */
-    public void testStronglyConnected3(Class strongConnectivityAlgorithm)
+    public void testStronglyConnected3(Class<?> strongConnectivityAlgorithm)
     {
         DirectedGraph<String, DefaultEdge> g = new DefaultDirectedGraph<>(DefaultEdge.class);
         g.addVertex(V1);
@@ -244,7 +244,7 @@ public class StrongConnectivityAlgorithmTest
         assertEquals(expectedSets, actualSets);
     }
 
-    public void testStronglyConnected4(Class strongConnectivityAlgorithm)
+    public void testStronglyConnected4(Class<?> strongConnectivityAlgorithm)
     {
         DefaultDirectedGraph<Integer, String> graph =
                 new DefaultDirectedGraph<>(
@@ -271,7 +271,7 @@ public class StrongConnectivityAlgorithmTest
         assertEquals(expected, new HashSet<>(sc.stronglyConnectedSets()));
     }
 
-    private <V,E> StrongConnectivityAlgorithm<V,E> getStrongConnectivityInspector(DirectedGraph<V,E> graph, Class strongConnectivityAlgorithm){
+    private <V,E> StrongConnectivityAlgorithm<V,E> getStrongConnectivityInspector(DirectedGraph<V,E> graph, Class<?> strongConnectivityAlgorithm){
         if(strongConnectivityAlgorithm==GabowStrongConnectivityInspector.class)
             return new GabowStrongConnectivityInspector<>(graph);
         else if(strongConnectivityAlgorithm==KosarajuStrongConnectivityInspector.class)

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/MaximumFlowMinimumCutAlgorithmTestBase.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/MaximumFlowMinimumCutAlgorithmTestBase.java
@@ -37,14 +37,12 @@ package org.jgrapht.alg.flow;
 
 import junit.framework.TestCase;
 import org.jgrapht.*;
-import org.jgrapht.alg.interfaces.MaximumFlowAlgorithm;
 import org.jgrapht.generate.RandomGraphGenerator;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.DirectedWeightedMultigraph;
 import org.jgrapht.graph.SimpleDirectedWeightedGraph;
 import org.jgrapht.graph.SimpleWeightedGraph;
 
-import java.util.Map;
 import java.util.Random;
 
 public abstract class MaximumFlowMinimumCutAlgorithmTestBase extends TestCase {

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/AsWeightedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/AsWeightedGraphTest.java
@@ -164,7 +164,7 @@ public class AsWeightedGraphTest
         assertEquals(graph.getEdgeWeight(e2), 5.0);
 
         try {
-            double d = graphView.getEdgeWeight(null);
+            graphView.getEdgeWeight(null);
             // should not get here
             assertFalse();
         } catch (NullPointerException ex) {

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/MaskEdgeSetTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/MaskEdgeSetTest.java
@@ -34,8 +34,6 @@
  */
 package org.jgrapht.graph;
 
-import java.util.*;
-
 import org.jgrapht.*;
 
 

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/MaskVertexSetTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/MaskVertexSetTest.java
@@ -34,8 +34,6 @@
  */
 package org.jgrapht.graph;
 
-import java.util.*;
-
 import org.jgrapht.*;
 
 

--- a/jgrapht-core/src/test/java/org/jgrapht/util/PrefetchIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/PrefetchIteratorTest.java
@@ -46,10 +46,10 @@ public class PrefetchIteratorTest
 
     public void testIteratorInterface()
     {
-        Iterator iterator = new IterateFrom1To99();
+        Iterator<Integer> iterator = new IterateFrom1To99();
         for (int i = 1; i < 100; i++) {
             assertEquals(true, iterator.hasNext());
-            assertEquals(i, iterator.next());
+            assertEquals(i, iterator.next().intValue());
         }
         assertEquals(false, iterator.hasNext());
         Exception exceptionThrown = null;
@@ -63,10 +63,10 @@ public class PrefetchIteratorTest
 
     public void testEnumInterface()
     {
-        Enumeration enumuration = new IterateFrom1To99();
+        Enumeration<Integer> enumuration = new IterateFrom1To99();
         for (int i = 1; i < 100; i++) {
             assertEquals(true, enumuration.hasMoreElements());
-            assertEquals(i, enumuration.nextElement());
+            assertEquals(i, enumuration.nextElement().intValue());
         }
         assertEquals(false, enumuration.hasMoreElements());
         Exception exceptionThrown = null;
@@ -82,11 +82,11 @@ public class PrefetchIteratorTest
 
     // This test class supplies enumeration of integer from 1 till 100.
     public static class IterateFrom1To99
-        implements Enumeration,
-            Iterator
+        implements Enumeration<Integer>,
+            Iterator<Integer>
     {
         private int counter = 0;
-        private PrefetchIterator nextSupplier;
+        private PrefetchIterator<Integer> nextSupplier;
 
         public IterateFrom1To99()
         {
@@ -111,13 +111,13 @@ public class PrefetchIteratorTest
 
         // forwarding to nextSupplier and return its returned value
         @Override
-        public Object nextElement()
+        public Integer nextElement()
         {
             return this.nextSupplier.nextElement();
         }
 
         @Override
-        public Object next()
+        public Integer next()
         {
             return this.nextSupplier.next();
         }


### PR DESCRIPTION
Before the 1.0 release, a small refactoring pass of the core test package to use generics. 

Reduces the eclipse warnings from around 200 to around 75.