### PR TITLE
Renamed getMaximumFlow to getFlowMap

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
@@ -346,7 +346,7 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
      *
      * @return <i>read-only</i> mapping from edges to doubles - flow values
      */
-    public Map<E, Double> getMaximumFlow(){
+    public Map<E, Double> getFlowMap(){
         if(maxFlow == null) //Lazily calculate the max flow map
             maxFlow=composeFlow();
         return maxFlow;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MaximumFlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MaximumFlowAlgorithm.java
@@ -31,6 +31,8 @@ import java.util.*;
  *
  * @param <V> vertex concept type
  * @param <E> edge concept type
+ *
+ * @TODO: Rename buildMaximumFlow(V source, V sink) to getMaximumFlow(V source, V sink)
  */
 public interface MaximumFlowAlgorithm<V, E>
 {
@@ -82,8 +84,23 @@ public interface MaximumFlowAlgorithm<V, E>
      * enforced in teh next version.
      *
      * @return <i>read-only</i> mapping from edges to doubles - flow values
+     * @deprecated Use {@link #getFlowMap()} instead
      */
     default Map<E, Double> getMaximumFlow(){
+        return getFlowMap();
+    }
+
+    /**
+     * Returns maximum flow, that was calculated during last <tt>
+     * calculateMaximumFlow</tt> call, or <tt>null</tt>, if there was no <tt>
+     * calculateMaximumFlow</tt> calls.
+     *
+     * NOTE: this function currently has a default implementation to guarantee backwards compatibility. This function should be
+     * enforced in teh next version.
+     *
+     * @return <i>read-only</i> mapping from edges to doubles - flow values
+     */
+    default Map<E, Double> getFlowMap(){
         throw new UnsupportedOperationException("Function not implemented");
     }
 


### PR DESCRIPTION
This pull request supersedes pull request #269.

To improve consistency within the algorithm interfaces, I propose to rename 2 functions within the flow interface:

buildMaximumFlow -> getMaximumFlow. This function, as the name now suggests, returns a MaximumFlow object
getMaximumFlow -> getFlowMap. This function returns a Map with flow values for each edge.

This is the first out of a 2-stage change: 
getMaximumFlow -> getFlowMap.

In the next release, we can change:
buildMaximumFlow -> getMaximumFlow