### PR TITLE
Fixed error in pom, assembly ID not specified

### DIFF
--- a/jgrapht-dist/pom.xml
+++ b/jgrapht-dist/pom.xml
@@ -48,6 +48,7 @@
 				<artifactId>maven-assembly-plugin</artifactId>
 				<executions>
 					<execution>
+                                                <id>JGraphT</id>
 						<phase>package</phase>
 						<goals>
 							<goal>single</goal>


### PR DESCRIPTION
As of version 2.2, the maven-assembly-plugin (which is used in jgrapht-dist/pom.xml), requires that an ID descriptor is provided. See `https://maven.apache.org/plugins/maven-assembly-plugin/faq.html#required-classifiers` for details.

Whenever an ID is not provided, the following error is thrown:

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:2.4.1:single (default) on project jgrapht-dist: Assembly is incorrectly configured: null: Assembly is incorrectly configured: null:
[ERROR] Assembly: null is not configured correctly: Assembly ID must be present and non-empty.

I'm not 100% sure what we should use as 'ID', so I set it to <id>JGraphT</id>. Feel free to override. 