### PR TITLE
Checkstyle plugin in maven profile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ language: java
 jdk:
   - oraclejdk8
 script:
-  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V && mvn test -B && mvn javadoc:aggregate
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V && mvn test -B && mvn javadoc:aggregate && mvn checkstyle:check -P checkstyle

--- a/etc/jgrapht_checks.xml
+++ b/etc/jgrapht_checks.xml
@@ -23,7 +23,14 @@
 		<module name="JavadocType">
 			<property name="scope" value="public" />
 		</module>
+		
+		<module name="MissingDeprecated">
+			<property name="skipNoJavadoc" value="true" />
+		</module>
+		<module name="MissingOverride" />
+
 		<module name="ConstantName" />
+
 		<module name="EqualsHashCode" />
 		<module name="StringLiteralEquality" />
 	</module>

--- a/etc/jgrapht_checks.xml
+++ b/etc/jgrapht_checks.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+"http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+
+<module name="Checker">
+	<!-- Checks for whitespace -->
+	<!-- See http://checkstyle.sf.net/config_whitespace.html -->
+	<module name="FileTabCharacter" />
+	<module name="NewlineAtEndOfFile">
+		<property name="fileExtensions" value="java, xml" />
+	</module>
+
+	<module name="TreeWalker">
+		<module name="JavadocMethod">
+			<property name="scope" value="public" />
+			<property name="allowUndeclaredRTE" value="true" />
+		</module>
+		<module name="JavadocMethod">
+			<property name="scope" value="protected" />
+			<property name="allowUndeclaredRTE" value="true" />
+		</module>
+		<module name="JavadocType">
+			<property name="scope" value="public" />
+		</module>
+		<module name="ConstantName" />
+		<module name="EqualsHashCode" />
+		<module name="StringLiteralEquality" />
+	</module>
+
+	<module name="JavadocPackage" />
+</module>

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/JGraphAdapterDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/JGraphAdapterDemo.java
@@ -68,6 +68,7 @@ public class JGraphAdapterDemo
     /**
      * {@inheritDoc}
      */
+    @Override
     public void init()
     {
         // create a JGraphT graph

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/JGraphXAdapterDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/JGraphXAdapterDemo.java
@@ -64,6 +64,7 @@ public class JGraphXAdapterDemo
     /**
      * {@inheritDoc}
      */
+    @Override
     public void init()
     {
         // create a JGraphT graph

--- a/pom.xml
+++ b/pom.xml
@@ -170,6 +170,38 @@
 			</modules>
 		</profile>
 		<profile>
+			<id>checkstyle</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-checkstyle-plugin</artifactId>
+						<version>2.17</version>
+						<dependencies>
+							<dependency>
+								<groupId>com.puppycrawl.tools</groupId>
+								<artifactId>checkstyle</artifactId>
+								<version>7.1.1</version>
+							</dependency>
+						</dependencies>
+						<executions>
+							<execution>
+								<id>checkstyle</id>
+								<phase>validate</phase>
+								<goals>
+									<goal>check</goal>
+								</goals>
+							</execution>
+						</executions>
+						<configuration>
+							<configLocation>etc/jgrapht_checks.xml</configLocation>
+							<linkXRef>false</linkXRef>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
 			<id>release-sign-artifacts</id>
 			<activation>
 				<property>


### PR DESCRIPTION
A very simple attempt to re-integrate checkstyle without breaking anything, by using a maven profile. 

Enabling maven profile "checkstyle" executes goal checkstyle:check in the validate phase and fails the build in case of errors. The configuration of the checks are in file etc/jgrapht_checks.xml

Usage: 
 - `mvn compile -P checkstyle` to compile
 - `mvn checkstyle:check -P checkstyle` to check against rules
 - `mvn checkstyle:checkstyle -P checkstyle` to generate  report per module
 - `mvn checkstyle:checkstyle-aggregate -P checkstyle` to generate aggregate report.

If profile "checkstyle" is not enabled, everything is like before.

As there are a lot of javadoc comments missing (currently around 700) warnings, perhaps it is better to avoid enabling it in Travis for now. 