### PR TITLE
2-approximation algorithm for metric TSP

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/HamiltonianCycle.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/HamiltonianCycle.java
@@ -28,7 +28,9 @@ import org.jgrapht.graph.*;
  * Problem</a>.
  *
  * @author Andrew Newell
+ * @deprecated Use {@link org.jgrapht.alg.tour.TwoApproxMetricTSP} instead.
  */
+@Deprecated
 public class HamiltonianCycle
 {
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/TSPAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/TSPAlgorithm.java
@@ -1,0 +1,48 @@
+/*
+ * (C) Copyright 2017-2017, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.interfaces;
+
+import org.jgrapht.*;
+
+/**
+ * An algorithm solving the
+ * <a href="https://en.wikipedia.org/wiki/Travelling_salesman_problem">Travelling salesman
+ * problem</a> (TSP).
+ * 
+ * <p>
+ * Given a list of cities and the distances between each pair of cities, what is the shortest
+ * possible route that visits each city exactly once and returns to the origin city?
+ * 
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ *
+ * @author Dimitrios Michail
+ */
+public interface TSPAlgorithm<V, E>
+{
+
+    /**
+     * Computes a tour.
+     *
+     * @param graph the input graph
+     * @return a tour
+     * @throws IllegalArgumentException if the graph is not complete
+     */
+    GraphPath<V, E> getTour(UndirectedGraph<V, E> graph);
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/TSPAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/TSPAlgorithm.java
@@ -41,8 +41,7 @@ public interface TSPAlgorithm<V, E>
      *
      * @param graph the input graph
      * @return a tour
-     * @throws IllegalArgumentException if the graph is not complete
      */
-    GraphPath<V, E> getTour(UndirectedGraph<V, E> graph);
+    GraphPath<V, E> getTour(Graph<V, E> graph);
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoApproxMetricTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoApproxMetricTSP.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.jgrapht.Graph;
 import org.jgrapht.GraphPath;
 import org.jgrapht.GraphTests;
 import org.jgrapht.UndirectedGraph;
@@ -46,7 +47,8 @@ import org.jgrapht.traverse.DepthFirstIterator;
  * <p>
  * This is an implementation of the folklore algorithm which returns a depth-first ordering of the
  * minimum spanning tree. The algorithm is a 2-approximation assuming that the instance satisfies
- * the triangle inequality. The running time is O(|V|^2 log|V|).
+ * the triangle inequality. The implementation requires the input graph to be undirected and
+ * complete. The running time is O(|V|^2 log|V|).
  * 
  * <p>
  * See <a href="https://en.wikipedia.org/wiki/Travelling_salesman_problem">wikipedia</a> for more
@@ -68,13 +70,20 @@ public class TwoApproxMetricTSP<V, E>
     }
 
     /**
-     * {@inheritDoc}
-     * 
      * Computes a 2-approximate tour.
+     * 
+     * @param graph the input graph
+     * @return a tour
+     * @throws IllegalArgumentException if the graph is not undirected
+     * @throws IllegalArgumentException if the graph is not complete
+     * @throws IllegalArgumentException if the graph contains no vertices
      */
     @Override
-    public GraphPath<V, E> getTour(UndirectedGraph<V, E> graph)
+    public GraphPath<V, E> getTour(Graph<V, E> graph)
     {
+        if (!(graph instanceof UndirectedGraph<?, ?>)) {
+            throw new IllegalArgumentException("Graph must be undirected");
+        }
         if (!GraphTests.isComplete(graph)) {
             throw new IllegalArgumentException("Graph is not complete");
         }
@@ -107,7 +116,7 @@ public class TwoApproxMetricTSP<V, E>
          */
         int n = graph.vertexSet().size();
         Set<V> found = new HashSet<>(n);
-        List<V> tour = new ArrayList<>(n);
+        List<V> tour = new ArrayList<>(n + 1);
         V start = graph.vertexSet().iterator().next();
         DepthFirstIterator<V, DefaultEdge> dfsIt = new DepthFirstIterator<>(mst, start);
         while (dfsIt.hasNext()) {
@@ -133,7 +142,7 @@ public class TwoApproxMetricTSP<V, E>
             tourWeight += graph.getEdgeWeight(e);
             u = v;
         }
-        return new GraphWalk<>(graph, start, start, null, tourEdges, tourWeight);
+        return new GraphWalk<>(graph, start, start, tour, tourEdges, tourWeight);
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoApproxMetricTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoApproxMetricTSP.java
@@ -1,0 +1,139 @@
+/*
+ * (C) Copyright 2017-2017, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.tour;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.jgrapht.GraphPath;
+import org.jgrapht.GraphTests;
+import org.jgrapht.UndirectedGraph;
+import org.jgrapht.alg.interfaces.TSPAlgorithm;
+import org.jgrapht.alg.spanning.KruskalMinimumSpanningTree;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.GraphWalk;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.traverse.DepthFirstIterator;
+
+/**
+ * A 2-approximation algorithm for the metric TSP problem.
+ * 
+ * <p>
+ * The travelling salesman problem (TSP) asks the following question: "Given a list of cities and
+ * the distances between each pair of cities, what is the shortest possible route that visits each
+ * city exactly once and returns to the origin city?". In the metric TSP, the intercity distances
+ * satisfy the triangle inequality.
+ * 
+ * <p>
+ * This is an implementation of the folklore algorithm which returns a depth-first ordering of the
+ * minimum spanning tree. The algorithm is a 2-approximation assuming that the instance satisfies
+ * the triangle inequality. The running time is O(|V|^2 log|V|).
+ * 
+ * <p>
+ * See <a href="https://en.wikipedia.org/wiki/Travelling_salesman_problem">wikipedia</a> for more
+ * details.
+ * 
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ *
+ * @author Dimitrios Michail
+ */
+public class TwoApproxMetricTSP<V, E>
+    implements TSPAlgorithm<V, E>
+{
+    /**
+     * Construct a new instance
+     */
+    public TwoApproxMetricTSP()
+    {
+    }
+
+    /**
+     * {@inheritDoc}
+     * 
+     * Computes a 2-approximate tour.
+     */
+    @Override
+    public GraphPath<V, E> getTour(UndirectedGraph<V, E> graph)
+    {
+        if (!GraphTests.isComplete(graph)) {
+            throw new IllegalArgumentException("Graph is not complete");
+        }
+        if (graph.vertexSet().isEmpty()) {
+            throw new IllegalArgumentException("Graph contains no vertices");
+        }
+
+        /*
+         * Special case singleton vertex
+         */
+        if (graph.vertexSet().size() == 1) {
+            V start = graph.vertexSet().iterator().next();
+            return new GraphWalk<>(
+                graph, start, start, Collections.singletonList(start), Collections.emptyList(), 0d);
+        }
+
+        /*
+         * Create MST
+         */
+        UndirectedGraph<V, DefaultEdge> mst = new SimpleGraph<>(DefaultEdge.class);
+        for (V v : graph.vertexSet()) {
+            mst.addVertex(v);
+        }
+        for (E e : new KruskalMinimumSpanningTree<>(graph).getSpanningTree().getEdges()) {
+            mst.addEdge(graph.getEdgeSource(e), graph.getEdgeTarget(e));
+        }
+
+        /*
+         * Perform a depth-first-search traversal
+         */
+        int n = graph.vertexSet().size();
+        Set<V> found = new HashSet<>(n);
+        List<V> tour = new ArrayList<>(n);
+        V start = graph.vertexSet().iterator().next();
+        DepthFirstIterator<V, DefaultEdge> dfsIt = new DepthFirstIterator<>(mst, start);
+        while (dfsIt.hasNext()) {
+            V v = dfsIt.next();
+            if (found.add(v)) {
+                tour.add(v);
+            }
+        }
+        // repeat the start vertex
+        tour.add(start);
+
+        /*
+         * Explicitly build the path.
+         */
+        List<E> tourEdges = new ArrayList<E>(n);
+        double tourWeight = 0d;
+        Iterator<V> tourIt = tour.iterator();
+        V u = tourIt.next();
+        while (tourIt.hasNext()) {
+            V v = tourIt.next();
+            E e = graph.getEdge(u, v);
+            tourEdges.add(e);
+            tourWeight += graph.getEdgeWeight(e);
+            u = v;
+        }
+        return new GraphWalk<>(graph, start, start, null, tourEdges, tourWeight);
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Graph tours related algorithms.
+ */
+package org.jgrapht.alg.tour;

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/tour/TwoApproxMetricTSPTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/tour/TwoApproxMetricTSPTest.java
@@ -1,0 +1,183 @@
+/*
+ * (C) Copyright 2017-2017, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.tour;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.jgrapht.GraphPath;
+import org.jgrapht.UndirectedGraph;
+import org.jgrapht.alg.spanning.KruskalMinimumSpanningTree;
+import org.jgrapht.generate.CompleteGraphGenerator;
+import org.jgrapht.graph.ClassBasedVertexFactory;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.SimpleWeightedGraph;
+import org.junit.Test;
+
+/**
+ * @author Dimitrios Michail
+ */
+public class TwoApproxMetricTSPTest
+{
+
+    @Test
+    public void testWikiExampleSymmetric4Cities()
+    {
+        SimpleWeightedGraph<String, DefaultWeightedEdge> g =
+            new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
+        g.addVertex("A");
+        g.addVertex("B");
+        g.addVertex("C");
+        g.addVertex("D");
+        g.setEdgeWeight(g.addEdge("A", "B"), 20d);
+        g.setEdgeWeight(g.addEdge("A", "C"), 42d);
+        g.setEdgeWeight(g.addEdge("A", "D"), 35d);
+        g.setEdgeWeight(g.addEdge("B", "C"), 30d);
+        g.setEdgeWeight(g.addEdge("B", "D"), 34d);
+        g.setEdgeWeight(g.addEdge("C", "D"), 12d);
+
+        GraphPath<String, DefaultWeightedEdge> tour =
+            new TwoApproxMetricTSP<String, DefaultWeightedEdge>().getTour(g);
+        assertHamiltonian(g, tour);
+        assertTrue(
+            2 * new KruskalMinimumSpanningTree<>(g).getSpanningTree().getWeight() >= tour
+                .getWeight());
+    }
+
+    @Test
+    public void testComplete()
+    {
+        final int maxSize = 50;
+
+        for (int i = 1; i < maxSize; i++) {
+            SimpleGraph<Object, DefaultEdge> g = new SimpleGraph<>(DefaultEdge.class);
+            CompleteGraphGenerator<Object, DefaultEdge> generator = new CompleteGraphGenerator<>(i);
+            generator.generateGraph(g, new ClassBasedVertexFactory<>(Object.class), null);
+
+            GraphPath<Object, DefaultEdge> tour =
+                new TwoApproxMetricTSP<Object, DefaultEdge>().getTour(g);
+            assertHamiltonian(g, tour);
+
+            double mstWeight = new KruskalMinimumSpanningTree<>(g).getSpanningTree().getWeight();
+            double tourWeight = tour.getWeight();
+            assertTrue(2 * mstWeight >= tourWeight);
+        }
+    }
+
+    @Test
+    public void testStar()
+    {
+        SimpleWeightedGraph<String, DefaultWeightedEdge> g =
+            new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addVertex("4");
+        g.addVertex("5");
+        g.addVertex("6");
+
+        g.setEdgeWeight(g.addEdge("1", "2"), 1d);
+        g.setEdgeWeight(g.addEdge("1", "3"), 1d);
+        g.setEdgeWeight(g.addEdge("1", "4"), 1d);
+        g.setEdgeWeight(g.addEdge("1", "5"), 2d);
+        g.setEdgeWeight(g.addEdge("1", "6"), 2d);
+
+        g.setEdgeWeight(g.addEdge("2", "3"), 2d);
+        g.setEdgeWeight(g.addEdge("2", "4"), 1d);
+        g.setEdgeWeight(g.addEdge("2", "5"), 1d);
+        g.setEdgeWeight(g.addEdge("2", "6"), 2d);
+
+        g.setEdgeWeight(g.addEdge("3", "4"), 1d);
+        g.setEdgeWeight(g.addEdge("3", "5"), 2d);
+        g.setEdgeWeight(g.addEdge("3", "6"), 1d);
+
+        g.setEdgeWeight(g.addEdge("4", "5"), 1d);
+        g.setEdgeWeight(g.addEdge("4", "6"), 1d);
+
+        g.setEdgeWeight(g.addEdge("5", "6"), 1d);
+
+        GraphPath<String, DefaultWeightedEdge> tour =
+            new TwoApproxMetricTSP<String, DefaultWeightedEdge>().getTour(g);
+        assertHamiltonian(g, tour);
+
+        double mstWeight = new KruskalMinimumSpanningTree<>(g).getSpanningTree().getWeight();
+        double tourWeight = tour.getWeight();
+        assertTrue(2 * mstWeight >= tourWeight);
+
+    }
+
+    private static <V, E> void assertHamiltonian(UndirectedGraph<V, E> g, GraphPath<V, E> path)
+    {
+        // check that all vertices are visited
+        List<V> vertices = path.getVertexList();
+        Iterator<V> vIt = vertices.iterator();
+        V start = vIt.next();
+        Set<V> visited = new HashSet<>();
+        while (vIt.hasNext()) {
+            V v = vIt.next();
+            assertTrue(visited.add(v));
+            if (!vIt.hasNext()) {
+                assert (v.equals(start));
+            }
+        }
+        visited.add(start);
+        assertEquals(visited.size(), g.vertexSet().size());
+
+        // check that edges are valid
+        List<E> edges = path.getEdgeList();
+        if (edges.isEmpty()) {
+            return;
+        }
+
+        E prev = null;
+        E first = null, last = null;
+        Iterator<E> it = edges.iterator();
+        while (it.hasNext()) {
+            E cur = it.next();
+            if (prev == null) {
+                first = cur;
+            } else {
+                assertTrue(
+                    g.getEdgeSource(cur).equals(g.getEdgeSource(prev))
+                        || g.getEdgeSource(cur).equals(g.getEdgeTarget(prev))
+                        || g.getEdgeTarget(cur).equals(g.getEdgeSource(prev))
+                        || g.getEdgeTarget(cur).equals(g.getEdgeTarget(prev)));
+            }
+            if (!it.hasNext()) {
+                last = cur;
+            }
+            prev = cur;
+        }
+        if (edges.size() > 1) {
+            assertTrue(
+                g.getEdgeSource(first).equals(g.getEdgeSource(last))
+                    || g.getEdgeSource(first).equals(g.getEdgeTarget(last))
+                    || g.getEdgeTarget(first).equals(g.getEdgeSource(last))
+                    || g.getEdgeTarget(first).equals(g.getEdgeTarget(last)));
+        }
+        assertEquals(edges.size(), g.vertexSet().size());
+    }
+
+}


### PR DESCRIPTION
Implemented the 2-approximation algorithm for metric TSP using a minimum spanning tree algorithm.

 - Added proper interface
 - Deprecated the old implementation which was O(V^3).
 - Added tests

It would be nice to also write Christofides algorithm, but we are missing a matching algorithm. Maybe later on.