### PR TITLE
Counting label frequencies bug fix in PushRelabelMFImpl

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -37,9 +37,8 @@ package org.jgrapht.alg.flow;
 import java.util.*;
 
 import org.jgrapht.*;
-import org.jgrapht.alg.flow.MaximumFlowAlgorithmBase.VertexExtensionBase;
 import org.jgrapht.alg.util.*;
-import org.jgrapht.alg.util.extension.ExtensionFactory;
+import org.jgrapht.alg.util.extension.*;
 
 
 /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -37,6 +37,7 @@ package org.jgrapht.alg.flow;
 import java.util.*;
 
 import org.jgrapht.*;
+import org.jgrapht.alg.flow.MaximumFlowAlgorithmBase.VertexExtensionBase;
 import org.jgrapht.alg.util.*;
 import org.jgrapht.alg.util.extension.ExtensionFactory;
 
@@ -145,19 +146,24 @@ public class PushRelabelMFImpl<V, E>
 
                     vx.label = ux.label + 1;
                     q.add(vx);
-
-                    // NOTA BENE:
-                    //  This is part of label-pruning mechanic which
-                    //  targets to diminish all 'useless' relabels during
-                    //  "flow-back" phase of the algorithm pushing excess
-                    //  flow back to the source
-
-                    if (!labeling.containsKey(vx.label)) {
-                        labeling.put(vx.label, 1);
-                    } else {
-                        labeling.put(vx.label, labeling.get(vx.label) + 1);
-                    }
                 }
+            }
+        }
+        
+        // NOTA BENE:
+        //  count label frequencies
+        //
+        //  This is part of label-pruning mechanic which
+        //  targets to diminish all 'useless' relabels during
+        //  "flow-back" phase of the algorithm pushing excess
+        //  flow back to the source
+        for (V v : network.vertexSet())
+        {
+            VertexExtension vx = getVertexExtension(v);
+            if (!labeling.containsKey(vx.label)) {
+                labeling.put(vx.label, 1);
+            } else {
+                labeling.put(vx.label, labeling.get(vx.label) + 1);
             }
         }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMinimumSTCutTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMinimumSTCutTest.java
@@ -81,6 +81,20 @@ public class PushRelabelMinimumSTCutTest extends MinimumSourceSinkCutTest{
         assertEquals(0d, cutWeight);
     }
     
+    public void testDisconnected()
+    {
+        SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> network =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        network.addVertex(0);
+        network.addVertex(1);
+        network.addVertex(2);
+        network.setEdgeWeight(network.addEdge(0, 1), 1.0);
+
+        MinimumSTCutAlgorithm<Integer, DefaultWeightedEdge> prSolver = this.createSolver(network);
+        double cutWeight = prSolver.calculateMinCut(0, 2);
+        assertEquals(0d, cutWeight);
+    }
+    
     public void testRandomDirectedGraphs(){
         for(int test=0; test<NR_RANDOM_TESTS; test++){
             DirectedGraph<Integer, DefaultWeightedEdge> network=generateDirectedGraph();

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMinimumSTCutTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMinimumSTCutTest.java
@@ -55,32 +55,30 @@ public class PushRelabelMinimumSTCutTest extends MinimumSourceSinkCutTest{
         return new PushRelabelMFImpl<>(network);
     }
 
-    public void testSmall() { 
-        int n = 6;
-        int m = 10;
-        int seed = 4;
-        RandomGraphGenerator<Integer, DefaultWeightedEdge> randomGraphGenerator = new RandomGraphGenerator<>(n, m, seed);
-        Random rand = new Random(seed);
+    public void testSmall()
+    {
         SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> network =
             new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
-        randomGraphGenerator.generateGraph(network, new IntegerVertexFactory(), null);
-        network
-            .edgeSet().stream().forEach(e -> network.setEdgeWeight(e, rand.nextInt(100)));
-        
-        int source=0;
-        int sink=5;
+        network.addVertex(0);
+        network.addVertex(1);
+        network.addVertex(2);
+        network.addVertex(3);
+        network.addVertex(4);
+        network.addVertex(5);
+        network.setEdgeWeight(network.addEdge(2, 4), 62.0);
+        network.setEdgeWeight(network.addEdge(3, 4), 52.0);
+        network.setEdgeWeight(network.addEdge(1, 4), 3.0);
+        network.setEdgeWeight(network.addEdge(0, 1), 58.0);
+        network.setEdgeWeight(network.addEdge(2, 0), 67.0);
+        network.setEdgeWeight(network.addEdge(1, 0), 5.0);
+        network.setEdgeWeight(network.addEdge(4, 0), 11.0);
+        network.setEdgeWeight(network.addEdge(4, 1), 46.0);
+        network.setEdgeWeight(network.addEdge(1, 3), 62.0);
+        network.setEdgeWeight(network.addEdge(4, 3), 27.0);
 
-        MinimumSTCutAlgorithm<Integer, DefaultWeightedEdge> prSolver=this.createSolver(network);
-        MinimumSTCutAlgorithm<Integer, DefaultWeightedEdge> ekSolver=new EdmondsKarpMFImpl<>(network);
-
-        double expectedCutWeight=ekSolver.calculateMinCut(source, sink);
-
-        double cutWeight=prSolver.calculateMinCut(source, sink);
-        Set<Integer> sourcePartition=prSolver.getSourcePartition();
-        Set<Integer> sinkPartition=prSolver.getSinkPartition();
-        Set<DefaultWeightedEdge> cutEdges=prSolver.getCutEdges();
-
-        this.verifyDirected(network, source, sink, expectedCutWeight, cutWeight, sourcePartition, sinkPartition, cutEdges);
+        MinimumSTCutAlgorithm<Integer, DefaultWeightedEdge> prSolver = this.createSolver(network);
+        double cutWeight = prSolver.calculateMinCut(0, 5);
+        assertEquals(0d, cutWeight);
     }
     
     public void testRandomDirectedGraphs(){

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMinimumSTCutTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMinimumSTCutTest.java
@@ -37,13 +37,13 @@ package org.jgrapht.alg.flow;
 
 import org.jgrapht.DirectedGraph;
 import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
 import org.jgrapht.UndirectedGraph;
 import org.jgrapht.alg.interfaces.MinimumSTCutAlgorithm;
-import org.jgrapht.generate.RandomGraphGenerator;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.SimpleDirectedWeightedGraph;
 
-import java.util.Random;
+import java.util.Arrays;
 import java.util.Set;
 
 /**
@@ -55,40 +55,33 @@ public class PushRelabelMinimumSTCutTest extends MinimumSourceSinkCutTest{
         return new PushRelabelMFImpl<>(network);
     }
 
-    public void testSmall()
+    public void testDisconnected1()
     {
         SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> network =
             new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
-        network.addVertex(0);
-        network.addVertex(1);
-        network.addVertex(2);
-        network.addVertex(3);
-        network.addVertex(4);
-        network.addVertex(5);
-        network.setEdgeWeight(network.addEdge(2, 4), 62.0);
-        network.setEdgeWeight(network.addEdge(3, 4), 52.0);
-        network.setEdgeWeight(network.addEdge(1, 4), 3.0);
-        network.setEdgeWeight(network.addEdge(0, 1), 58.0);
-        network.setEdgeWeight(network.addEdge(2, 0), 67.0);
-        network.setEdgeWeight(network.addEdge(1, 0), 5.0);
-        network.setEdgeWeight(network.addEdge(4, 0), 11.0);
-        network.setEdgeWeight(network.addEdge(4, 1), 46.0);
-        network.setEdgeWeight(network.addEdge(1, 3), 62.0);
-        network.setEdgeWeight(network.addEdge(4, 3), 27.0);
+        Graphs.addAllVertices(network, Arrays.asList(0, 1, 2, 3, 4, 5));
+        network.addEdge(2, 4);
+        network.addEdge(3, 4);
+        network.addEdge(1, 4);
+        network.addEdge(0, 1);
+        network.addEdge(2, 0);
+        network.addEdge(1, 0);
+        network.addEdge(4, 0);
+        network.addEdge(4, 1);
+        network.addEdge(1, 3);
+        network.addEdge(4, 3);
 
         MinimumSTCutAlgorithm<Integer, DefaultWeightedEdge> prSolver = this.createSolver(network);
         double cutWeight = prSolver.calculateMinCut(0, 5);
         assertEquals(0d, cutWeight);
     }
     
-    public void testDisconnected()
+    public void testDisconnected2()
     {
         SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> network =
             new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
-        network.addVertex(0);
-        network.addVertex(1);
-        network.addVertex(2);
-        network.setEdgeWeight(network.addEdge(0, 1), 1.0);
+        Graphs.addAllVertices(network, Arrays.asList(0, 1, 2));
+        network.addEdge(0, 1);
 
         MinimumSTCutAlgorithm<Integer, DefaultWeightedEdge> prSolver = this.createSolver(network);
         double cutWeight = prSolver.calculateMinCut(0, 2);


### PR DESCRIPTION
This is a fix (and two tests cases) for issue #270. 

The problem was that the code which counted the label frequencies assumed that the input graph is strongly connected. 