### PR TITLE
Small bug fix in MaximumFlowAlgorithmBase

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
@@ -139,6 +139,9 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
                 {
                     V v = directedGraph.getEdgeTarget(e);
                     VertexExtensionBase vx = vertexExtensionManager.getExtension(v);
+                    if (vx.prototype == null) { 
+                        vx.prototype = v;
+                    }
 
                     AnnotatedFlowEdge forwardEdge = createEdge(ux, vx, e, directedGraph.getEdgeWeight(e));
                     AnnotatedFlowEdge backwardEdge = createBackwardEdge(forwardEdge);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
@@ -129,19 +129,19 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
     {
         if(directed_graph) { //Directed graph
             DirectedGraph<V,E> directedGraph=(DirectedGraph<V,E>) network;
+            for (V v : directedGraph.vertexSet())
+            {
+                VertexExtensionBase vx = vertexExtensionManager.getExtension(v);
+                vx.prototype = v;
+            }
             for (V u : directedGraph.vertexSet())
             {
                 VertexExtensionBase ux = vertexExtensionManager.getExtension(u);
-
-                ux.prototype = u;
 
                 for (E e : directedGraph.outgoingEdgesOf(u))
                 {
                     V v = directedGraph.getEdgeTarget(e);
                     VertexExtensionBase vx = vertexExtensionManager.getExtension(v);
-                    if (vx.prototype == null) { 
-                        vx.prototype = v;
-                    }
 
                     AnnotatedFlowEdge forwardEdge = createEdge(ux, vx, e, directedGraph.getEdgeWeight(e));
                     AnnotatedFlowEdge backwardEdge = createBackwardEdge(forwardEdge);


### PR DESCRIPTION
A small bug fix.

Some vertices ended up with a null prototype vertex. This later on propagated into the construction of the backward edges of the network (if a reverse edge already existed in the input graph).