### PR TITLE
Resolved several missing tests and todo warnings

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
@@ -54,12 +54,6 @@ public class VertexDegreeComparator<V, E>
     private UndirectedGraph<V, E> graph;
 
     /**
-     * The sort order for vertex degree. <code>true</code> for ascending degree order (smaller
-     * degrees first), <code>false</code> for descending.
-     */
-    private boolean ascendingOrder;
-
-    /**
      * Order in which the vertices are sorted: ascending or descending
      */
     private Order order;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedDirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedDirectedGraph.java
@@ -48,6 +48,8 @@ public class AsUnweightedDirectedGraph<V, E>
     extends AsUnweightedGraph<V, E>
     implements DirectedGraph<V, E>
 {
+    private static final long serialVersionUID = 4999731801535663595L;
+
     /**
      * Constructor for AsUnweightedGraph.
      *

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/MaskEdgeSet.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/MaskEdgeSet.java
@@ -38,8 +38,6 @@ class MaskEdgeSet<V, E>
 
     private MaskFunctor<V, E> mask;
 
-    private transient TypeUtil<E> edgeTypeDecl = null;
-
     public MaskEdgeSet(Graph<V, E> graph, Set<E> edgeSet, MaskFunctor<V, E> mask)
     {
         this.graph = graph;
@@ -55,7 +53,7 @@ class MaskEdgeSet<V, E>
     {
         // Force a cast to type E. This is nonsense, of course, but
         // it's erased by the compiler anyway.
-        E e = (E) o;
+        E e = TypeUtil.uncheckedCast(o, null);
 
         // If o isn't an E, the first check will fail and
         // short-circuit, so we never try to test the mask on non-edge

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/MaskVertexSet.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/MaskVertexSet.java
@@ -35,8 +35,6 @@ class MaskVertexSet<V, E>
 
     private Set<V> vertexSet;
 
-    private transient TypeUtil<V> vertexTypeDecl = null;
-
     public MaskVertexSet(Set<V> vertexSet, MaskFunctor<V, E> mask)
     {
         this.vertexSet = vertexSet;
@@ -51,7 +49,7 @@ class MaskVertexSet<V, E>
     {
         // Force a cast to type V. This is nonsense, of course, but
         // it's erased by the compiler anyway.
-        V v = (V) o;
+        V v = TypeUtil.uncheckedCast(o, null);
 
         // If o isn't a V, the first check will fail and
         // short-circuit, so we never try to test the mask on

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleDirectedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleDirectedGraphTest.java
@@ -43,6 +43,18 @@ public class SimpleDirectedGraphTest
     private String v2 = "v2";
     private String v3 = "v3";
     private String v4 = "v4";
+    private DefaultEdge e12_1;
+    private DefaultEdge e12_2;
+    private DefaultEdge e12_3;
+    private DefaultEdge e21_1;
+    private DefaultEdge e21_2;
+    private DefaultEdge e13_1;
+    private DefaultEdge e23_1;
+    private DefaultEdge e31_1;
+    private DefaultEdge e32_1;
+    private DefaultEdge e23_2;
+    private DefaultEdge e34_1;
+    private DefaultEdge e41_1;
 
     // ~ Constructors -----------------------------------------------------------
 
@@ -148,7 +160,20 @@ public class SimpleDirectedGraphTest
     {
         init();
 
-        // TODO Implement containsEdge().
+        assertTrue(g2.containsEdge(e12_1));
+        assertTrue(g2.containsEdge(e21_1));
+
+        assertTrue(g3.containsEdge(e12_2));
+        assertTrue(g3.containsEdge(e21_2));
+        assertTrue(g3.containsEdge(e23_1));
+        assertTrue(g3.containsEdge(e32_1));
+        assertTrue(g3.containsEdge(e31_1));
+        assertTrue(g3.containsEdge(e13_1));
+
+        assertTrue(g4.containsEdge(e12_3));
+        assertTrue(g4.containsEdge(e23_2));
+        assertTrue(g4.containsEdge(e34_1));
+        assertTrue(g4.containsEdge(e41_1));
     }
 
     /**
@@ -186,7 +211,22 @@ public class SimpleDirectedGraphTest
     {
         init();
 
-        // TODO Implement containsVertex().
+        assertTrue(g1.containsVertex(v1));
+        assertFalse(g1.containsVertex(v2));
+
+        assertTrue(g2.containsVertex(v1));
+        assertTrue(g2.containsVertex(v2));
+        assertFalse(g2.containsVertex(v3));
+
+        assertTrue(g3.containsVertex(v1));
+        assertTrue(g3.containsVertex(v2));
+        assertTrue(g3.containsVertex(v3));
+        assertFalse(g3.containsVertex(v4));
+
+        assertTrue(g4.containsVertex(v1));
+        assertTrue(g4.containsVertex(v2));
+        assertTrue(g4.containsVertex(v3));
+        assertTrue(g4.containsVertex(v4));
     }
 
     /**
@@ -196,7 +236,25 @@ public class SimpleDirectedGraphTest
     {
         init();
 
-        // TODO Implement edgeSet().
+        assertEquals(0, g1.edgeSet().size());
+
+        assertEquals(2, g2.edgeSet().size());
+        assertTrue(g2.edgeSet().contains(e12_1));
+        assertTrue(g2.edgeSet().contains(e21_1));
+
+        assertEquals(6, g3.edgeSet().size());
+        assertTrue(g3.edgeSet().contains(e12_2));
+        assertTrue(g3.edgeSet().contains(e21_2));
+        assertTrue(g3.edgeSet().contains(e23_1));
+        assertTrue(g3.edgeSet().contains(e32_1));
+        assertTrue(g3.edgeSet().contains(e31_1));
+        assertTrue(g3.edgeSet().contains(e13_1));
+
+        assertEquals(4, g4.edgeSet().size());
+        assertTrue(g4.edgeSet().contains(e12_3));
+        assertTrue(g4.edgeSet().contains(e23_2));
+        assertTrue(g4.edgeSet().contains(e34_1));
+        assertTrue(g4.edgeSet().contains(e41_1));
     }
 
     /**
@@ -225,7 +283,13 @@ public class SimpleDirectedGraphTest
      */
     public void testGetAllEdges()
     {
-        init(); // TODO Implement getAllEdges().
+        init();
+
+        assertEquals(1, g3.getAllEdges(v1, v2).size());
+        assertTrue(g3.getAllEdges(v1, v2).contains(e12_2));
+
+        assertEquals(1, g3.getAllEdges(v2, v1).size());
+        assertTrue(g3.getAllEdges(v2, v1).contains(e21_2));
     }
 
     /**
@@ -233,7 +297,22 @@ public class SimpleDirectedGraphTest
      */
     public void testGetEdge()
     {
-        init(); // TODO Implement getEdge().
+        init();
+
+        assertEquals(e12_1, g2.getEdge(v1, v2));
+        assertEquals(e21_1, g2.getEdge(v2, v1));
+
+        assertEquals(e12_2, g3.getEdge(v1, v2));
+        assertEquals(e21_2, g3.getEdge(v2, v1));
+        assertEquals(e21_2, g3.getEdge(v2, v1));
+        assertEquals(e32_1, g3.getEdge(v3, v2));
+        assertEquals(e31_1, g3.getEdge(v3, v1));
+        assertEquals(e13_1, g3.getEdge(v1, v3));
+
+        assertEquals(e12_3, g4.getEdge(v1, v2));
+        assertEquals(e23_2, g4.getEdge(v2, v3));
+        assertEquals(e34_1, g4.getEdge(v3, v4));
+        assertEquals(e41_1, g4.getEdge(v4, v1));
     }
 
     /**
@@ -241,7 +320,14 @@ public class SimpleDirectedGraphTest
      */
     public void testGetEdgeFactory()
     {
-        init(); // TODO Implement getEdgeFactory().
+        init();
+
+        assertNotNull(g1.getEdgeFactory());
+        EdgeFactory<String, DefaultEdge> ef = g1.getEdgeFactory();
+        DefaultEdge e = ef.createEdge(v1, v2);
+        assertNotNull(e);
+        assertNull(g1.getEdgeSource(e));
+        assertNull(g1.getEdgeTarget(e));
     }
 
     /**
@@ -297,7 +383,17 @@ public class SimpleDirectedGraphTest
      */
     public void testOutDegreeOf()
     {
-        init(); // TODO Implement outDegreeOf().
+        init();
+
+        assertEquals(1, g2.outDegreeOf(v1));
+        assertEquals(1, g2.outDegreeOf(v2));
+        assertEquals(2, g3.outDegreeOf(v1));
+        assertEquals(2, g3.outDegreeOf(v2));
+        assertEquals(2, g3.outDegreeOf(v3));
+        assertEquals(1, g4.outDegreeOf(v1));
+        assertEquals(1, g4.outDegreeOf(v2));
+        assertEquals(1, g4.outDegreeOf(v3));
+        assertEquals(1, g4.outDegreeOf(v4));
     }
 
     /**
@@ -305,7 +401,33 @@ public class SimpleDirectedGraphTest
      */
     public void testOutgoingEdgesOf()
     {
-        init(); // TODO Implement outgoingEdgesOf().
+        init();
+
+        assertEquals(0, g1.outgoingEdgesOf(v1).size());
+
+        assertEquals(1, g2.outgoingEdgesOf(v1).size());
+        assertTrue(g2.outgoingEdgesOf(v1).contains(e12_1));
+        assertEquals(1, g2.outgoingEdgesOf(v2).size());
+        assertTrue(g2.outgoingEdgesOf(v2).contains(e21_1));
+
+        assertEquals(2, g3.outgoingEdgesOf(v1).size());
+        assertTrue(g3.outgoingEdgesOf(v1).contains(e12_2));
+        assertTrue(g3.outgoingEdgesOf(v1).contains(e13_1));
+        assertEquals(2, g3.outgoingEdgesOf(v2).size());
+        assertTrue(g3.outgoingEdgesOf(v2).contains(e23_1));
+        assertTrue(g3.outgoingEdgesOf(v2).contains(e21_2));
+        assertEquals(2, g3.outgoingEdgesOf(v3).size());
+        assertTrue(g3.outgoingEdgesOf(v3).contains(e31_1));
+        assertTrue(g3.outgoingEdgesOf(v3).contains(e32_1));
+
+        assertEquals(1, g4.outgoingEdgesOf(v1).size());
+        assertTrue(g4.outgoingEdgesOf(v1).contains(e12_3));
+        assertEquals(1, g4.outgoingEdgesOf(v2).size());
+        assertTrue(g4.outgoingEdgesOf(v2).contains(e23_2));
+        assertEquals(1, g4.outgoingEdgesOf(v3).size());
+        assertTrue(g4.outgoingEdgesOf(v3).contains(e34_1));
+        assertEquals(1, g4.outgoingEdgesOf(v4).size());
+        assertTrue(g4.outgoingEdgesOf(v4).contains(e41_1));
     }
 
     /**
@@ -328,7 +450,14 @@ public class SimpleDirectedGraphTest
      */
     public void testRemoveEdgeObjectObject()
     {
-        init(); // TODO Implement removeEdge().
+        init();
+
+        assertEquals(g4.edgeSet().size(), 4);
+        g4.removeEdge(v1, v2);
+        assertEquals(g4.edgeSet().size(), 3);
+        assertFalse(g4.removeEdge(eLoop));
+        assertTrue(g4.removeEdge(g4.getEdge(v2, v3)));
+        assertEquals(g4.edgeSet().size(), 2);
     }
 
     public void testRemoveAllEdgesObjectObject()
@@ -380,7 +509,25 @@ public class SimpleDirectedGraphTest
      */
     public void testVertexSet()
     {
-        init(); // TODO Implement vertexSet().
+        init();
+
+        assertEquals(1, g1.vertexSet().size());
+        assertTrue(g1.vertexSet().contains(v1));
+
+        assertEquals(2, g2.vertexSet().size());
+        assertTrue(g2.vertexSet().contains(v1));
+        assertTrue(g2.vertexSet().contains(v2));
+
+        assertEquals(3, g3.vertexSet().size());
+        assertTrue(g3.vertexSet().contains(v1));
+        assertTrue(g3.vertexSet().contains(v2));
+        assertTrue(g3.vertexSet().contains(v3));
+
+        assertEquals(4, g4.vertexSet().size());
+        assertTrue(g4.vertexSet().contains(v1));
+        assertTrue(g4.vertexSet().contains(v2));
+        assertTrue(g4.vertexSet().contains(v3));
+        assertTrue(g4.vertexSet().contains(v4));
     }
 
     public void testReversedView()
@@ -465,27 +612,27 @@ public class SimpleDirectedGraphTest
 
         g2.addVertex(v1);
         g2.addVertex(v2);
-        g2.addEdge(v1, v2);
-        g2.addEdge(v2, v1);
+        e12_1 = g2.addEdge(v1, v2);
+        e21_1 = g2.addEdge(v2, v1);
 
         g3.addVertex(v1);
         g3.addVertex(v2);
         g3.addVertex(v3);
-        g3.addEdge(v1, v2);
-        g3.addEdge(v2, v1);
-        g3.addEdge(v2, v3);
-        g3.addEdge(v3, v2);
-        g3.addEdge(v3, v1);
-        g3.addEdge(v1, v3);
+        e12_2 = g3.addEdge(v1, v2);
+        e21_2 = g3.addEdge(v2, v1);
+        e23_1 = g3.addEdge(v2, v3);
+        e32_1 = g3.addEdge(v3, v2);
+        e31_1 = g3.addEdge(v3, v1);
+        e13_1 = g3.addEdge(v1, v3);
 
         g4.addVertex(v1);
         g4.addVertex(v2);
         g4.addVertex(v3);
         g4.addVertex(v4);
-        g4.addEdge(v1, v2);
-        g4.addEdge(v2, v3);
-        g4.addEdge(v3, v4);
-        g4.addEdge(v4, v1);
+        e12_3 = g4.addEdge(v1, v2);
+        e23_2 = g4.addEdge(v2, v3);
+        e34_1 = g4.addEdge(v3, v4);
+        e41_1 = g4.addEdge(v4, v1);
     }
 }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleIdentityDirectedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleIdentityDirectedGraphTest.java
@@ -17,10 +17,16 @@
  */
 package org.jgrapht.graph;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.Set;
 
-import org.jgrapht.*;
-import org.jgrapht.graph.specifics.*;
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.EdgeFactory;
+import org.jgrapht.EnhancedTestCase;
+import org.jgrapht.graph.specifics.DirectedSpecifics;
+import org.jgrapht.util.TypeUtil;
 
 /**
  * A unit test for simple directed graph when the backing map is an IdentityHashMap
@@ -56,7 +62,7 @@ public class SimpleIdentityDirectedGraphTest
             if (o == null || getClass() != o.getClass())
                 return false;
 
-            Holder holder = (Holder) o;
+            Holder<T> holder = TypeUtil.uncheckedCast(o, null);
 
             return !(t != null ? !t.equals(holder.t) : holder.t != null);
 
@@ -72,6 +78,7 @@ public class SimpleIdentityDirectedGraphTest
     public static class SimpleIdentityDirectedGraph<V, E>
         extends SimpleDirectedGraph<V, E>
     {
+        private static final long serialVersionUID = 4600490314100246989L;
 
         public SimpleIdentityDirectedGraph(Class<? extends E> edgeClass)
         {
@@ -103,6 +110,18 @@ public class SimpleIdentityDirectedGraphTest
     private Holder<String> v2 = new Holder<>("v2");
     private Holder<String> v3 = new Holder<>("v3");
     private Holder<String> v4 = new Holder<>("v4");
+    private DefaultEdge e12_1;
+    private DefaultEdge e12_2;
+    private DefaultEdge e12_3;
+    private DefaultEdge e21_1;
+    private DefaultEdge e21_2;
+    private DefaultEdge e13_1;
+    private DefaultEdge e23_1;
+    private DefaultEdge e31_1;
+    private DefaultEdge e32_1;
+    private DefaultEdge e23_2;
+    private DefaultEdge e34_1;
+    private DefaultEdge e41_1;
 
     // ~ Constructors -----------------------------------------------------------
 
@@ -208,7 +227,20 @@ public class SimpleIdentityDirectedGraphTest
     {
         init();
 
-        // TODO Implement containsEdge().
+        assertTrue(g2.containsEdge(e12_1));
+        assertTrue(g2.containsEdge(e21_1));
+
+        assertTrue(g3.containsEdge(e12_2));
+        assertTrue(g3.containsEdge(e21_2));
+        assertTrue(g3.containsEdge(e23_1));
+        assertTrue(g3.containsEdge(e32_1));
+        assertTrue(g3.containsEdge(e31_1));
+        assertTrue(g3.containsEdge(e13_1));
+
+        assertTrue(g4.containsEdge(e12_3));
+        assertTrue(g4.containsEdge(e23_2));
+        assertTrue(g4.containsEdge(e34_1));
+        assertTrue(g4.containsEdge(e41_1));
     }
 
     /**
@@ -260,7 +292,25 @@ public class SimpleIdentityDirectedGraphTest
     {
         init();
 
-        // TODO Implement edgeSet().
+        assertEquals(0, g1.edgeSet().size());
+
+        assertEquals(2, g2.edgeSet().size());
+        assertTrue(g2.edgeSet().contains(e12_1));
+        assertTrue(g2.edgeSet().contains(e21_1));
+
+        assertEquals(6, g3.edgeSet().size());
+        assertTrue(g3.edgeSet().contains(e12_2));
+        assertTrue(g3.edgeSet().contains(e21_2));
+        assertTrue(g3.edgeSet().contains(e23_1));
+        assertTrue(g3.edgeSet().contains(e32_1));
+        assertTrue(g3.edgeSet().contains(e31_1));
+        assertTrue(g3.edgeSet().contains(e13_1));
+
+        assertEquals(4, g4.edgeSet().size());
+        assertTrue(g4.edgeSet().contains(e12_3));
+        assertTrue(g4.edgeSet().contains(e23_2));
+        assertTrue(g4.edgeSet().contains(e34_1));
+        assertTrue(g4.edgeSet().contains(e41_1));
     }
 
     /**
@@ -289,7 +339,13 @@ public class SimpleIdentityDirectedGraphTest
      */
     public void testGetAllEdges()
     {
-        init(); // TODO Implement getAllEdges().
+        init();
+
+        assertEquals(1, g3.getAllEdges(v1, v2).size());
+        assertTrue(g3.getAllEdges(v1, v2).contains(e12_2));
+
+        assertEquals(1, g3.getAllEdges(v2, v1).size());
+        assertTrue(g3.getAllEdges(v2, v1).contains(e21_2));
     }
 
     /**
@@ -297,7 +353,22 @@ public class SimpleIdentityDirectedGraphTest
      */
     public void testGetEdge()
     {
-        init(); // TODO Implement getEdge().
+        init();
+
+        assertEquals(e12_1, g2.getEdge(v1, v2));
+        assertEquals(e21_1, g2.getEdge(v2, v1));
+
+        assertEquals(e12_2, g3.getEdge(v1, v2));
+        assertEquals(e21_2, g3.getEdge(v2, v1));
+        assertEquals(e21_2, g3.getEdge(v2, v1));
+        assertEquals(e32_1, g3.getEdge(v3, v2));
+        assertEquals(e31_1, g3.getEdge(v3, v1));
+        assertEquals(e13_1, g3.getEdge(v1, v3));
+
+        assertEquals(e12_3, g4.getEdge(v1, v2));
+        assertEquals(e23_2, g4.getEdge(v2, v3));
+        assertEquals(e34_1, g4.getEdge(v3, v4));
+        assertEquals(e41_1, g4.getEdge(v4, v1));
     }
 
     /**
@@ -305,7 +376,14 @@ public class SimpleIdentityDirectedGraphTest
      */
     public void testGetEdgeFactory()
     {
-        init(); // TODO Implement getEdgeFactory().
+        init();
+
+        assertNotNull(g1.getEdgeFactory());
+        EdgeFactory<Holder<String>, DefaultEdge> ef = g1.getEdgeFactory();
+        DefaultEdge e = ef.createEdge(v1, v2);
+        assertNotNull(e);
+        assertNull(g1.getEdgeSource(e));
+        assertNull(g1.getEdgeTarget(e));
     }
 
     /**
@@ -361,7 +439,17 @@ public class SimpleIdentityDirectedGraphTest
      */
     public void testOutDegreeOf()
     {
-        init(); // TODO Implement outDegreeOf().
+        init();
+
+        assertEquals(1, g2.outDegreeOf(v1));
+        assertEquals(1, g2.outDegreeOf(v2));
+        assertEquals(2, g3.outDegreeOf(v1));
+        assertEquals(2, g3.outDegreeOf(v2));
+        assertEquals(2, g3.outDegreeOf(v3));
+        assertEquals(1, g4.outDegreeOf(v1));
+        assertEquals(1, g4.outDegreeOf(v2));
+        assertEquals(1, g4.outDegreeOf(v3));
+        assertEquals(1, g4.outDegreeOf(v4));
     }
 
     /**
@@ -369,7 +457,30 @@ public class SimpleIdentityDirectedGraphTest
      */
     public void testOutgoingEdgesOf()
     {
-        init(); // TODO Implement outgoingEdgesOf().
+        init();
+
+        assertEquals(0, g1.outgoingEdgesOf(v1).size());
+        assertEquals(1, g2.outgoingEdgesOf(v1).size());
+        assertTrue(g2.outgoingEdgesOf(v1).contains(e12_1));
+        assertEquals(1, g2.outgoingEdgesOf(v2).size());
+        assertTrue(g2.outgoingEdgesOf(v2).contains(e21_1));
+        assertEquals(2, g3.outgoingEdgesOf(v1).size());
+        assertTrue(g3.outgoingEdgesOf(v1).contains(e12_2));
+        assertTrue(g3.outgoingEdgesOf(v1).contains(e13_1));
+        assertEquals(2, g3.outgoingEdgesOf(v2).size());
+        assertTrue(g3.outgoingEdgesOf(v2).contains(e23_1));
+        assertTrue(g3.outgoingEdgesOf(v2).contains(e21_2));
+        assertEquals(2, g3.outgoingEdgesOf(v3).size());
+        assertTrue(g3.outgoingEdgesOf(v3).contains(e31_1));
+        assertTrue(g3.outgoingEdgesOf(v3).contains(e32_1));
+        assertEquals(1, g4.outgoingEdgesOf(v1).size());
+        assertTrue(g4.outgoingEdgesOf(v1).contains(e12_3));
+        assertEquals(1, g4.outgoingEdgesOf(v2).size());
+        assertTrue(g4.outgoingEdgesOf(v2).contains(e23_2));
+        assertEquals(1, g4.outgoingEdgesOf(v3).size());
+        assertTrue(g4.outgoingEdgesOf(v3).contains(e34_1));
+        assertEquals(1, g4.outgoingEdgesOf(v4).size());
+        assertTrue(g4.outgoingEdgesOf(v4).contains(e41_1));
     }
 
     /**
@@ -392,7 +503,14 @@ public class SimpleIdentityDirectedGraphTest
      */
     public void testRemoveEdgeObjectObject()
     {
-        init(); // TODO Implement removeEdge().
+        init();
+
+        assertEquals(g4.edgeSet().size(), 4);
+        g4.removeEdge(v1, v2);
+        assertEquals(g4.edgeSet().size(), 3);
+        assertFalse(g4.removeEdge(eLoop));
+        assertTrue(g4.removeEdge(g4.getEdge(v2, v3)));
+        assertEquals(g4.edgeSet().size(), 2);
     }
 
     public void testRemoveAllEdgesObjectObject()
@@ -444,7 +562,25 @@ public class SimpleIdentityDirectedGraphTest
      */
     public void testVertexSet()
     {
-        init(); // TODO Implement vertexSet().
+        init();
+
+        assertEquals(1, g1.vertexSet().size());
+        assertTrue(g1.vertexSet().contains(v1));
+
+        assertEquals(2, g2.vertexSet().size());
+        assertTrue(g2.vertexSet().contains(v1));
+        assertTrue(g2.vertexSet().contains(v2));
+
+        assertEquals(3, g3.vertexSet().size());
+        assertTrue(g3.vertexSet().contains(v1));
+        assertTrue(g3.vertexSet().contains(v2));
+        assertTrue(g3.vertexSet().contains(v3));
+
+        assertEquals(4, g4.vertexSet().size());
+        assertTrue(g4.vertexSet().contains(v1));
+        assertTrue(g4.vertexSet().contains(v2));
+        assertTrue(g4.vertexSet().contains(v3));
+        assertTrue(g4.vertexSet().contains(v4));
     }
 
     public void testReversedView()
@@ -529,27 +665,27 @@ public class SimpleIdentityDirectedGraphTest
 
         g2.addVertex(v1);
         g2.addVertex(v2);
-        g2.addEdge(v1, v2);
-        g2.addEdge(v2, v1);
+        e12_1 = g2.addEdge(v1, v2);
+        e21_1 = g2.addEdge(v2, v1);
 
         g3.addVertex(v1);
         g3.addVertex(v2);
         g3.addVertex(v3);
-        g3.addEdge(v1, v2);
-        g3.addEdge(v2, v1);
-        g3.addEdge(v2, v3);
-        g3.addEdge(v3, v2);
-        g3.addEdge(v3, v1);
-        g3.addEdge(v1, v3);
+        e12_2 = g3.addEdge(v1, v2);
+        e21_2 = g3.addEdge(v2, v1);
+        e23_1 = g3.addEdge(v2, v3);
+        e32_1 = g3.addEdge(v3, v2);
+        e31_1 = g3.addEdge(v3, v1);
+        e13_1 = g3.addEdge(v1, v3);
 
         g4.addVertex(v1);
         g4.addVertex(v2);
         g4.addVertex(v3);
         g4.addVertex(v4);
-        g4.addEdge(v1, v2);
-        g4.addEdge(v2, v3);
-        g4.addEdge(v3, v4);
-        g4.addEdge(v4, v1);
+        e12_3 = g4.addEdge(v1, v2);
+        e23_2 = g4.addEdge(v2, v3);
+        e34_1 = g4.addEdge(v3, v4);
+        e41_1 = g4.addEdge(v4, v1);
 
         // change vertex values
 

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/JGraphAdapterDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/JGraphAdapterDemo.java
@@ -128,7 +128,7 @@ public class JGraphAdapterDemo
         jg.setBackground(c);
     }
 
-    @SuppressWarnings("unchecked") // FIXME hb 28-nov-05: See FIXME below
+    @SuppressWarnings("unchecked") 
     private void positionVertexAt(Object vertex, int x, int y)
     {
         DefaultGraphCell cell = jgAdapter.getVertexCell(vertex);
@@ -139,7 +139,6 @@ public class JGraphAdapterDemo
 
         GraphConstants.setBounds(attr, newBounds);
 
-        // TODO: Clean up generics once JGraph goes generic
         AttributeMap cellAttr = new AttributeMap();
         cellAttr.put(cell, attr);
         jgAdapter.edit(cellAttr, null, null, null);

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTUtils.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTUtils.java
@@ -26,10 +26,7 @@ import org.jgrapht.*;
  * Class with DOT format related utilities.
  * 
  * @author Christoph Zauner
- * 
- * @deprecated in favor of implementing the current functionality directly by the user
  */
-@Deprecated
 public class DOTUtils
 {
     /** Keyword for representing strict graphs. */

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/JGraphModelAdapter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/JGraphModelAdapter.java
@@ -403,7 +403,6 @@ public class JGraphModelAdapter<V, E>
             // JGraphT forbid dangling edges so we cannot add the edge yet. If
             // later the edge becomes connected, we will add it.
         } else {
-            // FIXME hb 28-nov-05: waiting for jgraph to go generic
             Object jSource = getSourceVertex(this, jEdge);
             Object jTarget = getTargetVertex(this, jEdge);
 
@@ -451,7 +450,6 @@ public class JGraphModelAdapter<V, E>
         V jtVertex;
 
         if (jVertex instanceof DefaultGraphCell) {
-            // FIXME hb 28-nov-05: waiting for jgraph to go generic
             jtVertex = (V) ((DefaultGraphCell) jVertex).getUserObject();
         } else {
             // FIXME: Why toString? Explain if for a good reason otherwise fix.
@@ -634,7 +632,6 @@ public class JGraphModelAdapter<V, E>
     {
         AttributeMap attrs = new AttributeMap();
 
-        // FIXME hb 28-nov-05: waiting for graph to go generic
         attrs.put(edgeCell, getDefaultEdgeAttributes().clone());
 
         return attrs;
@@ -645,7 +642,6 @@ public class JGraphModelAdapter<V, E>
     {
         AttributeMap attrs = new AttributeMap();
 
-        // FIXME hb 28-nov-05: waiting for graph to go generic
         attrs.put(vertexCell, getDefaultVertexAttributes().clone());
 
         return attrs;
@@ -658,7 +654,6 @@ public class JGraphModelAdapter<V, E>
      * @param attrs
      * @param cs
      */
-    // FIXME hb 28-nov-05: waiting for graph to go generic
     private void internalInsertCell(GraphCell cell, AttributeMap attrs, ConnectionSet cs)
     {
         jCellsBeingAdded.add(cell);

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTExporterTest.java
@@ -41,8 +41,6 @@ public class DOTExporterTest
 
     private static final String NL = System.getProperty("line.separator");
 
-    // TODO jvs 23-Dec-2006: externalized diff-based testing framework
-
     private static final String UNDIRECTED = "graph G {" + NL + "  1 [ label=\"a\" ];" + NL
         + "  2 [ x=\"y\" ];" + NL + "  3;" + NL + "  1 -- 2;" + NL + "  3 -- 1;" + NL + "}" + NL;
 


### PR DESCRIPTION
Reduced the warnings and todos that show up in eclipse.
 - Added missing tests marked with TODO
 - Removed TODOs related with JGraph and generics, as JGraph is no longer developed.
 - Fixed several compiler warnings
