### PR TITLE
Feat/traverse/start vertices

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/ConnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/ConnectivityInspector.java
@@ -17,12 +17,12 @@
  */
 package org.jgrapht.alg;
 
-import java.util.*;
-
-import org.jgrapht.*;
+import org.jgrapht.Graph;
 import org.jgrapht.event.*;
-import org.jgrapht.graph.*;
-import org.jgrapht.traverse.*;
+import org.jgrapht.graph.AsUndirectedGraph;
+import org.jgrapht.traverse.BreadthFirstIterator;
+
+import java.util.*;
 
 /**
  * Allows obtaining various connectivity aspects of a graph. The <i>inspected graph</i> is specified
@@ -211,7 +211,7 @@ public class ConnectivityInspector<V, E>
             Set<V> vertexSet = graph.vertexSet();
 
             if (vertexSet.size() > 0) {
-                BreadthFirstIterator<V, E> i = new BreadthFirstIterator<>(graph, null);
+                BreadthFirstIterator<V, E> i = new BreadthFirstIterator<>(graph);
                 i.addTraversalListener(new MyTraversalListener());
 
                 while (i.hasNext()) {

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
@@ -17,9 +17,10 @@
  */
 package org.jgrapht.traverse;
 
-import java.util.*;
+import org.jgrapht.Graph;
 
-import org.jgrapht.*;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 /**
  * A breadth-first iterator for a directed or undirected graph.
@@ -47,7 +48,7 @@ public class BreadthFirstIterator<V, E>
      */
     public BreadthFirstIterator(Graph<V, E> g)
     {
-        this(g, null);
+        this(g, (V) null);
     }
 
     /**
@@ -62,6 +63,20 @@ public class BreadthFirstIterator<V, E>
     public BreadthFirstIterator(Graph<V, E> g, V startVertex)
     {
         super(g, startVertex);
+    }
+
+    /**
+     * Creates a new breadth-first iterator for the specified graph. Iteration will start at the
+     * specified start vertices and will be limited to the connected component that includes those
+     * vertices. If the specified start vertices is <code>null</code>, iteration will start at an
+     * arbitrary vertex and will not be limited, that is, will be able to traverse all the graph.
+     *
+     * @param g the graph to be iterated.
+     * @param startVertices the vertices iteration to be started.
+     */
+    public BreadthFirstIterator(Graph<V, E> g, Iterable<V> startVertices)
+    {
+        super(g, startVertices);
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/ClosestFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/ClosestFirstIterator.java
@@ -108,7 +108,7 @@ public class ClosestFirstIterator<V, E>
      */
     public ClosestFirstIterator(Graph<V, E> g, V startVertex, double radius)
     {
-        this(g, Collections.singletonList(startVertex), radius);
+        this(g, startVertex==null?null:Collections.singletonList(startVertex), radius);
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/ClosestFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/ClosestFirstIterator.java
@@ -20,6 +20,8 @@ package org.jgrapht.traverse;
 import org.jgrapht.*;
 import org.jgrapht.util.*;
 
+import java.util.Collections;
+
 /**
  * A closest-first iterator for a directed or undirected graph. For this iterator to work correctly
  * the graph must not be modified during iteration. Currently there are no means to ensure that, nor
@@ -59,7 +61,7 @@ public class ClosestFirstIterator<V, E>
      */
     public ClosestFirstIterator(Graph<V, E> g)
     {
-        this(g, null);
+        this(g, (V) null);
     }
 
     /**
@@ -77,6 +79,22 @@ public class ClosestFirstIterator<V, E>
     }
 
     /**
+     * Creates a new closest-first iterator for the specified graph. Iteration will start at the
+     * specified start vertices and will be limited to the connected component that includes those
+     * vertices. If the specified start vertex is <code>null</code>, iteration will start at an
+     * arbitrary vertex and will not be limited, that is, will be able to traverse all the graph.
+     *
+     * @param g the graph to be iterated.
+     * @param startVertices the vertices iteration to be started.
+     */
+    public ClosestFirstIterator(Graph<V, E> g, Iterable<V> startVertices)
+    {
+        this(g, startVertices, Double.POSITIVE_INFINITY);
+    }
+
+
+
+    /**
      * Creates a new radius-bounded closest-first iterator for the specified graph. Iteration will
      * start at the specified start vertex and will be limited to the subset of the connected
      * component which includes that vertex and is reachable via paths of weighted length less than
@@ -90,7 +108,24 @@ public class ClosestFirstIterator<V, E>
      */
     public ClosestFirstIterator(Graph<V, E> g, V startVertex, double radius)
     {
-        super(g, startVertex);
+        this(g, Collections.singletonList(startVertex), radius);
+    }
+
+    /**
+     * Creates a new radius-bounded closest-first iterator for the specified graph. Iteration will
+     * start at the specified start vertices and will be limited to the subset of the connected
+     * component which includes those vertices and their reachable via paths of weighted length less than
+     * or equal to the specified radius. The specified start vertex may not be <code>
+     * null</code>.
+     *
+     * @param g the graph to be iterated.
+     * @param startVertices the vertices iteration to be started.
+     * @param radius limit on weighted path length, or Double.POSITIVE_INFINITY for unbounded
+     *        search.
+     */
+    public ClosestFirstIterator(Graph<V, E> g, Iterable<V> startVertices, double radius)
+    {
+        super(g, startVertices);
         this.radius = radius;
         checkRadiusTraversal(isCrossComponentTraversal());
         initialized = true;

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
@@ -17,10 +17,11 @@
  */
 package org.jgrapht.traverse;
 
-import java.util.*;
+import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
+import org.jgrapht.event.ConnectedComponentTraversalEvent;
 
-import org.jgrapht.*;
-import org.jgrapht.event.*;
+import java.util.*;
 
 /**
  * Provides a cross-connected-component traversal functionality for iterator subclasses.
@@ -55,12 +56,18 @@ public abstract class CrossComponentIterator<V, E, D>
     /**
      * Iterator which provides start vertices for cross-component iteration.
      */
+    private Iterator<V> entireGraphVertexIterator = null;
+
+
+    /**
+     * Iterator which provides start vertices for specified start vertices.
+     */
     private Iterator<V> startVertexIterator = null;
 
     /**
-     * The start vertex.
+     * The current vertex.
      */
-    private V startVertex;
+    private V currentStartVertex;
 
     /**
      * The connected component state
@@ -74,7 +81,7 @@ public abstract class CrossComponentIterator<V, E, D>
      */
     public CrossComponentIterator(Graph<V, E> g)
     {
-        this(g, null);
+        this(g, (V) null);
     }
 
     /**
@@ -90,34 +97,57 @@ public abstract class CrossComponentIterator<V, E, D>
      */
     public CrossComponentIterator(Graph<V, E> g, V startVertex)
     {
+        this(g, startVertex==null?null:Collections.singletonList(startVertex));
+    }
+
+    /**
+     * Creates a new iterator for the specified graph. Iteration will start at the specified start
+     * vertices. If the specified start vertices is <code>
+     * null</code>, Iteration will start at an arbitrary graph vertex.
+     *
+     * @param g the graph to be iterated.
+     * @param startVertices the vertices iteration to be started.
+     *
+     * @throws IllegalArgumentException if <code>g==null</code> or does not contain
+     *         <code>currentStartVertex</code>
+     */
+    public CrossComponentIterator(Graph<V, E> g, Iterable<V> startVertices)
+    {
         super(g);
+
+        /*
+         * Initialize crossComponentTraversal and test for containment
+         */
+        this.entireGraphVertexIterator = graph.vertexSet().iterator();
+        if (startVertices == null) {
+            this.crossComponentTraversal = true;
+        } else {
+            this.crossComponentTraversal = false;
+            for (V v : startVertices) {
+                if (!graph.containsVertex(v)) {
+                    throw new IllegalArgumentException("graph must contain the start vertex");
+                }
+            }
+            this.startVertexIterator = startVertices.iterator();
+        }
 
         /*
          * Initialize start vertex
          */
-        this.startVertexIterator = graph.vertexSet().iterator();
-        if (startVertex == null) {
-            this.crossComponentTraversal = true;
-            // pick a start vertex if graph not empty
-            if (startVertexIterator.hasNext()) {
-                this.startVertex = startVertexIterator.next();
-            } else {
-                this.startVertex = null;
-            }
+        Iterator<V> it = crossComponentTraversal?entireGraphVertexIterator:startVertexIterator;
+        // pick a start vertex if possible
+        if (it.hasNext()) {
+            this.currentStartVertex = it.next();
         } else {
-            this.crossComponentTraversal = false;
-            if (graph.containsVertex(startVertex)) {
-                this.startVertex = startVertex;
-            } else {
-                throw new IllegalArgumentException("graph must contain the start vertex");
-            }
+            this.currentStartVertex = null;
         }
+
     }
 
     @Override
     public boolean hasNext()
     {
-        if (startVertex != null) {
+        if (currentStartVertex != null) {
             encounterStartVertex();
         }
 
@@ -129,22 +159,19 @@ public abstract class CrossComponentIterator<V, E, D>
                 }
             }
 
-            if (isCrossComponentTraversal()) {
-                while (startVertexIterator.hasNext()) {
-                    V v = startVertexIterator.next();
+            Iterator<V> it = isCrossComponentTraversal()?entireGraphVertexIterator:startVertexIterator;
+            while (it.hasNext()) {
+                V v = it.next();
 
-                    if (!isSeenVertex(v)) {
-                        encounterVertex(v, null);
-                        state = CCS_BEFORE_COMPONENT;
+                if (!isSeenVertex(v)) {
+                    encounterVertex(v, null);
+                    state = CCS_BEFORE_COMPONENT;
 
-                        return true;
-                    }
+                    return true;
                 }
-
-                return false;
-            } else {
-                return false;
             }
+
+            return false;
         } else {
             return true;
         }
@@ -153,7 +180,7 @@ public abstract class CrossComponentIterator<V, E, D>
     @Override
     public V next()
     {
-        if (startVertex != null) {
+        if (currentStartVertex != null) {
             encounterStartVertex();
         }
 
@@ -287,8 +314,8 @@ public abstract class CrossComponentIterator<V, E, D>
 
     private void encounterStartVertex()
     {
-        encounterVertex(startVertex, null);
-        startVertex = null;
+        encounterVertex(currentStartVertex, null);
+        currentStartVertex = null;
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
@@ -67,7 +67,7 @@ public abstract class CrossComponentIterator<V, E, D>
     /**
      * The current vertex.
      */
-    private V currentStartVertex;
+    private V startVertex;
 
     /**
      * The connected component state
@@ -109,7 +109,7 @@ public abstract class CrossComponentIterator<V, E, D>
      * @param startVertices the vertices iteration to be started.
      *
      * @throws IllegalArgumentException if <code>g==null</code> or does not contain
-     *         <code>currentStartVertex</code>
+     *         <code>startVertex</code>
      */
     public CrossComponentIterator(Graph<V, E> g, Iterable<V> startVertices)
     {
@@ -123,11 +123,6 @@ public abstract class CrossComponentIterator<V, E, D>
             this.crossComponentTraversal = true;
         } else {
             this.crossComponentTraversal = false;
-            for (V v : startVertices) {
-                if (!graph.containsVertex(v)) {
-                    throw new IllegalArgumentException("graph must contain the start vertex");
-                }
-            }
             this.startVertexIterator = startVertices.iterator();
         }
 
@@ -137,9 +132,12 @@ public abstract class CrossComponentIterator<V, E, D>
         Iterator<V> it = crossComponentTraversal?entireGraphVertexIterator:startVertexIterator;
         // pick a start vertex if possible
         if (it.hasNext()) {
-            this.currentStartVertex = it.next();
+            this.startVertex = it.next();
+            if (!graph.containsVertex(startVertex)) {
+                throw new IllegalArgumentException("graph must contain the start vertex");
+            }
         } else {
-            this.currentStartVertex = null;
+            this.startVertex = null;
         }
 
     }
@@ -147,7 +145,7 @@ public abstract class CrossComponentIterator<V, E, D>
     @Override
     public boolean hasNext()
     {
-        if (currentStartVertex != null) {
+        if (startVertex != null) {
             encounterStartVertex();
         }
 
@@ -162,7 +160,9 @@ public abstract class CrossComponentIterator<V, E, D>
             Iterator<V> it = isCrossComponentTraversal()?entireGraphVertexIterator:startVertexIterator;
             while (it!=null && it.hasNext()) {
                 V v = it.next();
-
+                if (!graph.containsVertex(v)) {
+                    throw new IllegalArgumentException("graph must contain the start vertex");
+                }
                 if (!isSeenVertex(v)) {
                     encounterVertex(v, null);
                     state = CCS_BEFORE_COMPONENT;
@@ -180,7 +180,7 @@ public abstract class CrossComponentIterator<V, E, D>
     @Override
     public V next()
     {
-        if (currentStartVertex != null) {
+        if (startVertex != null) {
             encounterStartVertex();
         }
 
@@ -314,8 +314,8 @@ public abstract class CrossComponentIterator<V, E, D>
 
     private void encounterStartVertex()
     {
-        encounterVertex(currentStartVertex, null);
-        currentStartVertex = null;
+        encounterVertex(startVertex, null);
+        startVertex = null;
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
@@ -160,7 +160,7 @@ public abstract class CrossComponentIterator<V, E, D>
             }
 
             Iterator<V> it = isCrossComponentTraversal()?entireGraphVertexIterator:startVertexIterator;
-            while (it.hasNext()) {
+            while (it!=null && it.hasNext()) {
                 V v = it.next();
 
                 if (!isSeenVertex(v)) {

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/DepthFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/DepthFirstIterator.java
@@ -17,10 +17,11 @@
  */
 package org.jgrapht.traverse;
 
-import java.util.*;
+import org.jgrapht.Graph;
+import org.jgrapht.util.TypeUtil;
 
-import org.jgrapht.*;
-import org.jgrapht.util.*;
+import java.util.ArrayDeque;
+import java.util.Deque;
 
 /**
  * A depth-first iterator for a directed or undirected graph.
@@ -77,7 +78,7 @@ public class DepthFirstIterator<V, E>
      */
     public DepthFirstIterator(Graph<V, E> g)
     {
-        this(g, null);
+        this(g, (V) null);
     }
 
     /**
@@ -92,6 +93,21 @@ public class DepthFirstIterator<V, E>
     public DepthFirstIterator(Graph<V, E> g, V startVertex)
     {
         super(g, startVertex);
+    }
+
+
+    /**
+     * Creates a new depth-first iterator for the specified graph. Iteration will start at the
+     * specified start vertices and will be limited to the connected component that includes those
+     * vertices. If the specified start vertices is <code>null</code>, iteration will start at an
+     * arbitrary vertex and will not be limited, that is, will be able to traverse all the graph.
+     *
+     * @param g the graph to be iterated.
+     * @param startVertices the vertices iteration to be started.
+     */
+    public DepthFirstIterator(Graph<V, E> g, Iterable<V> startVertices)
+    {
+        super(g, startVertices);
     }
 
     @Override

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/BreadthFirstIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/BreadthFirstIteratorTest.java
@@ -28,11 +28,11 @@ import org.jgrapht.graph.*;
  * the algorithm. This could cause false failures if the traversal implementation changes.
  * </p>
  *
- * @author Liviu Rau
+ * @author Liviu Rau, Patrick Sharp
  * @since Jul 30, 2003
  */
 public class BreadthFirstIteratorTest
-    extends AbstractGraphIteratorTest
+    extends CrossComponentIteratorTest
 {
     // ~ Methods ----------------------------------------------------------------
 
@@ -57,6 +57,26 @@ public class BreadthFirstIteratorTest
         i.setCrossComponentTraversal(true);
 
         return i;
+    }
+
+    @Override
+    String getExpectedCCStr1() {
+        return "orphan";
+    }
+
+    @Override
+    String getExpectedCCStr2() {
+        return "orphan,7,8,9,2,4";
+    }
+
+    @Override
+    String getExpectedCCStr3() {
+        return "orphan,7,8,9,2,4,3,5,6,1";
+    }
+
+    @Override
+    AbstractGraphIterator<String, DefaultWeightedEdge> createIterator(Graph<String, DefaultWeightedEdge> g, Iterable<String> startVertex) {
+        return new BreadthFirstIterator<>(g, startVertex);
     }
 }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/ClosestFirstIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/ClosestFirstIteratorTest.java
@@ -23,11 +23,11 @@ import org.jgrapht.graph.*;
 /**
  * Tests for ClosestFirstIterator.
  *
- * @author John V. Sichi
+ * @author John V. Sichi, Patrick Sharp
  * @since Sep 3, 2003
  */
 public class ClosestFirstIteratorTest
-    extends AbstractGraphIteratorTest
+    extends CrossComponentIteratorTest
 {
     // ~ Methods ----------------------------------------------------------------
 
@@ -99,6 +99,26 @@ public class ClosestFirstIteratorTest
         i.setCrossComponentTraversal(true);
 
         return i;
+    }
+
+    @Override
+    String getExpectedCCStr1() {
+        return "orphan";
+    }
+
+    @Override
+    String getExpectedCCStr2() {
+        return "orphan,7,9,4,8,2";
+    }
+
+    @Override
+    String getExpectedCCStr3() {
+        return "orphan,7,9,4,8,2,3,5,6,1";
+    }
+
+    @Override
+    AbstractGraphIterator<String, DefaultWeightedEdge> createIterator(Graph<String, DefaultWeightedEdge> g, Iterable<String> startVertex) {
+        return new ClosestFirstIterator<>(g, startVertex);
     }
 }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/DepthFirstIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/DepthFirstIteratorTest.java
@@ -17,10 +17,12 @@
  */
 package org.jgrapht.traverse;
 
-import java.util.*;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultDirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
 
-import org.jgrapht.*;
-import org.jgrapht.graph.*;
+import java.util.Iterator;
 
 /**
  * Tests for the {@link DepthFirstIteratorTest} class.
@@ -30,11 +32,11 @@ import org.jgrapht.graph.*;
  * the algorithm. This could cause false failures if the traversal implementation changes.
  * </p>
  *
- * @author Liviu Rau
+ * @author Liviu Rau, Patrick Sharp
  * @since Jul 30, 2003
  */
 public class DepthFirstIteratorTest
-    extends AbstractGraphIteratorTest
+    extends CrossComponentIteratorTest
 {
     // ~ Methods ----------------------------------------------------------------
 
@@ -55,6 +57,30 @@ public class DepthFirstIteratorTest
     {
         return "6:4:9:2:8:7:5:3:1:orphan:";
     }
+    @Override
+    String getExpectedCCStr1() {
+        return "orphan";
+    }
+
+    @Override
+    String getExpectedCCStr2() {
+        return "orphan,7,9,4,8,2";
+    }
+
+    @Override
+    String getExpectedCCStr3() {
+        return "orphan,7,9,4,8,2,3,6,1,5";
+    }
+
+    @Override
+    String getExpectedCCFinishString() {
+        return "orphan:4:9:2:8:7:1:6:5:3:";
+    }
+
+    @Override
+    AbstractGraphIterator<String, DefaultWeightedEdge> createIterator(Graph<String, DefaultWeightedEdge> g, Iterable<String> startVertex) {
+        return new DepthFirstIterator<>(g, startVertex);
+    }
 
     @Override
     AbstractGraphIterator<String, DefaultWeightedEdge> createIterator(
@@ -65,6 +91,8 @@ public class DepthFirstIteratorTest
 
         return i;
     }
+
+
 
     /**
      * See <a href="http://sf.net/projects/jgrapht">Sourceforge bug 1169182</a> for details.


### PR DESCRIPTION
Potential solution for issue #398

One error introduced with these changes is that with the addition a constructor of the form Constructor(graph, iterable) calls to Constructor(graph, null) are now ambiguous between Constructor(graph, vertex) and Constructor(graph, iterable)