### PR TITLE
Embedding beautiful math in jgrapht's javadoc through MathJax

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
@@ -39,7 +39,7 @@ import org.jgrapht.alg.util.extension.*;
  * &amp;0\leq f_{ij} \leq u_{ij} &amp; \forall (i,j)\in E
  * \end{align}
  * \]
- * Here $\delta^+(i)$ resp $\delta^-(i)$ denote resp the outgoing and incoming arc of vertex $i$.
+ * Here $\delta^+(i)$ resp $\delta^-(i)$ denote resp the outgoing and incoming arcs of vertex $i$.
  * <p>
  * The runtime complexity of this class is $O(nm^2)$, where $n$ is the number of vertices and $m$ the number of edges in the
  * graph. For a more efficient algorithm, consider using {@link PushRelabelMFImpl} instead.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
@@ -23,21 +23,29 @@ import org.jgrapht.*;
 import org.jgrapht.alg.util.extension.*;
 
 /**
- * A <a href = "http://en.wikipedia.org/wiki/Flow_network">flow network</a> is a directed graph
- * where each edge has a capacity and each edge receives a flow. The amount of flow on an edge can
- * not exceed the capacity of the edge (note, that all capacities must be non-negative). A flow must
- * satisfy the restriction that the amount of flow into a vertex equals the amount of flow out of
- * it, except when it is a source, which "produces" flow, or sink, which "consumes" flow.
+ * This class computes a maximum flow in a <a href = "http://en.wikipedia.org/wiki/Flow_network">flow network</a> using
+ * <a href = "http://en.wikipedia.org/wiki/Edmonds-Karp_algorithm">Edmonds-Karp algorithm</a>.
+ * Given is a weighted directed graph $G(V,E)$ with vertex set $V$ and edge set $E$. Each edge $(i,j)\in E$ has an associated
+ * non-negative capacity $u_{ij}$. The maximum flow problem involves finding a feasible flow from a source vertex $s$ to a sink vertex
+ * $t$ which is maximum. The amount of flow $f_{ij}$ through any edge $(i,j)$ cannot exceed capacity $u_{ij}$.
+ * Moreover, flow conservation must hold: the sum of flows entering a node must equal the sum of flows exiting that node,
+ * except for the source and the sink nodes.
+ * <p>
+ * Mathematically, the maximum flow problem is stated as follows:
+ * \[
+ * \begin{align}
+ * \max~&amp; \sum_{(i,j)\in \delta^+(s)}f_{ij} &amp;\\
+ * \mbox{s.t. }&amp;\sum_{(j,i)\in \delta^-(i)} f_{ij}=\sum_{(i,j)\in \delta^+(i)} f_{ij} &amp; \forall i\in V\setminus\{s,t\}\\
+ * &amp;0\leq f_{ij} \leq u_{ij} &amp; \forall (i,j)\in E
+ * \end{align}
+ * \]
+ * Here $\delta^+(i)$ resp $\delta^-(i)$ denote resp the outgoing and incoming arc of vertex $i$.
+ * <p>
+ * The runtime complexity of this class is $O(nm^2)$, where $n$ is the number of vertices and $m$ the number of edges in the
+ * graph. For a more efficient algorithm, consider using {@link PushRelabelMFImpl} instead.
  *
  * <p>
- * This class computes maximum flow in a network using
- * <a href = "http://en.wikipedia.org/wiki/Edmonds-Karp_algorithm">Edmonds-Karp algorithm</a>. Be
- * careful: for large networks this algorithm may consume significant amount of time (its
- * upper-bound complexity is O(VE^2), where V - amount of vertices, E - amount of edges in the
- * network).
- *
- * <p>
- * This class can also computes minimum s-t cuts. Effectively, to compute a minimum s-t cut, the
+ * This class can also compute minimum s-t cuts. Effectively, to compute a minimum s-t cut, the
  * implementation first computes a minimum s-t flow, after which a BFS is run on the residual graph.
  *
  * <p>

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClosenessCentrality.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClosenessCentrality.java
@@ -35,7 +35,7 @@ import org.jgrapht.graph.EdgeReversedGraph;
  * 
  * <p>
  * Computes the closeness centrality of each vertex of a graph. The closeness of a vertex $x$ is
- * defined as the reciprocal of the fairness, that is $H(x)= 1 / \sum_{y \neq x} d(x,y)$, where $d(x,y)$
+ * defined as the reciprocal of the farness, that is $H(x)= 1 / \sum_{y \neq x} d(x,y)$, where $d(x,y)$
  * is the shortest path distance from $x$ to $y$. When normalization is used, the score is multiplied by
  * $n-1$ where $n$ is the total number of vertices in the graph. For more details see
  * <a href="https://en.wikipedia.org/wiki/Closeness_centrality">wikipedia</a> and

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClosenessCentrality.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClosenessCentrality.java
@@ -55,7 +55,7 @@ import org.jgrapht.graph.EdgeReversedGraph;
  * 
  * <p>
  * Shortest paths are computed either by using Dijkstra's algorithm or Floyd-Warshall depending on
- * whether the graph has edges with negative edge weights. Thus, the running time is either $O(n (m +n \log_n))$ or
+ * whether the graph has edges with negative edge weights. Thus, the running time is either $O(n (m +n \log n))$ or
  * $O(n^3)$ respectively, where $n$ is the number of vertices and $m$ the number of edges of
  * the graph.
  * 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClosenessCentrality.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClosenessCentrality.java
@@ -34,10 +34,10 @@ import org.jgrapht.graph.EdgeReversedGraph;
  * Closeness centrality.
  * 
  * <p>
- * Computes the closeness centrality of each vertex of a graph. The closeness of a vertex x is
- * defined as the reciprocal of the fairness, that is \(H(x)= 1 / \sum_{y \neq x} d(x,y)\), where \(d(x,y)\)
- * is the shortest path distance from \(x\) to \(y\). When normalization is used, the score is multiplied by
- * \(n-1\) where \(n\) is the total number of vertices in the graph. For more details see
+ * Computes the closeness centrality of each vertex of a graph. The closeness of a vertex $x$ is
+ * defined as the reciprocal of the fairness, that is $H(x)= 1 / \sum_{y \neq x} d(x,y)$, where $d(x,y)$
+ * is the shortest path distance from $x$ to $y$. When normalization is used, the score is multiplied by
+ * $n-1$ where $n$ is the total number of vertices in the graph. For more details see
  * <a href="https://en.wikipedia.org/wiki/Closeness_centrality">wikipedia</a> and
  * <ul>
  * <li>Alex Bavelas. Communication patterns in task-oriented groups. J. Acoust. Soc. Am,
@@ -49,14 +49,14 @@ import org.jgrapht.graph.EdgeReversedGraph;
  * normalizes the scores. This behavior can be adjusted by the constructor arguments.
  *
  * <p>
- * When the graph is disconnected, the closeness centrality score equals 0 for all vertices. In the
+ * When the graph is disconnected, the closeness centrality score equals $0$ for all vertices. In the
  * case of weakly connected digraphs, the closeness centrality of several vertices might be 0. See
  * {@link HarmonicCentrality} for a different approach in case of disconnected graphs.
  * 
  * <p>
  * Shortest paths are computed either by using Dijkstra's algorithm or Floyd-Warshall depending on
- * whether the graph has edges with negative edge weights. Thus, the running time is either \(O(n (m +n \log_n))\) or
- * \(O(n^3)\) respectively, where \(n\) is the number of vertices and \(m\) the number of edges of
+ * whether the graph has edges with negative edge weights. Thus, the running time is either $O(n (m +n \log_n))$ or
+ * $O(n^3)$ respectively, where $n$ is the number of vertices and $m$ the number of edges of
  * the graph.
  * 
  * @param <V> the graph vertex type

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClosenessCentrality.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClosenessCentrality.java
@@ -35,9 +35,9 @@ import org.jgrapht.graph.EdgeReversedGraph;
  * 
  * <p>
  * Computes the closeness centrality of each vertex of a graph. The closeness of a vertex x is
- * defined as the reciprocal of the farness, that is H(x)= 1 / \sum_{y \neq x} d(x,y), where d(x,y)
- * is the shortest path distance from x to y. When normalization is used, the score is multiplied by
- * n-1 where n is the total number of vertices in the graph. For more details see
+ * defined as the reciprocal of the fairness, that is \(H(x)= 1 / \sum_{y \neq x} d(x,y)\), where \(d(x,y)\)
+ * is the shortest path distance from \(x\) to \(y\). When normalization is used, the score is multiplied by
+ * \(n-1\) where \(n\) is the total number of vertices in the graph. For more details see
  * <a href="https://en.wikipedia.org/wiki/Closeness_centrality">wikipedia</a> and
  * <ul>
  * <li>Alex Bavelas. Communication patterns in task-oriented groups. J. Acoust. Soc. Am,
@@ -55,8 +55,8 @@ import org.jgrapht.graph.EdgeReversedGraph;
  * 
  * <p>
  * Shortest paths are computed either by using Dijkstra's algorithm or Floyd-Warshall depending on
- * whether the graph has edges with negative edge weights. Thus, the running time is either O(n (m +
- * n logn)) or O(n^3) respectively, where n is the number of vertices and m the number of edges of
+ * whether the graph has edges with negative edge weights. Thus, the running time is either \(O(n (m +n \log_n))\) or
+ * \(O(n^3)\) respectively, where \(n\) is the number of vertices and \(m\) the number of edges of
  * the graph.
  * 
  * @param <V> the graph vertex type

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,8 @@
 						<exclude>org.jgrapht.experimental</exclude>
 						<show>protected</show>
 						<windowtitle>JGraphT : a free Java graph library</windowtitle>
+						<header>&apos;&lt;script type=&quot;text/javascript&quot; src=&quot;https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML&quot;&gt;&lt;/script&gt;&apos;</header>
+						<additionalparam>--allow-script-in-comments</additionalparam>
 					</configuration>
 				</plugin>
 				<!--This plugin's configuration is used to store Eclipse m2e settings 

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
 						<exclude>org.jgrapht.experimental</exclude>
 						<show>protected</show>
 						<windowtitle>JGraphT : a free Java graph library</windowtitle>
-						<header>&apos;&lt;script type=&quot;text/javascript&quot; src=&quot;https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML&quot;&gt;&lt;/script&gt;&apos;</header>
+						<header>&lt;script type=&quot;text/javascript&quot; src=&quot;https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML,http://jgrapht.org/mathjax/mathjaxConfig.js&quot;&gt;&lt;/script&gt;</header>
 						<additionalparam>--allow-script-in-comments</additionalparam>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
I've added support for displaying math in our javadoc through the usage of MathJax (mathjax.org). According to their website, MathJax is a JavaScript display engine for mathematics that works in all browsers. Websites like stackoverflow use mathjax extensively. 

**How it works:**
Including math in javadoc works exactly the same as including equations in latex. For inline equations use `$3+4=7$` for instance, i.e. wrap the equation in $ $ signs. For a math block, wrap the math in `\[ 4+5=9 \]`. Only equations are supported, so no other latex features. Nevertheless, we can do fancy stuff, e.g. define align environments. If you want to use a dollar sign to denote currency, you have to escape it: the price of this object is `4\$`. 

**Configuration:**
I've uploaded a small configuration script to our webspace:
http://jgrapht.org/mathjax/mathjaxConfig.js
Mostly I'm using the default configuration of MathJax which seems to suffice. If needed we can add custom configurations to the aforementioned configuration script. I also made a small modification to the main pom to add support for mathjax.

As an example of what we can do, I've modified the javadoc of two files: `ClosenessCentrality` and `EdmondsKarpMFImpl`. For instance, the `ClosenessCentrality` javadoc already contained the following latex code: `H(x)= 1 / \sum_{y \neq x} d(x,y)`. This is not very readable, unless you run this through a latex engine.
I recommend that you pull this branch to a local repository, and run mvn javadoc:aggregate to see the result. I've only modified two files since I wasn't sure whether you would like this.

**Quirks:**
So far, everything works surprisingly well. There are however minor issues we'll have to work around. For instance:
```
/**
* My javadoc
* \[\begin{align} 4+5 & 6+7 \end{align}\]
*/
```
would be correct. However, the javadoc parser complains that this is not "valid html". In fact, mvn javadoc:aggregate fails when you use this javadoc. The reason the error is thrown is because of the & sign. Replacing the & by the html encoding `&amp;` solves the issue. Thus far, this is the only major quirk I've found. There may however be more.

**Future (not this pull request):**
Gradually update the javadoc of the remaining files. I would prefer to streamline the javadoc a bit. For instance, each algorithmic class should at the very least state the runtime complexity of the algorithm, as well as the sources that were used to implement the algorithm. Ideally the javadoc also includes a reference to the paper that introduced the algorithm originally. 

Overall I really like this addition. Not only does it look more professional, it also helps in clearly defining what a particular algorithm does, what input it expects, and what the result will be. This resolves issue #396