### PR TITLE
Edmonds blossom compare objects with equals

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/EdmondsBlossomShrinking.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/EdmondsBlossomShrinking.java
@@ -159,16 +159,13 @@ public class EdmondsBlossomShrinking<V, E>
 
                     Set<V> blossom = new HashSet<>();
 
-                    // ?
                     markPath(v, to, stem, blossom);
                     markPath(to, v, stem, blossom);
 
-                    // ???
                     graph.vertexSet().stream().filter(
                         i -> contracted.containsKey(i) && blossom.contains(contracted.get(i)))
                         .forEach(i -> {
                             contracted.put(i, stem);
-                            // ???
                             if (!used.contains(i)) {
                                 used.add(i);
                                 q.add(i);


### PR DESCRIPTION
This is a fix for the issue https://github.com/jgrapht/jgrapht/issues/217 caused by comparing refence types with == sign, instead of .equals.