### PR TITLE
optimized DFS iterator and added additional functionality

### DIFF
--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/IgnoreDirectionTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/IgnoreDirectionTest.java
@@ -52,7 +52,7 @@ public class IgnoreDirectionTest
     @Override
     String getExpectedFinishString()
     {
-        return "5:6:3:1:2:8:7:9:4:orphan:";
+        return "4:9:7:8:2:1:3:6:5:orphan:";
     }
 
     @Override


### PR DESCRIPTION
I've re-implemented the DFS iterator:
- new implementation is faster, more concise and better readable than original
- added additional functionality which allows one to query the depth of a node in the DFS tree. Moreover, you can now also query the parent of a node in the DFS tree, as well as the edge between a child node and its parent. The latter is particularly useful in a multigraph. This functionality could (as far as I could tell) not be implemented through a TraversalListener. Obviously, this additional functionality requires a little more bookkeeping which comes with some computational overhead.

Let me know what you think about this new extension. I could also add the same functionality to the BFS iterator. 

Finally, I believe there's a minor bug in the BFS iterator: the BFS iterator never invokes `finishVertex(vertex);`, i.e. the code should probably read:
```
@Override
    protected void encounterVertex(V vertex, E edge)
    {
        putSeenData(vertex, null);
        finishVertex(vertex);
        queue.add(vertex);
    }
```