### PR TITLE
Unified name providers for exporters using a common interface

### DIFF
--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLExportDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLExportDemo.java
@@ -165,14 +165,14 @@ public final class GraphMLExportDemo
 
         // create GraphML exporter
         GraphMLExporter<GraphVertex, DefaultWeightedEdge> exporter =
-            new GraphMLExporter<>(new VertexNameProvider<GraphVertex>()
+            new GraphMLExporter<>(new ComponentNameProvider<GraphVertex>()
             {
                 @Override
-                public String getVertexName(GraphVertex v)
+                public String getName(GraphVertex v)
                 {
                     return v.id;
                 }
-            }, null, new IntegerEdgeNameProvider<>(), null);
+            }, null, new IntegerComponentNameProvider<>(), null);
 
         // set to export the internal edge weights
         exporter.setExportEdgeWeights(true);

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/CSVExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/CSVExporter.java
@@ -55,7 +55,7 @@ public class CSVExporter<V, E>
 {
     private static final char DEFAULT_DELIMITER = ',';
 
-    private final VertexNameProvider<V> vertexIDProvider;
+    private final ComponentNameProvider<V> vertexIDProvider;
     private final Set<CSVFormat.Parameter> parameters;
     private CSVFormat format;
     private char delimiter;
@@ -66,7 +66,7 @@ public class CSVExporter<V, E>
      */
     public CSVExporter()
     {
-        this(new IntegerNameProvider<>(), CSVFormat.ADJACENCY_LIST, DEFAULT_DELIMITER);
+        this(new IntegerComponentNameProvider<>(), CSVFormat.ADJACENCY_LIST, DEFAULT_DELIMITER);
     }
 
     /**
@@ -76,7 +76,7 @@ public class CSVExporter<V, E>
      */
     public CSVExporter(CSVFormat format)
     {
-        this(new IntegerNameProvider<>(), format, DEFAULT_DELIMITER);
+        this(new IntegerComponentNameProvider<>(), format, DEFAULT_DELIMITER);
     }
 
     /**
@@ -87,7 +87,7 @@ public class CSVExporter<V, E>
      */
     public CSVExporter(CSVFormat format, char delimiter)
     {
-        this(new IntegerNameProvider<>(), format, delimiter);
+        this(new IntegerComponentNameProvider<>(), format, delimiter);
     }
 
     /**
@@ -97,7 +97,7 @@ public class CSVExporter<V, E>
      * @param format the format to use
      * @param delimiter delimiter to use
      */
-    public CSVExporter(VertexNameProvider<V> vertexIDProvider, CSVFormat format, char delimiter)
+    public CSVExporter(ComponentNameProvider<V> vertexIDProvider, CSVFormat format, char delimiter)
     {
         if (vertexIDProvider == null) {
             throw new IllegalArgumentException("Vertex id provider cannot be null");
@@ -207,9 +207,9 @@ public class CSVExporter<V, E>
     private void exportAsEdgeList(Graph<V, E> g, PrintWriter out)
     {
         for (E e : g.edgeSet()) {
-            exportEscapedField(out, vertexIDProvider.getVertexName(g.getEdgeSource(e)));
+            exportEscapedField(out, vertexIDProvider.getName(g.getEdgeSource(e)));
             out.print(delimiter);
-            exportEscapedField(out, vertexIDProvider.getVertexName(g.getEdgeTarget(e)));
+            exportEscapedField(out, vertexIDProvider.getName(g.getEdgeTarget(e)));
             out.println();
         }
     }
@@ -218,21 +218,21 @@ public class CSVExporter<V, E>
     {
         if (g instanceof DirectedGraph<?, ?>) {
             for (V v : g.vertexSet()) {
-                exportEscapedField(out, vertexIDProvider.getVertexName(v));
+                exportEscapedField(out, vertexIDProvider.getName(v));
                 for (E e : ((DirectedGraph<V, E>) g).outgoingEdgesOf(v)) {
                     V w = Graphs.getOppositeVertex(g, e, v);
                     out.print(delimiter);
-                    exportEscapedField(out, vertexIDProvider.getVertexName(w));
+                    exportEscapedField(out, vertexIDProvider.getName(w));
                 }
                 out.println();
             }
         } else {
             for (V v : g.vertexSet()) {
-                exportEscapedField(out, vertexIDProvider.getVertexName(v));
+                exportEscapedField(out, vertexIDProvider.getName(v));
                 for (E e : g.edgesOf(v)) {
                     V w = Graphs.getOppositeVertex(g, e, v);
                     out.print(delimiter);
-                    exportEscapedField(out, vertexIDProvider.getVertexName(w));
+                    exportEscapedField(out, vertexIDProvider.getName(w));
                 }
                 out.println();
             }
@@ -250,14 +250,14 @@ public class CSVExporter<V, E>
         if (exportNodeId) {
             for (V v : g.vertexSet()) {
                 out.print(delimiter);
-                exportEscapedField(out, vertexIDProvider.getVertexName(v));
+                exportEscapedField(out, vertexIDProvider.getName(v));
             }
             out.println();
         }
         int n = g.vertexSet().size();
         for (V v : g.vertexSet()) {
             if (exportNodeId) {
-                exportEscapedField(out, vertexIDProvider.getVertexName(v));
+                exportEscapedField(out, vertexIDProvider.getName(v));
                 out.print(delimiter);
             }
             int i = 0;

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/ComponentNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/ComponentNameProvider.java
@@ -1,0 +1,39 @@
+/*
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.ext;
+
+/**
+ * Provides a name for a component.
+ *
+ * @param <T> the type of the component
+ */
+public interface ComponentNameProvider<T>
+{
+
+    /**
+     * Returns a unique name. This is useful when exporting a graph, as it ensures that all
+     * vertices/edges are assigned simple, consistent names.
+     *
+     * @param component the component to be named
+     * @return the name of the component
+     */
+    String getName(T component);
+
+}
+
+// End ComponentNameProvider.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/ComponentUpdater.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/ComponentUpdater.java
@@ -20,36 +20,20 @@ package org.jgrapht.ext;
 import java.util.*;
 
 /**
- * Type to handle updates to a vertex when an import gets more information about a vertex after it
- * has been created.
+ * Type to handle updates to a component when an import gets more information about it after it has
+ * been created.
  *
- * @param <V> the vertex type
- * 
- * @deprecated in favor of {@link ComponentUpdater}
+ * @param <T> the component type
  */
-@Deprecated
-public interface VertexUpdater<V>
- extends ComponentUpdater<V>
+public interface ComponentUpdater<T>
 {
-    /**
-     * Update vertex with the extra attributes.
-     *
-     * @param vertex to update
-     * @param attributes to add to the vertex
-     */
-    void updateVertex(V vertex, Map<String, String> attributes);
-    
     /**
      * Update component with the extra attributes.
      *
      * @param component to update
      * @param attributes to add to the component
      */
-    @Override
-    default void update(V component, Map<String, String> attributes) { 
-        this.updateVertex(component, attributes);
-    }
-    
+    void update(T component, Map<String, String> attributes);
 }
 
-// End VertexUpdater.java
+// End ComponentUpdater.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
@@ -102,7 +102,7 @@ public class DOTImporter<V, E>
     private static final int DONE = 32;
 
     private VertexProvider<V> vertexProvider;
-    private VertexUpdater<V> vertexUpdater;
+    private ComponentUpdater<V> vertexUpdater;
     private EdgeProvider<V, E> edgeProvider;
 
     /**
@@ -123,13 +123,13 @@ public class DOTImporter<V, E>
      *
      * @param vertexProvider Provider to create a vertex
      * @param edgeProvider Provider to create an edge
-     * @param updater Method used to update an existing Vertex
+     * @param vertexUpdater Method used to update an existing Vertex
      */
     public DOTImporter(
-        VertexProvider<V> vertexProvider, EdgeProvider<V, E> edgeProvider, VertexUpdater<V> updater)
+        VertexProvider<V> vertexProvider, EdgeProvider<V, E> edgeProvider, ComponentUpdater<V> vertexUpdater)
     {
         this.vertexProvider = vertexProvider;
-        this.vertexUpdater = updater;
+        this.vertexUpdater = vertexUpdater;
         this.edgeProvider = edgeProvider;
     }
 
@@ -537,7 +537,7 @@ public class DOTImporter<V, E>
             vertexes.put(id, vertex);
         } else {
             if (vertexUpdater != null) {
-                vertexUpdater.updateVertex(existing, attributes);
+                vertexUpdater.update(existing, attributes);
             } else {
                 throw new ImportException(
                     "Update required for vertex " + id + " but no vertexUpdater provided");

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTUtils.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTUtils.java
@@ -22,25 +22,31 @@ import java.io.*;
 import org.jgrapht.*;
 
 /**
+ * Class with DOT format related utilities.
+ * 
  * @author Christoph Zauner
+ * 
+ * @deprecated in favor of implementing the current functionality directly by the user
  */
+@Deprecated
 public class DOTUtils
 {
     /**
-     * Convert a graph into a String in DOT format.
+     * Convert a graph into a string in DOT format.
      * 
      * @param graph the input graph
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
-     * @return a {@link String} representation in DOT format of the given graph.
+     * @return a {@link String} representation in DOT format of the given graph
+     * @deprecated in favor of implementing the current functionality directly by the user
      */
+    @Deprecated
     public static <V, E> String convertGraphToDotString(Graph<V, E> graph)
     {
-
         StringWriter outputWriter = new StringWriter();
-        new DOTExporter<V, E>(new IntegerNameProvider<V>(),
+        new DOTExporter<V, E>(new IntegerComponentNameProvider<V>(),
             // vertex name provider
-            new StringNameProvider<V>(),
+            new StringComponentNameProvider<V>(),
             // edge label provider
             null).exportGraph(graph, outputWriter);
 

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/EdgeNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/EdgeNameProvider.java
@@ -21,8 +21,12 @@ package org.jgrapht.ext;
  * Assigns a display name for each of the graph edges.
  * 
  * @param <E> the graph edge type
+ * 
+ * @deprecated in favor of {@link ComponentNameProvider}
  */
+@Deprecated
 public interface EdgeNameProvider<E>
+    extends ComponentNameProvider<E>
 {
     /**
      * Returns a unique name for an edge. This is useful when exporting a graph, as it ensures that
@@ -33,6 +37,20 @@ public interface EdgeNameProvider<E>
      * @return the name of the edge
      */
     String getEdgeName(E edge);
+
+    /**
+     * Returns a unique name for an edge. This is useful when exporting a graph, as it ensures that
+     * all edges are assigned simple, consistent names.
+     *
+     * @param edge the edge to be named
+     *
+     * @return the name of the edge
+     */
+    @Override
+    default String getName(E edge)
+    {
+        return this.getEdgeName(edge);
+    }
 }
 
 // End EdgeNameProvider.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
@@ -69,10 +69,10 @@ public class GmlExporter<V, E>
         EXPORT_EDGE_WEIGHTS
     }
 
-    private VertexNameProvider<V> vertexIDProvider;
-    private VertexNameProvider<V> vertexLabelProvider;
-    private EdgeNameProvider<E> edgeIDProvider;
-    private EdgeNameProvider<E> edgeLabelProvider;
+    private ComponentNameProvider<V> vertexIDProvider;
+    private ComponentNameProvider<V> vertexLabelProvider;
+    private ComponentNameProvider<E> edgeIDProvider;
+    private ComponentNameProvider<E> edgeLabelProvider;
     private final Set<Parameter> parameters;
 
     /**
@@ -81,7 +81,8 @@ public class GmlExporter<V, E>
      */
     public GmlExporter()
     {
-        this(new IntegerNameProvider<>(), null, new IntegerEdgeNameProvider<>(), null);
+        this(
+            new IntegerComponentNameProvider<>(), null, new IntegerComponentNameProvider<>(), null);
     }
 
     /**
@@ -95,8 +96,8 @@ public class GmlExporter<V, E>
      *        using the toString() method of the edge object.
      */
     public GmlExporter(
-        VertexNameProvider<V> vertexIDProvider, VertexNameProvider<V> vertexLabelProvider,
-        EdgeNameProvider<E> edgeIDProvider, EdgeNameProvider<E> edgeLabelProvider)
+        ComponentNameProvider<V> vertexIDProvider, ComponentNameProvider<V> vertexLabelProvider,
+        ComponentNameProvider<E> edgeIDProvider, ComponentNameProvider<E> edgeLabelProvider)
     {
         this.vertexIDProvider = vertexIDProvider;
         this.vertexLabelProvider = vertexLabelProvider;
@@ -123,10 +124,10 @@ public class GmlExporter<V, E>
         for (V from : g.vertexSet()) {
             out.println(TAB1 + "node");
             out.println(TAB1 + "[");
-            out.println(TAB2 + "id" + DELIM + vertexIDProvider.getVertexName(from));
+            out.println(TAB2 + "id" + DELIM + vertexIDProvider.getName(from));
             if (exportVertexLabels) {
                 String label = (vertexLabelProvider == null) ? from.toString()
-                    : vertexLabelProvider.getVertexName(from);
+                    : vertexLabelProvider.getName(from);
                 out.println(TAB2 + "label" + DELIM + quoted(label));
             }
             out.println(TAB1 + "]");
@@ -141,15 +142,15 @@ public class GmlExporter<V, E>
         for (E edge : g.edgeSet()) {
             out.println(TAB1 + "edge");
             out.println(TAB1 + "[");
-            String id = edgeIDProvider.getEdgeName(edge);
+            String id = edgeIDProvider.getName(edge);
             out.println(TAB2 + "id" + DELIM + id);
-            String s = vertexIDProvider.getVertexName(g.getEdgeSource(edge));
+            String s = vertexIDProvider.getName(g.getEdgeSource(edge));
             out.println(TAB2 + "source" + DELIM + s);
-            String t = vertexIDProvider.getVertexName(g.getEdgeTarget(edge));
+            String t = vertexIDProvider.getName(g.getEdgeTarget(edge));
             out.println(TAB2 + "target" + DELIM + t);
             if (exportEdgeLabels) {
-                String label = (edgeLabelProvider == null) ? edge.toString()
-                    : edgeLabelProvider.getEdgeName(edge);
+                String label =
+                    (edgeLabelProvider == null) ? edge.toString() : edgeLabelProvider.getName(edge);
                 out.println(TAB2 + "label" + DELIM + quoted(label));
             }
             if (exportEdgeWeights && g instanceof WeightedGraph) {
@@ -172,7 +173,7 @@ public class GmlExporter<V, E>
 
         for (V from : g.vertexSet()) {
             // assign ids in vertex set iteration order
-            vertexIDProvider.getVertexName(from);
+            vertexIDProvider.getName(from);
         }
 
         exportHeader(out);

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -47,10 +47,10 @@ public class GraphMLExporter<V, E>
     implements GraphExporter<V, E>
 {
     // providers
-    private VertexNameProvider<V> vertexIDProvider;
-    private VertexNameProvider<V> vertexLabelProvider;
-    private EdgeNameProvider<E> edgeIDProvider;
-    private EdgeNameProvider<E> edgeLabelProvider;
+    private ComponentNameProvider<V> vertexIDProvider;
+    private ComponentNameProvider<V> vertexLabelProvider;
+    private ComponentNameProvider<E> edgeIDProvider;
+    private ComponentNameProvider<E> edgeLabelProvider;
     private ComponentAttributeProvider<V> vertexAttributeProvider;
     private ComponentAttributeProvider<E> edgeAttributeProvider;
 
@@ -79,7 +79,9 @@ public class GraphMLExporter<V, E>
      */
     public GraphMLExporter()
     {
-        this(new IntegerNameProvider<>(), null, null, new IntegerEdgeNameProvider<>(), null, null);
+        this(
+            new IntegerComponentNameProvider<>(), null, null, new IntegerComponentNameProvider<>(),
+            null, null);
     }
 
     /**
@@ -93,8 +95,8 @@ public class GraphMLExporter<V, E>
      *        exported.
      */
     public GraphMLExporter(
-        VertexNameProvider<V> vertexIDProvider, VertexNameProvider<V> vertexLabelProvider,
-        EdgeNameProvider<E> edgeIDProvider, EdgeNameProvider<E> edgeLabelProvider)
+        ComponentNameProvider<V> vertexIDProvider, ComponentNameProvider<V> vertexLabelProvider,
+        ComponentNameProvider<E> edgeIDProvider, ComponentNameProvider<E> edgeLabelProvider)
     {
         this(vertexIDProvider, vertexLabelProvider, null, edgeIDProvider, edgeLabelProvider, null);
     }
@@ -114,9 +116,10 @@ public class GraphMLExporter<V, E>
      *        attributes will be exported.
      */
     public GraphMLExporter(
-        VertexNameProvider<V> vertexIDProvider, VertexNameProvider<V> vertexLabelProvider,
-        ComponentAttributeProvider<V> vertexAttributeProvider, EdgeNameProvider<E> edgeIDProvider,
-        EdgeNameProvider<E> edgeLabelProvider, ComponentAttributeProvider<E> edgeAttributeProvider)
+        ComponentNameProvider<V> vertexIDProvider, ComponentNameProvider<V> vertexLabelProvider,
+        ComponentAttributeProvider<V> vertexAttributeProvider,
+        ComponentNameProvider<E> edgeIDProvider, ComponentNameProvider<E> edgeLabelProvider,
+        ComponentAttributeProvider<E> edgeAttributeProvider)
     {
         if (vertexIDProvider == null) {
             throw new IllegalArgumentException("Vertex ID provider must not be null");
@@ -354,7 +357,7 @@ public class GraphMLExporter<V, E>
      * 
      * @return the vertex label provider
      */
-    public VertexNameProvider<V> getVertexLabelProvider()
+    public ComponentNameProvider<V> getVertexLabelProvider()
     {
         return vertexLabelProvider;
     }
@@ -364,7 +367,7 @@ public class GraphMLExporter<V, E>
      * 
      * @param vertexLabelProvider the vertex label provider to set
      */
-    public void setVertexLabelProvider(VertexNameProvider<V> vertexLabelProvider)
+    public void setVertexLabelProvider(ComponentNameProvider<V> vertexLabelProvider)
     {
         this.vertexLabelProvider = vertexLabelProvider;
     }
@@ -374,7 +377,7 @@ public class GraphMLExporter<V, E>
      * 
      * @return the edge label provider
      */
-    public EdgeNameProvider<E> getEdgeLabelProvider()
+    public ComponentNameProvider<E> getEdgeLabelProvider()
     {
         return edgeLabelProvider;
     }
@@ -384,7 +387,7 @@ public class GraphMLExporter<V, E>
      * 
      * @param edgeLabelProvider the edge label provider to set
      */
-    public void setEdgeLabelProvider(EdgeNameProvider<E> edgeLabelProvider)
+    public void setEdgeLabelProvider(ComponentNameProvider<E> edgeLabelProvider)
     {
         this.edgeLabelProvider = edgeLabelProvider;
     }
@@ -570,11 +573,11 @@ public class GraphMLExporter<V, E>
         for (V v : g.vertexSet()) {
             // <node>
             AttributesImpl attr = new AttributesImpl();
-            attr.addAttribute("", "", "id", "CDATA", vertexIDProvider.getVertexName(v));
+            attr.addAttribute("", "", "id", "CDATA", vertexIDProvider.getName(v));
             handler.startElement("", "", "node", attr);
 
             if (vertexLabelProvider != null) {
-                String vertexLabel = vertexLabelProvider.getVertexName(v);
+                String vertexLabel = vertexLabelProvider.getName(v);
                 if (vertexLabel != null) {
                     writeData(handler, "vertex_label_key", vertexLabel);
                 }
@@ -620,15 +623,15 @@ public class GraphMLExporter<V, E>
         for (E e : g.edgeSet()) {
             // <edge>
             AttributesImpl attr = new AttributesImpl();
-            attr.addAttribute("", "", "id", "CDATA", edgeIDProvider.getEdgeName(e));
+            attr.addAttribute("", "", "id", "CDATA", edgeIDProvider.getName(e));
             attr.addAttribute(
-                "", "", "source", "CDATA", vertexIDProvider.getVertexName(g.getEdgeSource(e)));
+                "", "", "source", "CDATA", vertexIDProvider.getName(g.getEdgeSource(e)));
             attr.addAttribute(
-                "", "", "target", "CDATA", vertexIDProvider.getVertexName(g.getEdgeTarget(e)));
+                "", "", "target", "CDATA", vertexIDProvider.getName(g.getEdgeTarget(e)));
             handler.startElement("", "", "edge", attr);
 
             if (edgeLabelProvider != null) {
-                String edgeLabel = edgeLabelProvider.getEdgeName(e);
+                String edgeLabel = edgeLabelProvider.getName(e);
                 if (edgeLabel != null) {
                     writeData(handler, "edge_label_key", edgeLabel);
                 }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerComponentNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerComponentNameProvider.java
@@ -20,23 +20,19 @@ package org.jgrapht.ext;
 import java.util.*;
 
 /**
- * Assigns a unique integer to represent each edge. Each instance of IntegerEdgeNameProvider
- * maintains an internal map between every edge it has ever seen and the unique integer representing
- * that edge. As a result it is probably desirable to have a separate instance for each distinct
- * graph.
+ * Assigns a unique integer to represent each component. Each instance of provider maintains an
+ * internal map between every component it has ever seen and the unique integer representing that
+ * edge. As a result it is probably desirable to have a separate instance for each distinct graph.
  * 
- * @param <E> the graph edge type
+ * @param <T> the component type
  *
  * @author Trevor Harmon
- * 
- * @deprecated in favor of {@link IntegerComponentNameProvider}
  */
-@Deprecated
-public class IntegerEdgeNameProvider<E>
-    implements EdgeNameProvider<E>
+public class IntegerComponentNameProvider<T>
+    implements ComponentNameProvider<T>
 {
     private int nextID = 1;
-    private final Map<E, Integer> idMap = new HashMap<>();
+    private final Map<T, Integer> idMap = new HashMap<>();
 
     /**
      * Clears all cached identifiers, and resets the unique identifier counter.
@@ -48,21 +44,20 @@ public class IntegerEdgeNameProvider<E>
     }
 
     /**
-     * Returns the String representation of an edge.
+     * Returns the string representation of a component.
      *
-     * @param edge the edge to be named
+     * @param component the component to be named
      */
     @Override
-    public String getEdgeName(E edge)
+    public String getName(T component)
     {
-        Integer id = idMap.get(edge);
+        Integer id = idMap.get(component);
         if (id == null) {
             id = nextID++;
-            idMap.put(edge, id);
+            idMap.put(component, id);
         }
-
         return id.toString();
     }
 }
 
-// End IntegerEdgeNameProvider.java
+// End IntegerComponentNameProvider.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/IntegerNameProvider.java
@@ -17,10 +17,6 @@
  */
 package org.jgrapht.ext;
 
-import java.util.*;
-
-import org.jgrapht.event.*;
-
 /**
  * Assigns a unique integer to represent each vertex. Each instance of IntegerNameProvider maintains
  * an internal map between every vertex it has ever seen and the unique integer representing that
@@ -29,42 +25,13 @@ import org.jgrapht.event.*;
  * @param <V> the graph vertex type
  *
  * @author Charles Fry
+ * 
+ * @deprecated in favor of {@link IntegerComponentNameProvider}
  */
+@Deprecated
 public class IntegerNameProvider<V>
-    implements VertexNameProvider<V>
+    extends IntegerComponentNameProvider<V>
 {
-    private int nextID = 1;
-    private final Map<V, Integer> idMap = new HashMap<>();
-
-    /**
-     * Clears all cached identifiers, and resets the unique identifier counter.
-     */
-    public void clear()
-    {
-        nextID = 1;
-        idMap.clear();
-    }
-
-    /**
-     * Returns the String representation of the unique integer representing a vertex.
-     *
-     * @param vertex the vertex to be named
-     *
-     * @return the name of
-     *
-     * @see GraphListener#edgeAdded(GraphEdgeChangeEvent)
-     */
-    @Override
-    public String getVertexName(V vertex)
-    {
-        Integer id = idMap.get(vertex);
-        if (id == null) {
-            id = nextID++;
-            idMap.put(vertex, id);
-        }
-
-        return id.toString();
-    }
 }
 
 // End IntegerNameProvider.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/MatrixExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/MatrixExporter.java
@@ -45,7 +45,7 @@ public class MatrixExporter<V, E>
 {
     private final String delimiter = " ";
     private Format format;
-    private VertexNameProvider<V> vertexIDProvider;
+    private ComponentNameProvider<V> vertexIDProvider;
 
     /**
      * Formats supported by the exporter.
@@ -76,7 +76,7 @@ public class MatrixExporter<V, E>
      */
     public MatrixExporter()
     {
-        this(Format.SPARSE_ADJACENCY_MATRIX, new IntegerNameProvider<>());
+        this(Format.SPARSE_ADJACENCY_MATRIX, new IntegerComponentNameProvider<>());
     }
 
     /**
@@ -86,7 +86,7 @@ public class MatrixExporter<V, E>
      */
     public MatrixExporter(Format format)
     {
-        this(format, new IntegerNameProvider<>());
+        this(format, new IntegerComponentNameProvider<>());
     }
 
     /**
@@ -95,7 +95,7 @@ public class MatrixExporter<V, E>
      * @param format format to use
      * @param vertexIDProvider for generating vertex identifiers. Must not be null.
      */
-    public MatrixExporter(Format format, VertexNameProvider<V> vertexIDProvider)
+    public MatrixExporter(Format format, ComponentNameProvider<V> vertexIDProvider)
     {
         this.format = format;
         if (vertexIDProvider == null) {
@@ -155,7 +155,7 @@ public class MatrixExporter<V, E>
     {
         for (V from : g.vertexSet()) {
             // assign ids in vertex set iteration order
-            vertexIDProvider.getVertexName(from);
+            vertexIDProvider.getName(from);
         }
 
         PrintWriter out = new PrintWriter(writer);
@@ -176,10 +176,10 @@ public class MatrixExporter<V, E>
 
     private void exportAdjacencyMatrixVertex(PrintWriter writer, V from, List<V> neighbors)
     {
-        String fromName = vertexIDProvider.getVertexName(from);
+        String fromName = vertexIDProvider.getName(from);
         Map<String, ModifiableInteger> counts = new LinkedHashMap<>();
         for (V to : neighbors) {
-            String toName = vertexIDProvider.getVertexName(to);
+            String toName = vertexIDProvider.getName(to);
             ModifiableInteger count = counts.get(toName);
             if (count == null) {
                 count = new ModifiableInteger(0);
@@ -208,19 +208,19 @@ public class MatrixExporter<V, E>
     {
         PrintWriter out = new PrintWriter(writer);
 
-        VertexNameProvider<V> nameProvider = new IntegerNameProvider<>();
+        ComponentNameProvider<V> nameProvider = new IntegerComponentNameProvider<>();
         for (V from : g.vertexSet()) {
             // assign ids in vertex set iteration order
-            nameProvider.getVertexName(from);
+            nameProvider.getName(from);
         }
 
         for (V from : g.vertexSet()) {
-            String fromName = nameProvider.getVertexName(from);
+            String fromName = nameProvider.getName(from);
 
             List<V> neighbors = Graphs.neighborListOf(g, from);
             exportEntry(out, fromName, fromName, Integer.toString(neighbors.size()));
             for (V to : neighbors) {
-                String toName = nameProvider.getVertexName(to);
+                String toName = nameProvider.getName(to);
                 exportEntry(out, fromName, toName, "-1");
             }
         }
@@ -232,14 +232,14 @@ public class MatrixExporter<V, E>
     {
         PrintWriter out = new PrintWriter(writer);
 
-        VertexNameProvider<V> nameProvider = new IntegerNameProvider<>();
+        ComponentNameProvider<V> nameProvider = new IntegerComponentNameProvider<>();
         for (V from : g.vertexSet()) {
             // assign ids in vertex set iteration order
-            nameProvider.getVertexName(from);
+            nameProvider.getName(from);
         }
 
         for (V from : g.vertexSet()) {
-            String fromName = nameProvider.getVertexName(from);
+            String fromName = nameProvider.getName(from);
             Set<V> neighbors = new LinkedHashSet<>(Graphs.neighborListOf(g, from));
             if (neighbors.isEmpty()) {
                 exportEntry(out, fromName, fromName, "0");
@@ -247,7 +247,7 @@ public class MatrixExporter<V, E>
                 exportEntry(out, fromName, fromName, "1");
 
                 for (V to : neighbors) {
-                    String toName = nameProvider.getVertexName(to);
+                    String toName = nameProvider.getName(to);
                     double value = -1 / Math.sqrt(g.degreeOf(from) * g.degreeOf(to));
                     exportEntry(out, fromName, toName, Double.toString(value));
                 }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/StringComponentNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/StringComponentNameProvider.java
@@ -1,0 +1,45 @@
+/*
+ * (C) Copyright 2005-2016, by Trevor Harmon and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.ext;
+
+/**
+ * Generates names by invoking {@link #toString()} on them. This assumes that the object's
+ * {@link #toString()} method returns a unique string representation.
+ *
+ * @param <T> the component type
+ * 
+ * @author Trevor Harmon
+ */
+public class StringComponentNameProvider<T>
+    implements ComponentNameProvider<T>
+{
+
+    /**
+     * Returns the string representation of a component.
+     *
+     * @param component the component
+     * @return a unique string representation
+     */
+    @Override
+    public String getName(T component)
+    {
+        return component.toString();
+    }
+}
+
+// End StringComponentNameProvider.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/StringEdgeNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/StringEdgeNameProvider.java
@@ -24,22 +24,13 @@ package org.jgrapht.ext;
  * @param <E> the graph edge type
  *
  * @author Trevor Harmon
+ *
+ * @deprecated in favor of {@link StringComponentNameProvider}
  */
+@Deprecated
 public class StringEdgeNameProvider<E>
-    implements EdgeNameProvider<E>
+    extends StringComponentNameProvider<E>
 {
-
-    /**
-     * Returns the String representation an edge.
-     *
-     * @param edge the edge to be named
-     * @return a unique String edge representation
-     */
-    @Override
-    public String getEdgeName(E edge)
-    {
-        return edge.toString();
-    }
 }
 
 // End StringEdgeNameProvider.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/StringNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/StringNameProvider.java
@@ -24,7 +24,10 @@ package org.jgrapht.ext;
  * @param <V> the graph vertex type
  *
  * @author Charles Fry
+ * 
+ * @deprecated in favor of {@link StringComponentNameProvider}
  */
+@Deprecated
 public class StringNameProvider<V>
     implements VertexNameProvider<V>
 {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/VertexNameProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/VertexNameProvider.java
@@ -22,8 +22,11 @@ package org.jgrapht.ext;
  * 
  * @param <V> the graph vertex type
  * 
+ * @deprecated in favor of {@link ComponentNameProvider}
  */
+@Deprecated
 public interface VertexNameProvider<V>
+    extends ComponentNameProvider<V>
 {
     /**
      * Returns a unique name for a vertex. This is useful when exporting a a graph, as it ensures
@@ -34,6 +37,20 @@ public interface VertexNameProvider<V>
      * @return the name of the vertex
      */
     String getVertexName(V vertex);
+
+    /**
+     * Returns a unique name for a vertex. This is useful when exporting a a graph, as it ensures
+     * that all vertices are assigned simple, consistent names.
+     *
+     * @param vertex the vertex to be named
+     *
+     * @return the name of the vertex
+     */
+    @Override
+    default String getName(V vertex)
+    {
+        return this.getVertexName(vertex);
+    }
 }
 
 // End VertexNameProvider.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/VisioExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/VisioExporter.java
@@ -43,14 +43,14 @@ import org.jgrapht.*;
 public class VisioExporter<V, E>
     implements GraphExporter<V, E>
 {
-    private VertexNameProvider<V> vertexNameProvider;
+    private ComponentNameProvider<V> vertexNameProvider;
 
     /**
      * Creates a new VisioExporter with the specified naming policy.
      *
      * @param vertexNameProvider the vertex name provider to be used for naming the Visio shapes.
      */
-    public VisioExporter(VertexNameProvider<V> vertexNameProvider)
+    public VisioExporter(ComponentNameProvider<V> vertexNameProvider)
     {
         this.vertexNameProvider = vertexNameProvider;
     }
@@ -60,7 +60,7 @@ public class VisioExporter<V, E>
      */
     public VisioExporter()
     {
-        this(new StringNameProvider<>());
+        this(new StringComponentNameProvider<>());
     }
 
     /**
@@ -87,8 +87,8 @@ public class VisioExporter<V, E>
 
     private void exportEdge(PrintWriter out, E edge, Graph<V, E> g)
     {
-        String sourceName = vertexNameProvider.getVertexName(g.getEdgeSource(edge));
-        String targetName = vertexNameProvider.getVertexName(g.getEdgeTarget(edge));
+        String sourceName = vertexNameProvider.getName(g.getEdgeSource(edge));
+        String targetName = vertexNameProvider.getName(g.getEdgeTarget(edge));
 
         out.print("Link,");
 
@@ -107,7 +107,7 @@ public class VisioExporter<V, E>
 
     private void exportVertex(PrintWriter out, V vertex)
     {
-        String name = vertexNameProvider.getVertexName(vertex);
+        String name = vertexNameProvider.getName(vertex);
 
         out.print("Shape,");
         out.print(name);

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/CSVExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/CSVExporterTest.java
@@ -37,23 +37,25 @@ public class CSVExporterTest
 
     private static final String NL = System.getProperty("line.separator");
 
-    private static VertexNameProvider<Integer> nameProvider = new VertexNameProvider<Integer>()
-    {
-        @Override
-        public String getVertexName(Integer vertex)
+    private static ComponentNameProvider<Integer> nameProvider =
+        new ComponentNameProvider<Integer>()
         {
-            return String.valueOf(vertex);
-        }
-    };
+            @Override
+            public String getName(Integer vertex)
+            {
+                return String.valueOf(vertex);
+            }
+        };
 
-    private static VertexNameProvider<String> stringNameProvider = new VertexNameProvider<String>()
-    {
-        @Override
-        public String getVertexName(String vertex)
+    private static ComponentNameProvider<String> stringNameProvider =
+        new ComponentNameProvider<String>()
         {
-            return vertex;
-        }
-    };
+            @Override
+            public String getName(String vertex)
+            {
+                return vertex;
+            }
+        };
 
     // @formatter:off
     private static final String UNDIRECTED_EDGE_LIST =

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
@@ -81,7 +81,7 @@ public class DOTExporterTest
             };
 
         DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(
-            new IntegerNameProvider<>(), null, null, vertexAttributeProvider, null);
+            new IntegerComponentNameProvider<>(), null, null, vertexAttributeProvider, null);
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
@@ -91,8 +91,8 @@ public class DOTExporterTest
     public void testValidNodeIDs()
         throws ExportException
     {
-        DOTExporter<String, DefaultEdge> exporter =
-            new DOTExporter<>(new StringNameProvider<>(), new StringNameProvider<>(), null);
+        DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(
+            new StringComponentNameProvider<>(), new StringComponentNameProvider<>(), null);
 
         List<String> validVertices =
             Arrays.asList("-9.78", "-.5", "12", "a", "12", "abc_78", "\"--34asdf\"");
@@ -115,6 +115,32 @@ public class DOTExporterTest
             }
         }
     }
+
+    public void testDifferentGraphID()
+        throws UnsupportedEncodingException, ExportException
+    {
+        UndirectedGraph<String, DefaultEdge> g = new SimpleGraph<>(DefaultEdge.class);
+
+        DOTExporter<String,
+            DefaultEdge> exporter = new DOTExporter<>(
+                new IntegerComponentNameProvider<>(), null, null, null, null,
+                new ComponentNameProvider<Graph<String, DefaultEdge>>()
+                {
+                    @Override
+                    public String getName(Graph<String, DefaultEdge> component)
+                    {
+                        return "MyGraph";
+                    }
+                });
+
+        final String correctResult = "graph MyGraph {" + NL + "}" + NL;
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.exportGraph(g, os);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(correctResult, res);
+    }
+
 }
 
 // End DOTExporterTest.java

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
@@ -114,10 +114,10 @@ public class DOTImporterTest
                 {
                     return new DefaultEdge();
                 }
-            }, new VertexUpdater<String>()
+            }, new ComponentUpdater<String>()
             {
                 @Override
-                public void updateVertex(String vertex, Map<String, String> attributes)
+                public void update(String vertex, Map<String, String> attributes)
                 {
                 }
             });
@@ -169,14 +169,14 @@ public class DOTImporterTest
         start.addEdge("b", "d");
 
         DOTExporter<String, DefaultEdge> exporter =
-            new DOTExporter<String, DefaultEdge>(new VertexNameProvider<String>()
+            new DOTExporter<String, DefaultEdge>(new ComponentNameProvider<String>()
             {
                 @Override
-                public String getVertexName(String vertex)
+                public String getName(String vertex)
                 {
                     return vertex;
                 }
-            }, null, new IntegerEdgeNameProvider<DefaultEdge>());
+            }, null, new IntegerComponentNameProvider<DefaultEdge>());
 
         DOTImporter<String, DefaultEdge> importer = buildImporter();
 
@@ -226,10 +226,10 @@ public class DOTImporterTest
                 {
                     return new DefaultEdge();
                 }
-            }, new VertexUpdater<String>()
+            }, new ComponentUpdater<String>()
             {
                 @Override
-                public void updateVertex(String vertex, Map<String, String> attributes)
+                public void update(String vertex, Map<String, String> attributes)
                 {
                     // do nothing strings can't update.
                 }
@@ -410,10 +410,10 @@ public class DOTImporterTest
                 {
                     return new DefaultEdge();
                 }
-            }, new VertexUpdater<TestVertex>()
+            }, new ComponentUpdater<TestVertex>()
             {
                 @Override
-                public void updateVertex(TestVertex vertex, Map<String, String> attributes)
+                public void update(TestVertex vertex, Map<String, String> attributes)
                 {
                     vertex.getAttributes().putAll(attributes);
                 }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/GraphMLExporterTest.java
@@ -365,18 +365,18 @@ public class GraphMLExporterTest
         g.setEdgeWeight(g.getEdge(V3, V1), 15.0);
 
         GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<>(
-            new IntegerNameProvider<String>(), new VertexNameProvider<String>()
+            new IntegerComponentNameProvider<String>(), new ComponentNameProvider<String>()
             {
                 @Override
-                public String getVertexName(String vertex)
+                public String getName(String vertex)
                 {
                     return vertex;
                 }
-            }, new IntegerEdgeNameProvider<DefaultWeightedEdge>(),
-            new EdgeNameProvider<DefaultWeightedEdge>()
+            }, new IntegerComponentNameProvider<DefaultWeightedEdge>(),
+            new ComponentNameProvider<DefaultWeightedEdge>()
             {
                 @Override
-                public String getEdgeName(DefaultWeightedEdge edge)
+                public String getName(DefaultWeightedEdge edge)
                 {
                     return edge.toString();
                 }
@@ -437,19 +437,19 @@ public class GraphMLExporterTest
         g.setEdgeWeight(g.getEdge(V3, V1), 15.0);
 
         GraphMLExporter<String, DefaultWeightedEdge> exporter = new GraphMLExporter<>();
-        exporter.setVertexLabelProvider(new VertexNameProvider<String>()
+        exporter.setVertexLabelProvider(new ComponentNameProvider<String>()
         {
             @Override
-            public String getVertexName(String vertex)
+            public String getName(String vertex)
             {
                 return "myvertex-" + vertex;
             }
         });
         exporter.setVertexLabelAttributeName("custom_vertex_label");
-        exporter.setEdgeLabelProvider(new EdgeNameProvider<DefaultWeightedEdge>()
+        exporter.setEdgeLabelProvider(new ComponentNameProvider<DefaultWeightedEdge>()
         {
             @Override
-            public String getEdgeName(DefaultWeightedEdge edge)
+            public String getName(DefaultWeightedEdge edge)
             {
                 return "myedge-" + edge.toString();
             }
@@ -560,8 +560,8 @@ public class GraphMLExporterTest
 
         GraphMLExporter<String,
             DefaultWeightedEdge> exporter = new GraphMLExporter<>(
-                new IntegerNameProvider<>(), null, vertexAttributeProvider,
-                new IntegerEdgeNameProvider<>(), null, edgeAttributeProvider);
+                new IntegerComponentNameProvider<>(), null, vertexAttributeProvider,
+                new IntegerComponentNameProvider<>(), null, edgeAttributeProvider);
         exporter.setExportEdgeWeights(true);
         exporter.registerAttribute(
             "color", GraphMLExporter.AttributeCategory.NODE, GraphMLExporter.AttributeType.STRING,
@@ -637,8 +637,8 @@ public class GraphMLExporterTest
 
         GraphMLExporter<String,
             DefaultWeightedEdge> exporter = new GraphMLExporter<>(
-                new IntegerNameProvider<>(), null, vertexAttributeProvider,
-                new IntegerEdgeNameProvider<>(), null, edgeAttributeProvider);
+                new IntegerComponentNameProvider<>(), null, vertexAttributeProvider,
+                new IntegerComponentNameProvider<>(), null, edgeAttributeProvider);
         exporter.setExportEdgeWeights(true);
         exporter.registerAttribute(
             "color", GraphMLExporter.AttributeCategory.NODE, GraphMLExporter.AttributeType.STRING,


### PR DESCRIPTION
@jsichi, @jkinable Last minute change hopefully in time for the 1.0 release. 

Instead of having two interfaces EdgeNameProvider and VertexNameProvider which do exactly the same thing, we now have only a `ComponentNameProvider<T>` where T is either an edge or a vertex.

This enables us to easily implement the functionality of pull request #286 by having one more provider in the DOTExporter for the graph identifier.
  