### PR TITLE
handle multiple times escaped backslashes  (based on even/odd backslashes count)

### DIFF
--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/DOTImporter.java
@@ -730,16 +730,28 @@ public class DOTImporter<V, E>
         }
     }
 
+    private boolean isEscapedItself(String input, int start)
+    {
+        int backslashCount = 0;
+
+        while (input.charAt(start - backslashCount) == '\\')
+        {
+            backslashCount += 1;
+        }
+
+        boolean isEven = (backslashCount % 2) == 0;
+
+        return isEven;
+    }
+
     private int findNextQuote(String input, int start)
     {
         int result = start;
         do {
             result = input.indexOf('\"', result + 1);
             // if the previous character is an escape then keep going
-        } while ((input.charAt(result - 1) == '\\')
-            && !((input.charAt(result - 1) == '\\') && (input.charAt(result - 2) == '\\'))); // unless
-                                                                                             // its
-                                                                                             // escaped
+        } while (!isEscapedItself(input, result - 1));     // unless its escaped
+
         return result;
     }
 }

--- a/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
+++ b/jgrapht-ext/src/test/java/org/jgrapht/ext/DOTImporterTest.java
@@ -594,6 +594,41 @@ public class DOTImporterTest
             "wrong parsing", "node", ((TestVertex) result.vertexSet().toArray()[0]).getId());
     }
 
+    public void testLabelsWithDoubleEscape()
+            throws ImportException
+    {
+        String escapedLabel = "<?xml version=\\\\\\\"1.0\\\\\\\" encoding=\\\\\\\"UTF-8\\\\\\\" standalone=\\\\\\\"no\\\\\\\"?>";
+        String input = "graph G {\n node [ label=\"" + escapedLabel + "\" ];\n}\n";
+        Multigraph<TestVertex, DefaultEdge> result =
+                new Multigraph<TestVertex, DefaultEdge>(DefaultEdge.class);
+        DOTImporter<TestVertex, DefaultEdge> importer =
+                new DOTImporter<TestVertex, DefaultEdge>(new VertexProvider<TestVertex>()
+                {
+                    @Override
+                    public TestVertex buildVertex(String label, Map<String, String> attributes)
+                    {
+                        if (label.equals("node")) {
+                            Assert.assertEquals(attributes.get("label"), escapedLabel);
+                        }
+                        return new TestVertex(label, attributes);
+                    }
+                }, new EdgeProvider<TestVertex, DefaultEdge>()
+                {
+                    @Override
+                    public DefaultEdge buildEdge(
+                            TestVertex from, TestVertex to, String label, Map<String, String> attributes)
+                    {
+                        return new DefaultEdge();
+                    }
+                });
+
+        importer.importGraph(result, new StringReader(input));
+        Assert.assertEquals("wrong size of vertexSet", 1, result.vertexSet().size());
+        Assert.assertEquals("wrong size of edgeSet", 0, result.edgeSet().size());
+        Assert.assertEquals(
+                "wrong parsing", "node", ((TestVertex) result.vertexSet().toArray()[0]).getId());
+    }
+
     public void testNoLineEndBetweenNodes()
         throws ImportException
     {


### PR DESCRIPTION
Backslashes can be escaped multiple times. 
E.g. we serialize in JSON an object which contains "<?xml version="1.0" encoding="UTF-8" standalone="no"?>" and put that JSON-string into an attribute of graph node. So in graph we have a node with attribute looks like "<?xml version=\\"1.0\\" encoding=\\"UTF-8\\" standalone=\\"no\\"?>" - three backslashes in a row.
So it seems that best way to decide is "(quote) escaped or not is to count backslashes count and even/odd criteria.
