### PR TITLE
Replaced anonymous class with lambda-exp

### DIFF
--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLDemo.java
@@ -145,14 +145,7 @@ public final class GraphMLDemo
     {
         // create GraphML exporter
         GraphMLExporter<CustomVertex, DefaultWeightedEdge> exporter =
-            new GraphMLExporter<>(new ComponentNameProvider<CustomVertex>()
-            {
-                @Override
-                public String getName(CustomVertex v)
-                {
-                    return v.id;
-                }
-            }, null, new IntegerComponentNameProvider<>(), null);
+            new GraphMLExporter<>((CustomVertex v) -> v.id, null, new IntegerComponentNameProvider<>(), null);
 
         // set to export the internal edge weights
         exporter.setExportEdgeWeights(true);

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLDemo.java
@@ -145,7 +145,7 @@ public final class GraphMLDemo
     {
         // create GraphML exporter
         GraphMLExporter<CustomVertex, DefaultWeightedEdge> exporter =
-            new GraphMLExporter<>((CustomVertex v) -> v.id, null, new IntegerComponentNameProvider<>(), null);
+            new GraphMLExporter<>((v) -> v.id, null, new IntegerComponentNameProvider<>(), null);
 
         // set to export the internal edge weights
         exporter.setExportEdgeWeights(true);


### PR DESCRIPTION
Hi, lambda expressions can be used in place of anonymous classes to make code look more clean and compact especially when the class implements an interface that contains only one method. So, I made a very small change to address this issue.