### PR TITLE
Improvements to GMLExporter/Importer

### DIFF
--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
@@ -69,9 +69,9 @@ public class GmlExporter<V, E>
         EXPORT_EDGE_WEIGHTS
     }
 
-    private ComponentNameProvider<V> vertexIDProvider;
+    private ComponentNameProvider<V> vertexIDProvider = new IntegerComponentNameProvider<>();
     private ComponentNameProvider<V> vertexLabelProvider;
-    private ComponentNameProvider<E> edgeIDProvider;
+    private ComponentNameProvider<E> edgeIDProvider = new IntegerComponentNameProvider<>();
     private ComponentNameProvider<E> edgeLabelProvider;
     private final Set<Parameter> parameters;
 
@@ -81,8 +81,7 @@ public class GmlExporter<V, E>
      */
     public GmlExporter()
     {
-        this(
-            new IntegerComponentNameProvider<>(), null, new IntegerComponentNameProvider<>(), null);
+        this(null, null);
     }
 
     /**
@@ -95,13 +94,10 @@ public class GmlExporter<V, E>
      * @param edgeLabelProvider for generating edge labels. If null, edge labels will be generated
      *        using the toString() method of the edge object.
      */
-    public GmlExporter(
-        ComponentNameProvider<V> vertexIDProvider, ComponentNameProvider<V> vertexLabelProvider,
-        ComponentNameProvider<E> edgeIDProvider, ComponentNameProvider<E> edgeLabelProvider)
+    public GmlExporter(ComponentNameProvider<V> vertexLabelProvider,
+        ComponentNameProvider<E> edgeLabelProvider)
     {
-        this.vertexIDProvider = vertexIDProvider;
         this.vertexLabelProvider = vertexLabelProvider;
-        this.edgeIDProvider = edgeIDProvider;
         this.edgeLabelProvider = edgeLabelProvider;
         this.parameters = new HashSet<>();
     }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlExporter.java
@@ -87,10 +87,8 @@ public class GmlExporter<V, E>
     /**
      * Constructs a new GmlExporter object with the given ID and label providers.
      *
-     * @param vertexIDProvider for generating vertex IDs. Must not be null.
      * @param vertexLabelProvider for generating vertex labels. If null, vertex labels will be
      *        generated using the toString() method of the vertex object.
-     * @param edgeIDProvider for generating vertex IDs. Must not be null.
      * @param edgeLabelProvider for generating edge labels. If null, edge labels will be generated
      *        using the toString() method of the edge object.
      */

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
@@ -40,6 +40,7 @@ import org.jgrapht.ext.GmlParser.*;
  * graph [
  *   node [ 
  *     id 1
+ *     label "node label string"
  *   ]
  *   node [
  *     id 2
@@ -51,11 +52,13 @@ import org.jgrapht.ext.GmlParser.*;
  *     source 1
  *     target 2 
  *     weight 2.0
+ *     label "label string"
  *   ]
  *   edge [
  *     source 2
  *     target 3
  *     weight 3.0
+ *     label "another label string"
  *   ]
  * ]
  * </pre>
@@ -151,7 +154,8 @@ public class GmlImporter<V, E>
      * 
      * @param graph the output graph
      * @param input the input reader
-     * @throws ImportException in case an error occurs, such as I/O or parse error
+     * @throws ImportException in case an error occurs, such a parse error
+     * @throws IOException if there is an I/O error
      */
     @Override
     public void importGraph(Graph<V, E> graph, Reader input)
@@ -215,6 +219,7 @@ public class GmlImporter<V, E>
         private static final String ID = "id";
         private static final String SOURCE = "source";
         private static final String TARGET = "target";
+        private static final String LABEL = "label";
 
         private boolean foundGraph;
         private boolean insideGraph;
@@ -225,36 +230,62 @@ public class GmlImporter<V, E>
         private Integer sourceId;
         private Integer targetId;
         private Double weight;
+        private String label;
 
-        private Set<Integer> nodes;
-        private int singletons;
+        /**
+         * Maps IDs, which are always integers, to the corresponding node labels
+         * for nodes that are connected in the graph.
+         */
+        private HashMap<Integer, String> nodeLabels;
+        /** Labels for stand-alone nodes that are not connected.  Note that these
+         * can be NULL.
+         */
+        private List<String> singletonLabels;
         private List<PartialEdge> edges;
 
         public void updateGraph(Graph<V, E> graph)
             throws ImportException
         {
             if (foundGraph) {
-                // add nodes
+                // Add connected nodes
                 int maxV = 1;
                 Map<Integer, V> map = new HashMap<Integer, V>();
-                for (Integer id : nodes) {
+                for (Integer id : nodeLabels.keySet()) {
+                	String label = nodeLabels.get(id);
+                	// Substitute the ID for the label if no label provided
+                	if (label == null || (label != null && label.equals(""))) {
+                		label = id + "";
+                	}
                     maxV = Math.max(maxV, id);
-                    V vertex =
-                        vertexProvider.buildVertex(id.toString(), new HashMap<String, String>());
-                    map.put(id, vertex);
-                    graph.addVertex(vertex);
+                    V vertex = vertexProvider.buildVertex(label, new HashMap<String, String>());
+                    if (vertex != null) {
+                    	map.put(id, vertex);
+                    	graph.addVertex(vertex);
+                    }
                 }
 
-                // add singleton nodes
-                for (int i = 0; i < singletons; i++) {
-                    String label = String.valueOf(maxV + 1 + i);
-                    graph.addVertex(
-                        vertexProvider.buildVertex(label, new HashMap<String, String>()));
+                // Add singleton nodes--those with no IDs and that are not connected.
+                for (int i = 0; i < singletonLabels.size(); i++) {
+                	String label = singletonLabels.get(i);
+                	// For nodes that for whatever reason do not have IDs set in the file,
+                	// assign the next higher ID as the label.
+                	if (label == null || (label != null && label.equals(""))) {
+                		label = String.valueOf(maxV + 1 + i);
+                	}
+                	V vertex = vertexProvider.buildVertex(label, new HashMap<String, String>());
+                	if (vertex != null) {
+                		graph.addVertex(vertex);
+                	}
                 }
 
-                // add edges
+                // Add edges
                 for (PartialEdge pe : edges) {
-                    String label = "e_" + pe.source + "_" + pe.target;
+                    String label = pe.label;
+                    // If no label assigned, then substitute e_X_Y where X is the source ID
+                    // and Y is the target ID.
+                    if (label == null || (label != null && label.equals(""))) {
+                    	label = "e_" + pe.source + "_" + pe.target;
+                    }
                     V from = map.get(pe.source);
                     if (from == null) {
                         throw new ImportException("Node " + pe.source + " does not exist");
@@ -263,12 +294,14 @@ public class GmlImporter<V, E>
                     if (to == null) {
                         throw new ImportException("Node " + pe.target + " does not exist");
                     }
-                    E e = edgeProvider.buildEdge(from, to, label, new HashMap<String, String>());
-                    graph.addEdge(from, to, e);
-                    if (pe.weight != null) {
-                        if (graph instanceof WeightedGraph<?, ?>) {
-                            ((WeightedGraph<V, E>) graph).setEdgeWeight(e, pe.weight);
-                        }
+                    E edge = edgeProvider.buildEdge(from, to, label, new HashMap<String, String>());
+                    if (edge != null) {
+                    	graph.addEdge(from, to, edge);
+                    	if (pe.weight != null) {
+                    		if (graph instanceof WeightedGraph<?, ?>) {
+                    			((WeightedGraph<V, E>) graph).setEdgeWeight(edge, pe.weight);
+                    		}
+                    	}
                     }
                 }
 
@@ -282,12 +315,23 @@ public class GmlImporter<V, E>
             insideGraph = false;
             insideNode = false;
             insideEdge = false;
-            nodes = new HashSet<Integer>();
-            singletons = 0;
+            nodeLabels = new HashMap<>();
+            singletonLabels = new ArrayList<>();
             edges = new ArrayList<PartialEdge>();
             level = 0;
         }
-
+        
+        @Override
+        public void enterStringKeyValue(GmlParser.StringKeyValueContext ctx)
+        {
+        	String key = ctx.ID().getText();
+        	
+        	if ((insideEdge || insideNode) && level == 2 && key.equals(LABEL)) {
+        		// Label will be enclosed in quotes and may contain escape sequences
+        		label = StringUtility.deQuote(ctx.STRING().getText());
+        	}
+        }
+        
         @Override
         public void enterNumberKeyValue(GmlParser.NumberKeyValueContext ctx)
         {
@@ -330,11 +374,13 @@ public class GmlImporter<V, E>
             } else if (level == 1 && insideGraph && key.equals(NODE)) {
                 insideNode = true;
                 nodeId = null;
+                label = null;
             } else if (level == 1 && insideGraph && key.equals(EDGE)) {
                 insideEdge = true;
                 sourceId = null;
                 targetId = null;
                 weight = null;
+                label = null;
             }
             level++;
         }
@@ -347,34 +393,38 @@ public class GmlImporter<V, E>
             if (level == 0 && key.equals(GRAPH)) {
                 insideGraph = false;
             } else if (level == 1 && insideGraph && key.equals(NODE)) {
-                if (nodeId == null) {
-                    singletons++;
+                if (nodeId != null) {
+                	// Normal case: The node has an ID, so record its ID and its label.
+                	nodeLabels.put(nodeId, label);
                 } else {
-                    nodes.add(nodeId);
+                	// A node without a numeric identifier is called a singleton in this
+                	// context.  Lacking an identifier, it cannot be connected.  All we
+                	// can do is track its label.  The label may be null!
+                	singletonLabels.add(label);
                 }
                 insideNode = false;
             } else if (level == 1 && insideGraph && key.equals(EDGE)) {
                 if (sourceId != null && targetId != null) {
-                    edges.add(new PartialEdge(sourceId, targetId, weight));
+                    edges.add(new PartialEdge(sourceId, targetId, weight, label));
                 }
                 insideEdge = false;
             }
-
         }
-
     }
-
+    
     private class PartialEdge
     {
         Integer source;
         Integer target;
         Double weight;
+        String label;
 
-        public PartialEdge(Integer source, Integer target, Double weight)
+        public PartialEdge(Integer source, Integer target, Double weight, String label)
         {
             this.source = source;
             this.target = target;
             this.weight = weight;
+            this.label = label;
         }
     }
 

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GmlImporter.java
@@ -154,8 +154,7 @@ public class GmlImporter<V, E>
      * 
      * @param graph the output graph
      * @param input the input reader
-     * @throws ImportException in case an error occurs, such a parse error
-     * @throws IOException if there is an I/O error
+     * @throws ImportException in case an error occurs, such as I/O or parse error
      */
     @Override
     public void importGraph(Graph<V, E> graph, Reader input)

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/StringUtility.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/StringUtility.java
@@ -2,25 +2,25 @@ package org.jgrapht.ext;
 
 public class StringUtility
 {
-	/**
-	 * Removes quotes from a string
-	 * 
-	 * @param in a quoted string
-	 * @return the string without enclosing quotes; if <code>in</code> is not
-	 *         quoted, the original string is returned.
-	 */
-	public static String deQuote (String in)
-	{
-		int len = in.length();
-		
-		if (in.charAt(0) == '\"' && in.charAt(len - 1) == '\"') {
-			if (len > 2) {
-				return in.substring(1, len - 1);
-			} else {
-				return "";
-			}
-		}
+    /**
+     * Removes quotes from a string
+     * 
+     * @param in a quoted string
+     * @return the string without enclosing quotes; if <code>in</code> is not
+     *         quoted, the original string is returned.
+     */
+    public static String deQuote (String in)
+    {
+        int len = in.length();
 
-		return in;
-	}
+        if (in.charAt(0) == '\"' && in.charAt(len - 1) == '\"') {
+            if (len > 2) {
+                return in.substring(1, len - 1);
+            } else {
+                return "";
+            }
+        }
+
+        return in;
+    }
 }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/StringUtility.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/StringUtility.java
@@ -1,0 +1,26 @@
+package org.jgrapht.ext;
+
+public class StringUtility
+{
+	/**
+	 * Removes quotes from a string
+	 * 
+	 * @param in a quoted string
+	 * @return the string without enclosing quotes; if <code>in</code> is not
+	 *         quoted, the original string is returned.
+	 */
+	public static String deQuote (String in)
+	{
+		int len = in.length();
+		
+		if (in.charAt(0) == '\"' && in.charAt(len - 1) == '\"') {
+			if (len > 2) {
+				return in.substring(1, len - 1);
+			} else {
+				return "";
+			}
+		}
+
+		return in;
+	}
+}


### PR DESCRIPTION
Hi folks,

Great library.  Thanks for making it available.

I noticed that the GMLImporter and GMLExporter functionality isn't symmetric.  It is not possible to export a graph with labels and re-create the same graph on import, because labels in the GML file are ignored.  This is especially important because labels are the sole means of saving object data.

Also, GMLExporter required a name provider for vertex and edge IDs.  The PDF linked in the Javadoc to the official file format specification is broken, but the GML examples I have found always use integers for the IDs, and the IDs were not being quoted in the output so that they could be taken as strings.  Therefore I have modified the constructor for GMLExporter to no longer accept name providers for the IDs, but instead only for labels, and hard-coded the use of the Integer name provider.

I have changed GMLImporter to read and de-quote the label fields for vertices and edges and pass them to the EdgeProvider and VertexProvider.  (Previously the IDs were being passed, in the case of vertices, or a generated edge name e_X_Y, which is useless and incorrect.)  I added null checks so that the VertexProvider or EdgeProvider can return null if for some reason it is not possible to create an edge or vertex from the label data.  If null is returned, the vertex or edge is omitted from the graph.

Also, strings are not properly escaped on export, e.g. a string with a quote " will not be escaped to \" during output, and strings are not de-escaped on import.  On my system I'm using the Apache Commons Lang escapeJava() and unescapeJava(), but that adds another dependency to your project.  Therefore I have not included those changes.

I should probably be using GraphML instead, but I had issues with the resource paths getting munged up when trying to load the DTDs, so I went this route.  Hope others find these fixes useful.

I did not modify the JUnit tests for these changes, but I have run this through a successful test build.