### PR TITLE
Minor bug fix in Barabasi-Albert graph generator

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/generate/BarabasiAlbertGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/BarabasiAlbertGraphGenerator.java
@@ -132,16 +132,18 @@ public class BarabasiAlbertGraphGenerator<V, E>
         /*
          * Create complete graph with m0 nodes
          */
-        List<V> nodes = new ArrayList<>(n * m);
         Set<V> oldNodes = new HashSet<>(target.vertexSet());
+        Set<V> newNodes = new HashSet<>();
         new CompleteGraphGenerator<V, E>(m0).generateGraph(target, vertexFactory, resultMap);
-        target.vertexSet().stream().filter(v -> !oldNodes.contains(v)).forEach(nodes::add);
+        target.vertexSet().stream().filter(v -> !oldNodes.contains(v)).forEach(newNodes::add);
 
+        List<V> nodes = new ArrayList<>(n * m);
+        nodes.addAll(newNodes);
         /*
-         * Augment node list to have node multiplicity equal to m0-1.
+         * Augment node list to have node multiplicity equal to min(1,m0-1).
          */
         for (int i = 0; i < m0 - 2; i++) {
-            nodes.addAll(target.vertexSet());
+            nodes.addAll(newNodes);
         }
 
         /*

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/BarabasiAlbertGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/BarabasiAlbertGraphGeneratorTest.java
@@ -113,5 +113,20 @@ public class BarabasiAlbertGraphGeneratorTest
 
         assertEquals(20, g.vertexSet().size());
     }
+    
+    @Test
+    public void testUndirectedWithGraphWhichAlreadyHasSomeVertices()
+    {
+        final long seed = 5;
+
+        GraphGenerator<Integer, DefaultEdge, Integer> gen =
+            new BarabasiAlbertGraphGenerator<>(3, 2, 10, seed);
+        Graph<Integer, DefaultEdge> g = new SimpleGraph<>(DefaultEdge.class);
+        g.addVertex(1000);
+        gen.generateGraph(g, new IntegerVertexFactory(), null);
+
+        assertEquals(11, g.vertexSet().size());
+    }
+    
 
 }


### PR DESCRIPTION
A minor bug fix to make `BarabasiAlbertGraphGenerator` work properly even if the output graph is not initially empty.

@jkinable This complements the previous pull-request, no need to add any history remarks.