### PR TITLE
GML import attributes support

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/AbstractBaseExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/AbstractBaseExporter.java
@@ -1,0 +1,108 @@
+/*
+ * (C) Copyright 2017-2017, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.io;
+
+import java.util.Objects;
+
+/**
+ * Base implementation for a graph exporter.
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ *
+ * @author Dimitrios Michail
+ * @since March 2017
+ */
+abstract class AbstractBaseExporter<V, E>
+{
+    /**
+     * Provides an identifier for a vertex.
+     */
+    protected ComponentNameProvider<V> vertexIDProvider;
+
+    /**
+     * Provides an identifier for an edge.
+     */
+    protected ComponentNameProvider<E> edgeIDProvider;
+
+    /**
+     * Constructor
+     *
+     * @param vertexIDProvider the vertex id provider. Must not be null.
+     */
+    public AbstractBaseExporter(ComponentNameProvider<V> vertexIDProvider)
+    {
+        this(vertexIDProvider, null);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param vertexIDProvider the vertex id provider. Must not be null.
+     * @param edgeIDProvider the edge id provider
+     */
+    public AbstractBaseExporter(
+        ComponentNameProvider<V> vertexIDProvider, ComponentNameProvider<E> edgeIDProvider)
+    {
+        this.vertexIDProvider =
+            Objects.requireNonNull(vertexIDProvider, "Vertex id provider cannot be null");
+        this.edgeIDProvider = edgeIDProvider;
+    }
+
+    /**
+     * Get the vertex id provider
+     *
+     * @return the vertex id provider
+     */
+    public ComponentNameProvider<V> getVertexIDProvider()
+    {
+        return vertexIDProvider;
+    }
+
+    /**
+     * Set the vertex id provider
+     *
+     * @param vertexIDProvider the new vertex id provider. Must not be null.
+     */
+    public void setVertexIDProvider(ComponentNameProvider<V> vertexIDProvider)
+    {
+        this.vertexIDProvider =
+            Objects.requireNonNull(vertexIDProvider, "Vertex id provider cannot be null");
+    }
+
+    /**
+     * Get the edge id provider
+     *
+     * @return The edge provider
+     */
+    public ComponentNameProvider<E> getEdgeIDProvider()
+    {
+        return edgeIDProvider;
+    }
+
+    /**
+     * Set the edge id provider.
+     *
+     * @param edgeIDProvider the new edge id provider. Must not be null.
+     */
+    public void setEdgeIDProvider(ComponentNameProvider<E> edgeIDProvider)
+    {
+        this.edgeIDProvider = edgeIDProvider;
+    }
+
+}

--- a/jgrapht-io/src/main/java/org/jgrapht/io/AbstractBaseImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/AbstractBaseImporter.java
@@ -63,9 +63,6 @@ abstract class AbstractBaseImporter<V, E>
         this(vertexProvider, edgeProvider, (c, a) -> {
         }, (c, a) -> {
         });
-        this.vertexProvider =
-            Objects.requireNonNull(vertexProvider, "Vertex provider cannot be null");
-        this.edgeProvider = Objects.requireNonNull(edgeProvider, "Edge provider cannot be null");
     }
 
     /**

--- a/jgrapht-io/src/main/java/org/jgrapht/io/AbstractBaseImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/AbstractBaseImporter.java
@@ -1,0 +1,171 @@
+/*
+ * (C) Copyright 2017-2017, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.io;
+
+import java.util.Objects;
+
+import org.jgrapht.Graph;
+
+/**
+ * Base implementation for a graph importer.
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ *
+ * @author Dimitrios Michail
+ * @since March 2017
+ */
+abstract class AbstractBaseImporter<V, E>
+{
+    /**
+     * Constructs new vertices
+     */
+    protected VertexProvider<V> vertexProvider;
+
+    /**
+     * Constructs new edges
+     */
+    protected EdgeProvider<V, E> edgeProvider;
+
+    /**
+     * Updates already constructed vertices
+     */
+    protected ComponentUpdater<V> vertexUpdater;
+
+    /**
+     * Updates graph properties
+     */
+    protected ComponentUpdater<Graph<V, E>> graphUpdater;
+
+    /**
+     * Constructor
+     *
+     * @param vertexProvider the vertex provider. Must not be null.
+     * @param edgeProvider the edge provider. Must not be null.
+     */
+    public AbstractBaseImporter(VertexProvider<V> vertexProvider, EdgeProvider<V, E> edgeProvider)
+    {
+        this(vertexProvider, edgeProvider, (c, a) -> {
+        }, (c, a) -> {
+        });
+        this.vertexProvider =
+            Objects.requireNonNull(vertexProvider, "Vertex provider cannot be null");
+        this.edgeProvider = Objects.requireNonNull(edgeProvider, "Edge provider cannot be null");
+    }
+
+    /**
+     * Constructor
+     *
+     * @param vertexProvider the vertex provider. Must not be null.
+     * @param edgeProvider the edge provider. Must not be null.
+     * @param vertexUpdater the vertex updater. Must not be null.
+     * @param graphUpdater the graph updater. Must not be null.
+     */
+    public AbstractBaseImporter(
+        VertexProvider<V> vertexProvider, EdgeProvider<V, E> edgeProvider,
+        ComponentUpdater<V> vertexUpdater, ComponentUpdater<Graph<V, E>> graphUpdater)
+    {
+        this.vertexProvider =
+            Objects.requireNonNull(vertexProvider, "Vertex provider cannot be null");
+        this.edgeProvider = Objects.requireNonNull(edgeProvider, "Edge provider cannot be null");
+        this.vertexUpdater = Objects.requireNonNull(vertexUpdater, "Vertex updater cannot be null");
+        this.graphUpdater = Objects.requireNonNull(graphUpdater, "Graph updater cannot be null");
+    }
+
+    /**
+     * Get the vertex provider
+     *
+     * @return the vertex provider
+     */
+    public VertexProvider<V> getVertexProvider()
+    {
+        return vertexProvider;
+    }
+
+    /**
+     * Set the vertex provider
+     *
+     * @param vertexProvider the new vertex provider. Must not be null.
+     */
+    public void setVertexProvider(VertexProvider<V> vertexProvider)
+    {
+        this.vertexProvider =
+            Objects.requireNonNull(vertexProvider, "Vertex provider cannot be null");
+    }
+
+    /**
+     * Get the edge provider
+     *
+     * @return The edge provider
+     */
+    public EdgeProvider<V, E> getEdgeProvider()
+    {
+        return edgeProvider;
+    }
+
+    /**
+     * Set the edge provider.
+     *
+     * @param edgeProvider the new edge provider. Must not be null.
+     */
+    public void setEdgeProvider(EdgeProvider<V, E> edgeProvider)
+    {
+        this.edgeProvider = Objects.requireNonNull(edgeProvider, "Edge provider cannot be null");
+    }
+
+    /**
+     * Get the vertex updater
+     *
+     * @return the vertex updater
+     */
+    public ComponentUpdater<V> getVertexUpdater()
+    {
+        return vertexUpdater;
+    }
+
+    /**
+     * Set the vertex updater.
+     *
+     * @param vertexUpdater the new vertex updater. Must not be null.
+     */
+    public void setVertexUpdater(ComponentUpdater<V> vertexUpdater)
+    {
+        this.vertexUpdater = Objects.requireNonNull(vertexUpdater, "Vertex updater cannot be null");
+    }
+
+    /**
+     * Get the graph updater.
+     *
+     * @return the graph updater
+     */
+    public ComponentUpdater<Graph<V, E>> getGraphUpdater()
+    {
+        return graphUpdater;
+    }
+
+    /**
+     * Set the graph updater.
+     *
+     * @param graphUpdater the new graph updater. Must not be null.
+     */
+    public void setGraphUpdater(ComponentUpdater<Graph<V, E>> graphUpdater)
+    {
+        this.graphUpdater = Objects.requireNonNull(graphUpdater, "Graph updater cannot be null");
+    }
+
+}

--- a/jgrapht-io/src/main/java/org/jgrapht/io/CSVExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/CSVExporter.java
@@ -51,11 +51,11 @@ import org.jgrapht.*;
  * @since August 2016
  */
 public class CSVExporter<V, E>
+    extends AbstractBaseExporter<V, E>
     implements GraphExporter<V, E>
 {
     private static final char DEFAULT_DELIMITER = ',';
 
-    private final ComponentNameProvider<V> vertexIDProvider;
     private final Set<CSVFormat.Parameter> parameters;
     private CSVFormat format;
     private char delimiter;
@@ -99,10 +99,7 @@ public class CSVExporter<V, E>
      */
     public CSVExporter(ComponentNameProvider<V> vertexIDProvider, CSVFormat format, char delimiter)
     {
-        if (vertexIDProvider == null) {
-            throw new IllegalArgumentException("Vertex id provider cannot be null");
-        }
-        this.vertexIDProvider = vertexIDProvider;
+        super(vertexIDProvider);
         this.format = format;
         if (!DSVUtils.isValidDelimiter(delimiter)) {
             throw new IllegalArgumentException("Character cannot be used as a delimiter");

--- a/jgrapht-io/src/main/java/org/jgrapht/io/CSVImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/CSVImporter.java
@@ -63,13 +63,12 @@ import org.jgrapht.io.CSVParser;
  * @since August 2016
  */
 public class CSVImporter<V, E>
+    extends AbstractBaseImporter<V, E>
     implements GraphImporter<V, E>
 {
     private static final char DEFAULT_DELIMITER = ',';
 
     private CSVFormat format;
-    private VertexProvider<V> vertexProvider;
-    private EdgeProvider<V, E> edgeProvider;
     private char delimiter;
     private final Set<CSVFormat.Parameter> parameters;
 
@@ -109,14 +108,7 @@ public class CSVImporter<V, E>
         VertexProvider<V> vertexProvider, EdgeProvider<V, E> edgeProvider, CSVFormat format,
         char delimiter)
     {
-        if (vertexProvider == null) {
-            throw new IllegalArgumentException("Vertex provider cannot be null");
-        }
-        this.vertexProvider = vertexProvider;
-        if (edgeProvider == null) {
-            throw new IllegalArgumentException("Edge provider cannot be null");
-        }
-        this.edgeProvider = edgeProvider;
+        super(vertexProvider, edgeProvider);
         this.format = format;
         if (!DSVUtils.isValidDelimiter(delimiter)) {
             throw new IllegalArgumentException("Character cannot be used as a delimiter");

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DIMACSExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DIMACSExporter.java
@@ -38,6 +38,7 @@ import org.jgrapht.*;
  * @since January 2017
  */
 public class DIMACSExporter<V, E>
+    extends AbstractBaseExporter<V, E>
     implements GraphExporter<V, E>
 {
     /**
@@ -47,7 +48,6 @@ public class DIMACSExporter<V, E>
 
     private static final String HEADER = "Generated using the JGraphT library";
 
-    private final ComponentNameProvider<V> vertexIDProvider;
     private final Set<Parameter> parameters;
     private DIMACSFormat format;
 
@@ -88,8 +88,7 @@ public class DIMACSExporter<V, E>
      */
     public DIMACSExporter(ComponentNameProvider<V> vertexIDProvider, DIMACSFormat format)
     {
-        this.vertexIDProvider =
-            Objects.requireNonNull(vertexIDProvider, "Vertex id provider cannot be null");
+        super(vertexIDProvider);
         this.format = Objects.requireNonNull(format, "Format cannot be null");
         this.parameters = new HashSet<>();
     }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DIMACSImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DIMACSImporter.java
@@ -68,10 +68,9 @@ import org.jgrapht.*;
  * @param <E> the graph edge type
  */
 public class DIMACSImporter<V, E>
+    extends AbstractBaseImporter<V, E>
     implements GraphImporter<V, E>
 {
-    private VertexProvider<V> vertexProvider;
-    private EdgeProvider<V, E> edgeProvider;
     private final double defaultWeight;
 
     // ~ Constructors ----------------------------------------------------------
@@ -86,14 +85,7 @@ public class DIMACSImporter<V, E>
     public DIMACSImporter(
         VertexProvider<V> vertexProvider, EdgeProvider<V, E> edgeProvider, double defaultWeight)
     {
-        if (vertexProvider == null) {
-            throw new IllegalArgumentException("Vertex provider cannot be null");
-        }
-        this.vertexProvider = vertexProvider;
-        if (edgeProvider == null) {
-            throw new IllegalArgumentException("Edge provider cannot be null");
-        }
-        this.edgeProvider = edgeProvider;
+        super(vertexProvider, edgeProvider);
         this.defaultWeight = defaultWeight;
     }
 
@@ -109,52 +101,6 @@ public class DIMACSImporter<V, E>
     }
 
     // ~ Methods ---------------------------------------------------------------
-
-    /**
-     * Get the vertex provider
-     * 
-     * @return the vertex provider
-     */
-    public VertexProvider<V> getVertexProvider()
-    {
-        return vertexProvider;
-    }
-
-    /**
-     * Set the vertex provider
-     * 
-     * @param vertexProvider the new vertex provider. Must not be null.
-     */
-    public void setVertexProvider(VertexProvider<V> vertexProvider)
-    {
-        if (vertexProvider == null) {
-            throw new IllegalArgumentException("Vertex provider cannot be null");
-        }
-        this.vertexProvider = vertexProvider;
-    }
-
-    /**
-     * Get the edge provider
-     * 
-     * @return The edge provider
-     */
-    public EdgeProvider<V, E> getEdgeProvider()
-    {
-        return edgeProvider;
-    }
-
-    /**
-     * Set the edge provider.
-     * 
-     * @param edgeProvider the new edge provider. Must not be null.
-     */
-    public void setEdgeProvider(EdgeProvider<V, E> edgeProvider)
-    {
-        if (edgeProvider == null) {
-            throw new IllegalArgumentException("Edge provider cannot be null");
-        }
-        this.edgeProvider = edgeProvider;
-    }
 
     /**
      * Import a graph.

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
@@ -37,6 +37,7 @@ import org.jgrapht.graph.*;
  * @author Trevor Harmon
  */
 public class DOTExporter<V, E>
+    extends AbstractBaseExporter<V, E>
     implements GraphExporter<V, E>
 {
     /**
@@ -45,7 +46,6 @@ public class DOTExporter<V, E>
     public static final String DEFAULT_GRAPH_ID = "G";
 
     private ComponentNameProvider<Graph<V, E>> graphIDProvider;
-    private ComponentNameProvider<V> vertexIDProvider;
     private ComponentNameProvider<V> vertexLabelProvider;
     private ComponentNameProvider<E> edgeLabelProvider;
     private ComponentAttributeProvider<V> vertexAttributeProvider;
@@ -128,7 +128,7 @@ public class DOTExporter<V, E>
         ComponentAttributeProvider<E> edgeAttributeProvider,
         ComponentNameProvider<Graph<V, E>> graphIDProvider)
     {
-        this.vertexIDProvider = vertexIDProvider;
+        super(vertexIDProvider);
         this.vertexLabelProvider = vertexLabelProvider;
         this.edgeLabelProvider = edgeLabelProvider;
         this.vertexAttributeProvider = vertexAttributeProvider;

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DOTImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DOTImporter.java
@@ -27,7 +27,6 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CommonTokenFactory;
@@ -58,6 +57,7 @@ import org.jgrapht.Graph;
  * @param <E> the graph edge type
  */
 public class DOTImporter<V, E>
+    extends AbstractBaseImporter<V, E>
     implements GraphImporter<V, E>
 {
     /**
@@ -69,11 +69,6 @@ public class DOTImporter<V, E>
     private static final CharSequenceTranslator UNESCAPE_ID = new AggregateTranslator(
         new LookupTranslator(
             new String[][] { { "\\\\", "\\" }, { "\\\"", "\"" }, { "\\'", "'" }, { "\\", "" } }));
-
-    private VertexProvider<V> vertexProvider;
-    private ComponentUpdater<V> vertexUpdater;
-    private EdgeProvider<V, E> edgeProvider;
-    private ComponentUpdater<Graph<V, E>> graphUpdater;
 
     /**
      * Constructs a new importer.
@@ -112,13 +107,9 @@ public class DOTImporter<V, E>
         VertexProvider<V> vertexProvider, EdgeProvider<V, E> edgeProvider,
         ComponentUpdater<V> vertexUpdater, ComponentUpdater<Graph<V, E>> graphUpdater)
     {
-        this.vertexProvider =
-            Objects.requireNonNull(vertexProvider, "Vertex provider cannot be null");
-        this.edgeProvider = Objects.requireNonNull(edgeProvider, "Edge provider cannot be null");
-        this.vertexUpdater = (vertexUpdater != null) ? vertexUpdater : (c, a) -> {
-        };
-        this.graphUpdater = (graphUpdater != null) ? graphUpdater : (c, a) -> {
-        };
+        super(vertexProvider, edgeProvider, (vertexUpdater != null) ? vertexUpdater : (c, a) -> {
+        }, (graphUpdater != null) ? graphUpdater : (c, a) -> {
+        });
     }
 
     /**

--- a/jgrapht-io/src/main/java/org/jgrapht/io/GmlExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/GmlExporter.java
@@ -73,7 +73,8 @@ public class GmlExporter<V, E>
          */
         EXPORT_EDGE_WEIGHTS,
         /**
-         * If set the exporter escapes all strings as Java strings
+         * If set the exporter escapes all strings as Java strings, otherwise no escaping is
+         * performed.
          */
         ESCAPE_STRINGS_AS_JAVA,
     }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/GraphMLExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/GraphMLExporter.java
@@ -44,12 +44,11 @@ import org.xml.sax.helpers.*;
  * @author Dimitrios Michail
  */
 public class GraphMLExporter<V, E>
+    extends AbstractBaseExporter<V, E>
     implements GraphExporter<V, E>
 {
     // providers
-    private ComponentNameProvider<V> vertexIDProvider;
     private ComponentNameProvider<V> vertexLabelProvider;
-    private ComponentNameProvider<E> edgeIDProvider;
     private ComponentNameProvider<E> edgeLabelProvider;
     private ComponentAttributeProvider<V> vertexAttributeProvider;
     private ComponentAttributeProvider<E> edgeAttributeProvider;
@@ -121,16 +120,11 @@ public class GraphMLExporter<V, E>
         ComponentNameProvider<E> edgeIDProvider, ComponentNameProvider<E> edgeLabelProvider,
         ComponentAttributeProvider<E> edgeAttributeProvider)
     {
-        if (vertexIDProvider == null) {
-            throw new IllegalArgumentException("Vertex ID provider must not be null");
-        }
-        this.vertexIDProvider = vertexIDProvider;
+        super(
+            vertexIDProvider,
+            Objects.requireNonNull(edgeIDProvider, "Edge ID provider must not be null"));
         this.vertexLabelProvider = vertexLabelProvider;
         this.vertexAttributeProvider = vertexAttributeProvider;
-        if (edgeIDProvider == null) {
-            throw new IllegalArgumentException("Edge ID provider must not be null");
-        }
-        this.edgeIDProvider = edgeIDProvider;
         this.edgeLabelProvider = edgeLabelProvider;
         this.edgeAttributeProvider = edgeAttributeProvider;
     }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/GraphMLImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/GraphMLImporter.java
@@ -102,10 +102,10 @@ import org.xml.sax.helpers.DefaultHandler;
  * </pre>
  * 
  * <p>
- * The importer reads the input into a graph which is provided by the user. In case the graph is an
- * instance of {@link org.jgrapht.WeightedGraph} and the corresponding edge key with
- * attr.name="weight" is defined, the importer also reads edge weights. Otherwise edge weights are
- * ignored.
+ * The importer reads the input into a graph which is provided by the user. In case the graph is
+ * weighted and the corresponding edge key with attr.name="weight" is defined, the importer also
+ * reads edge weights. Otherwise edge weights are ignored. To test whether the graph is weighted,
+ * method {@link Graph#getType()} can be used.
  * 
  * <p>
  * GraphML-Attributes Values are read as string key-value pairs and passed on to the
@@ -130,13 +130,11 @@ import org.xml.sax.helpers.DefaultHandler;
  * @since July 2016
  */
 public class GraphMLImporter<V, E>
+    extends AbstractBaseImporter<V, E>
     implements GraphImporter<V, E>
 {
     private static final String GRAPHML_SCHEMA_FILENAME = "graphml.xsd";
     private static final String XLINK_SCHEMA_FILENAME = "xlink.xsd";
-
-    private VertexProvider<V> vertexProvider;
-    private EdgeProvider<V, E> edgeProvider;
 
     // special attributes
     private static final String EDGE_WEIGHT_DEFAULT_ATTRIBUTE_NAME = "weight";
@@ -150,60 +148,7 @@ public class GraphMLImporter<V, E>
      */
     public GraphMLImporter(VertexProvider<V> vertexProvider, EdgeProvider<V, E> edgeProvider)
     {
-        if (vertexProvider == null) {
-            throw new IllegalArgumentException("Vertex provider cannot be null");
-        }
-        this.vertexProvider = vertexProvider;
-        if (edgeProvider == null) {
-            throw new IllegalArgumentException("Edge provider cannot be null");
-        }
-        this.edgeProvider = edgeProvider;
-    }
-
-    /**
-     * Get the vertex provider
-     * 
-     * @return the vertex provider
-     */
-    public VertexProvider<V> getVertexProvider()
-    {
-        return vertexProvider;
-    }
-
-    /**
-     * Set the vertex provider
-     * 
-     * @param vertexProvider the new vertex provider. Must not be null.
-     */
-    public void setVertexProvider(VertexProvider<V> vertexProvider)
-    {
-        if (vertexProvider == null) {
-            throw new IllegalArgumentException("Vertex provider cannot be null");
-        }
-        this.vertexProvider = vertexProvider;
-    }
-
-    /**
-     * Get the edge provider
-     * 
-     * @return The edge provider
-     */
-    public EdgeProvider<V, E> getEdgeProvider()
-    {
-        return edgeProvider;
-    }
-
-    /**
-     * Set the edge provider.
-     * 
-     * @param edgeProvider the new edge provider. Must not be null.
-     */
-    public void setEdgeProvider(EdgeProvider<V, E> edgeProvider)
-    {
-        if (edgeProvider == null) {
-            throw new IllegalArgumentException("Edge provider cannot be null");
-        }
-        this.edgeProvider = edgeProvider;
+        super(vertexProvider, edgeProvider);
     }
 
     /**

--- a/jgrapht-io/src/main/java/org/jgrapht/io/MatrixExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/MatrixExporter.java
@@ -41,11 +41,11 @@ import org.jgrapht.util.*;
  * @author Dimitrios Michail
  */
 public class MatrixExporter<V, E>
+    extends AbstractBaseExporter<V, E>
     implements GraphExporter<V, E>
 {
     private final String delimiter = " ";
     private Format format;
-    private ComponentNameProvider<V> vertexIDProvider;
 
     /**
      * Formats supported by the {@link MatrixExporter} exporter.
@@ -97,11 +97,8 @@ public class MatrixExporter<V, E>
      */
     public MatrixExporter(Format format, ComponentNameProvider<V> vertexIDProvider)
     {
+        super(vertexIDProvider);
         this.format = format;
-        if (vertexIDProvider == null) {
-            throw new IllegalArgumentException("Vertex ID provider must not be null");
-        }
-        this.vertexIDProvider = vertexIDProvider;
     }
 
     /**

--- a/jgrapht-io/src/main/java/org/jgrapht/io/VisioExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/VisioExporter.java
@@ -41,18 +41,17 @@ import org.jgrapht.*;
  * @author Avner Linder
  */
 public class VisioExporter<V, E>
+    extends AbstractBaseExporter<V, E>
     implements GraphExporter<V, E>
 {
-    private ComponentNameProvider<V> vertexNameProvider;
-
     /**
      * Creates a new VisioExporter with the specified naming policy.
      *
-     * @param vertexNameProvider the vertex name provider to be used for naming the Visio shapes.
+     * @param vertexIDProvider the vertex id provider to be used for naming the Visio shapes
      */
-    public VisioExporter(ComponentNameProvider<V> vertexNameProvider)
+    public VisioExporter(ComponentNameProvider<V> vertexIDProvider)
     {
-        this.vertexNameProvider = vertexNameProvider;
+        super(vertexIDProvider);
     }
 
     /**
@@ -87,8 +86,8 @@ public class VisioExporter<V, E>
 
     private void exportEdge(PrintWriter out, E edge, Graph<V, E> g)
     {
-        String sourceName = vertexNameProvider.getName(g.getEdgeSource(edge));
-        String targetName = vertexNameProvider.getName(g.getEdgeTarget(edge));
+        String sourceName = vertexIDProvider.getName(g.getEdgeSource(edge));
+        String targetName = vertexIDProvider.getName(g.getEdgeTarget(edge));
 
         out.print("Link,");
 
@@ -107,7 +106,7 @@ public class VisioExporter<V, E>
 
     private void exportVertex(PrintWriter out, V vertex)
     {
-        String name = vertexNameProvider.getName(vertex);
+        String name = vertexIDProvider.getName(vertex);
 
         out.print("Shape,");
         out.print(name);

--- a/jgrapht-io/src/test/java/org/jgrapht/io/GmlImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/GmlImporterTest.java
@@ -17,49 +17,34 @@
  */
 package org.jgrapht.io;
 
-import java.io.*;
-import java.util.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import org.jgrapht.*;
-import org.jgrapht.graph.*;
+import java.io.ByteArrayOutputStream;
+import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
 
-import junit.framework.*;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.jgrapht.graph.Pseudograph;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.WeightedPseudograph;
+import org.junit.Test;
 
 /**
- * .
+ * Tests for {@link GmlImporter}.
  * 
  * @author Dimitrios Michail
  */
 public class GmlImporterTest
-    extends TestCase
 {
 
-    public <E> Graph<String, E> readGraph(
-        String input, Class<? extends E> edgeClass, boolean directed, boolean weighted)
-        throws ImportException
-    {
-        Graph<String, E> g;
-        if (directed) {
-            if (weighted) {
-                g = new DirectedWeightedPseudograph<String, E>(edgeClass);
-            } else {
-                g = new DirectedPseudograph<String, E>(edgeClass);
-            }
-        } else {
-            if (weighted) {
-                g = new WeightedPseudograph<String, E>(edgeClass);
-            } else {
-                g = new Pseudograph<String, E>(edgeClass);
-            }
-        }
-
-        GmlImporter<String, E> importer = new GmlImporter<String, E>(
-            (l, a) -> l, (f, t, l, a) -> g.getEdgeFactory().createEdge(f, t));
-        importer.importGraph(g, new StringReader(input));
-
-        return g;
-    }
-
+    @Test
     public void testUndirectedUnweighted()
         throws ImportException
     {
@@ -106,6 +91,7 @@ public class GmlImporterTest
         assertTrue(g.containsEdge("3", "1"));
     }
 
+    @Test
     public void testIgnoreWeightsUndirectedUnweighted()
         throws ImportException
     {
@@ -144,6 +130,7 @@ public class GmlImporterTest
         assertTrue(g.containsEdge("1", "2"));
     }
 
+    @Test
     public void testNoGraph()
         throws ImportException
     {
@@ -164,6 +151,7 @@ public class GmlImporterTest
         assertEquals(0, g2.edgeSet().size());
     }
 
+    @Test
     public void testIgnore()
         throws ImportException
     {
@@ -228,6 +216,7 @@ public class GmlImporterTest
         assertTrue(g.containsEdge("3", "1"));
     }
 
+    @Test
     public void testUndirectedUnweightedWrongOrder()
         throws ImportException
     {
@@ -274,6 +263,7 @@ public class GmlImporterTest
         assertTrue(g.containsEdge("3", "1"));
     }
 
+    @Test
     public void testDirectedPseudographUnweighted()
         throws ImportException
     {
@@ -329,6 +319,7 @@ public class GmlImporterTest
         assertEquals(7, g.edgeSet().size());
     }
 
+    @Test
     public void testDirectedWeighted()
         throws ImportException
     {
@@ -365,10 +356,11 @@ public class GmlImporterTest
         assertEquals(2, g.edgeSet().size());
         assertTrue(g.containsEdge("1", "2"));
         assertTrue(g.containsEdge("3", "1"));
-        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")));
-        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")), 1e-9);
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")), 1e-9);
     }
 
+    @Test
     public void testDirectedWeightedWithComments()
         throws ImportException
     {
@@ -407,10 +399,11 @@ public class GmlImporterTest
         assertEquals(2, g.edgeSet().size());
         assertTrue(g.containsEdge("1", "2"));
         assertTrue(g.containsEdge("3", "1"));
-        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")));
-        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")), 1e-9);
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")), 1e-9);
     }
 
+    @Test
     public void testDirectedWeightedSingleLine()
         throws ImportException
     {
@@ -427,10 +420,11 @@ public class GmlImporterTest
         assertEquals(2, g.edgeSet().size());
         assertTrue(g.containsEdge("1", "2"));
         assertTrue(g.containsEdge("3", "1"));
-        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")));
-        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("1", "2")), 1e-9);
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "1")), 1e-9);
     }
 
+    @Test
     public void testParserError()
     {
         // @formatter:off
@@ -444,6 +438,7 @@ public class GmlImporterTest
         }
     }
 
+    @Test
     public void testMissingVertices()
     {
         // @formatter:off
@@ -457,6 +452,7 @@ public class GmlImporterTest
         }
     }
 
+    @Test
     public void testExportImport()
         throws ImportException, ExportException, UnsupportedEncodingException
     {
@@ -484,11 +480,12 @@ public class GmlImporterTest
         assertTrue(g2.containsEdge("1", "2"));
         assertTrue(g2.containsEdge("2", "3"));
         assertTrue(g2.containsEdge("3", "3"));
-        assertEquals(2.0, g2.getEdgeWeight(g2.getEdge("1", "2")));
-        assertEquals(3.0, g2.getEdgeWeight(g2.getEdge("2", "3")));
-        assertEquals(5.0, g2.getEdgeWeight(g2.getEdge("3", "3")));
+        assertEquals(2.0, g2.getEdgeWeight(g2.getEdge("1", "2")), 1e-9);
+        assertEquals(3.0, g2.getEdgeWeight(g2.getEdge("2", "3")), 1e-9);
+        assertEquals(5.0, g2.getEdgeWeight(g2.getEdge("3", "3")), 1e-9);
     }
 
+    @Test
     public void testNotSupportedGraph()
     {
         // @formatter:off
@@ -498,26 +495,9 @@ public class GmlImporterTest
 
         Graph<String, DefaultEdge> g = new SimpleGraph<>(DefaultEdge.class);
 
-        VertexProvider<String> vp = new VertexProvider<String>()
-        {
-            @Override
-            public String buildVertex(String label, Map<String, String> attributes)
-            {
-                return label;
-            }
-        };
-
-        EdgeProvider<String, DefaultEdge> ep = new EdgeProvider<String, DefaultEdge>()
-        {
-
-            @Override
-            public DefaultEdge buildEdge(
-                String from, String to, String label, Map<String, String> attributes)
-            {
-                return g.getEdgeFactory().createEdge(from, to);
-            }
-
-        };
+        VertexProvider<String> vp = (label, attributes) -> label;
+        EdgeProvider<String, DefaultEdge> ep =
+            (from, to, label, attributes) -> g.getEdgeFactory().createEdge(from, to);
 
         try {
             GmlImporter<String, DefaultEdge> importer =
@@ -527,6 +507,199 @@ public class GmlImporterTest
         } catch (ImportException e) {
         }
 
+    }
+
+    @Test(expected = ImportException.class)
+    public void testNodeIdBadType()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id \"1\"\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+        readGraph(input, DefaultEdge.class, false, false);
+    }
+
+    @Test(expected = ImportException.class)
+    public void testEdgeSourceBadType()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source \"1\"\n"
+                     + "    target 2\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+        readGraph(input, DefaultEdge.class, false, false);
+    }
+
+    @Test(expected = ImportException.class)
+    public void testEdgeTargetBadType()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target \"2\"\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+        readGraph(input, DefaultEdge.class, false, false);
+    }
+
+    @Test(expected = ImportException.class)
+    public void testEdgeWeightBadType()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "    weight \"2.0\"\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+        readGraph(input, DefaultEdge.class, false, false);
+    }
+
+    @Test
+    public void testAttributesSupport()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "    label \"Edge 1-2\""
+                     + "    name \"Name 12\""
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 3\n"
+                     + "    target 1\n"
+                     + "    label \"Edge 3-1\""
+                     + "    name \"Name 31\""
+                     + "  ]\n"
+                     + "  edge [\n"
+                     + "    source 2\n"
+                     + "    target 3\n"
+                     + "    label \"Edge 2-3\""
+                     + "    name \"Name 23\""
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "    label \"Node\t\t1\""
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "    label \"Node\t\t2\""
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 3\n"
+                     + "    label \"Node\t\t3\""
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    label \"Node\t\t?\""
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    label \"Node\t\t?\""
+                     + "  ]\n"                     
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = new DirectedWeightedPseudograph<>(DefaultEdge.class);
+
+        VertexProvider<String> vp = (id, attributes) -> {
+            assertNotNull(attributes);
+            if (Integer.parseInt(id) >= 4) {
+                assertEquals("Node\t\t?", attributes.get("label"));
+            } else {
+                assertEquals("Node\t\t" + id, attributes.get("label"));
+            }
+            return id;
+        };
+        EdgeProvider<String, DefaultEdge> ep = (from, to, label, attributes) -> {
+            assertNotNull(attributes);
+            assertEquals("Edge " + from + "-" + to, attributes.get("label"));
+            assertEquals("Name " + from + to, attributes.get("name"));
+            return g.getEdgeFactory().createEdge(from, to);
+        };
+
+        GmlImporter<String, DefaultEdge> importer = new GmlImporter<String, DefaultEdge>(vp, ep);
+        importer.importGraph(g, new StringReader(input));
+
+        assertEquals(5, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsVertex("4"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "3"));
+        assertTrue(g.containsEdge("3", "1"));
+    }
+
+    // ~ Private Methods ------------------------------------------------------
+
+    private <E> Graph<String, E> readGraph(
+        String input, Class<? extends E> edgeClass, boolean directed, boolean weighted)
+        throws ImportException
+    {
+        Graph<String, E> g;
+        if (directed) {
+            if (weighted) {
+                g = new DirectedWeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new DirectedPseudograph<String, E>(edgeClass);
+            }
+        } else {
+            if (weighted) {
+                g = new WeightedPseudograph<String, E>(edgeClass);
+            } else {
+                g = new Pseudograph<String, E>(edgeClass);
+            }
+        }
+
+        GmlImporter<String, E> importer = new GmlImporter<String, E>(
+            (l, a) -> l, (f, t, l, a) -> g.getEdgeFactory().createEdge(f, t));
+        importer.importGraph(g, new StringReader(input));
+
+        return g;
     }
 
 }


### PR DESCRIPTION
Added support for attributes in `GmlImporter` and minor refactoring to avoid code duplication in jgrapht-io submodule.

Makes #326 obsolete.

