### PR TITLE
Revised Subgraph and MaskSubgraph

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/BlockCutpointGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/BlockCutpointGraph.java
@@ -166,9 +166,8 @@ public class BlockCutpointGraph<V, E>
         vertexComponent.add(edge.getSource());
         vertexComponent.add(edge.getTarget());
 
-        VertexComponentForbiddenFunction mask =
-            new VertexComponentForbiddenFunction(vertexComponent);
-        UndirectedGraph<V, E> biconnectedSubgraph = new UndirectedMaskSubgraph<>(this.graph, mask);
+        UndirectedGraph<V, E> biconnectedSubgraph =
+            new UndirectedMaskSubgraph<>(this.graph, v -> !vertexComponent.contains(v), e -> false);
         for (V vertex : vertexComponent) {
             this.vertex2block.put(vertex, biconnectedSubgraph);
             getBiconnectedSubgraphs(vertex).add(biconnectedSubgraph);
@@ -279,29 +278,6 @@ public class BlockCutpointGraph<V, E>
         public V getTarget()
         {
             return this.target;
-        }
-    }
-
-    private class VertexComponentForbiddenFunction
-        implements MaskFunctor<V, E>
-    {
-        private Set<V> vertexComponent;
-
-        public VertexComponentForbiddenFunction(Set<V> vertexComponent)
-        {
-            this.vertexComponent = vertexComponent;
-        }
-
-        @Override
-        public boolean isEdgeMasked(E edge)
-        {
-            return false;
-        }
-
-        @Override
-        public boolean isVertexMasked(V vertex)
-        {
-            return !this.vertexComponent.contains(vertex);
         }
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElementList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/RankingPathElementList.java
@@ -306,17 +306,21 @@ final class RankingPathElementList<V, E>
         }
 
         ConnectivityInspector<V, E> connectivityInspector;
-        MaskFunctor<V, E> connectivityMask;
+        PathMask<V, E> connectivityMask;
 
         if (this.graph instanceof DirectedGraph<?, ?>) {
             connectivityMask = new PathMask<>(prevPathElement);
-            DirectedMaskSubgraph<V, E> connectivityGraph =
-                new DirectedMaskSubgraph<>((DirectedGraph<V, E>) this.graph, connectivityMask);
+            DirectedMaskSubgraph<V,
+                E> connectivityGraph = new DirectedMaskSubgraph<>(
+                    (DirectedGraph<V, E>) this.graph, v -> connectivityMask.isVertexMasked(v),
+                    e -> connectivityMask.isEdgeMasked(e));
             connectivityInspector = new ConnectivityInspector<>(connectivityGraph);
         } else {
             connectivityMask = new PathMask<>(prevPathElement);
-            UndirectedMaskSubgraph<V, E> connectivityGraph =
-                new UndirectedMaskSubgraph<>((UndirectedGraph<V, E>) this.graph, connectivityMask);
+            UndirectedMaskSubgraph<V,
+                E> connectivityGraph = new UndirectedMaskSubgraph<>(
+                    (UndirectedGraph<V, E>) this.graph, v -> connectivityMask.isVertexMasked(v),
+                    e -> connectivityMask.isEdgeMasked(e));
             connectivityInspector = new ConnectivityInspector<>(connectivityGraph);
         }
 
@@ -382,7 +386,6 @@ final class RankingPathElementList<V, E>
     }
 
     private static class PathMask<V, E>
-        implements MaskFunctor<V, E>
     {
         private Set<E> maskedEdges;
 
@@ -407,15 +410,11 @@ final class RankingPathElementList<V, E>
             this.maskedVertices.add(pathElement.getVertex());
         }
 
-        // implement MaskFunctor
-        @Override
         public boolean isEdgeMasked(E edge)
         {
             return this.maskedEdges.contains(edge);
         }
 
-        // implement MaskFunctor
-        @Override
         public boolean isVertexMasked(V vertex)
         {
             return this.maskedVertices.contains(vertex);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/EdgeBasedTwoApproxVCImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/EdgeBasedTwoApproxVCImpl.java
@@ -71,7 +71,7 @@ public class EdgeBasedTwoApproxVCImpl<V, E>
         Set<V> cover = new LinkedHashSet<>();
 
         // G'=(V',E') <-- G(V,E)
-        Subgraph<V, E, Graph<V, E>> sg = new Subgraph<>(graph, null, null);
+        UndirectedGraph<V, E> sg = new UndirectedSubgraph<>(graph, null, null);
 
         // while E' is non-empty
         while (!sg.edgeSet().isEmpty()) {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedMaskSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedMaskSubgraph.java
@@ -17,10 +17,13 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import org.jgrapht.DirectedGraph;
 
 /**
- * A directed graph that is a {@link MaskSubgraph} on another graph.
+ * A directed graph that is a {@link MaskSubgraph} of another graph.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -38,11 +41,71 @@ public class DirectedMaskSubgraph<V, E>
      * @param base the base graph
      * @param mask vertices and edges to exclude in the subgraph. If a vertex/edge is masked, it is
      *        as if it is not in the subgraph.
+     * @deprecated in favor of using lambdas
      */
+    @Deprecated
     public DirectedMaskSubgraph(DirectedGraph<V, E> base, MaskFunctor<V, E> mask)
     {
         super(base, mask);
     }
+
+    /**
+     * Create a new directed {@link MaskSubgraph} of another graph.
+     *
+     * @param base the base graph
+     * @param vertexMask vertices to exclude in the subgraph. If a vertex is masked, it is as if it
+     *        is not in the subgraph. Edges incident to the masked vertex are also masked.
+     * @param edgeMask edges to exclude in the subgraph. If an edge is masked, it is as if it is not
+     *        in the subgraph.
+     */
+    public DirectedMaskSubgraph(
+        DirectedGraph<V, E> base, Predicate<V> vertexMask, Predicate<E> edgeMask)
+    {
+        super(base, vertexMask, edgeMask);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int inDegreeOf(V vertex)
+    {
+        return incomingEdgesOf(vertex).size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<E> incomingEdgesOf(V vertex)
+    {
+        assertVertexExist(vertex);
+
+        return new MaskEdgeSet<>(
+            base, ((DirectedGraph<V, E>) base).incomingEdgesOf(vertex), vertexMask, edgeMask);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int outDegreeOf(V vertex)
+    {
+        return outgoingEdgesOf(vertex).size();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<E> outgoingEdgesOf(V vertex)
+    {
+        assertVertexExist(vertex);
+
+        return new MaskEdgeSet<>(
+            base, ((DirectedGraph<V, E>) base).outgoingEdgesOf(vertex), vertexMask, edgeMask);
+    }
+
 }
 
 // End DirectedMaskSubgraph.java

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedSubgraph.java
@@ -17,13 +17,14 @@
  */
 package org.jgrapht.graph;
 
-import java.util.*;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import org.jgrapht.*;
-import org.jgrapht.util.*;
+import org.jgrapht.DirectedGraph;
 
 /**
- * A directed graph that is a subgraph on other graph.
+ * A directed graph that is a subgraph of another graph.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -51,79 +52,67 @@ public class DirectedSubgraph<V, E>
     }
 
     /**
-     * @see DirectedGraph#inDegreeOf(Object)
+     * Creates a new directed induced subgraph.
+     *
+     * @param base the base (backing) graph on which the subgraph will be based.
+     * @param vertexSubset vertices to include in the subgraph. If <code>
+     * null</code> then all vertices are included.
+     */
+    public DirectedSubgraph(DirectedGraph<V, E> base, Set<V> vertexSubset)
+    {
+        this(base, vertexSubset, null);
+    }
+
+    /**
+     * Creates a new directed induced subgraph with all vertices included.
+     *
+     * @param base the base (backing) graph on which the subgraph will be based.
+     */
+    public DirectedSubgraph(DirectedGraph<V, E> base)
+    {
+        this(base, null, null);
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public int inDegreeOf(V vertex)
     {
-        assertVertexExist(vertex);
-
-        int degree = 0;
-
-        for (E e : getBase().incomingEdgesOf(vertex)) {
-            if (containsEdge(e)) {
-                degree++;
-            }
-        }
-
-        return degree;
+        return incomingEdgesOf(vertex).size();
     }
 
     /**
-     * @see DirectedGraph#incomingEdgesOf(Object)
+     * {@inheritDoc}
      */
     @Override
     public Set<E> incomingEdgesOf(V vertex)
     {
         assertVertexExist(vertex);
 
-        Set<E> edges = new ArrayUnenforcedSet<>();
-
-        for (E e : getBase().incomingEdgesOf(vertex)) {
-            if (containsEdge(e)) {
-                edges.add(e);
-            }
-        }
-
-        return edges;
+        return base.incomingEdgesOf(vertex).stream().filter(e -> edgeSet.contains(e)).collect(
+            Collectors.toCollection(() -> new LinkedHashSet<>()));
     }
 
     /**
-     * @see DirectedGraph#outDegreeOf(Object)
+     * {@inheritDoc}
      */
     @Override
     public int outDegreeOf(V vertex)
     {
-        assertVertexExist(vertex);
-
-        int degree = 0;
-
-        for (E e : getBase().outgoingEdgesOf(vertex)) {
-            if (containsEdge(e)) {
-                degree++;
-            }
-        }
-
-        return degree;
+        return outgoingEdgesOf(vertex).size();
     }
 
     /**
-     * @see DirectedGraph#outgoingEdgesOf(Object)
+     * {@inheritDoc}
      */
     @Override
     public Set<E> outgoingEdgesOf(V vertex)
     {
         assertVertexExist(vertex);
 
-        Set<E> edges = new ArrayUnenforcedSet<>();
-
-        for (E e : getBase().outgoingEdgesOf(vertex)) {
-            if (containsEdge(e)) {
-                edges.add(e);
-            }
-        }
-
-        return edges;
+        return base.outgoingEdgesOf(vertex).stream().filter(e -> edgeSet.contains(e)).collect(
+            Collectors.toCollection(() -> new LinkedHashSet<>()));
     }
 }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedSubgraph.java
@@ -41,12 +41,13 @@ public class DirectedSubgraph<V, E>
      * Creates a new directed subgraph.
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>
-     * null</code> then all vertices are included.
-     * @param edgeSubset edges to in include in the subgraph. If <code>
-     * null</code> then all the edges whose vertices found in the graph are included.
+     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     *        vertices are included.
+     * @param edgeSubset edges to include in the subgraph. If <code>null</code> then all the edges
+     *        whose vertices found in the graph are included.
      */
-    public DirectedSubgraph(DirectedGraph<V, E> base, Set<V> vertexSubset, Set<E> edgeSubset)
+    public DirectedSubgraph(
+        DirectedGraph<V, E> base, Set<? extends V> vertexSubset, Set<? extends E> edgeSubset)
     {
         super(base, vertexSubset, edgeSubset);
     }
@@ -55,10 +56,10 @@ public class DirectedSubgraph<V, E>
      * Creates a new directed induced subgraph.
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>
-     * null</code> then all vertices are included.
+     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     *        vertices are included.
      */
-    public DirectedSubgraph(DirectedGraph<V, E> base, Set<V> vertexSubset)
+    public DirectedSubgraph(DirectedGraph<V, E> base, Set<? extends V> vertexSubset)
     {
         this(base, vertexSubset, null);
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedWeightedSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedWeightedSubgraph.java
@@ -22,7 +22,7 @@ import java.util.*;
 import org.jgrapht.*;
 
 /**
- * A directed weighted graph that is a subgraph on other graph.
+ * A directed weighted graph that is a subgraph of another graph.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -49,6 +49,29 @@ public class DirectedWeightedSubgraph<V, E>
     {
         super((DirectedGraph<V, E>) base, vertexSubset, edgeSubset);
     }
+
+    /**
+     * Creates a new weighted directed induced subgraph.
+     *
+     * @param base the base (backing) graph on which the subgraph will be based.
+     * @param vertexSubset vertices to include in the subgraph. If <code>
+     * null</code> then all vertices are included.
+     */
+    public DirectedWeightedSubgraph(WeightedGraph<V, E> base, Set<V> vertexSubset)
+    {
+        this(base, vertexSubset, null);
+    }
+
+    /**
+     * Creates a new weighted directed induced subgraph with all vertices included.
+     *
+     * @param base the base (backing) graph on which the subgraph will be based.
+     */
+    public DirectedWeightedSubgraph(WeightedGraph<V, E> base)
+    {
+        this(base, null, null);
+    }
+
 }
 
 // End DirectedWeightedSubgraph.java

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedWeightedSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedWeightedSubgraph.java
@@ -20,6 +20,7 @@ package org.jgrapht.graph;
 import java.util.*;
 
 import org.jgrapht.*;
+import org.jgrapht.util.*;
 
 /**
  * A directed weighted graph that is a subgraph of another graph.
@@ -39,25 +40,25 @@ public class DirectedWeightedSubgraph<V, E>
      * Creates a new weighted directed subgraph.
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>
-     * null</code> then all vertices are included.
-     * @param edgeSubset edges to in include in the subgraph. If <code>
-     * null</code> then all the edges whose vertices found in the graph are included.
+     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     *        vertices are included.
+     * @param edgeSubset edges to in include in the subgraph. If <code>null</code> then all the
+     *        edges whose vertices found in the graph are included.
      */
     public DirectedWeightedSubgraph(
-        WeightedGraph<V, E> base, Set<V> vertexSubset, Set<E> edgeSubset)
+        WeightedGraph<V, E> base, Set<? extends V> vertexSubset, Set<? extends E> edgeSubset)
     {
-        super((DirectedGraph<V, E>) base, vertexSubset, edgeSubset);
+        super(TypeUtil.uncheckedCast(base, null), vertexSubset, edgeSubset);
     }
 
     /**
      * Creates a new weighted directed induced subgraph.
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>
-     * null</code> then all vertices are included.
+     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     *        vertices are included.
      */
-    public DirectedWeightedSubgraph(WeightedGraph<V, E> base, Set<V> vertexSubset)
+    public DirectedWeightedSubgraph(WeightedGraph<V, E> base, Set<? extends V> vertexSubset)
     {
         this(base, vertexSubset, null);
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/MaskFunctor.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/MaskFunctor.java
@@ -25,7 +25,10 @@ package org.jgrapht.graph;
  *
  * @author Guillaume Boulmier
  * @since July 5, 2007
+ * 
+ * @deprecated in favor of using lambdas
  */
+@Deprecated
 public interface MaskFunctor<V, E>
 {
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/Subgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/Subgraph.java
@@ -79,6 +79,15 @@ import org.jgrapht.event.GraphVertexChangeEvent;
  * {@link LinkedHashSet}).
  * </p>
  *
+ * <p>
+ * Note that this implementation tries to maintain a "live-window" on the base graph, which has
+ * implications in the performance of the various operations. For example iterating over the
+ * adjacent edges of a vertex takes time proportional to the number of adjacent edges of the vertex
+ * in the base graph even if the subgraph contains only a small subset of those edges. Therefore,
+ * the user must be aware that using this implementation for certain algorithms might come with
+ * computational overhead. For certain algorithms it is better to maintain a subgraph by hand
+ * instead of using this implementation as a black box.
+ *
  * @param <V> the vertex type
  * @param <E> the edge type
  * @param <G> the type of the base graph
@@ -421,9 +430,15 @@ public class Subgraph<V, E, G extends Graph<V, E>>
 
     private void initialize(Set<? extends V> vertexFilter, Set<? extends E> edgeFilter)
     {
+        if (vertexFilter == null && edgeFilter == null) {
+            vertexSet.addAll(base.vertexSet());
+            edgeSet.addAll(base.edgeSet());
+            return;
+        }
+
         // add vertices
         if (vertexFilter == null) {
-            base.vertexSet().stream().forEach(v -> vertexSet.add(v));
+            vertexSet.addAll(base.vertexSet());
         } else {
             if (vertexFilter.size() > base.vertexSet().size()) {
                 base.vertexSet().stream().filter(v -> vertexFilter.contains(v)).forEach(

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/Subgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/Subgraph.java
@@ -109,12 +109,12 @@ public class Subgraph<V, E, G extends Graph<V, E>>
      * Creates a new Subgraph.
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>
-     * null</code> then all vertices are included.
-     * @param edgeSubset edges to in include in the subgraph. If <code>
-     * null</code> then all the edges whose vertices found in the graph are included.
+     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     *        vertices are included.
+     * @param edgeSubset edges to in include in the subgraph. If <code>null</code> then all the
+     *        edges whose vertices found in the graph are included.
      */
-    public Subgraph(G base, Set<V> vertexSubset, Set<E> edgeSubset)
+    public Subgraph(G base, Set<? extends V> vertexSubset, Set<? extends E> edgeSubset)
     {
         super();
 
@@ -134,10 +134,10 @@ public class Subgraph<V, E, G extends Graph<V, E>>
      * identical to the call Subgraph(base, vertexSubset, null).
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>
-     * null</code> then all vertices are included.
+     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     *        vertices are included.
      */
-    public Subgraph(G base, Set<V> vertexSubset)
+    public Subgraph(G base, Set<? extends V> vertexSubset)
     {
         this(base, vertexSubset, null);
     }
@@ -419,7 +419,7 @@ public class Subgraph<V, E, G extends Graph<V, E>>
         ((WeightedGraph<V, E>) base).setEdgeWeight(e, weight);
     }
 
-    private void initialize(Set<V> vertexFilter, Set<E> edgeFilter)
+    private void initialize(Set<? extends V> vertexFilter, Set<? extends E> edgeFilter)
     {
         // add vertices
         if (vertexFilter == null) {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedMaskSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedMaskSubgraph.java
@@ -17,10 +17,11 @@
  */
 package org.jgrapht.graph;
 
+import java.util.function.*;
 import org.jgrapht.*;
 
 /**
- * An undirected graph that is a {@link MaskSubgraph} on another graph.
+ * An undirected graph that is a {@link MaskSubgraph} of another graph.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -38,11 +39,38 @@ public class UndirectedMaskSubgraph<V, E>
      * @param base the base graph
      * @param mask vertices and edges to exclude in the subgraph. If a vertex/edge is masked, it is
      *        as if it is not in the subgraph.
+     * @deprecated in favor of using lambdas
      */
+    @Deprecated
     public UndirectedMaskSubgraph(UndirectedGraph<V, E> base, MaskFunctor<V, E> mask)
     {
         super(base, mask);
     }
+
+    /**
+     * Create a new undirected {@link MaskSubgraph} of another graph.
+     *
+     * @param base the base graph
+     * @param vertexMask vertices to exclude in the subgraph. If a vertex is masked, it is as if it
+     *        is not in the subgraph. Edges incident to the masked vertex are also masked.
+     * @param edgeMask edges to exclude in the subgraph. If an edge is masked, it is as if it is not
+     *        in the subgraph.
+     */
+    public UndirectedMaskSubgraph(
+        UndirectedGraph<V, E> base, Predicate<V> vertexMask, Predicate<E> edgeMask)
+    {
+        super(base, vertexMask, edgeMask);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int degreeOf(V vertex)
+    {
+        return edgesOf(vertex).size();
+    }
+
 }
 
 // End UndirectedMaskSubgraph.java

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedSubgraph.java
@@ -40,12 +40,13 @@ public class UndirectedSubgraph<V, E>
      * Creates a new undirected subgraph.
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>
-     * null</code> then all vertices are included.
-     * @param edgeSubset edges to in include in the subgraph. If <code>
-     * null</code> then all the edges whose vertices found in the graph are included.
+     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     *        vertices are included.
+     * @param edgeSubset edges to in include in the subgraph. If <code>null</code> then all the
+     *        edges whose vertices found in the graph are included.
      */
-    public UndirectedSubgraph(UndirectedGraph<V, E> base, Set<V> vertexSubset, Set<E> edgeSubset)
+    public UndirectedSubgraph(
+        UndirectedGraph<V, E> base, Set<? extends V> vertexSubset, Set<? extends E> edgeSubset)
     {
         super(base, vertexSubset, edgeSubset);
     }
@@ -54,10 +55,10 @@ public class UndirectedSubgraph<V, E>
      * Creates a new undirected induced subgraph.
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>
-     * null</code> then all vertices are included.
+     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     *        vertices are included.
      */
-    public UndirectedSubgraph(UndirectedGraph<V, E> base, Set<V> vertexSubset)
+    public UndirectedSubgraph(UndirectedGraph<V, E> base, Set<? extends V> vertexSubset)
     {
         this(base, vertexSubset, null);
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedSubgraph.java
@@ -17,12 +17,13 @@
  */
 package org.jgrapht.graph;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.Set;
 
-import org.jgrapht.*;
+import org.jgrapht.UndirectedGraph;
 
 /**
- * An undirected graph that is a subgraph on other graph.
+ * An undirected graph that is a subgraph of another graph.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -50,7 +51,29 @@ public class UndirectedSubgraph<V, E>
     }
 
     /**
-     * @see UndirectedGraph#degreeOf(Object)
+     * Creates a new undirected induced subgraph.
+     *
+     * @param base the base (backing) graph on which the subgraph will be based.
+     * @param vertexSubset vertices to include in the subgraph. If <code>
+     * null</code> then all vertices are included.
+     */
+    public UndirectedSubgraph(UndirectedGraph<V, E> base, Set<V> vertexSubset)
+    {
+        this(base, vertexSubset, null);
+    }
+
+    /**
+     * Creates a new undirected induced subgraph with all vertices included.
+     *
+     * @param base the base (backing) graph on which the subgraph will be based.
+     */
+    public UndirectedSubgraph(UndirectedGraph<V, E> base)
+    {
+        this(base, null, null);
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public int degreeOf(V vertex)
@@ -58,17 +81,14 @@ public class UndirectedSubgraph<V, E>
         assertVertexExist(vertex);
 
         int degree = 0;
-
-        for (E e : getBase().edgesOf(vertex)) {
-            if (containsEdge(e)) {
+        Iterator<E> it = base.edgesOf(vertex).stream().filter(e -> edgeSet.contains(e)).iterator();
+        while (it.hasNext()) {
+            E e = it.next();
+            degree++;
+            if (getEdgeSource(e).equals(getEdgeTarget(e))) {
                 degree++;
-
-                if (getEdgeSource(e).equals(getEdgeTarget(e))) {
-                    degree++;
-                }
             }
         }
-
         return degree;
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedWeightedSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedWeightedSubgraph.java
@@ -49,6 +49,29 @@ public class UndirectedWeightedSubgraph<V, E>
     {
         super((UndirectedGraph<V, E>) base, vertexSubset, edgeSubset);
     }
+
+    /**
+     * Creates a new weighted undirected induced subgraph.
+     *
+     * @param base the base (backing) graph on which the subgraph will be based.
+     * @param vertexSubset vertices to include in the subgraph. If <code>
+     * null</code> then all vertices are included.
+     */
+    public UndirectedWeightedSubgraph(WeightedGraph<V, E> base, Set<V> vertexSubset)
+    {
+        this(base, vertexSubset, null);
+    }
+
+    /**
+     * Creates a new weighted undirected induced subgraph with all vertices included.
+     *
+     * @param base the base (backing) graph on which the subgraph will be based.
+     */
+    public UndirectedWeightedSubgraph(WeightedGraph<V, E> base)
+    {
+        this(base, null, null);
+    }
+
 }
 
 // End UndirectedWeightedSubgraph.java

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedWeightedSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/UndirectedWeightedSubgraph.java
@@ -20,6 +20,7 @@ package org.jgrapht.graph;
 import java.util.*;
 
 import org.jgrapht.*;
+import org.jgrapht.util.*;
 
 /**
  * An undirected weighted graph that is a subgraph on other graph.
@@ -39,25 +40,25 @@ public class UndirectedWeightedSubgraph<V, E>
      * Creates a new undirected weighted subgraph.
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>
-     * null</code> then all vertices are included.
-     * @param edgeSubset edges to in include in the subgraph. If <code>
-     * null</code> then all the edges whose vertices found in the graph are included.
+     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     *        vertices are included.
+     * @param edgeSubset edges to in include in the subgraph. If <code>null</code> then all the
+     *        edges whose vertices found in the graph are included.
      */
     public UndirectedWeightedSubgraph(
-        WeightedGraph<V, E> base, Set<V> vertexSubset, Set<E> edgeSubset)
+        WeightedGraph<V, E> base, Set<? extends V> vertexSubset, Set<? extends E> edgeSubset)
     {
-        super((UndirectedGraph<V, E>) base, vertexSubset, edgeSubset);
+        super(TypeUtil.uncheckedCast(base, null), vertexSubset, edgeSubset);
     }
 
     /**
      * Creates a new weighted undirected induced subgraph.
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>
-     * null</code> then all vertices are included.
+     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     *        vertices are included.
      */
-    public UndirectedWeightedSubgraph(WeightedGraph<V, E> base, Set<V> vertexSubset)
+    public UndirectedWeightedSubgraph(WeightedGraph<V, E> base, Set<? extends V> vertexSubset)
     {
         this(base, vertexSubset, null);
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/MaskEdgeSetTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/MaskEdgeSetTest.java
@@ -17,6 +17,8 @@
  */
 package org.jgrapht.graph;
 
+import java.util.Iterator;
+
 import org.jgrapht.*;
 
 /**
@@ -52,23 +54,8 @@ public class MaskEdgeSetTest
         loop1 = directed.addEdge(v1, v1);
         loop2 = directed.addEdge(v4, v4);
 
-        // Functor that masks vertex v1 and and the edge v2-v3
-        MaskFunctor<String, DefaultEdge> mask = new MaskFunctor<String, DefaultEdge>()
-        {
-            @Override
-            public boolean isEdgeMasked(DefaultEdge edge)
-            {
-                return (edge == e2);
-            }
-
-            @Override
-            public boolean isVertexMasked(String vertex)
-            {
-                return (vertex == v1);
-            }
-        };
-
-        testMaskedEdgeSet = new MaskEdgeSet<>(directed, directed.edgeSet(), mask);
+        testMaskedEdgeSet =
+            new MaskEdgeSet<>(directed, directed.edgeSet(), v -> v == v1, e -> e == e2);
     }
 
     public void testContains()
@@ -86,5 +73,15 @@ public class MaskEdgeSetTest
     public void testSize()
     {
         assertEquals(2, testMaskedEdgeSet.size());
+    }
+
+    public void testIterator()
+    {
+        Iterator<DefaultEdge> it = testMaskedEdgeSet.iterator();
+        assertTrue(it.hasNext());
+        assertEquals(e3, it.next());
+        assertTrue(it.hasNext());
+        assertEquals(loop2, it.next());
+        assertFalse(it.hasNext());
     }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/MaskVertexSetTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/MaskVertexSetTest.java
@@ -17,6 +17,7 @@
  */
 package org.jgrapht.graph;
 
+import java.util.*;
 import org.jgrapht.*;
 
 /**
@@ -32,9 +33,9 @@ public class MaskVertexSetTest
     private String v2 = "v2";
     private String v3 = "v3";
     private String v4 = "v4";
-    private DefaultEdge e1, e2;
+    private DefaultEdge e1;
 
-    private MaskVertexSet<String, DefaultEdge> testMaskVertexSet;
+    private MaskVertexSet<String> testMaskVertexSet;
 
     @Override
     protected void setUp()
@@ -47,25 +48,9 @@ public class MaskVertexSetTest
         directed.addVertex(v4);
 
         e1 = directed.addEdge(v1, v2);
-        e2 = directed.addEdge(v2, v3);
+        directed.addEdge(v2, v3);
 
-        // Functor that masks vertex v1 and and the edge v2-v3
-        MaskFunctor<String, DefaultEdge> mask = new MaskFunctor<String, DefaultEdge>()
-        {
-            @Override
-            public boolean isEdgeMasked(DefaultEdge edge)
-            {
-                return (edge == e2);
-            }
-
-            @Override
-            public boolean isVertexMasked(String vertex)
-            {
-                return (vertex == v1);
-            }
-        };
-
-        testMaskVertexSet = new MaskVertexSet<>(directed.vertexSet(), mask);
+        testMaskVertexSet = new MaskVertexSet<>(directed.vertexSet(), v -> v == v1);
     }
 
     public void testContains()
@@ -79,5 +64,17 @@ public class MaskVertexSetTest
     public void testSize()
     {
         assertEquals(3, testMaskVertexSet.size());
+    }
+
+    public void testIterator()
+    {
+        Iterator<String> it = testMaskVertexSet.iterator();
+        assertTrue(it.hasNext());
+        assertEquals(v2, it.next());
+        assertTrue(it.hasNext());
+        assertEquals(v3, it.next());
+        assertTrue(it.hasNext());
+        assertEquals(v4, it.next());
+        assertFalse(it.hasNext());
     }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SubgraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SubgraphTest.java
@@ -154,6 +154,88 @@ public class SubgraphTest
 
         assertFalse(subgraph.containsEdge(v1, v2));
     }
+
+    public void testEdges()
+    {
+        UndirectedGraph<Integer, DefaultEdge> g = new Pseudograph<>(DefaultEdge.class);
+        Graphs.addAllVertices(g, Arrays.asList(1, 2, 3, 4, 5));
+        g.addEdge(1, 2);
+        g.addEdge(1, 2);
+        g.addEdge(1, 3);
+        DefaultEdge e14 = g.addEdge(1, 4);
+        g.addEdge(2, 3);
+        g.addEdge(2, 1);
+        g.addEdge(3, 3);
+        g.addEdge(4, 5);
+        g.addEdge(5, 5);
+        g.addEdge(5, 2);
+
+        UndirectedSubgraph<Integer, DefaultEdge> sg = new UndirectedSubgraph<>(g);
+        assertEquals(10, sg.edgeSet().size());
+        sg.removeVertex(2);
+        assertEquals(5, sg.edgeSet().size());
+        assertEquals(2, sg.edgesOf(1).size());
+        assertFalse(sg.containsVertex(2));
+        assertEquals(2, sg.edgesOf(3).size());
+        assertEquals(2, sg.edgesOf(4).size());
+        assertEquals(2, sg.edgesOf(5).size());
+
+        sg.removeEdge(e14);
+        assertEquals(4, sg.edgeSet().size());
+        assertEquals(1, sg.edgesOf(1).size());
+        assertEquals(2, sg.edgesOf(3).size());
+        assertEquals(1, sg.edgesOf(4).size());
+        assertEquals(2, sg.edgesOf(5).size());
+
+        assertEquals(10, g.edgeSet().size());
+    }
+
+    public void testNonValidVerticesFilter()
+    {
+        UndirectedGraph<Integer, DefaultEdge> g = new Pseudograph<>(DefaultEdge.class);
+        Graphs.addAllVertices(g, Arrays.asList(1, 2, 3, 4, 5));
+        g.addEdge(1, 2);
+        g.addEdge(1, 2);
+        g.addEdge(1, 3);
+        g.addEdge(1, 4);
+        g.addEdge(2, 3);
+        g.addEdge(2, 1);
+        g.addEdge(3, 3);
+        g.addEdge(4, 5);
+        g.addEdge(5, 5);
+        g.addEdge(5, 2);
+
+        UndirectedSubgraph<Integer, DefaultEdge> sg = new UndirectedSubgraph<>(
+            g, new HashSet<>(Arrays.asList(1, 3, 100, 200, 300, 500, 800, 1000)));
+        assertEquals(2, sg.edgeSet().size());
+        assertEquals(2, sg.vertexSet().size());
+    }
+
+    public void testNonValidEdgesFilter()
+    {
+        UndirectedGraph<Integer, DefaultEdge> g = new Pseudograph<>(DefaultEdge.class);
+        Graphs.addAllVertices(g, Arrays.asList(1, 2, 3, 4, 5));
+        DefaultEdge e1 = g.addEdge(1, 2);
+        g.addEdge(1, 2);
+        DefaultEdge e2 = g.addEdge(1, 3);
+        DefaultEdge e3 = g.addEdge(1, 4);
+        g.addEdge(2, 3);
+        g.addEdge(2, 1);
+        g.addEdge(3, 3);
+        DefaultEdge e4 = g.addEdge(4, 5);
+        DefaultEdge e5 = g.addEdge(5, 5);
+        g.addEdge(5, 2);
+
+        DefaultEdge nonValid1 = g.addEdge(5, 1);
+        g.removeEdge(nonValid1);
+        DefaultEdge nonValid2 = g.addEdge(5, 1);
+        g.removeEdge(nonValid2);
+
+        UndirectedSubgraph<Integer, DefaultEdge> sg = new UndirectedSubgraph<>(
+            g, null, new HashSet<>(Arrays.asList(e1, e2, e3, e4, e5, nonValid1, nonValid2)));
+        assertEquals(5, sg.edgeSet().size());
+        assertEquals(5, sg.vertexSet().size());
+    }
 }
 
 // End SubgraphTest.java


### PR DESCRIPTION
This is a first pass for the revision of subgraph(s) and mask-subgraph(s).

Main changes:
- Revised subgraph and subclasses to use Java 8 features.
- Optimized the initialization of subgraph to also take care of issue #120.
- Revised `MaskSubgraph` by using Java 8 predicates instead of the `MaskFunctor` interface. `MaskSubgraph` was already avoiding copying. Deprecated the `MaskFunctor` interface.

This is relevant to issue #296.

For now I avoided more aggressive optimizations in `SubGraph` like indexing the existing edges. If we want to do that, I think it is best to do this in a second round.
