### PR TITLE
Bellman-Ford return null instead of empty path

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TreeSingleSourcePathsImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TreeSingleSourcePathsImpl.java
@@ -130,7 +130,7 @@ public class TreeSingleSourcePathsImpl<V, E>
 
         V cur = targetVertex;
         Pair<Double, E> p = map.get(cur);
-        if (p == null) {
+        if (p == null || p.getFirst().equals(Double.POSITIVE_INFINITY)) {
             return null;
         }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPathTest.java
@@ -71,6 +71,19 @@ public class BellmanFordShortestPathTest
         assertEquals(Arrays.asList(new DefaultWeightedEdge[] { e15 }), path);
     }
 
+    public void testNoPath()
+    {
+        DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =
+            new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+        g.addVertex("a");
+        g.addVertex("b");
+
+        BellmanFordShortestPath<String, DefaultWeightedEdge> alg = new BellmanFordShortestPath<>(g);
+        SingleSourcePaths<String, DefaultWeightedEdge> paths = alg.getPaths("a");
+        assertEquals(paths.getWeight("b"), Double.POSITIVE_INFINITY);
+        assertNull(paths.getPath("b"));
+    }
+
     public void testWikipediaExampleBellmanFord()
     {
         DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =


### PR DESCRIPTION
Fixed bug where bellman-ford returned empty path instead of null.