### PR TITLE
Fixed issue #408

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/JohnsonShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/JohnsonShortestPaths.java
@@ -43,7 +43,13 @@ import org.jgrapht.graph.DirectedPseudograph;
  * Dijkstra's algorithm to be used on the transformed graph.
  * 
  * <p>
- * Running time is O(|V||E| + |V|^2 log|V|).
+ * Running time is $O(n m + n^2 \log n)$.
+ *
+ * <p>
+ * Since Johnson's algorithm creates additional vertices, this implementation requires the user to
+ * provide a {@link VertexFactory}. Since the graph already contains vertices, care must be taken so
+ * that the provided vertex factory does not return nodes that are already contained in the original
+ * input graph.
  * 
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -96,6 +102,9 @@ public class JohnsonShortestPaths<V, E>
 
     /**
      * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException in case the provided vertex factory creates vertices which
+     *         are already in the original graph
      */
     @Override
     public GraphPath<V, E> getPath(V source, V sink)
@@ -112,6 +121,9 @@ public class JohnsonShortestPaths<V, E>
 
     /**
      * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException in case the provided vertex factory creates vertices which
+     *         are already in the original graph
      */
     @Override
     public double getPathWeight(V source, V sink)
@@ -128,6 +140,9 @@ public class JohnsonShortestPaths<V, E>
 
     /**
      * {@inheritDoc}
+     *
+     * @throws IllegalArgumentException in case the provided vertex factory creates vertices which
+     *         are already in the original graph
      */
     @Override
     public SingleSourcePaths<V, E> getPaths(V source)
@@ -225,10 +240,12 @@ public class JohnsonShortestPaths<V, E>
             Map<V, Pair<Double, E>> newDistanceAndPredecessorMap = new HashMap<>();
             for (V u : g.vertexSet()) {
                 Pair<Double, E> oldPair = distanceAndPredecessorMap.get(u);
-                Pair<Double, E> newPair = Pair.of(
-                    oldPair.getFirst() - vertexWeights.get(v) + vertexWeights.get(u),
-                    oldPair.getSecond());
-                newDistanceAndPredecessorMap.put(u, newPair);
+                if (oldPair != null) {
+                    Pair<Double, E> newPair = Pair.of(
+                        oldPair.getFirst() - vertexWeights.get(v) + vertexWeights.get(u),
+                        oldPair.getSecond());
+                    newDistanceAndPredecessorMap.put(u, newPair);
+                }
             }
 
             // store shortest path tree

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/JohnsonShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/JohnsonShortestPathsTest.java
@@ -18,19 +18,24 @@
 package org.jgrapht.alg.shortestpath;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import java.util.function.Supplier;
 
 import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
 import org.jgrapht.VertexFactory;
 import org.jgrapht.generate.GnpRandomGraphGenerator;
 import org.jgrapht.generate.GraphGenerator;
+import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.DirectedWeightedPseudograph;
 import org.jgrapht.graph.IntegerVertexFactory;
+import org.jgrapht.graph.SimpleDirectedGraph;
 import org.junit.Test;
 
 /**
@@ -49,6 +54,28 @@ public class JohnsonShortestPathsTest
             return "vertex" + i++;
         }
     };
+
+    @Test
+    public void testIssue408()
+    {
+        Graph<Integer, DefaultEdge> graph = new SimpleDirectedGraph<>(DefaultEdge.class);
+        Graphs.addAllVertices(graph, Arrays.asList(0,1,2,3,4,5,6));
+        graph.addEdge(0,1);
+        graph.addEdge(1,2);
+        graph.addEdge(2,3);
+        graph.addEdge(3,0);
+
+        graph.addEdge(4,5);
+        graph.addEdge(5,6);
+        graph.addEdge(6,4);
+
+        JohnsonShortestPaths<Integer, DefaultEdge> sp =
+            new JohnsonShortestPaths<>(graph, new IntegerVertexFactory(7));
+
+        assertEquals(2.0, sp.getPathWeight(0,2), 0.0);
+        assertEquals(1.0, sp.getPathWeight(4,5), 0.0);
+        assertTrue(Double.isInfinite(sp.getPathWeight(3, 4)));
+    }
 
     @Test
     public void testWikipediaExample()


### PR DESCRIPTION
Fixed issue #408 which manifested on weakly connected graphs. 

- Also upgraded the documentation to explain the fact that the vertex factory needs to return distinct vertices from the vertices already contained in the input graph.
- Added test

