### PR TITLE
BUGFIX on pushRelabel max flow algorithm

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -197,13 +197,12 @@ public class PushRelabelMFImpl<V, E>
      */
     public double calculateMaximumFlow(V source, V sink)
     {
-        System.out.println("calculateMaximumFlow") ;
         init(source, sink);
-System.out.println("init done");
+
         Queue<VertexExtension> active = new ArrayDeque<>();
-System.out.println("active created") ;
+
         initialize(getVertexExtension(source), getVertexExtension(sink), active);
-System.out.println("initialize done") ;
+
         while (!active.isEmpty()) {
             VertexExtension ux = active.poll();
             for (;;) {
@@ -242,14 +241,14 @@ System.out.println("initialize done") ;
                 }
             }
         }
-System.out.println("while done") ;
+
         // Calculate the max flow that reaches the sink. There may be more efficient ways to do
         // this.
         for (E e : network.edgesOf(sink)) {
             AnnotatedFlowEdge edge = edgeExtensionManager.getExtension(e);
             maxFlowValue += (directedGraph ? edge.flow : edge.flow + edge.getInverse().flow);
         }
-System.out.println("for done");
+
         if (DIAGNOSTIC_ENABLED) {
             diagnostic.dump();
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -197,12 +197,13 @@ public class PushRelabelMFImpl<V, E>
      */
     public double calculateMaximumFlow(V source, V sink)
     {
+        System.out.println("calculateMaximumFlow") ;
         init(source, sink);
-
+System.out.println("init done");
         Queue<VertexExtension> active = new ArrayDeque<>();
-
+System.out.println("active created") ;
         initialize(getVertexExtension(source), getVertexExtension(sink), active);
-
+System.out.println("initialize done") ;
         while (!active.isEmpty()) {
             VertexExtension ux = active.poll();
             for (;;) {
@@ -241,14 +242,14 @@ public class PushRelabelMFImpl<V, E>
                 }
             }
         }
-
+System.out.println("while done") ;
         // Calculate the max flow that reaches the sink. There may be more efficient ways to do
         // this.
         for (E e : network.edgesOf(sink)) {
             AnnotatedFlowEdge edge = edgeExtensionManager.getExtension(e);
             maxFlowValue += (directedGraph ? edge.flow : edge.flow + edge.getInverse().flow);
         }
-
+System.out.println("for done");
         if (DIAGNOSTIC_ENABLED) {
             diagnostic.dump();
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -208,8 +208,8 @@ public class PushRelabelMFImpl<V, E>
             for (;;) {
                 for (AnnotatedFlowEdge ex : ux.getOutgoing()) {
                     if (isAdmissible(ex)) {
-                        if ((ex.getTarget().prototype != sink)
-                            && (ex.getTarget().prototype != source))
+                        if ((! ex.getTarget().prototype.equals(sink))
+                            && (! ex.getTarget().prototype.equals(source)))
                         {
                             active.offer(ex.getTarget());
                         }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMFImplTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMFImplTest.java
@@ -31,4 +31,26 @@ public class PushRelabelMFImplTest
     {
         return new PushRelabelMFImpl<>(network);
     }
+
+    public void testPushRelabelWithNonIdenticalNode() {
+        SimpleDirectedGraph<String,DefaultEdge> g1 = new SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge.class) ;
+
+        g1.addVertex("v0");
+        g1.addVertex("v1");
+        g1.addVertex("v2");
+        g1.addVertex("v3");
+        g1.addVertex("v4");
+        g1.addEdge("v0","v2");
+        g1.addEdge("v3","v4");
+        g1.addEdge("v1","v0");
+        g1.addEdge("v0","v4");
+        g1.addEdge("v0","v1");
+        g1.addEdge("v2","v1");
+
+        MaximumFlowAlgorithm<String, DefaultEdge> mf1 = new PushRelabelMFImpl<>(g1);
+        String sourceFlow = "v" + new String("v3").substring(1) ;
+        String sinkFlow = "v0" ;
+        double flow = mf1.calculateMaximumFlow(sourceFlow,sinkFlow);
+        assertEquals(0.0, flow);
+    }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/TestPushRelabel.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/TestPushRelabel.java
@@ -1,0 +1,34 @@
+package org.jgrapht.alg.flow;
+
+import junit.framework.TestCase;
+import org.jgrapht.alg.interfaces.MaximumFlowAlgorithm;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.SimpleDirectedGraph;
+
+/**
+ * Created by vernemat on 23/05/2017.
+ */
+public class TestPushRelabel extends TestCase {
+
+    public void testPushRelabelWithNonIdenticalNode() {
+        SimpleDirectedGraph<String,DefaultEdge> g1 = new SimpleDirectedGraph<String, DefaultEdge>(DefaultEdge.class) ;
+
+        g1.addVertex("v0");
+        g1.addVertex("v1");
+        g1.addVertex("v2");
+        g1.addVertex("v3");
+        g1.addVertex("v4");
+        g1.addEdge("v0","v2");
+        g1.addEdge("v3","v4");
+        g1.addEdge("v1","v0");
+        g1.addEdge("v0","v4");
+        g1.addEdge("v0","v1");
+        g1.addEdge("v2","v1");
+
+        MaximumFlowAlgorithm<String, DefaultEdge> mf1 = new PushRelabelMFImpl(g1);
+        String sourceFlow = "v" + new String("v3").substring(1) ;
+        String sinkFlow = "v0" ;
+        double flow = mf1.calculateMaximumFlow(sourceFlow,sinkFlow);
+        assertEquals(0.0, flow);
+    }
+}


### PR DESCRIPTION
PushRelabel implementation leads to NullPointerException in certain graphs, when the object passed as parameter to calculateMaxFlow is equals but not identical to the corresponding node in the graph.

I created a test case that exhibits the problem and propose a patch. 
