### PR TITLE
Astarbug

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/AStarShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/AStarShortestPath.java
@@ -239,9 +239,7 @@ public class AStarShortestPath<V, E>
      * In short, a heuristic is consistent iff <code>h(u)&le; d(u,v)+h(v)</code>, for every edge (u,v), where d(u,v) is
      * the weight of edge (u,v) and h(u) is the estimated cost to reach the target node from vertex u. Most natural
      * admissible heuristics, such as Manhattan or Euclidian distance, are consistent heuristics.
-     * @return true if the heuristic is consistent
-     * Convenience method: tests whether the heuristic is consistent. This method is not used in the implementation.
-     * @param admissibleHeuristic heuristic
+     * @param admissibleHeuristic admissible heuristic
      * @return true is the heuristic is consistent
      */
     public boolean isConsistentHeuristic(AStarAdmissibleHeuristic<V> admissibleHeuristic){

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/AStarShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/AStarShortestPath.java
@@ -33,11 +33,17 @@ import org.jgrapht.util.*;
  * new instance of this class has to be created. The heuristic is implemented using a FibonacciHeap
  * data structure to maintain the set of open nodes. However, there still exist several approaches
  * in literature to improve the performance of this heuristic which one could consider to implement.
- * Another issue to take into consideration is the following: given to candidate nodes, i, j to
+ * Another issue to take into consideration is the following: given two candidate nodes, i, j to
  * expand, where f(i)=f(j), g(i)&gt;g(j), h(i)&lt;g(j), f(i)=g(i)+h(i), g(i) is the actual distance
  * from the source node to i, h(i) is the estimated distance from i to the target node. Usually a
  * depth-first search is desired, so ideally we would expand node i first. Using the FibonacciHeap,
  * this is not necessarily the case though. This could be improved in a later version.
+ *
+ * <p>Note: This implementation works with both consistent and inconsistent admissible heuristics. For details on
+ * consistency, refer to the description of the method {@link #isConsistentHeuristic(AStarAdmissibleHeuristic)}. However, this class is
+ * <i>not</i> optimized for inconsistent heuristics. Several opportunities to improve both worst case and average
+ * runtime complexities for A* with inconsistent heuristics described in literature can be used to
+ * improve this implementation!
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -120,6 +126,7 @@ public class AStarShortestPath<V, E>
         }
 
         this.initialize(admissibleHeuristic);
+
         gScoreMap.put(sourceVertex, 0.0);
         FibonacciHeapNode<V> heapNode = new FibonacciHeapNode<>(sourceVertex);
         openList.insert(heapNode, 0.0);
@@ -156,36 +163,33 @@ public class AStarShortestPath<V, E>
 
         for (E edge : outgoingEdges) {
             V successor = Graphs.getOppositeVertex(graph, edge, currentNode.getData());
-            if ((successor == currentNode.getData()) || closedList.contains(successor)) { // Ignore
-                                                                                          // self-loops
-                                                                                          // or
-                                                                                          // nodes
-                                                                                          // which
-                                                                                          // have
-                                                                                          // already
-                                                                                          // been
-                                                                                          // expanded
+
+            if (successor == currentNode.getData()) // Ignore self-loop
                 continue;
-            }
 
             double gScore_current = gScoreMap.get(currentNode.getData());
             double tentativeGScore = gScore_current + graph.getEdgeWeight(edge);
+            double fScore = tentativeGScore + admissibleHeuristic.getCostEstimate(successor, endVertex);
 
-            if (!vertexToHeapNodeMap.containsKey(successor)
-                || (tentativeGScore < gScoreMap.get(successor)))
-            {
+            if (vertexToHeapNodeMap.containsKey(successor)){ //We re-encountered a vertex. It's either in the open or closed list.
+                if(tentativeGScore >= gScoreMap.get(successor)) //Ignore path since it is non-improving
+                    continue;
+
                 cameFrom.put(successor, edge);
                 gScoreMap.put(successor, tentativeGScore);
 
-                double fScore =
-                    tentativeGScore + admissibleHeuristic.getCostEstimate(successor, endVertex);
-                if (!vertexToHeapNodeMap.containsKey(successor)) {
-                    FibonacciHeapNode<V> heapNode = new FibonacciHeapNode<>(successor);
-                    openList.insert(heapNode, fScore);
-                    vertexToHeapNodeMap.put(successor, heapNode);
-                } else {
+                if(closedList.contains(successor)){ //it's in the closed list. Move node back to open list, since we discovered a shorter path to this node
+                    closedList.remove(successor);
+                    openList.insert(vertexToHeapNodeMap.get(successor), fScore);
+                }else{ //It's in the open list
                     openList.decreaseKey(vertexToHeapNodeMap.get(successor), fScore);
                 }
+            }else{ //We've encountered a new vertex.
+                cameFrom.put(successor, edge);
+                gScoreMap.put(successor, tentativeGScore);
+                FibonacciHeapNode<V> heapNode = new FibonacciHeapNode<>(successor);
+                openList.insert(heapNode, fScore);
+                vertexToHeapNodeMap.put(successor, heapNode);
             }
         }
     }
@@ -225,6 +229,34 @@ public class AStarShortestPath<V, E>
     public int getNumberOfExpandedNodes()
     {
         return numberOfExpandedNodes;
+    }
+
+    /**
+     * Returns true if the provided heuristic is a <i>consistent</i> or <i>monotone</i> heuristic wrt the graph provided
+     * at construction time. A heuristic is monotonic if its estimate is always less than or equal to the estimated
+     * distance from any neighboring vertex to the goal, plus the step cost of reaching that neighbor. For details, refer to
+     * <a href="https://en.wikipedia.org/wiki/Consistent_heuristic">https://en.wikipedia.org/wiki/Consistent_heuristic</a>.
+     * In short, a heuristic is consistent iff <code>h(u)&le; d(u,v)+h(v)</code>, for every edge (u,v), where d(u,v) is
+     * the weight of edge (u,v) and h(u) is the estimated cost to reach the target node from vertex u. Most natural
+     * admissible heuristics, such as Manhattan or Euclidian distance, are consistent heuristics.
+     * @return true if the heuristic is consistent
+     * Convenience method: tests whether the heuristic is consistent. This method is not used in the implementation.
+     * @param admissibleHeuristic heuristic
+     * @return true is the heuristic is consistent
+     */
+    public boolean isConsistentHeuristic(AStarAdmissibleHeuristic<V> admissibleHeuristic){
+        for(V targetVertex : graph.vertexSet()) {
+            for (E e : graph.edgeSet()) {
+                double weight = graph.getEdgeWeight(e);
+                V edgeSource = graph.getEdgeSource(e);
+                V edgeTarget = graph.getEdgeTarget(e);
+                double h_x = admissibleHeuristic.getCostEstimate(edgeSource, targetVertex);
+                double h_y = admissibleHeuristic.getCostEstimate(edgeTarget, targetVertex);
+                if (h_x > weight + h_y)
+                    return false;
+            }
+        }
+        return true;
     }
 }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java
@@ -38,6 +38,7 @@ public interface AStarAdmissibleHeuristic<V>
      * @return an estimate of the distance from the source to the target vertex
      */
     double getCostEstimate(V sourceVertex, V targetVertex);
+
 }
 
 // End AStarAdmissibleHeuristic.java

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/AStarShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/AStarShortestPathTest.java
@@ -173,6 +173,63 @@ public class AStarShortestPathTest
         assertEquals(path.getEdgeList().size(), 2);
     }
 
+    public void testWeightedGraph1()
+    {
+        WeightedGraph<Integer, DefaultWeightedEdge> g =
+            new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+        g.addVertex(0);
+        g.addVertex(1);
+        g.addVertex(2);
+        g.addVertex(3);
+
+        g.setEdgeWeight(g.addEdge(0, 1), 0.5822723681370429);
+        g.setEdgeWeight(g.addEdge(0, 3), 0.8512429683406786);
+        g.setEdgeWeight(g.addEdge(3, 0), 0.22867383417976428);
+        g.setEdgeWeight(g.addEdge(1, 2), 0.1531858692059932);
+        g.setEdgeWeight(g.addEdge(3, 1), 0.9639222864568235);
+        g.setEdgeWeight(g.addEdge(2, 2), 0.23262564370920258);
+        g.setEdgeWeight(g.addEdge(2, 2), 0.6166416559599189);
+        g.setEdgeWeight(g.addEdge(3, 3), 0.6088954021459719);
+        g.setEdgeWeight(g.addEdge(3, 3), 0.2476189990121238);
+
+        AStarAdmissibleHeuristic<Integer> h = new AStarAdmissibleHeuristic<Integer>()
+        {
+
+            @Override
+            public double getCostEstimate(Integer s, Integer t)
+            {
+                if (s.intValue() == 0 && t.intValue() == 1) {
+                    // actual = 0.5822723681370429
+                    return 0.5822723681370429;
+                }
+                if (s.intValue() == 3 && t.intValue() == 1) {
+                    // actual = 0.8109462023168071
+                    return 0.8109462023168071;
+                }
+                if (s.intValue() == 3 && t.intValue() == 2) {
+                    // actual = 0.9641320715228003
+                    return 0.9639222864568235;
+                }
+                if (s.intValue() == 0 && t.intValue() == 1) {
+                    // actual = 0.5822723681370429
+                    return 0.5822723681370429;
+                }
+                if (s.intValue() == 0 && t.intValue() == 2) {
+                    // actual = 0.7354582373430361
+                    return 0.7354582373430361;
+                }
+
+                // all other zero
+                return 0d;
+            }
+        };
+
+        // shortest path from 3 to 2 is 3->0->1->2 with weight 0.9641320715228003
+        assertEquals(
+            0.9641320715228003, new AStarShortestPath<>(g).getShortestPath(3, 2, h).getWeight(),
+            1e-9);
+    }
+
     private class ManhattanDistance
         implements AStarAdmissibleHeuristic<Node>
     {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/AStarShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/AStarShortestPathTest.java
@@ -80,7 +80,7 @@ public class AStarShortestPathTest
             for (int j = 0; j < labyrinth[0].length(); j++) {
                 if (labyrinth[i].charAt(j) == '#' || labyrinth[i].charAt(j) == ' ')
                     continue;
-                nodes[i][j] = new Node(i, j);
+                nodes[i][j] = new Node(i, j/2);
                 graph.addVertex(nodes[i][j]);
                 if (labyrinth[i].charAt(j) == 'S')
                     sourceNode = nodes[i][j];
@@ -126,6 +126,7 @@ public class AStarShortestPathTest
         assertNotNull(path);
         assertEquals((int) path.getWeight(), 47);
         assertEquals(path.getEdgeList().size(), 47);
+        assertTrue(aStarShortestPath.isConsistentHeuristic(new EuclideanDistance()));
     }
 
     /**
@@ -139,6 +140,7 @@ public class AStarShortestPathTest
         GraphPath<Node, DefaultWeightedEdge> path =
             aStarShortestPath.getShortestPath(sourceNode, targetNode, new ManhattanDistance());
         assertNull(path);
+        assertTrue(aStarShortestPath.isConsistentHeuristic(new ManhattanDistance()));
     }
 
     /**
@@ -171,9 +173,10 @@ public class AStarShortestPathTest
         assertNotNull(path);
         assertEquals((int) path.getWeight(), 6);
         assertEquals(path.getEdgeList().size(), 2);
+        assertTrue(aStarShortestPath.isConsistentHeuristic(new ManhattanDistance()));
     }
 
-    public void testWeightedGraph1()
+    public void testInconsistentHeuristic()
     {
         WeightedGraph<Integer, DefaultWeightedEdge> g =
             new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
@@ -224,10 +227,12 @@ public class AStarShortestPathTest
             }
         };
 
+        AStarShortestPath<Integer, DefaultWeightedEdge> alg=new AStarShortestPath<>(g);
         // shortest path from 3 to 2 is 3->0->1->2 with weight 0.9641320715228003
         assertEquals(
-            0.9641320715228003, new AStarShortestPath<>(g).getShortestPath(3, 2, h).getWeight(),
+            0.9641320715228003, alg.getShortestPath(3, 2, h).getWeight(),
             1e-9);
+        assertFalse(alg.isConsistentHeuristic(h));
     }
 
     private class ManhattanDistance


### PR DESCRIPTION
Fixes bug #335 .
The A* search algorithm can now correctly handle inconsistent admissible heuristics. This obviously comes with a (severe) performance penalty. There are several variations on A* search described in literature which are better capable of dealing with inconsistent heuristics.

Some technical details:
In A* search with inconsistent heuristic: sometimes a new, shorter, path is discovered to a node in the 'closed' list. A node resides in the 'closed' list if it has been fully expanded in a previous iteration of the algorithm. If a new shorter path is discovered, the closed node is returned to the open list. This situation can never occur when a consistent heuristic is used.