### PR TITLE
Enforce valid nodes in FibonacciHeap

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/util/FibonacciHeap.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/FibonacciHeap.java
@@ -21,8 +21,8 @@ import java.util.*;
 
 /**
  * This class implements a Fibonacci heap data structure. Much of the code in this class is based on
- * the algorithms in the "Introduction to Algorithms"by Cormen, Leiserson, and Rivest in Chapter 21.
- * The amortized running time of most of these methods is O(1), making it a very fast data
+ * the algorithms in the "Introduction to Algorithms" by Cormen, Leiserson, and Rivest in Chapter
+ * 21. The amortized running time of most of these methods is O(1), making it a very fast data
  * structure. Several have an actual running time of O(1). removeMin() and delete() have O(log n)
  * amortized running times because they do the heap consolidation. If you attempt to store nodes in
  * this heap with key values of -Infinity (Double.NEGATIVE_INFINITY) the <code>delete()</code>
@@ -113,6 +113,10 @@ public class FibonacciHeap<T>
                 "decreaseKey() got larger key value. Current key: " + x.key + " new key: " + k);
         }
 
+        if (x.right == null) {
+            throw new IllegalArgumentException("Invalid heap node");
+        }
+
         x.key = k;
 
         FibonacciHeapNode<T> y = x.parent;
@@ -161,9 +165,14 @@ public class FibonacciHeap<T>
      *
      * @param node new node to insert into heap
      * @param key key value associated with data object
+     * @throws IllegalArgumentException if the node already belongs to a heap
      */
     public void insert(FibonacciHeapNode<T> node, double key)
     {
+        if (node.right != null) {
+            throw new IllegalArgumentException("Invalid heap node");
+        }
+
         node.key = key;
 
         // concatenate node into min list
@@ -177,6 +186,8 @@ public class FibonacciHeap<T>
                 minNode = node;
             }
         } else {
+            node.left = node;
+            node.right = node;
             minNode = node;
         }
 
@@ -254,6 +265,13 @@ public class FibonacciHeap<T>
 
             // decrement size of heap
             nNodes--;
+
+            // clear z
+            z.left = null;
+            z.right = null;
+            z.degree = 0;
+            z.child = null;
+            z.mark = false;
         }
 
         return z;

--- a/jgrapht-core/src/main/java/org/jgrapht/util/FibonacciHeapNode.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/FibonacciHeapNode.java
@@ -69,15 +69,12 @@ public class FibonacciHeapNode<T>
     int degree;
 
     /**
-     * Default constructor. Initializes the right and left pointers, making this a circular
-     * doubly-linked list.
+     * Constructs a new node.
      *
      * @param data data for this node
      */
     public FibonacciHeapNode(T data)
     {
-        right = this;
-        left = this;
         this.data = data;
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/util/FibonacciHeapTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/FibonacciHeapTest.java
@@ -68,6 +68,109 @@ public class FibonacciHeapTest
         // tally should come back down to zero, or thereabouts (due to roundoff)
         assertEquals(0.0, t, 0.00001);
     }
+
+    public void testValidReinsert()
+    {
+        FibonacciHeapNode<String> n1 = new FibonacciHeapNode<>("1");
+        FibonacciHeapNode<String> n2 = new FibonacciHeapNode<>("2");
+        FibonacciHeapNode<String> n3 = new FibonacciHeapNode<>("3");
+        FibonacciHeapNode<String> n4 = new FibonacciHeapNode<>("4");
+
+        FibonacciHeap<String> h = new FibonacciHeap<>();
+        h.insert(n1, 1d);
+        h.insert(n2, 2d);
+        h.insert(n3, 3d);
+        h.insert(n4, 4d);
+
+        assertEquals("1", h.min().getData());
+        h.removeMin();
+        h.insert(n1, 5d);
+        assertEquals("2", h.min().getData());
+        h.removeMin();
+        assertEquals("3", h.min().getData());
+        h.removeMin();
+        assertEquals("4", h.min().getData());
+        h.removeMin();
+        assertEquals("1", h.min().getData());
+        h.removeMin();
+        assertTrue(h.isEmpty());
+    }
+
+    public void testBadReinsert()
+    {
+        FibonacciHeapNode<String> n1 = new FibonacciHeapNode<>("1");
+        FibonacciHeapNode<String> n2 = new FibonacciHeapNode<>("2");
+        FibonacciHeapNode<String> n3 = new FibonacciHeapNode<>("3");
+        FibonacciHeapNode<String> n4 = new FibonacciHeapNode<>("4");
+
+        FibonacciHeap<String> h = new FibonacciHeap<>();
+        h.insert(n1, 1d);
+        h.insert(n2, 2d);
+        h.insert(n3, 3d);
+        h.insert(n4, 4d);
+
+        assertEquals("1", h.min().getData());
+        try {
+            h.insert(n2, 5d);
+            fail("Reinsert allowed!");
+        } catch (IllegalArgumentException e) {
+            // ignore
+        }
+    }
+
+    public void testBadDecreaseKey()
+    {
+        FibonacciHeapNode<String> n1 = new FibonacciHeapNode<>("1");
+        FibonacciHeapNode<String> n2 = new FibonacciHeapNode<>("2");
+        FibonacciHeapNode<String> n3 = new FibonacciHeapNode<>("3");
+        FibonacciHeapNode<String> n4 = new FibonacciHeapNode<>("4");
+
+        FibonacciHeap<String> h = new FibonacciHeap<>();
+        h.insert(n1, 1d);
+        h.insert(n2, 2d);
+        h.insert(n3, 3d);
+        h.insert(n4, 4d);
+
+        assertEquals("1", h.min().getData());
+        h.decreaseKey(n4, 0.5);
+        assertEquals("4", h.min().getData());
+        h.removeMin();
+        assertEquals("1", h.min().getData());
+        try {
+            h.decreaseKey(n4, 0.1);
+            fail("Invalid decrease key allowed!");
+        } catch (IllegalArgumentException e) {
+            // ignore
+        }
+    }
+
+    public void testBadDelete()
+    {
+        FibonacciHeapNode<String> n1 = new FibonacciHeapNode<>("1");
+        FibonacciHeapNode<String> n2 = new FibonacciHeapNode<>("2");
+        FibonacciHeapNode<String> n3 = new FibonacciHeapNode<>("3");
+        FibonacciHeapNode<String> n4 = new FibonacciHeapNode<>("4");
+
+        FibonacciHeap<String> h = new FibonacciHeap<>();
+        h.insert(n1, 1d);
+        h.insert(n2, 2d);
+        h.insert(n3, 3d);
+        h.insert(n4, 4d);
+
+        assertEquals("1", h.min().getData());
+        h.removeMin();
+        assertEquals("2", h.min().getData());
+        try {
+            h.delete(n1);
+            fail("Invalid delete allowed!");
+        } catch (IllegalArgumentException e) {
+            // ignore
+        }
+        h.delete(n2);
+        h.delete(n3);
+        h.delete(n4);
+    }
+
 }
 
 // End FibonacciHeapTest.java


### PR DESCRIPTION
Small changes in the Fibonacci Heap to enforce the invariant that a `FibonacciHeapNode` does not get inserted into some heap while it belongs into the same or another heap.

This is a general fix for issue #339.

Note that there are still a few ways to badly use a `FibonacciHeap` such as using two heaps `h1` and `h2` and using nodes that belong to `h1` through a reference to `h2`. We do not try to cover those as they require a more generic mechanism to keep track in which heap each node belongs to (i.e. union-find). 

