### PR TITLE
GraphWalk revision

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
@@ -131,14 +131,6 @@ public interface GraphPath<V, E>
         return getEdgeList().size();
     }
 
-    /**
-     * Exception thrown in the event that the path is invalid.
-     */
-    class InvalidGraphPathException extends RuntimeException{
-
-        public InvalidGraphPathException(String message){ super(message);}
-
-    }
 }
 
 

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphPath.java
@@ -131,6 +131,15 @@ public interface GraphPath<V, E>
         return getEdgeList().size();
     }
 
+    /**
+     * Exception thrown in the event that the path is invalid.
+     */
+    class InvalidGraphPathException extends RuntimeException{
+
+        public InvalidGraphPathException(String message){ super(message);}
+
+    }
 }
+
 
 // End GraphPath.java

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HierholzerEulerianCycle.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HierholzerEulerianCycle.java
@@ -144,7 +144,7 @@ public class HierholzerEulerianCycle<V, E>
         } else if (g.vertexSet().size() == 0) {
             throw new IllegalArgumentException("Null graph not permitted");
         } else if (GraphTests.isEmpty(g)) {
-            return new GraphWalk<>(g, null, null, Collections.emptyList(), 0d);
+            return GraphWalk.emptyWalk(g);
         }
 
         /*

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
@@ -214,7 +214,7 @@ public class AllDirectedPaths<V, E>
         // Bootstrap the search with the source vertices
         for (V source : sourceVertices) {
             if (targetVertices.contains(source)) {
-                completePaths.add(new GraphWalk<>(graph, source, source, new ArrayList<>(), 0));
+                completePaths.add(GraphWalk.singletonWalk(graph, source, 0d));
             }
 
             for (E edge : graph.outgoingEdgesOf(source)) {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseShortestPathAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseShortestPathAlgorithm.java
@@ -105,9 +105,7 @@ abstract class BaseShortestPathAlgorithm<V, E>
     protected final GraphPath<V, E> createEmptyPath(V source, V sink)
     {
         if (source.equals(sink)) {
-            return new GraphWalk<>(
-                graph, source, sink, Collections.singletonList(source), Collections.emptyList(),
-                0d);
+            return GraphWalk.singletonWalk(graph, source, 0d);
         } else {
             return null;
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ListSingleSourcePathsImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ListSingleSourcePathsImpl.java
@@ -115,9 +115,7 @@ public class ListSingleSourcePathsImpl<V, E>
         GraphPath<V, E> p = paths.get(targetVertex);
         if (p == null) {
             if (source.equals(targetVertex)) {
-                return new GraphWalk<>(
-                    graph, source, targetVertex, Collections.singletonList(source),
-                    Collections.emptyList(), 0d);
+                return GraphWalk.singletonWalk(graph, source, 0d);
             } else {
                 return null;
             }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TreeSingleSourcePathsImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TreeSingleSourcePathsImpl.java
@@ -123,7 +123,7 @@ public class TreeSingleSourcePathsImpl<V, E>
     public GraphPath<V, E> getPath(V targetVertex)
     {
         if (source.equals(targetVertex)) {
-            return new GraphWalk<>(g, source, targetVertex, null, Collections.emptyList(), 0d);
+            return GraphWalk.singletonWalk(g, source, 0d);
         }
 
         LinkedList<E> edgeList = new LinkedList<>();

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
@@ -435,7 +435,7 @@ public class GraphWalk<V, E>
     }
 
     /**
-     * Convenience method which creates a walk consisting of a single vertex.
+     * Convenience method which creates a walk consisting of a single vertex with weight 0.0.
      * @param graph input graph
      * @param v single vertex
      * @param <V> vertex type
@@ -464,6 +464,7 @@ public class GraphWalk<V, E>
  * Exception thrown in the event that the path is invalid.
  */
 class InvalidGraphWalkException extends RuntimeException{
+    private static final long serialVersionUID = 3811666107707436479L;
 
     public InvalidGraphWalkException(String message){ super(message);}
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
@@ -29,13 +29,24 @@ import org.jgrapht.*;
  * {@code e_i} has endpoints {@code v_(i-1)} and {@code v_i}. The class makes no assumptions with
  * respect to the shape of the walk: edges may be repeated, and the start and end point of the walk
  * may be different.
- * 
+ *
+ * <p>
  * See <a href="http://mathworld.wolfram.com/Walk.html">http://mathworld.wolfram.com/Walk.html</a>
  * GraphWalk is the default implementation of {@link GraphPath}.
  *
+ * <p>
+ * Two special cases exist:
+ * <ol>
+ * <li>A GraphWalk consisting of a single vertex v. In this case, the edge list is empty (the length of the path equals 0),
+ * the vertex list contains a single vertex v, and the start and end vertex equal v.</li>
+ * <li>An empty Graphwalk. In this case, both the edge and vertex lists are empty, and the start and end vertex are null.</li>
+ *</ol>
+ *
+ * <p>
  * This class is implemented as a light-weight data structure; this class does not verify whether
  * the sequence of edges or the sequence of vertices provided during construction forms an actual
  * walk. It is the responsibility of the invoking class to provide correct input data.
+ *
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -110,6 +121,8 @@ public class GraphWalk<V, E>
     {
         if (vertexList == null && edgeList == null)
             throw new IllegalArgumentException("Vertex list and edge list cannot both be null!");
+        if(startVertex ==null ^ endVertex == null)
+            throw new IllegalArgumentException("Either the start and end vertices must both be null, or they must both be not null (one of them is null)");
 
         this.graph = graph;
         this.startVertex = startVertex;
@@ -173,6 +186,191 @@ public class GraphWalk<V, E>
             return vertexList.toString();
         else
             return edgeList.toString();
+    }
+
+    @Override
+    public boolean equals(Object o){
+        if(o==null || !(o instanceof GraphWalk))
+            return false;
+        else if(this==o)
+            return true;
+        GraphWalk<V,E> other=(GraphWalk<V,E>) o;
+        return this.startVertex.equals(other.getStartVertex()) && this.endVertex.equals(other.getEndVertex()) &&
+            this.getEdgeList().equals(other.getEdgeList()); //Quite expensive if both paths are expressed as vertex lists
+    }
+
+    /**
+     * Reverses the direction of the path. This method does NOT verify whether the path is feasible wrt the input graph.
+     * In case of directed/mixed graphs, the arc directions will be reversed. An error is thrown if reversing an arc (u,v) is impossible
+     * because arc (v,u) is not present in the graph.
+     */
+    @TODO: it would be better if these methods are not void, but return a new GraphWalk (use arraylists)
+    @TODO: create an iterator which walks over the path
+    public void reverse(){
+        V temp=this.startVertex;
+        this.startVertex=this.endVertex;
+        this.endVertex=temp;
+
+        if (vertexList != null)
+            Collections.reverse(vertexList);
+
+        if(graph.getType().isUndirected() && edgeList != null) {
+            Collections.reverse(edgeList);
+        }else{
+            this.weight=0; //Update weights since we will be using different edges
+            if(this.edgeList instanceof ArrayList){
+                for(int i=edgeList.size()-1; i>=0; i--){
+                    E e = edgeList.get(i);
+                    V u = graph.getEdgeSource(e);
+                    V v = graph.getEdgeTarget(e);
+                    edgeList.set(i, graph.getEdge(v,u));
+                    this.weight+=graph.getEdgeWeight(e);
+                }
+            }else {
+                ListIterator<E> listIterator = this.edgeList.listIterator(edgeList.size());
+                while (listIterator.hasPrevious()) {
+                    E e = listIterator.previous();
+                    V u = graph.getEdgeSource(e);
+                    V v = graph.getEdgeTarget(e);
+                    listIterator.remove();
+                    listIterator.add(graph.getEdge(v, u));
+                    this.weight+=graph.getEdgeWeight(e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Concatenates the specified GraphPath to the end of this GraphPath. This action can only be performed if the end vertex of this
+     * GraphPath is the same as the start vertex of the extending GraphPath
+     * @param extension GraphPath used for the concatenation.
+     */
+    public void concat(GraphPath<V,E> extension){
+        if(!this.endVertex.equals(extension.getStartVertex()))
+            throw new IllegalArgumentException("This path can only be extended by another path if the end vertex of the orginal path and the start vertex of the extension are equal.");
+        if(vertexList != null) {
+            List<V> vertexListExtension = extension.getVertexList();
+            if(!vertexListExtension.isEmpty())
+                vertexList.addAll(vertexListExtension.subList(1, vertexListExtension.size()));
+        }
+        if(edgeList != null)
+            edgeList.addAll(extension.getEdgeList());
+        this.endVertex=extension.getEndVertex();
+        this.weight+=extension.getWeight();
+    }
+
+    /**
+     *
+     * @param beginIndex
+     */
+    public void subPath(int beginIndex){
+        if(edgeList != null){
+            if(edgeList.size() < beginIndex)
+                throw new IndexOutOfBoundsException("BeginIndex cannot be larger than the number of edges in the path");
+            Iterator<E> it=edgeList.iterator();
+            for( int i=0; i<beginIndex; i++){
+                E edge=it.next();
+                this.weight-= graph.getEdgeWeight(edge);
+                it.remove();
+            }
+            if(vertexList!=null)
+                vertexList=vertexList.subList(beginIndex, vertexList.size());
+        }else{
+            if(vertexList.size() < beginIndex+1)
+                throw new IndexOutOfBoundsException("BeginIndex cannot be larger than the number of vertices in the path -1");
+            for( int i=0; i<beginIndex; i++){
+                E edge=graph.getEdge(vertexList.get(i), vertexList.get(i+1));
+                this.weight-= graph.getEdgeWeight(edge);
+            }
+            vertexList=vertexList.subList(beginIndex, vertexList.size());
+        }
+    }
+
+    public void subPath(int beginIndex, int endIndex){
+        this.subPath(beginIndex);
+    }
+
+    /**
+     * Returns true if the path is an empty path, that is, a path with startVertex=endVertex=null and with an empty vertex and edge list.
+     * @return Returns true if the path is an empty path.
+     */
+    public boolean isEmpty(){
+        return startVertex==null;
+    }
+
+    /**
+     * Convenience method which verifies whether the given path is feasible wrt the input graph and forms an actual path.
+     * @throws InvalidGraphWalkException if the path is invalid
+     */
+    public void verify() throws InvalidGraphWalkException{
+
+        if(isEmpty()) //Empty path
+            return;
+
+        List<V> vertices=this.getVertexList();
+        List<E> edges=this.getEdgeList();
+
+        //Verify that the path is an actual path in the graph
+        if(edges.size()+1 != vertices.size())
+            throw new InvalidGraphWalkException("VertexList and edgeList do not correspond to the same path (cardinality of vertexList +1 must equal the cardinality of the edgeList)");
+
+        //Check start and end vertex
+        if(!startVertex.equals(vertices.get(0)))
+            throw new InvalidGraphWalkException("The start vertex must be the first vertex in the vertex list");
+        if(!endVertex.equals(vertices.get(vertices.size()-1)))
+            throw new InvalidGraphWalkException("The end vertex must be the last vertex in the vertex list");
+
+        //All vertices and edges in the path must be contained in the graph
+        if(!graph.vertexSet().containsAll(vertices))
+            throw new InvalidGraphWalkException("Not all vertices in the path are contained in the graph");
+
+        if(!graph.edgeSet().containsAll(edges))
+            throw new InvalidGraphWalkException("Not all edges in the path are contained in the graph");
+
+        //Verify that the sequence of vertices and edges forms an actual path in the graph.
+        for(int i=0; i<vertexList.size()-1; i++){
+            V u=vertices.get(i);
+            V v=vertices.get(i+1);
+            E edge=edges.get(i);
+
+            if(graph.getType().isDirected()){ //Directed graph
+                if(!graph.getEdgeSource(edge).equals(u) || graph.getEdgeTarget(edge).equals(v))
+                    throw new InvalidGraphWalkException("VertexList and edgeList do not form a feasible path");
+            }else{ //Undirected or mixed
+                if(!Graphs.getOppositeVertex(graph, edge, u).equals(v))
+                    throw new InvalidGraphWalkException("VertexList and edgeList do not form a feasible path");
+            }
+        }
+    }
+
+    /**
+     * Convenience method which creates an empty walk.
+     * @param graph input graph
+     * @param <V> vertex type
+     * @param <E> edge type
+     * @return an empty walk
+     */
+    public static <V,E> GraphWalk<V,E> emptyWalk(Graph<V,E> graph){
+        return new GraphWalk<>(graph, null, null, Collections.emptyList(), Collections.emptyList(), 0.0);
+    }
+
+    /**
+     * Convenience method which creates a walk consisting of a single vertex.
+     * @param graph input graph
+     * @param v single vertex
+     * @param <V> vertex type
+     * @param <E> edge type
+     * @return an empty walk
+     */
+    public static <V,E> GraphWalk<V,E> singletonWalk(Graph<V,E> graph, V v){
+        return new GraphWalk<>(graph, v, v, Collections.singletonList(v), Collections.emptyList(), 0.0);
+    }
+
+
+    protected class InvalidGraphWalkException extends Exception{
+
+        public InvalidGraphWalkException(String message){ super(message);}
+
     }
 }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
@@ -49,7 +49,7 @@ public class GraphWalkTest
         new GraphWalk<>(graph, 0, 0, Collections.emptyList(), Collections.emptyList(), 0);
     }
 
-    @Test(expected = GraphPath.InvalidGraphPathException.class)
+    @Test(expected = InvalidGraphWalkException.class)
     public void testInvalidPath3()
     {
         Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
@@ -59,7 +59,7 @@ public class GraphWalkTest
         gw.verify();
     }
 
-    @Test(expected = GraphPath.InvalidGraphPathException.class)
+    @Test(expected = InvalidGraphWalkException.class)
     public void testInvalidPath4()
     {
         Graph<Integer, DefaultEdge> graph=new SimpleGraph<>(DefaultEdge.class);
@@ -73,7 +73,7 @@ public class GraphWalkTest
         gw.verify();
     }
 
-    @Test(expected = GraphPath.InvalidGraphPathException.class)
+    @Test(expected = InvalidGraphWalkException.class)
     public void testInvalidPath5()
     {
         Graph<Integer, DefaultEdge> graph=new SimpleGraph<>(DefaultEdge.class);
@@ -154,26 +154,31 @@ public class GraphWalkTest
 
     @Test
     public void testReversePathUndirected(){
-        Graph<Integer, DefaultEdge> graph=new SimpleGraph<>(DefaultEdge.class);
+        Graph<Integer, DefaultWeightedEdge> graph=new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
         Graphs.addAllVertices(graph, Arrays.asList(0,1,2,3));
-        DefaultEdge e1=graph.addEdge(0,1);
-        DefaultEdge e2=graph.addEdge(1,2);
-        DefaultEdge e3=graph.addEdge(2,3);
+        DefaultWeightedEdge e1=Graphs.addEdge(graph, 0,1,2);
+        DefaultWeightedEdge e2=Graphs.addEdge(graph, 1,2,3);
+        DefaultWeightedEdge e3=Graphs.addEdge(graph, 2,3,4);
 
-        GraphWalk<Integer, DefaultEdge> gw1=new GraphWalk<>(graph, 0, 3, Arrays.asList(0,1,2,3), null, 0);
-        GraphWalk<Integer, DefaultEdge> gw2=new GraphWalk<>(graph, 0, 3, null, Arrays.asList(e1, e2, e3), 0);
+        GraphWalk<Integer, DefaultWeightedEdge> gw1=new GraphWalk<>(graph, 0, 3, Arrays.asList(0,1,2,3), null, 9);
+        GraphWalk<Integer, DefaultWeightedEdge> gw2=new GraphWalk<>(graph, 0, 3, null, Arrays.asList(e1, e2, e3), 9);
 
-        GraphWalk<Integer, DefaultEdge> rev1=gw1.reverse(gw -> gw1.getWeight());
+        GraphWalk<Integer, DefaultWeightedEdge> rev1=gw1.reverse(gw -> gw1.getWeight());
         rev1.verify();
-        GraphWalk<Integer, DefaultEdge> rev2=gw2.reverse(gw -> gw2.getWeight());
+        GraphWalk<Integer, DefaultWeightedEdge> rev2=gw2.reverse(gw -> gw2.getWeight());
         rev2.verify();
 
-        GraphWalk<Integer, DefaultEdge> revPath=new GraphWalk<>(graph, 3, 0, null, Arrays.asList(e3, e2, e1), 0);
+        GraphWalk<Integer, DefaultWeightedEdge> revPath=new GraphWalk<>(graph, 3, 0, null, Arrays.asList(e3, e2, e1), 9);
         Assert.assertEquals(revPath, rev1);
         Assert.assertEquals(revPath, rev2);
+
+        rev1=gw1.reverse();
+        Assert.assertEquals(9.0, gw1.getWeight(), 0.0000000001);
+        rev2=gw2.reverse();
+        Assert.assertEquals(9.0, gw2.getWeight(), 0.0000000001);
     }
 
-    @Test(expected = GraphPath.InvalidGraphPathException.class)
+    @Test(expected = InvalidGraphWalkException.class)
     public void testReverseInvalidPathDirected(){
         Graph<Integer, DefaultEdge> graph=new SimpleDirectedGraph<>(DefaultEdge.class);
         Graphs.addAllVertices(graph, Arrays.asList(0,1,2,3));
@@ -205,6 +210,9 @@ public class GraphWalkTest
 
         Assert.assertEquals(revPath, rev1);
         Assert.assertEquals(15, rev1.getWeight(), 0.00000001);
+
+        GraphWalk<Integer, DefaultWeightedEdge> rev2=gw1.reverse();
+        Assert.assertEquals(15, rev2.getWeight(), 0.00000001);
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
@@ -21,58 +21,246 @@ import java.util.*;
 
 import org.jgrapht.*;
 import org.jgrapht.generate.*;
+import org.junit.*;
 
 /**
- * .
  *
  * @author Joris Kinable
  */
 public class GraphWalkTest
-    extends EnhancedTestCase
 {
 
-    private Graph<Integer, DefaultEdge> completeGraph;
-
-    public void setUp()
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidPath1()
     {
-        VertexFactory<Integer> vertexFactory = new IntegerVertexFactory();
-        CompleteGraphGenerator<Integer, DefaultEdge> completeGraphGenerator =
-            new CompleteGraphGenerator<>(5);
-        completeGraph = new SimpleGraph<>(DefaultEdge.class);
-        completeGraphGenerator.generateGraph(completeGraph, vertexFactory, new HashMap<>());
+        Graph<Integer, DefaultEdge> graph = new Pseudograph<>(DefaultEdge.class);
+        graph.addVertex(0);
+        graph.addEdge(0,0);
+        //Invalid: the path's edgeList should contain the edge (0,0)
+        new GraphWalk<>(graph, 0, 0, Arrays.asList(0,0), Collections.emptyList(), 0);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidPath2()
+    {
+        Graph<Integer, DefaultEdge> graph = new Pseudograph<>(DefaultEdge.class);
+        graph.addVertex(0);
+        //Invalid: the path's vertexList and edgeList cannot both be empty
+        new GraphWalk<>(graph, 0, 0, Collections.emptyList(), Collections.emptyList(), 0);
+    }
+
+    @Test(expected = GraphPath.InvalidGraphPathException.class)
+    public void testInvalidPath3()
+    {
+        Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
+        graph.addVertex(0);
+        //Invalid: The graph does not contain a self loop from 0 to 0.
+        GraphWalk<Integer, DefaultEdge> gw=new GraphWalk<>(graph, 0, 0, Arrays.asList(0,0), null, 0);
+        gw.verify();
+    }
+
+    @Test(expected = GraphPath.InvalidGraphPathException.class)
+    public void testInvalidPath4()
+    {
+        Graph<Integer, DefaultEdge> graph=new SimpleGraph<>(DefaultEdge.class);
+        Graphs.addAllVertices(graph, Arrays.asList(0,1,2,3));
+        graph.addEdge(0,1);
+        graph.addEdge(1,2);
+        graph.addEdge(2,3);
+
+        //Invalid: The graph does not contain an edge from 1 to 3
+        GraphWalk<Integer, DefaultEdge> gw=new GraphWalk<>(graph, 0, 2, Arrays.asList(0,1,3,2), null, 0);
+        gw.verify();
+    }
+
+    @Test(expected = GraphPath.InvalidGraphPathException.class)
+    public void testInvalidPath5()
+    {
+        Graph<Integer, DefaultEdge> graph=new SimpleGraph<>(DefaultEdge.class);
+        Graphs.addAllVertices(graph, Arrays.asList(0,1,2,3));
+        DefaultEdge e1=graph.addEdge(0,1);
+        graph.addEdge(1,2);
+        DefaultEdge e3=graph.addEdge(2,3);
+
+        //Invalid: the path jumps from vertex 1 to vertex 2 (edge (1,2) is skipped)
+        GraphWalk<Integer, DefaultEdge> gw=new GraphWalk<>(graph, 0, 2, null, Arrays.asList(e1, e3), 0);
+        gw.verify();
+    }
+
+    @Test
+    public void testValidPaths(){
+        Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
+        graph.addVertex(0);
+
+        //empty path
+        GraphWalk<Integer,DefaultEdge> gw1=new GraphWalk<>(graph, null, null, Collections.emptyList(), Collections.emptyList(), 0);
+        gw1.verify();
+        GraphWalk<Integer,DefaultEdge> gw2=new GraphWalk<>(graph, null, null, null, Collections.emptyList(), 0);
+        gw2.verify();
+        GraphWalk<Integer,DefaultEdge> gw3=new GraphWalk<>(graph, null, null, Collections.emptyList(), null, 0);
+        gw3.verify();
+
+        //singleton path
+        GraphWalk<Integer,DefaultEdge> gw4=new GraphWalk<>(graph, 0, 0, Collections.singletonList(0), Collections.emptyList(), 0);
+        gw4.verify();
+        GraphWalk<Integer,DefaultEdge> gw5=new GraphWalk<>(graph, Collections.singletonList(0), 0);
+        gw5.verify();
+
+    }
+
+    @Test
     public void testEmptyPath()
     {
-        List<GraphPath<Integer, DefaultEdge>> paths = new ArrayList<>();
-        paths.add(new GraphWalk<>(completeGraph, null, null, Collections.emptyList(), 0));
-        paths.add(new GraphWalk<>(completeGraph, Collections.emptyList(), 0));
-        for (GraphPath<Integer, DefaultEdge> path : paths) {
-            assertEquals(0, path.getLength());
-            assertEquals(Collections.emptyList(), path.getVertexList());
-            assertEquals(Collections.emptyList(), path.getEdgeList());
+        Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
+        List<GraphWalk<Integer, DefaultEdge>> paths = new ArrayList<>();
+        paths.add(new GraphWalk<>(graph, null, null, Collections.emptyList(), 0));
+        paths.add(new GraphWalk<>(graph, Collections.emptyList(), 0));
+        for (GraphWalk<Integer, DefaultEdge> path : paths) {
+            Assert.assertEquals(0, path.getLength());
+            Assert.assertEquals(Collections.emptyList(), path.getVertexList());
+            Assert.assertEquals(Collections.emptyList(), path.getEdgeList());
+            Assert.assertTrue(path.isEmpty());
+            Assert.assertEquals(GraphWalk.emptyWalk(graph), path);
         }
     }
 
+    @Test
     public void testNonSimplePath()
     {
+        VertexFactory<Integer> vertexFactory = new IntegerVertexFactory();
+        CompleteGraphGenerator<Integer, DefaultEdge> completeGraphGenerator =
+                new CompleteGraphGenerator<>(5);
+        Graph<Integer, DefaultEdge> completeGraph = new SimpleGraph<>(DefaultEdge.class);
+        completeGraphGenerator.generateGraph(completeGraph, vertexFactory, new HashMap<>());
+
         List<Integer> vertexList = Arrays.asList(0, 1, 2, 3, 2, 3, 4);
         List<DefaultEdge> edgeList = new ArrayList<>();
         for (int i = 0; i < vertexList.size() - 1; i++)
             edgeList.add(completeGraph.getEdge(vertexList.get(i), vertexList.get(i + 1)));
         GraphPath<Integer, DefaultEdge> p1 = new GraphWalk<>(completeGraph, 0, 4, edgeList, 10);
-        assertEquals(0, p1.getStartVertex().intValue());
-        assertEquals(4, p1.getEndVertex().intValue());
-        assertEquals(vertexList, p1.getVertexList());
-        assertEquals(edgeList.size(), p1.getLength());
-        assertEquals(10.0, p1.getWeight());
+        Assert.assertEquals(0, p1.getStartVertex().intValue());
+        Assert.assertEquals(4, p1.getEndVertex().intValue());
+        Assert.assertEquals(vertexList, p1.getVertexList());
+        Assert.assertEquals(edgeList.size(), p1.getLength());
+        Assert.assertEquals(10.0, p1.getWeight(), 0.0000000001);
 
         GraphPath<Integer, DefaultEdge> p2 = new GraphWalk<>(completeGraph, vertexList, 10);
-        assertEquals(0, p2.getStartVertex().intValue());
-        assertEquals(4, p2.getEndVertex().intValue());
-        assertEquals(edgeList, p2.getEdgeList());
-        assertEquals(edgeList.size(), p2.getLength());
-        assertEquals(10.0, p2.getWeight());
+        Assert.assertEquals(0, p2.getStartVertex().intValue());
+        Assert.assertEquals(4, p2.getEndVertex().intValue());
+        Assert.assertEquals(edgeList, p2.getEdgeList());
+        Assert.assertEquals(edgeList.size(), p2.getLength());
+        Assert.assertEquals(10.0, p2.getWeight(), 0.0000000001);
+    }
+
+    @Test
+    public void testReversePathUndirected(){
+        Graph<Integer, DefaultEdge> graph=new SimpleGraph<>(DefaultEdge.class);
+        Graphs.addAllVertices(graph, Arrays.asList(0,1,2,3));
+        DefaultEdge e1=graph.addEdge(0,1);
+        DefaultEdge e2=graph.addEdge(1,2);
+        DefaultEdge e3=graph.addEdge(2,3);
+
+        GraphWalk<Integer, DefaultEdge> gw1=new GraphWalk<>(graph, 0, 3, Arrays.asList(0,1,2,3), null, 0);
+        GraphWalk<Integer, DefaultEdge> gw2=new GraphWalk<>(graph, 0, 3, null, Arrays.asList(e1, e2, e3), 0);
+
+        GraphWalk<Integer, DefaultEdge> rev1=gw1.reverse(gw -> gw1.getWeight());
+        rev1.verify();
+        GraphWalk<Integer, DefaultEdge> rev2=gw2.reverse(gw -> gw2.getWeight());
+        rev2.verify();
+
+        GraphWalk<Integer, DefaultEdge> revPath=new GraphWalk<>(graph, 3, 0, null, Arrays.asList(e3, e2, e1), 0);
+        Assert.assertEquals(revPath, rev1);
+        Assert.assertEquals(revPath, rev2);
+    }
+
+    @Test(expected = GraphPath.InvalidGraphPathException.class)
+    public void testReverseInvalidPathDirected(){
+        Graph<Integer, DefaultEdge> graph=new SimpleDirectedGraph<>(DefaultEdge.class);
+        Graphs.addAllVertices(graph, Arrays.asList(0,1,2,3));
+        graph.addEdge(0,1);
+        graph.addEdge(1,2);
+        graph.addEdge(2,3);
+
+        GraphWalk<Integer, DefaultEdge> gw1=new GraphWalk<>(graph, 0, 3, Arrays.asList(0,1,2,3), null, 0);
+        //Walk cannot be reversed since reverse arcs do not exist
+        gw1.reverse(gw -> gw.edgeList.stream().mapToDouble(gw.graph::getEdgeWeight).sum());
+    }
+
+    @Test
+    public void testReversePathDirected(){
+        Graph<Integer, DefaultWeightedEdge> graph=new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        Graphs.addAllVertices(graph, Arrays.asList(0,1,2,3));
+        Graphs.addEdge(graph, 0, 1, 1);
+        Graphs.addEdge(graph, 1, 2, 2);
+        Graphs.addEdge(graph, 2, 3, 3);
+
+        DefaultWeightedEdge e1=Graphs.addEdge(graph, 3, 2, 4);
+        DefaultWeightedEdge e2=Graphs.addEdge(graph, 2, 1, 5);
+        DefaultWeightedEdge e3=Graphs.addEdge(graph, 1, 0, 6);
+
+        GraphWalk<Integer, DefaultWeightedEdge> gw1=new GraphWalk<>(graph, 0, 3, Arrays.asList(0,1,2,3), null, 0);
+        GraphWalk<Integer, DefaultWeightedEdge> rev1=gw1.reverse(gw -> gw.getEdgeList().stream().mapToDouble(gw.graph::getEdgeWeight).sum());
+        rev1.verify();
+        GraphWalk<Integer, DefaultWeightedEdge> revPath=new GraphWalk<>(graph, 3, 0, null, Arrays.asList(e1, e2, e3), 15);
+
+        Assert.assertEquals(revPath, rev1);
+        Assert.assertEquals(15, rev1.getWeight(), 0.00000001);
+    }
+
+    /**
+     * Cannot extend empty path
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalConcatPath1(){
+        Graph<Integer, DefaultEdge> graph=new SimpleDirectedWeightedGraph<>(DefaultEdge.class);
+        graph.addVertex(0);
+        GraphWalk<Integer, DefaultEdge> gw1=GraphWalk.emptyWalk(graph);
+        GraphWalk<Integer, DefaultEdge> gw2=GraphWalk.singletonWalk(graph, 0, 10);
+        gw1.concat(gw2, gw-> gw1.getWeight()+gw2.getWeight());
+    }
+
+    /**
+     * Cannot concat two paths which do not end/start at the same vertex
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void testIllegalConcatPath2(){
+        Graph<Integer, DefaultEdge> graph=new SimpleDirectedWeightedGraph<>(DefaultEdge.class);
+        graph.addVertex(0);
+        graph.addVertex(1);
+        GraphWalk<Integer, DefaultEdge> gw1=GraphWalk.singletonWalk(graph, 0, 10);
+        GraphWalk<Integer, DefaultEdge> gw2=GraphWalk.singletonWalk(graph, 1, 12);
+        gw1.concat(gw2, gw-> gw1.getWeight()+gw2.getWeight());
+    }
+
+    @Test
+    public void testConcatPath1(){
+        Graph<Integer, DefaultEdge> graph=new SimpleDirectedWeightedGraph<>(DefaultEdge.class);
+        Graphs.addAllVertices(graph, Arrays.asList(0,1,2,3));
+        graph.addEdge(0,1);
+        graph.addEdge(1,2);
+        DefaultEdge e3= graph.addEdge(2,3);
+        DefaultEdge e4= graph.addEdge(3,1);
+        GraphWalk<Integer, DefaultEdge> gw1=new GraphWalk<>(graph, 0, 2, Arrays.asList(0,1,2), null, 5);
+        GraphWalk<Integer, DefaultEdge> gw2=new GraphWalk<>(graph, 2, 1, null, Arrays.asList(e3, e4), 7);
+        GraphWalk<Integer, DefaultEdge> gw3=gw1.concat(gw2, gw-> gw1.getWeight()+gw2.getWeight());
+        gw3.verify();
+
+        GraphWalk<Integer, DefaultEdge> expected=new GraphWalk<>(graph, 0, 1, Arrays.asList(0,1,2,3,1), null, 12);
+        Assert.assertEquals(expected, gw3);
+        Assert.assertEquals(12, gw3.getWeight(), 0.00000001);
+    }
+
+    @Test
+    public void testConcatPathWithSingleton(){
+        Graph<Integer, DefaultEdge> graph=new SimpleDirectedWeightedGraph<>(DefaultEdge.class);
+        Graphs.addAllVertices(graph, Arrays.asList(0,1));
+        graph.addEdge(0,1);
+        GraphWalk<Integer, DefaultEdge> gw1=new GraphWalk<>(graph, 0, 1, Arrays.asList(0,1), null, 5);
+        GraphWalk<Integer, DefaultEdge> gw2=GraphWalk.singletonWalk(graph, 1, 10);
+        GraphWalk<Integer, DefaultEdge> gw3=gw1.concat(gw2, gw-> gw1.getWeight()+gw2.getWeight());
+        gw3.verify();
+        //Concatenation with singleton shouldn't result in a different path.
+        Assert.assertEquals(gw1, gw3);
     }
 
 }


### PR DESCRIPTION
- added additional input checks to the GraphWalk class
- added additional functionality (reverse, concat, equals, hashCode), mimicking Java´s String class
- added a method to verify the validity of a path

There were quite a few ways to misuse the GraphWalk class. This PR enforces stricter rules on the GraphWalk class, thereby reducing some ambiguity. For instance, it was quite unclear how to create an empty GraphWalk (GraphWalk with no edges or vertices), or how to create a GraphWalk with only a single vertex but no edges.
If a GraphWalk is defined as a tupple: (startVertex, endVertex, vertexList, edgeList), then the old implementation permitted for instance the following instantiations of GraphWalk:
- `(u, u, emptyList, emptyList)` //Illegal: vertexList must contain vertex u
- `(u, u, [u], emptyList)` //correct
- `(u, u, [u,u], emptyList)` //Illegal: if the vertexList is [u,u], then the edgeList should contain edge (u,u), and the graph must contain a selfloop for u.
Many other illegal variations are now excluded as well.

GraphWalk was designed to be as efficient as possible. Consequently, during construction it doesn´t check whether the path is valid wrt the input graph. To facilitate debugging and testing, I´ve added a verification method.

Let me know what you think in terms of the design. Perhaps it would be better to shift some functionality from GraphWalk to GraphPath, since most algorithms return a GraphPath.
