### PR TITLE
A minor backport to build using Android SDK 24

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/RecursiveExactVCImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/RecursiveExactVCImpl.java
@@ -70,7 +70,7 @@ public class RecursiveExactVCImpl<V, E>
      * view. As such, all operations can be simplified to bitset operations, which may improve the
      * algorithm's performance.
      **/
-    NeighborIndex<V, E> neighborIndex;
+    private NeighborIndex<V, E> neighborIndex;
 
     /** Map for memoization **/
     private Map<BitSet, BitSetCover> memo;
@@ -106,7 +106,6 @@ public class RecursiveExactVCImpl<V, E>
     public VertexCover<V> getVertexCover(
         UndirectedGraph<V, E> graph, Map<V, Double> vertexWeightMap)
     {
-
         // Initialize
         this.graph = graph;
         memo = new HashMap<>();
@@ -207,10 +206,12 @@ public class RecursiveExactVCImpl<V, E>
         double weight = this.getWeight(neighbors);
         BitSetCover rightCover = calculateCoverRecursively(
             indexNextVertex + 1, visitedRightBranch, accumulatedWeight + weight);
-        rightCover.addAllVertices(
-            neighbors.stream().mapToInt(vertexIDDictionary::get).boxed().collect(
-                Collectors.toList()),
-            weight);
+
+        List<Integer> neighborsIndices = new ArrayList<Integer>();
+        for(V v: neighbors) { 
+            neighborsIndices.add(vertexIDDictionary.get(v));
+        }
+        rightCover.addAllVertices(neighborsIndices,weight);
 
         // Left branch (vertex v is added to the cover, and we solve for G_{v}):
         BitSet visitedLeftBranch = (BitSet) visited.clone();
@@ -242,10 +243,15 @@ public class RecursiveExactVCImpl<V, E>
      */
     private double getWeight(Collection<V> vertices)
     {
-        if (weighted)
-            return vertices.stream().mapToDouble(vertexWeightMap::get).sum();
-        else
+        if (weighted) { 
+            double total = 0d;
+            for(V v: vertices) { 
+                total += vertexWeightMap.get(v);
+            }
+            return total;
+        } else { 
             return vertices.size();
+        }
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/RecursiveExactVCImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/RecursiveExactVCImpl.java
@@ -206,11 +206,8 @@ public class RecursiveExactVCImpl<V, E>
         double weight = this.getWeight(neighbors);
         BitSetCover rightCover = calculateCoverRecursively(
             indexNextVertex + 1, visitedRightBranch, accumulatedWeight + weight);
-
-        List<Integer> neighborsIndices = new ArrayList<Integer>();
-        for(V v: neighbors) { 
-            neighborsIndices.add(vertexIDDictionary.get(v));
-        }
+        List<Integer> neighborsIndices =
+            neighbors.stream().map(vertexIDDictionary::get).collect(Collectors.toList());
         rightCover.addAllVertices(neighborsIndices,weight);
 
         // Left branch (vertex v is added to the cover, and we solve for G_{v}):
@@ -244,11 +241,7 @@ public class RecursiveExactVCImpl<V, E>
     private double getWeight(Collection<V> vertices)
     {
         if (weighted) { 
-            double total = 0d;
-            for(V v: vertices) { 
-                total += vertexWeightMap.get(v);
-            }
-            return total;
+            return vertices.stream().map(vertexWeightMap::get).reduce(0d, Double::sum);
         } else { 
             return vertices.size();
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedAcyclicGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedAcyclicGraph.java
@@ -116,8 +116,7 @@ public class DirectedAcyclicGraph<V, E>
             Objects.requireNonNull(visitedStrategyFactory, "Visited factory cannot be null");
         this.topoOrderMap =
             Objects.requireNonNull(topoOrderMap, "Topological order map cannot be null");
-        this.topoComparator = (Comparator<V> & Serializable) (o1, o2) -> topoOrderMap
-            .getTopologicalIndex(o1).compareTo(topoOrderMap.getTopologicalIndex(o2));
+        this.topoComparator = new TopoComparator();
     }
 
     @Override
@@ -1040,6 +1039,25 @@ public class DirectedAcyclicGraph<V, E>
         extends Exception
     {
         private static final long serialVersionUID = 5583471522212552754L;
+    }
+
+    /**
+     * Comparator for vertices based on their topological ordering
+     * 
+     * @author Peter Giles
+     */
+    private class TopoComparator
+        implements Comparator<V>, Serializable
+    {
+        private static final long serialVersionUID = 8144905376266340066L;
+
+        @Override
+        public int compare(V o1, V o2)
+        {
+            return topoOrderMap
+                .getTopologicalIndex(o1).compareTo(topoOrderMap.getTopologicalIndex(o2));
+        }
+
     }
 
     /**


### PR DESCRIPTION
This is a very small backport to fix the issue that was reported in the [mailing-list](http://jgrapht-users.107614.n3.nabble.com/Issue-when-import-Jgrapht-libs-into-Android-Studio-td4025116.html).

Android SDK 24 and newer versions include support for Java8 using the Jack and Jill tools. There are some bugs remaining which means that some code is still not yet supported. In our case this manifested in the vertex cover code as well as with serializable lambdas.

I tested the library and android studio manages to generate the apk using this setup 

```
android {
    compileSdkVersion 25
    buildToolsVersion "25.0.2"
    defaultConfig {
        applicationId "org.jgrapht.demo"
        minSdkVersion 24
        targetSdkVersion 25
        versionCode 1
        versionName "1.0"
        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

        jackOptions {
            enabled true
        }
    }
    buildTypes {
        release {
            minifyEnabled false
            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
        }
    }
    compileOptions {
        sourceCompatibility JavaVersion.VERSION_1_8
        targetCompatibility JavaVersion.VERSION_1_8
    }
}
```