### PR TITLE
Hide autogenerated classes of antlr

### DIFF
--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -105,7 +105,71 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<!-- Make antlr4 generated classes package protected, until antlr4 provides 
+					official support for this. See https://github.com/antlr/antlr4/issues/972. 
+					Important: this plugin must be AFTER the antlr4-maven-plugin as they are 
+					bound to the same phase (generate-sources). -->
+				<groupId>com.google.code.maven-replacer-plugin</groupId>
+				<artifactId>replacer</artifactId>
+				<version>1.5.3</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals>
+							<goal>replace</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<basedir>${project.basedir}</basedir>
+					<includes>
+						<include>target/generated-sources/antlr4/**/*.java</include>
+					</includes>
+					<variableTokenValueMap xml:space="preserve">
+						<![CDATA[public class=class,public interface=interface]]>
+					</variableTokenValueMap>
+				</configuration>
+			</plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>
+											com.google.code.maven-replacer-plugin
+										</groupId>
+										<artifactId>
+											replacer
+										</artifactId>
+										<versionRange>
+											[1.5.3,)
+										</versionRange>
+										<goals>
+											<goal>replace</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<execute>
+											<runOnIncremental>false</runOnIncremental>
+										</execute>
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
A small change in `pom.xml` of jgrapht-ext package in order to make package private all autogenerated classes of antlr. This change significantly improves the javadocs and avoids user confusion.

Antlr v4 does not support this out-of-the-box yet, so we use the replacer plugin until then. 