### PR TITLE
Added basic support for graph attributes in DOTExporter

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
@@ -19,6 +19,7 @@ package org.jgrapht.io;
 
 import java.io.*;
 import java.util.*;
+import java.util.Map.*;
 
 import org.jgrapht.*;
 import org.jgrapht.graph.*;
@@ -50,6 +51,7 @@ public class DOTExporter<V, E>
     private ComponentNameProvider<E> edgeLabelProvider;
     private ComponentAttributeProvider<V> vertexAttributeProvider;
     private ComponentAttributeProvider<E> edgeAttributeProvider;
+    private Map<String, String> graphAttributes;
 
     /**
      * Constructs a new DOTExporter object with an integer name provider for the vertex IDs and null
@@ -135,6 +137,7 @@ public class DOTExporter<V, E>
         this.edgeAttributeProvider = edgeAttributeProvider;
         this.graphIDProvider =
             (graphIDProvider == null) ? any -> DEFAULT_GRAPH_ID : graphIDProvider;
+        this.graphAttributes = new HashMap<>();
     }
 
     /**
@@ -170,6 +173,17 @@ public class DOTExporter<V, E>
         }
         header += " " + graphId + " {";
         out.println(header);
+
+        // graph attributes
+        for(Entry<String, String> attr: graphAttributes.entrySet()) {
+            out.print(indent);
+            out.print(attr.getKey());
+            out.print('=');
+            out.print(attr.getValue());
+            out.println(";");
+        }
+
+        // vertex set
         for (V v : g.vertexSet()) {
             out.print(indent + getVertexID(v));
 
@@ -186,6 +200,7 @@ public class DOTExporter<V, E>
             out.println(";");
         }
 
+        // edge set
         for (E e : g.edgeSet()) {
             String source = getVertexID(g.getEdgeSource(e));
             String target = getVertexID(g.getEdgeTarget(e));
@@ -208,6 +223,30 @@ public class DOTExporter<V, E>
         out.println("}");
 
         out.flush();
+    }
+
+    /**
+     * Clear a graph attribute.
+     *
+     * @param key the graph attribute key
+     */
+    public void removeGraphAttribute(String key)
+    {
+        Objects.requireNonNull(key, "Graph attribute key cannot be null");
+        graphAttributes.remove(key);
+    }
+
+    /**
+     * Set a graph attribute.
+     *
+     * @param key the graph attribute key
+     * @param value the graph attribute value
+     */
+    public void putGraphAttribute(String key, String value)
+    {
+        Objects.requireNonNull(key, "Graph attribute key cannot be null");
+        Objects.requireNonNull(value, "Graph attribute value cannot be null");
+        graphAttributes.put(key, value);
     }
 
     private void renderAttributes(PrintWriter out, String labelName, Map<String, String> attributes)

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
@@ -137,7 +137,7 @@ public class DOTExporter<V, E>
         this.edgeAttributeProvider = edgeAttributeProvider;
         this.graphIDProvider =
             (graphIDProvider == null) ? any -> DEFAULT_GRAPH_ID : graphIDProvider;
-        this.graphAttributes = new HashMap<>();
+        this.graphAttributes = new LinkedHashMap<>();
     }
 
     /**

--- a/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
@@ -50,6 +50,19 @@ public class DOTExporterTest
     private static final String UNDIRECTED = "graph G {" + NL + "  1 [ label=\"a\" ];" + NL
         + "  2 [ x=\"y\" ];" + NL + "  3;" + NL + "  1 -- 2;" + NL + "  3 -- 1;" + NL + "}" + NL;
 
+    // @formatter:off
+    private static final String UNDIRECTED_WITH_GRAPH_ATTRIBUTES =
+        "graph G {" + NL +
+        "  overlap=false;" + NL +
+        "  splines=true;" + NL +
+        "  1;" + NL +
+        "  2;" + NL +
+        "  3;" + NL +
+        "  1 -- 2;" + NL +
+        "  3 -- 1;" + NL +
+        "}" + NL;
+    // @formatter:on
+
     // ~ Methods ----------------------------------------------------------------
 
     public void testUndirected()
@@ -57,6 +70,7 @@ public class DOTExporterTest
     {
         testUndirected(new SimpleGraph<>(DefaultEdge.class), true);
         testUndirected(new Multigraph<>(DefaultEdge.class), false);
+        testUndirectedWithGraphAttributes(new Multigraph<>(DefaultEdge.class), false);
     }
 
     private void testUndirected(Graph<String, DefaultEdge> g, boolean strict)
@@ -96,6 +110,30 @@ public class DOTExporterTest
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals((strict) ? "strict " + UNDIRECTED : UNDIRECTED, res);
+    }
+
+    private void testUndirectedWithGraphAttributes(Graph<String, DefaultEdge> g, boolean strict)
+        throws UnsupportedEncodingException, ExportException
+    {
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+
+        DOTExporter<String, DefaultEdge> exporter =
+            new DOTExporter<>(new IntegerComponentNameProvider<>(), null, null, null, null);
+
+        exporter.putGraphAttribute("overlap", "false");
+        exporter.putGraphAttribute("splines", "true");
+
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.exportGraph(g, os);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(
+            (strict) ? "strict " + UNDIRECTED_WITH_GRAPH_ATTRIBUTES
+                : UNDIRECTED_WITH_GRAPH_ATTRIBUTES,
+            res);
     }
 
     public void testValidNodeIDs()


### PR DESCRIPTION
Basic support for graph attributes in `DOTExporter` (see #421).