### PR TITLE
AbstractBaseGraph and Specifics dependencies cleanup

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -495,13 +495,37 @@ public abstract class AbstractBaseGraph<V, E>
     protected Specifics<V, E> createSpecifics()
     {
         if (this instanceof DirectedGraph<?, ?>) {
-            return new FastLookupDirectedSpecifics<>(this);
+            return createDirectedSpecifics();
         } else if (this instanceof UndirectedGraph<?, ?>) {
-            return new FastLookupUndirectedSpecifics<>(this);
+            return createUndirectedSpecifics();
         } else {
             throw new IllegalArgumentException(
                 "must be instance of either DirectedGraph or UndirectedGraph");
         }
+    }
+
+    /**
+     * Create undirected specifics for the graph
+     * 
+     * @return undirected specifics for the graph
+     * @deprecated specifics can be changed by overriding directly {@link #createSpecifics()}.
+     */
+    @Deprecated
+    protected Specifics<V, E> createUndirectedSpecifics()
+    {
+        return new FastLookupUndirectedSpecifics<>(this);
+    }
+
+    /**
+     * Create directed specifics for the graph
+     * 
+     * @return directed specifics for the graph
+     * @deprecated specifics can be changed by overriding directly {@link #createSpecifics()}.
+     */
+    @Deprecated
+    protected Specifics<V, E> createDirectedSpecifics()
+    {
+        return new FastLookupDirectedSpecifics<>(this);
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/ArrayUnenforcedSetEdgeSetFactory.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/ArrayUnenforcedSetEdgeSetFactory.java
@@ -1,0 +1,51 @@
+/*
+ * (C) Copyright 2003-2016, by Barak Naveh and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.graph.specifics;
+
+import java.io.Serializable;
+import java.util.Set;
+
+import org.jgrapht.graph.EdgeSetFactory;
+import org.jgrapht.util.ArrayUnenforcedSet;
+
+/**
+ * An edge set factory which creates {@link ArrayUnenforcedSet} of size 1, suitable for small degree
+ * vertices.
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ * 
+ * @author Barak Naveh
+ */
+public class ArrayUnenforcedSetEdgeSetFactory<V, E>
+    implements EdgeSetFactory<V, E>, Serializable
+{
+    private static final long serialVersionUID = 5936902837403445985L;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Set<E> createEdgeSet(V vertex)
+    {
+        // NOTE: use size 1 to keep memory usage under control
+        // for the common case of vertices with low degree
+        return new ArrayUnenforcedSet<>(1);
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -37,8 +37,7 @@ import org.jgrapht.util.*;
  * @author Joris Kinable
  */
 public class DirectedSpecifics<V, E>
-    extends Specifics<V, E>
-    implements Serializable
+    implements Specifics<V, E>, Serializable
 {
     private static final long serialVersionUID = 8971725103718958232L;
     private static final String NOT_IN_DIRECTED_GRAPH = "no such operation in a directed graph";
@@ -54,21 +53,35 @@ public class DirectedSpecifics<V, E>
      */
     public DirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph)
     {
-        this(abstractBaseGraph, new LinkedHashMap<>());
+        this(abstractBaseGraph, new LinkedHashMap<>(), new ArrayUnenforcedSetEdgeSetFactory<>());
     }
 
     /**
      * Construct a new directed specifics.
      * 
      * @param abstractBaseGraph the graph for which these specifics are for
-     * @param vertexMap a container to use the edges
+     * @param vertexMap map for the storage of vertex edge sets
      */
     public DirectedSpecifics(
         AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, DirectedEdgeContainer<V, E>> vertexMap)
     {
+        this(abstractBaseGraph, vertexMap, new ArrayUnenforcedSetEdgeSetFactory<>());
+    }
+
+    /**
+     * Construct a new directed specifics.
+     * 
+     * @param abstractBaseGraph the graph for which these specifics are for
+     * @param vertexMap map for the storage of vertex edge sets
+     * @param edgeSetFactory factory for the creation of vertex edge sets
+     */
+    public DirectedSpecifics(
+        AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, DirectedEdgeContainer<V, E>> vertexMap,
+        EdgeSetFactory<V, E> edgeSetFactory)
+    {
         this.abstractBaseGraph = abstractBaseGraph;
         this.vertexMapDirected = vertexMap;
-        this.edgeSetFactory = abstractBaseGraph.getEdgeSetFactory();
+        this.edgeSetFactory = edgeSetFactory;
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph.specifics;
 
-import java.io.*;
 import java.util.*;
 
 import org.jgrapht.graph.*;
@@ -36,7 +35,6 @@ import org.jgrapht.util.*;
  */
 public class FastLookupDirectedSpecifics<V, E>
     extends DirectedSpecifics<V, E>
-    implements Serializable
 {
     private static final long serialVersionUID = 4089085208843722263L;
 
@@ -53,19 +51,33 @@ public class FastLookupDirectedSpecifics<V, E>
      */
     public FastLookupDirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph)
     {
-        this(abstractBaseGraph, new LinkedHashMap<>());
+        this(abstractBaseGraph, new LinkedHashMap<>(), new ArrayUnenforcedSetEdgeSetFactory<>());
     }
 
     /**
      * Construct a new fast lookup directed specifics.
      * 
      * @param abstractBaseGraph the graph for which these specifics are for
-     * @param vertexMap a container to use the edges
+     * @param vertexMap map for the storage of vertex edge sets
      */
     public FastLookupDirectedSpecifics(
         AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, DirectedEdgeContainer<V, E>> vertexMap)
     {
-        super(abstractBaseGraph, vertexMap);
+        this(abstractBaseGraph, vertexMap, new ArrayUnenforcedSetEdgeSetFactory<>());
+    }
+
+    /**
+     * Construct a new fast lookup directed specifics.
+     * 
+     * @param abstractBaseGraph the graph for which these specifics are for
+     * @param vertexMap map for the storage of vertex edge sets
+     * @param edgeSetFactory factory for the creation of vertex edge sets
+     */
+    public FastLookupDirectedSpecifics(
+        AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, DirectedEdgeContainer<V, E>> vertexMap,
+        EdgeSetFactory<V, E> edgeSetFactory)
+    {
+        super(abstractBaseGraph, vertexMap, edgeSetFactory);
         this.touchingVerticesToEdgeMap = new HashMap<>();
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph.specifics;
 
-import java.io.*;
 import java.util.*;
 
 import org.jgrapht.graph.*;
@@ -36,7 +35,6 @@ import org.jgrapht.util.*;
  */
 public class FastLookupUndirectedSpecifics<V, E>
     extends UndirectedSpecifics<V, E>
-    implements Serializable
 {
     private static final long serialVersionUID = 225772727571597846L;
 
@@ -53,19 +51,35 @@ public class FastLookupUndirectedSpecifics<V, E>
      */
     public FastLookupUndirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph)
     {
-        this(abstractBaseGraph, new LinkedHashMap<>());
+        this(abstractBaseGraph, new LinkedHashMap<>(), new ArrayUnenforcedSetEdgeSetFactory<>());
     }
 
     /**
      * Construct a new fast lookup undirected specifics.
      * 
      * @param abstractBaseGraph the graph for which these specifics are for
-     * @param vertexMap a container to use for the edges
+     * @param vertexMap map for the storage of vertex edge sets
      */
     public FastLookupUndirectedSpecifics(
-        AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, UndirectedEdgeContainer<V, E>> vertexMap)
+        AbstractBaseGraph<V, E> abstractBaseGraph,
+        Map<V, UndirectedEdgeContainer<V, E>> vertexMap)
     {
-        super(abstractBaseGraph, vertexMap);
+        this(abstractBaseGraph, vertexMap, new ArrayUnenforcedSetEdgeSetFactory<>());
+    }
+
+    /**
+     * Construct a new fast lookup undirected specifics.
+     * 
+     * @param abstractBaseGraph the graph for which these specifics are for
+     * @param vertexMap map for the storage of vertex edge sets
+     * @param edgeSetFactory factory for the creation of vertex edge sets
+     */
+    public FastLookupUndirectedSpecifics(
+        AbstractBaseGraph<V, E> abstractBaseGraph,
+        Map<V, UndirectedEdgeContainer<V, E>> vertexMap,
+        EdgeSetFactory<V, E> edgeSetFactory)
+    {
+        super(abstractBaseGraph, vertexMap, edgeSetFactory);
         this.touchingVerticesToEdgeMap = new HashMap<>();
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
@@ -17,11 +17,10 @@
  */
 package org.jgrapht.graph.specifics;
 
-import java.io.*;
 import java.util.*;
 
 /**
- * A base class encapsulating the basic graph operations. Different implementations have different
+ * An interface encapsulating the basic graph operations. Different implementations have different
  * space-time tradeoffs.
  *
  * @param <V> the graph vertex type
@@ -29,24 +28,21 @@ import java.util.*;
  *
  * @author Barak Naveh
  */
-public abstract class Specifics<V, E>
-    implements Serializable
+public interface Specifics<V, E>
 {
-    private static final long serialVersionUID = 785196247314761183L;
-
     /**
      * Adds a vertex.
      *
      * @param vertex vertex to be added.
      */
-    public abstract void addVertex(V vertex);
+    void addVertex(V vertex);
 
     /**
      * Get the vertex set.
      * 
      * @return the vertex set
      */
-    public abstract Set<V> getVertexSet();
+    Set<V> getVertexSet();
 
     /**
      * Returns a set of all edges connecting source vertex to target vertex if such vertices exist
@@ -58,7 +54,7 @@ public abstract class Specifics<V, E>
      *
      * @return a set of all edges connecting source vertex to target vertex.
      */
-    public abstract Set<E> getAllEdges(V sourceVertex, V targetVertex);
+    Set<E> getAllEdges(V sourceVertex, V targetVertex);
 
     /**
      * Returns an edge connecting source vertex to target vertex if such vertices and such edge
@@ -75,14 +71,14 @@ public abstract class Specifics<V, E>
      *
      * @return an edge connecting source vertex to target vertex.
      */
-    public abstract E getEdge(V sourceVertex, V targetVertex);
+    E getEdge(V sourceVertex, V targetVertex);
 
     /**
      * Adds the specified edge to the edge containers of its source and target vertices.
      *
      * @param e the edge
      */
-    public abstract void addEdgeToTouchingVertices(E e);
+    void addEdgeToTouchingVertices(E e);
 
     /**
      * Returns the degree of the specified vertex. A degree of a vertex in an undirected graph is
@@ -92,7 +88,7 @@ public abstract class Specifics<V, E>
      *
      * @return the degree of the specified vertex.
      */
-    public abstract int degreeOf(V vertex);
+    int degreeOf(V vertex);
 
     /**
      * Returns a set of all edges touching the specified vertex. If no edges are touching the
@@ -101,7 +97,7 @@ public abstract class Specifics<V, E>
      * @param vertex the vertex for which a set of touching edges is to be returned.
      * @return a set of all edges touching the specified vertex.
      */
-    public abstract Set<E> edgesOf(V vertex);
+    Set<E> edgesOf(V vertex);
 
     /**
      * Returns the "in degree" of the specified vertex.
@@ -109,7 +105,7 @@ public abstract class Specifics<V, E>
      * @param vertex vertex whose in degree is to be calculated.
      * @return the in degree of the specified vertex.
      */
-    public abstract int inDegreeOf(V vertex);
+    int inDegreeOf(V vertex);
 
     /**
      * Returns a set of all edges incoming into the specified vertex.
@@ -117,7 +113,7 @@ public abstract class Specifics<V, E>
      * @param vertex the vertex for which the list of incoming edges to be returned.
      * @return a set of all edges incoming into the specified vertex.
      */
-    public abstract Set<E> incomingEdgesOf(V vertex);
+    Set<E> incomingEdgesOf(V vertex);
 
     /**
      * Returns the "out degree" of the specified vertex.
@@ -125,7 +121,7 @@ public abstract class Specifics<V, E>
      * @param vertex vertex whose out degree is to be calculated.
      * @return the out degree of the specified vertex.
      */
-    public abstract int outDegreeOf(V vertex);
+    int outDegreeOf(V vertex);
 
     /**
      * Returns a set of all edges outgoing from the specified vertex.
@@ -134,12 +130,12 @@ public abstract class Specifics<V, E>
      *
      * @return a set of all edges outgoing from the specified vertex.
      */
-    public abstract Set<E> outgoingEdgesOf(V vertex);
+    Set<E> outgoingEdgesOf(V vertex);
 
     /**
      * Removes the specified edge from the edge containers of its source and target vertices.
      *
      * @param e the edge
      */
-    public abstract void removeEdgeFromTouchingVertices(E e);
+    void removeEdgeFromTouchingVertices(E e);
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
@@ -37,8 +37,7 @@ import org.jgrapht.util.*;
  * @author Joris Kinable
  */
 public class UndirectedSpecifics<V, E>
-    extends Specifics<V, E>
-    implements Serializable
+    implements Specifics<V, E>, Serializable
 {
     private static final long serialVersionUID = 6494588405178655873L;
     private static final String NOT_IN_UNDIRECTED_GRAPH =
@@ -55,21 +54,37 @@ public class UndirectedSpecifics<V, E>
      */
     public UndirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph)
     {
-        this(abstractBaseGraph, new LinkedHashMap<>());
+        this(abstractBaseGraph, new LinkedHashMap<>(), new ArrayUnenforcedSetEdgeSetFactory<>());
     }
 
     /**
      * Construct a new undirected specifics.
      * 
      * @param abstractBaseGraph the graph for which these specifics are for
-     * @param vertexMap a container to use for the edges
+     * @param vertexMap map for the storage of vertex edge sets
      */
     public UndirectedSpecifics(
-        AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, UndirectedEdgeContainer<V, E>> vertexMap)
+        AbstractBaseGraph<V, E> abstractBaseGraph,
+        Map<V, UndirectedEdgeContainer<V, E>> vertexMap)
+    {
+        this(abstractBaseGraph, vertexMap, new ArrayUnenforcedSetEdgeSetFactory<>());
+    }
+
+    /**
+     * Construct a new undirected specifics.
+     * 
+     * @param abstractBaseGraph the graph for which these specifics are for
+     * @param vertexMap map for the storage of vertex edge sets
+     * @param edgeSetFactory factory for the creation of vertex edge sets
+     */
+    public UndirectedSpecifics(
+        AbstractBaseGraph<V, E> abstractBaseGraph,
+        Map<V, UndirectedEdgeContainer<V, E>> vertexMap,
+        EdgeSetFactory<V, E> edgeSetFactory)
     {
         this.abstractBaseGraph = abstractBaseGraph;
         this.vertexMapUndirected = vertexMap;
-        this.edgeSetFactory = abstractBaseGraph.getEdgeSetFactory();
+        this.edgeSetFactory = edgeSetFactory;
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/DefaultDirectedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/DefaultDirectedGraphTest.java
@@ -17,9 +17,15 @@
  */
 package org.jgrapht.graph;
 
-import java.util.*;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 
-import org.jgrapht.*;
+import org.jgrapht.DirectedGraph;
+import org.jgrapht.EnhancedTestCase;
+import org.jgrapht.Graphs;
+import org.jgrapht.graph.specifics.DirectedSpecifics;
+import org.jgrapht.graph.specifics.FastLookupDirectedSpecifics;
 
 /**
  * A unit test for directed multigraph.
@@ -43,9 +49,26 @@ public class DefaultDirectedGraphTest
      */
     public void testEdgeSetFactory()
     {
-        DirectedMultigraph<String, DefaultEdge> g = new DirectedMultigraph<>(DefaultEdge.class);
-        g.setEdgeSetFactory(new LinkedHashSetFactory<>());
-        initMultiTriangle(g);
+        DirectedMultigraph<String, DefaultEdge> g =
+            new LinkedHashSetDirectedMultigraph<>(DefaultEdge.class);
+
+        g.addVertex(v1);
+        g.addVertex(v2);
+        g.addVertex(v3);
+
+        DefaultEdge e1 = g.addEdge(v1, v2);
+        DefaultEdge e2 = g.addEdge(v2, v1);
+        DefaultEdge e3 = g.addEdge(v2, v3);
+        DefaultEdge e4 = g.addEdge(v3, v1);
+
+        Iterator<DefaultEdge> iter = g.edgeSet().iterator();
+        assertEquals(e1, iter.next());
+        assertEquals(e2, iter.next());
+        assertEquals(e3, iter.next());
+        assertEquals(e4, iter.next());
+        assertFalse(iter.hasNext());
+
+        assertEquals("([v1, v2, v3], [(v1,v2), (v2,v1), (v2,v3), (v3,v1)])", g.toString());
     }
 
     /**
@@ -147,20 +170,27 @@ public class DefaultDirectedGraphTest
 
     // ~ Inner Classes ----------------------------------------------------------
 
-    private static class LinkedHashSetFactory<V, E>
-        implements EdgeSetFactory<V, E>
+    /**
+     * A graph implementation with an edge factory using linked hash sets.
+     * 
+     * @param <V> the graph vertex type
+     * @param <E> the graph edge type
+     */
+    private class LinkedHashSetDirectedMultigraph<V, E>
+        extends DirectedMultigraph<V, E>
     {
-        /**
-         * .
-         *
-         * @param vertex
-         *
-         * @return an empty list.
-         */
-        @Override
-        public Set<E> createEdgeSet(V vertex)
+        private static final long serialVersionUID = -1826738982402033648L;
+
+        public LinkedHashSetDirectedMultigraph(Class<? extends E> edgeClass)
         {
-            return new LinkedHashSet<>();
+            super(edgeClass);
+        }
+
+        @Override
+        protected DirectedSpecifics<V, E> createSpecifics()
+        {
+            return new FastLookupDirectedSpecifics<>(
+                this, new LinkedHashMap<>(), v -> new LinkedHashSet<>());
         }
     }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleIdentityDirectedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleIdentityDirectedGraphTest.java
@@ -26,6 +26,7 @@ import org.jgrapht.DirectedGraph;
 import org.jgrapht.EdgeFactory;
 import org.jgrapht.EnhancedTestCase;
 import org.jgrapht.graph.specifics.DirectedSpecifics;
+import org.jgrapht.graph.specifics.Specifics;
 import org.jgrapht.util.TypeUtil;
 
 /**
@@ -91,7 +92,7 @@ public class SimpleIdentityDirectedGraphTest
         }
 
         @Override
-        protected DirectedSpecifics<V, E> createDirectedSpecifics()
+        protected Specifics<V, E> createSpecifics()
         {
             return new DirectedSpecifics<>(this, new IdentityHashMap<>());
         }

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/graph/GraphPerformanceTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/graph/GraphPerformanceTest.java
@@ -232,12 +232,13 @@ public class GraphPerformanceTest
     /**
      * Creates an memory efficient graph implementation.
      * 
-     * @param <V>
-     * @param <E>
+     * @param <V> the graph vertex type
+     * @param <E> the graph edge type
      */
     public static class MemoryEfficientDirectedWeightedGraph<V, E>
         extends SimpleDirectedWeightedGraph<V, E>
     {
+        private static final long serialVersionUID = -1826738982402033648L;
 
         public MemoryEfficientDirectedWeightedGraph(Class<? extends E> edgeClass)
         {
@@ -245,7 +246,7 @@ public class GraphPerformanceTest
         }
 
         @Override
-        protected DirectedSpecifics<V, E> createDirectedSpecifics()
+        protected Specifics<V, E> createSpecifics()
         {
             return new DirectedSpecifics<>(this);
         }


### PR DESCRIPTION
This is mostly an internal cleanup of the interactions between `AbstractBaseGraph` and `Specifics`.

 - Removed dependency between `AbstractBaseGraph` and `EdgeSetFactory`. Now `AbstractBaseGraph` contains a `Specifics` implementation which in turn uses an `EdgeSetFactory` in order to create edge sets.
 - Changed Specifics into an interface since is was an abstract class where all methods were abstract.
 - Changed `AbstractBaseGraph` to contain only one factory method for the creation of `Specifics`. 

All these make it easier for someone to understand the interactions between the classes.