### PR TITLE
Replaced VertexPair with Pair and UnorderedVertexPair with UnorderedPair

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/Pair.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/Pair.java
@@ -39,12 +39,12 @@ public class Pair<A, B>
     /**
      * The first pair element
      */
-    public A first;
+    protected final A first;
 
     /**
      * The second pair element
      */
-    public B second;
+    protected final B second;
 
     /**
      * Create a new pair
@@ -58,24 +58,71 @@ public class Pair<A, B>
         this.second = b;
     }
 
-    @Override
-    public boolean equals(Object other)
+    /**
+     * Get the first element of the pair
+     * 
+     * @return the first element of the pair
+     */
+    public A getFirst()
     {
-        return (other instanceof Pair) && Objects.equals(this.first, ((Pair<A, B>) other).first)
-            && Objects.equals(this.second, ((Pair<A, B>) other).second);
+        return first;
+    }
+
+    /**
+     * Get the second element of the pair
+     * 
+     * @return the second element of the pair
+     */
+    public B getSecond()
+    {
+        return second;
+    }
+
+    /**
+     * Assess if this pair contains an element.
+     *
+     * @param e The element in question
+     *
+     * @return true if contains the element, false otherwise
+     * 
+     * @param <E> the element type
+     */
+    public <E> boolean hasElement(E e)
+    {
+        if (e == null) {
+            return first == null || second == null;
+        } else {
+            return e.equals(first) || e.equals(second);
+        }
+    }
+
+    @Override
+    public String toString()
+    {
+        return "(" + first + "," + second + ")";
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        else if (!(o instanceof Pair))
+            return false;
+
+        @SuppressWarnings("unchecked") Pair<A, B> other = (Pair<A, B>) o;
+        return Objects.equals(first, other.first) && Objects.equals(second, other.second);
     }
 
     @Override
     public int hashCode()
     {
-        return (this.first == null) ? ((this.second == null) ? 0 : (this.second.hashCode() + 1))
-            : ((this.second == null) ? (this.first.hashCode() + 3)
-                : ((this.first.hashCode() * 19) + this.second.hashCode()));
+        return Objects.hash(first, second);
     }
 
     /**
      * Creates new pair of elements pulling of the necessity to provide corresponding types of the
-     * elements supplied
+     * elements supplied.
      *
      * @param a first element
      * @param b second element

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/UnorderedPair.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/UnorderedPair.java
@@ -1,0 +1,95 @@
+/*
+ * (C) Copyright 2003-2016, by Joris Kinable and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.util;
+
+import java.io.Serializable;
+import java.util.*;
+
+/**
+ * Generic unordered pair.
+ * 
+ * <p>
+ * Although the instances of this class are immutable, it is impossible to ensure that the
+ * references passed to the constructor will not be modified by the caller.
+ * 
+ * @param <A> the first element type
+ * @param <B> the second element type
+ * 
+ * @author Joris Kinable
+ * 
+ */
+public class UnorderedPair<A, B>
+    extends Pair<A, B>
+    implements Serializable
+{
+    private static final long serialVersionUID = -3110454174542533876L;
+
+    /**
+     * Create a new unordered pair
+     * 
+     * @param a an element
+     * @param b another element
+     */
+    public UnorderedPair(A a, B b)
+    {
+        super(a, b);
+    }
+
+    @Override
+    public String toString()
+    {
+        return "{" + first + "," + second + "}";
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o)
+            return true;
+        else if (!(o instanceof UnorderedPair))
+            return false;
+
+        @SuppressWarnings("unchecked") UnorderedPair<A, B> other = (UnorderedPair<A, B>) o;
+
+        return (Objects.equals(first, other.first) && Objects.equals(second, other.second))
+            || (Objects.equals(first, other.second) && Objects.equals(second, other.first));
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int hash1 = first == null ? 0 : first.hashCode();
+        int hash2 = second == null ? 0 : second.hashCode();
+        return hash1 > hash2 ? hash1 * 31 + hash2 : hash2 * 31 + hash1;
+    }
+
+    /**
+     * Creates new unordered pair of elements pulling of the necessity to provide corresponding
+     * types of the elements supplied.
+     *
+     * @param a first element
+     * @param b second element
+     * @param <A> the first element type
+     * @param <B> the second element type
+     * @return new unordered pair
+     */
+    public static <A, B> UnorderedPair<A, B> of(A a, B b)
+    {
+        return new UnorderedPair<>(a, b);
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
@@ -20,6 +20,7 @@ package org.jgrapht.graph.specifics;
 import java.io.*;
 import java.util.*;
 
+import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
 
@@ -44,7 +45,7 @@ public class FastLookupDirectedSpecifics<V, E>
      * Maps a pair of vertices <u,v> to a set of edges {(u,v)}. In case of a multigraph, all edges
      * which touch both u,v are included in the set
      */
-    protected Map<VertexPair<V>, ArrayUnenforcedSet<E>> touchingVerticesToEdgeMap;
+    protected Map<Pair<V, V>, ArrayUnenforcedSet<E>> touchingVerticesToEdgeMap;
 
     /**
      * Construct a new fast lookup directed specifics.
@@ -79,7 +80,7 @@ public class FastLookupDirectedSpecifics<V, E>
             && abstractBaseGraph.containsVertex(targetVertex))
         {
             Set<E> edges =
-                touchingVerticesToEdgeMap.get(new VertexPair<>(sourceVertex, targetVertex));
+                touchingVerticesToEdgeMap.get(new Pair<>(sourceVertex, targetVertex));
             return edges == null ? Collections.emptySet() : new ArrayUnenforcedSet<>(edges);
         } else {
             return null;
@@ -92,7 +93,7 @@ public class FastLookupDirectedSpecifics<V, E>
     @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
-        List<E> edges = touchingVerticesToEdgeMap.get(new VertexPair<>(sourceVertex, targetVertex));
+        List<E> edges = touchingVerticesToEdgeMap.get(new Pair<>(sourceVertex, targetVertex));
         if (edges == null || edges.isEmpty())
             return null;
         else
@@ -111,7 +112,7 @@ public class FastLookupDirectedSpecifics<V, E>
         getEdgeContainer(source).addOutgoingEdge(e);
         getEdgeContainer(target).addIncomingEdge(e);
 
-        VertexPair<V> vertexPair = new VertexPair<>(source, target);
+        Pair<V, V> vertexPair = new Pair<>(source, target);
         if (!touchingVerticesToEdgeMap.containsKey(vertexPair)) {
             ArrayUnenforcedSet<E> edgeSet = new ArrayUnenforcedSet<>();
             edgeSet.add(e);
@@ -135,7 +136,7 @@ public class FastLookupDirectedSpecifics<V, E>
         // Remove the edge from the touchingVerticesToEdgeMap. If there are no more remaining edges
         // for a pair
         // of touching vertices, remove the pair from the map.
-        VertexPair<V> vertexPair = new VertexPair<>(source, target);
+        Pair<V, V> vertexPair = new Pair<>(source, target);
         if (touchingVerticesToEdgeMap.containsKey(vertexPair)) {
             ArrayUnenforcedSet<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);
             edgeSet.remove(e);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
@@ -20,6 +20,7 @@ package org.jgrapht.graph.specifics;
 import java.io.*;
 import java.util.*;
 
+import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
 
@@ -44,7 +45,7 @@ public class FastLookupUndirectedSpecifics<V, E>
      * Maps a pair of vertices <u,v> to a set of edges {(u,v)}. In case of a multigraph, all edges
      * which touch both u,v are included in the set
      */
-    protected Map<VertexPair<V>, ArrayUnenforcedSet<E>> touchingVerticesToEdgeMap;
+    protected Map<Pair<V, V>, ArrayUnenforcedSet<E>> touchingVerticesToEdgeMap;
 
     /**
      * Construct a new fast lookup undirected specifics.
@@ -79,7 +80,7 @@ public class FastLookupUndirectedSpecifics<V, E>
             && abstractBaseGraph.containsVertex(targetVertex))
         {
             Set<E> edges = touchingVerticesToEdgeMap
-                .get(new UnorderedVertexPair<>(sourceVertex, targetVertex));
+                .get(new UnorderedPair<>(sourceVertex, targetVertex));
             return edges == null ? Collections.emptySet() : new ArrayUnenforcedSet<>(edges);
         } else {
             return null;
@@ -93,7 +94,7 @@ public class FastLookupUndirectedSpecifics<V, E>
     public E getEdge(V sourceVertex, V targetVertex)
     {
         List<E> edges =
-            touchingVerticesToEdgeMap.get(new UnorderedVertexPair<>(sourceVertex, targetVertex));
+            touchingVerticesToEdgeMap.get(new UnorderedPair<>(sourceVertex, targetVertex));
         if (edges == null || edges.isEmpty())
             return null;
         else
@@ -112,7 +113,7 @@ public class FastLookupUndirectedSpecifics<V, E>
         getEdgeContainer(source).addEdge(e);
 
         // Add edge to touchingVerticesToEdgeMap for the UnorderedPair {u,v}
-        VertexPair<V> vertexPair = new UnorderedVertexPair<>(source, target);
+        Pair<V, V> vertexPair = new UnorderedPair<>(source, target);
         if (!touchingVerticesToEdgeMap.containsKey(vertexPair)) {
             ArrayUnenforcedSet<E> edgeSet = new ArrayUnenforcedSet<>();
             edgeSet.add(e);
@@ -142,7 +143,7 @@ public class FastLookupUndirectedSpecifics<V, E>
         // Remove the edge from the touchingVerticesToEdgeMap. If there are no more remaining edges
         // for a pair
         // of touching vertices, remove the pair from the map.
-        VertexPair<V> vertexPair = new UnorderedVertexPair<>(source, target);
+        Pair<V, V> vertexPair = new UnorderedPair<>(source, target);
         if (touchingVerticesToEdgeMap.containsKey(vertexPair)) {
             ArrayUnenforcedSet<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);
             edgeSet.remove(e);

--- a/jgrapht-core/src/main/java/org/jgrapht/util/UnorderedVertexPair.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/UnorderedVertexPair.java
@@ -24,7 +24,10 @@ package org.jgrapht.util;
  * @param <V> the graph vertex type
  *
  * @author Joris Kinable
+ * 
+ * @deprecated in favor of {@link org.jgrapht.alg.util.UnorderedPair}
  */
+@Deprecated
 public class UnorderedVertexPair<V>
     extends VertexPair<V>
 {

--- a/jgrapht-core/src/main/java/org/jgrapht/util/VertexPair.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/VertexPair.java
@@ -28,7 +28,10 @@ import java.util.*;
  *
  * @author Soren (soren@tanesha.net)
  * @author Joris Kinable
+ * 
+ * @deprecated in favor of {@link org.jgrapht.alg.util.Pair}
  */
+@Deprecated
 public class VertexPair<V>
     implements Serializable
 {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/KuhnMunkresMinimalWeightBipartitePerfectMatchingTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/KuhnMunkresMinimalWeightBipartitePerfectMatchingTest.java
@@ -20,9 +20,9 @@ package org.jgrapht.alg;
 import java.util.*;
 
 import org.jgrapht.*;
+import org.jgrapht.alg.util.*;
 import org.jgrapht.generate.*;
 import org.jgrapht.graph.*;
-import org.jgrapht.util.*;
 import org.junit.Assert;
 
 import junit.framework.*;
@@ -104,7 +104,7 @@ public class KuhnMunkresMinimalWeightBipartitePerfectMatchingTest
     {
 
         class _
-            extends VertexPair<V>
+            extends Pair<V, V>
         {
             public _(V _1, V _2)
             {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/util/PairTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/util/PairTest.java
@@ -1,0 +1,262 @@
+/*
+ * (C) Copyright 2016-2016, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+/**
+ * Test {@link Pair} and {@link UnorderedPair} classes.
+ *
+ * @author Dimitrios Michail
+ */
+public class PairTest
+{
+
+    private static final String ANOTHER = "another";
+    private static final String CUSTOM = "custom";
+
+    @Test
+    public void testPair()
+    {
+        Pair<String, Custom> p = Pair.of(CUSTOM, new Custom(1));
+        
+        assertEquals(CUSTOM, p.getFirst());
+        assertNotEquals(ANOTHER, p.getFirst());
+        
+        assertEquals(new Custom(1), p.getSecond());
+        assertNotEquals(new Custom(2), p.getSecond());
+        
+        assertTrue(p.hasElement(CUSTOM));
+        assertFalse(p.hasElement(ANOTHER));
+        assertTrue(p.hasElement(new Custom(1)));
+        assertFalse(p.hasElement(new Custom(2)));
+        assertFalse(p.hasElement(null));
+    }
+    
+    @Test
+    public void testUnorderedPair()
+    {
+        Pair<String, Custom> p = UnorderedPair.of(CUSTOM, new Custom(1));
+        
+        assertEquals(CUSTOM, p.getFirst());
+        assertNotEquals(ANOTHER, p.getFirst());
+        
+        assertEquals(new Custom(1), p.getSecond());
+        assertNotEquals(new Custom(2), p.getSecond());
+        
+        assertTrue(p.hasElement(CUSTOM));
+        assertFalse(p.hasElement(ANOTHER));
+        assertTrue(p.hasElement(new Custom(1)));
+        assertFalse(p.hasElement(new Custom(2)));
+        assertFalse(p.hasElement(null));
+    }
+    
+    @Test
+    public void testPairWithNull()
+    {
+        Pair<String, Custom> p = Pair.of(null, new Custom(1));
+        
+        assertNull(p.getFirst());
+        assertEquals(new Custom(1), p.getSecond());
+        
+        assertTrue(p.hasElement(null));
+        assertTrue(p.hasElement(new Custom(1)));
+    }
+    
+    @Test
+    public void testUnorderedPairWithNull()
+    {
+        Pair<String, Custom> p = UnorderedPair.of(null, new Custom(1));
+        
+        assertNull(p.getFirst());
+        assertEquals(new Custom(1), p.getSecond());
+        
+        assertTrue(p.hasElement(null));
+        assertTrue(p.hasElement(new Custom(1)));
+    }
+    
+    @Test
+    public void testPairEquals() { 
+        Pair<String, Custom> p1 = Pair.of(CUSTOM, new Custom(1));
+        Pair<String, Custom> p2 = Pair.of(ANOTHER, new Custom(1));
+        Pair<String, Custom> p3 = Pair.of(ANOTHER, new Custom(2));
+        Pair<String, Custom> p4 = Pair.of(CUSTOM, new Custom(1));
+        Pair<String, Custom> p5 = Pair.of(CUSTOM, new Custom(2));
+        Pair<Custom, String> p6 = Pair.of(new Custom(1), CUSTOM);
+        
+        assertNotEquals(p1, p2);
+        assertNotEquals(p1, p3);
+        assertEquals(p1, p4);
+        assertNotEquals(p1, p5);
+        assertNotEquals(p1, p6);
+        assertNotEquals(p2, p3);
+        assertNotEquals(p2, p4);
+        assertNotEquals(p2, p5);
+        assertNotEquals(p2, p6);
+        assertNotEquals(p3, p4);
+        assertNotEquals(p3, p5);
+        assertNotEquals(p3, p6);
+        assertNotEquals(p4, p5);
+        assertNotEquals(p4, p6);
+        assertNotEquals(p5, p6);
+    }
+    
+    @Test
+    public void testUnorderedPairEquals() { 
+        Pair<String, Custom> p1 = UnorderedPair.of(CUSTOM, new Custom(1));
+        Pair<String, Custom> p2 = UnorderedPair.of(ANOTHER, new Custom(1));
+        Pair<String, Custom> p3 = UnorderedPair.of(ANOTHER, new Custom(2));
+        Pair<String, Custom> p4 = UnorderedPair.of(CUSTOM, new Custom(1));
+        Pair<String, Custom> p5 = UnorderedPair.of(CUSTOM, new Custom(2));
+        Pair<Custom, String> p6 = UnorderedPair.of(new Custom(1), CUSTOM);
+        
+        assertNotEquals(p1, p2);
+        assertNotEquals(p1, p3);
+        assertEquals(p1, p4);
+        assertNotEquals(p1, p5);
+        assertEquals(p1, p6);
+        assertNotEquals(p2, p3);
+        assertNotEquals(p2, p4);
+        assertNotEquals(p2, p5);
+        assertNotEquals(p2, p6);
+        assertNotEquals(p3, p4);
+        assertNotEquals(p3, p5);
+        assertNotEquals(p3, p6);
+        assertNotEquals(p4, p5);
+        assertEquals(p4, p6);
+        assertNotEquals(p5, p6);
+    }
+    
+    @Test
+    public void testPairEqualsWithNull() { 
+        Pair<String, Custom> p1 = Pair.of(CUSTOM, null);
+        Pair<Custom, String> p2 = Pair.of(null, CUSTOM);
+        Pair<String, Custom> p3 = Pair.of(ANOTHER, null);
+        Pair<String, Custom> p4 = Pair.of(CUSTOM, null);
+        Pair<String, Custom> p5 = Pair.of(CUSTOM, new Custom(1));
+        
+        assertNotEquals(p1, p2);
+        assertNotEquals(p1, p3);
+        assertEquals(p1, p4);
+        assertNotEquals(p1, p5);
+        assertNotEquals(p2, p3);
+        assertNotEquals(p2, p4);
+        assertNotEquals(p2, p5);
+        assertNotEquals(p3, p4);
+        assertNotEquals(p3, p5);
+        assertNotEquals(p4, p5);
+    }
+    
+    @Test
+    public void testUnorderedPairEqualsWithNull() { 
+        Pair<String, Custom> p1 = UnorderedPair.of(CUSTOM, null);
+        Pair<Custom, String> p2 = UnorderedPair.of(null, CUSTOM);
+        Pair<String, Custom> p3 = UnorderedPair.of(ANOTHER, null);
+        Pair<String, Custom> p4 = UnorderedPair.of(CUSTOM, null);
+        Pair<String, Custom> p5 = UnorderedPair.of(CUSTOM, new Custom(1));
+        
+        assertEquals(p1, p2);
+        assertNotEquals(p1, p3);
+        assertEquals(p1, p4);
+        assertNotEquals(p1, p5);
+        assertNotEquals(p2, p3);
+        assertEquals(p2, p4);
+        assertNotEquals(p2, p5);
+        assertNotEquals(p3, p4);
+        assertNotEquals(p3, p5);
+        assertNotEquals(p4, p5);
+    }
+    
+    @Test
+    public void testDifferentTypesEqualsWithNull() {
+        Pair<String, Custom> p1 = Pair.of(null, null);
+        Pair<String, Custom> p2 = Pair.of(null, null);
+        Pair<Custom, String> p3 = Pair.of(null, null);
+        assertEquals(p1, p2);
+        assertEquals(p2, p3);
+        assertEquals(p3, p1);
+        
+        UnorderedPair<String, Custom> p4 = UnorderedPair.of(null, null);
+        UnorderedPair<String, Custom> p5 = UnorderedPair.of(null, null);
+        UnorderedPair<Custom, String> p6 = UnorderedPair.of(null, null);
+        assertEquals(p4, p5);
+        assertEquals(p5, p6);
+        assertEquals(p6, p4);
+    }
+    
+    @Test
+    public void testUnorderedSameHashCode() {
+        UnorderedPair<String, Custom> p1 = UnorderedPair.of(CUSTOM, new Custom(1));
+        UnorderedPair<Custom, String> p2 = UnorderedPair.of(new Custom(1), CUSTOM);
+        assertEquals(p1.hashCode(), p2.hashCode());
+    }
+
+    class Custom
+    {
+        private int id;
+
+        public Custom(int id)
+        {
+            this.id = id;
+        }
+
+        public int getId()
+        {
+            return id;
+        }
+
+        @Override
+        public int hashCode()
+        {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + getOuterType().hashCode();
+            result = prime * result + id;
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Custom other = (Custom) obj;
+            if (!getOuterType().equals(other.getOuterType()))
+                return false;
+            if (id != other.id)
+                return false;
+            return true;
+        }
+
+        private PairTest getOuterType()
+        {
+            return PairTest.this;
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 			<dependency>
 				<groupId>junit</groupId>
 				<artifactId>junit</artifactId>
-				<version>4.10</version>
+				<version>4.12</version>
 				<scope>test</scope>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Cleanup of different pair implementations (see also #155)

 - Made Pair look similar to VertexPair
 - Used UnorderedVertexPair as a skeleton for UnorderedPair
 - Added tests for Pair and UnorderedPair classes
 - Deprecated VertexPair and UnorderedVertexPair

Also updated JUnit version to 4.12 (latest stable release) to be able to use methods like `assertNotEquals`.

Maybe move Pair and UnorderedPair in the org.jgrapht.util package instead of the org.jgrapht.alg.util?