### PR TITLE
Added type information in attributes for graph importers/exporters

### DIFF
--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/CSVImporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/CSVImporter.java
@@ -18,6 +18,8 @@
 package org.jgrapht.ext;
 
 import java.io.Reader;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.jgrapht.Graph;
 
@@ -103,15 +105,18 @@ public class CSVImporter<V, E>
         switch (format) {
         case ADJACENCY_LIST:
             this.delegate = new org.jgrapht.io.CSVImporter<>(
-                vertexProvider, edgeProvider, org.jgrapht.io.CSVFormat.ADJACENCY_LIST, delimiter);
+                delegateProvider(vertexProvider), delegateProvider(edgeProvider),
+                org.jgrapht.io.CSVFormat.ADJACENCY_LIST, delimiter);
             break;
         case EDGE_LIST:
             this.delegate = new org.jgrapht.io.CSVImporter<>(
-                vertexProvider, edgeProvider, org.jgrapht.io.CSVFormat.EDGE_LIST, delimiter);
+                delegateProvider(vertexProvider), delegateProvider(edgeProvider),
+                org.jgrapht.io.CSVFormat.EDGE_LIST, delimiter);
             break;
         case MATRIX:
             this.delegate = new org.jgrapht.io.CSVImporter<>(
-                vertexProvider, edgeProvider, org.jgrapht.io.CSVFormat.MATRIX, delimiter);
+                delegateProvider(vertexProvider), delegateProvider(edgeProvider),
+                org.jgrapht.io.CSVFormat.MATRIX, delimiter);
             break;
         }
     }
@@ -242,6 +247,24 @@ public class CSVImporter<V, E>
         } catch (org.jgrapht.io.ImportException e) {
             throw new ImportException(e);
         }
+    }
+
+    private org.jgrapht.io.EdgeProvider<V, E> delegateProvider(EdgeProvider<V, E> edgeProvider)
+    {
+        return (from, to, label, attributes) -> {
+            return edgeProvider.buildEdge(
+                from, to, label, attributes.entrySet().stream().collect(
+                    Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString())));
+        };
+    }
+
+    private org.jgrapht.io.VertexProvider<V> delegateProvider(VertexProvider<V> vertexProvider)
+    {
+        return (id, attributes) -> {
+            return vertexProvider.buildVertex(
+                id, attributes.entrySet().stream().collect(
+                    Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString())));
+        };
     }
 
 }

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/ComponentAttributeProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/ComponentAttributeProvider.java
@@ -17,6 +17,8 @@
  */
 package org.jgrapht.ext;
 
+import java.util.Map;
+
 /**
  * Provides display attributes for vertices and/or edges in a graph.
  *
@@ -27,8 +29,18 @@ package org.jgrapht.ext;
  */
 @Deprecated
 public interface ComponentAttributeProvider<T>
-    extends org.jgrapht.io.ComponentAttributeProvider<T>
 {
+
+    /**
+     * Returns a set of attribute key/value pairs for a vertex or edge. If order is important in the
+     * output, be sure to use an order-deterministic map implementation.
+     *
+     * @param component vertex or edge for which attributes are to be obtained
+     *
+     * @return key/value pairs, or null if no attributes should be supplied
+     */
+    public Map<String, String> getComponentAttributes(T component);
+
 }
 
 // End ComponentAttributeProvider.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/ComponentUpdater.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/ComponentUpdater.java
@@ -17,6 +17,8 @@
  */
 package org.jgrapht.ext;
 
+import java.util.Map;
+
 /**
  * Type to handle updates to a component when an import gets more information about it after it has
  * been created.
@@ -26,8 +28,16 @@ package org.jgrapht.ext;
  */
 @Deprecated
 public interface ComponentUpdater<T>
-    extends org.jgrapht.io.ComponentUpdater<T>
 {
+
+    /**
+     * Update component with the extra attributes.
+     *
+     * @param component to update
+     * @param attributes to add to the component
+     */
+    void update(T component, Map<String, String> attributes);
+
 }
 
 // End ComponentUpdater.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/EdgeProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/EdgeProvider.java
@@ -17,6 +17,8 @@
  */
 package org.jgrapht.ext;
 
+import java.util.Map;
+
 /**
  * Defines a provider of edges of type E
  *
@@ -27,8 +29,20 @@ package org.jgrapht.ext;
  */
 @Deprecated
 public interface EdgeProvider<V, E>
-    extends org.jgrapht.io.EdgeProvider<V, E>
 {
+
+    /**
+     * Construct an edge.
+     *
+     * @param from the source vertex
+     * @param to the target vertex
+     * @param label the label of the edge.
+     * @param attributes extra attributes for the edge.
+     *
+     * @return the edge
+     */
+    E buildEdge(V from, V to, String label, Map<String, String> attributes);
+
 }
 
 // End EdgeProvider.java

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/GraphMLExporter.java
@@ -147,7 +147,7 @@ public class GraphMLExporter<V, E>
     /**
      * Denotes the category of a GraphML-Attribute.
      * 
-     * @deprecated Use {@link org.jgrapht.io.GraphMLExporter.AttributeCategory} instead.
+     * @deprecated Use attribute support from {@link org.jgrapht.io.GraphMLExporter} instead.
      */
     @Deprecated
     public enum AttributeCategory
@@ -178,7 +178,7 @@ public class GraphMLExporter<V, E>
     /**
      * Denotes the type of a GraphML-Attribute.
      * 
-     * @deprecated Use {@link org.jgrapht.io.GraphMLExporter.AttributeType} instead.
+     * @deprecated Use attribute support from {@link org.jgrapht.io.GraphMLExporter} instead.
      */
     @Deprecated
     public enum AttributeType

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/VertexProvider.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/VertexProvider.java
@@ -17,6 +17,8 @@
  */
 package org.jgrapht.ext;
 
+import java.util.Map;
+
 /**
  * Creates a Vertex of type V
  *
@@ -25,8 +27,17 @@ package org.jgrapht.ext;
  */
 @Deprecated
 public interface VertexProvider<V>
-    extends org.jgrapht.io.VertexProvider<V>
 {
+
+    /**
+     * Create a vertex
+     *
+     * @param id a unique identifier for the vertex
+     * @param attributes any other attributes of the vertex
+     * @return the vertex
+     */
+    V buildVertex(String id, Map<String, String> attributes);
+
 }
 
 // End VertexProvider.java

--- a/jgrapht-io/src/main/java/org/jgrapht/io/Attribute.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/Attribute.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2015-2017, by Wil Selwood and Contributors.
+ * (C) Copyright 2017-2017, by Dimitrios Michail and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -17,23 +17,25 @@
  */
 package org.jgrapht.io;
 
-import java.util.*;
-
 /**
- * Creates a vertex.
- *
- * @param <V> the vertex type
+ * An attribute
+ * 
+ * @author Dimitrios Michail
  */
-public interface VertexProvider<V>
+public interface Attribute
 {
     /**
-     * Create a vertex
-     *
-     * @param id a unique identifier for the vertex
-     * @param attributes any other attributes of the vertex
-     * @return the vertex
+     * Get the value of the attribute
+     * 
+     * @return the value of the attribute
      */
-    V buildVertex(String id, Map<String, Attribute> attributes);
-}
+    String getValue();
 
-// End VertexProvider.java
+    /**
+     * Get the type of the attribute
+     * 
+     * @return the type of the attribute
+     */
+    AttributeType getType();
+
+}

--- a/jgrapht-io/src/main/java/org/jgrapht/io/AttributeType.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/AttributeType.java
@@ -1,0 +1,76 @@
+/*
+ * (C) Copyright 2017-2017, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.io;
+
+/**
+ * Denotes the type of an attribute.
+ * 
+ * @author Dimitrios Michail
+ */
+public enum AttributeType
+{
+    BOOLEAN("boolean"),
+    INT("int"),
+    LONG("long"),
+    FLOAT("float"),
+    DOUBLE("double"),
+    STRING("string");
+
+    private String name;
+
+    private AttributeType(String name)
+    {
+        this.name = name;
+    }
+
+    /**
+     * Get a string representation of the attribute type
+     * 
+     * @return the string representation of the attribute type
+     */
+    public String toString()
+    {
+        return name;
+    }
+
+    /**
+     * Create a type from a string representation
+     * 
+     * @param value the name of the type
+     * @return the attribute type
+     */
+    public static AttributeType create(String value)
+    {
+        switch (value) {
+        case "boolean":
+            return BOOLEAN;
+        case "int":
+            return INT;
+        case "long":
+            return LONG;
+        case "float":
+            return FLOAT;
+        case "double":
+            return DOUBLE;
+        case "string":
+            return STRING;
+        }
+        throw new IllegalArgumentException("Type " + value + " is unknown");
+    }
+
+}

--- a/jgrapht-io/src/main/java/org/jgrapht/io/CSVImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/CSVImporter.java
@@ -303,8 +303,7 @@ public class CSVImporter<V, E>
 
                 try {
                     String label = "e_" + source + "_" + target;
-                    E e = edgeProvider
-                        .buildEdge(source, target, label, new HashMap<String, String>());
+                    E e = edgeProvider.buildEdge(source, target, label, new HashMap<>());
                     graph.addEdge(source, target, e);
                 } catch (IllegalArgumentException e) {
                     throw new ParseCancellationException(
@@ -461,7 +460,8 @@ public class CSVImporter<V, E>
                 V target = vertices.get(targetName);
 
                 String label = "e_" + source + "_" + target;
-                E e = edgeProvider.buildEdge(source, target, label, new HashMap<String, String>());
+                E e =
+                    edgeProvider.buildEdge(source, target, label, new HashMap<>());
                 graph.addEdge(source, target, e);
 
                 if (weight != null) {

--- a/jgrapht-io/src/main/java/org/jgrapht/io/ComponentAttributeProvider.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/ComponentAttributeProvider.java
@@ -36,7 +36,7 @@ public interface ComponentAttributeProvider<T>
      *
      * @return key/value pairs, or null if no attributes should be supplied
      */
-    public Map<String, String> getComponentAttributes(T component);
+    public Map<String, Attribute> getComponentAttributes(T component);
 }
 
 // End ComponentAttributeProvider.java

--- a/jgrapht-io/src/main/java/org/jgrapht/io/ComponentUpdater.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/ComponentUpdater.java
@@ -33,7 +33,7 @@ public interface ComponentUpdater<T>
      * @param component to update
      * @param attributes to add to the component
      */
-    void update(T component, Map<String, String> attributes);
+    void update(T component, Map<String, Attribute> attributes);
 }
 
 // End ComponentUpdater.java

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DIMACSImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DIMACSImporter.java
@@ -135,7 +135,7 @@ public class DIMACSImporter<V, E>
         Map<Integer, V> map = new HashMap<Integer, V>();
         for (int i = 0; i < size; i++) {
             Integer id = Integer.valueOf(i + 1);
-            V vertex = vertexProvider.buildVertex(id.toString(), new HashMap<String, String>());
+            V vertex = vertexProvider.buildVertex(id.toString(), new HashMap<String, Attribute>());
             map.put(id, vertex);
             graph.addVertex(vertex);
         }
@@ -173,8 +173,7 @@ public class DIMACSImporter<V, E>
                 }
 
                 try {
-
-                    E e = edgeProvider.buildEdge(from, to, label, new HashMap<String, String>());
+                    E e = edgeProvider.buildEdge(from, to, label, new HashMap<String, Attribute>());
                     graph.addEdge(from, to, e);
 
                     if (graph.getType().isWeighted()) {

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
@@ -191,7 +191,7 @@ public class DOTExporter<V, E>
             if (vertexLabelProvider != null) {
                 labelName = vertexLabelProvider.getName(v);
             }
-            Map<String, String> attributes = null;
+            Map<String, Attribute> attributes = null;
             if (vertexAttributeProvider != null) {
                 attributes = vertexAttributeProvider.getComponentAttributes(v);
             }
@@ -211,7 +211,7 @@ public class DOTExporter<V, E>
             if (edgeLabelProvider != null) {
                 labelName = edgeLabelProvider.getName(e);
             }
-            Map<String, String> attributes = null;
+            Map<String, Attribute> attributes = null;
             if (edgeAttributeProvider != null) {
                 attributes = edgeAttributeProvider.getComponentAttributes(e);
             }
@@ -249,26 +249,29 @@ public class DOTExporter<V, E>
         graphAttributes.put(key, value);
     }
 
-    private void renderAttributes(PrintWriter out, String labelName, Map<String, String> attributes)
+    private void renderAttributes(PrintWriter out, String labelName, Map<String, Attribute> attributes)
     {
-        if ((labelName == null) && (attributes == null)) {
+        if (labelName == null && attributes == null) {
             return;
         }
         out.print(" [ ");
-        if ((labelName == null)) {
-            labelName = attributes.get("label");
+        if (labelName == null) {
+            Attribute labelAttribute = attributes.get("label");
+            if (labelAttribute != null) { 
+                labelName = labelAttribute.getValue();
+            }
         }
         if (labelName != null) {
             out.print("label=\"" + labelName + "\" ");
         }
         if (attributes != null) {
-            for (Map.Entry<String, String> entry : attributes.entrySet()) {
+            for (Map.Entry<String, Attribute> entry : attributes.entrySet()) {
                 String name = entry.getKey();
                 if (name.equals("label")) {
                     // already handled by special case above
                     continue;
                 }
-                out.print(name + "=\"" + entry.getValue() + "\" ");
+                out.print(name + "=\"" + entry.getValue().getValue() + "\" ");
             }
         }
         out.print("]");

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DefaultAttribute.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DefaultAttribute.java
@@ -1,0 +1,174 @@
+/*
+ * (C) Copyright 2017-2017, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.io;
+
+import java.io.Serializable;
+
+/**
+ * Default implementation of an attribute.
+ * 
+ * @param <T> the underlying type
+ * 
+ * @author Dimitrios Michail
+ */
+public class DefaultAttribute<T>
+    implements Attribute, Serializable
+{
+    private static final long serialVersionUID = 366113727410278952L;
+
+    private T value;
+    private AttributeType type;
+
+    /**
+     * Create a new attribute
+     * 
+     * @param value the value
+     * @param type the type
+     */
+    public DefaultAttribute(T value, AttributeType type)
+    {
+        this.value = value;
+        this.type = type;
+    }
+
+    /**
+     * Get the string value of the attribute
+     * 
+     * @return the string value of the attribute
+     */
+    @Override
+    public String getValue()
+    {
+        return value.toString();
+    }
+
+    @Override
+    public String toString()
+    {
+        return value.toString();
+    }
+
+    /**
+     * Get the type of the attribute
+     * 
+     * @return the type of the attribute
+     */
+    @Override
+    public AttributeType getType()
+    {
+        return type;
+    }
+
+    /**
+     * Create a boolean attribute
+     * 
+     * @param value the value
+     * @return the attribute
+     */
+    public static Attribute createAttribute(Boolean value)
+    {
+        return new DefaultAttribute<>(value, AttributeType.BOOLEAN);
+    }
+
+    /**
+     * Create an integer attribute
+     * 
+     * @param value the value
+     * @return the attribute
+     */
+    public static Attribute createAttribute(Integer value)
+    {
+        return new DefaultAttribute<>(value, AttributeType.INT);
+    }
+
+    /**
+     * Create a long attribute
+     * 
+     * @param value the value
+     * @return the attribute
+     */
+    public static Attribute createAttribute(Long value)
+    {
+        return new DefaultAttribute<>(value, AttributeType.LONG);
+    }
+
+    /**
+     * Create a float attribute
+     * 
+     * @param value the value
+     * @return the attribute
+     */
+    public static Attribute createAttribute(Float value)
+    {
+        return new DefaultAttribute<>(value, AttributeType.FLOAT);
+    }
+
+    /**
+     * Create a double attribute
+     * 
+     * @param value the value
+     * @return the attribute
+     */
+    public static Attribute createAttribute(Double value)
+    {
+        return new DefaultAttribute<>(value, AttributeType.DOUBLE);
+    }
+
+    /**
+     * Create a string attribute
+     * 
+     * @param value the value
+     * @return the attribute
+     */
+    public static Attribute createAttribute(String value)
+    {
+        return new DefaultAttribute<>(value, AttributeType.STRING);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        return result;
+    }
+
+    @Override
+    @SuppressWarnings("rawtypes")
+    public boolean equals(Object obj)
+    {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        DefaultAttribute other = (DefaultAttribute) obj;
+        if (type != other.type)
+            return false;
+        if (value == null) {
+            if (other.value != null)
+                return false;
+        } else if (!value.equals(other.value))
+            return false;
+        return true;
+    }
+
+}

--- a/jgrapht-io/src/main/java/org/jgrapht/io/EdgeProvider.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/EdgeProvider.java
@@ -37,7 +37,7 @@ public interface EdgeProvider<V, E>
      *
      * @return the edge
      */
-    E buildEdge(V from, V to, String label, Map<String, String> attributes);
+    E buildEdge(V from, V to, String label, Map<String, Attribute> attributes);
 }
 
 // End EdgeProvider.java

--- a/jgrapht-io/src/main/java/org/jgrapht/io/GmlImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/GmlImporter.java
@@ -246,29 +246,41 @@ public class GmlImporter<V, E>
         {
             String key = ctx.ID().getText();
 
-            if (insideNode && level == 2 && key.equals(ID)) {
-                try {
-                    nodeId = Integer.parseInt(ctx.NUMBER().getText());
-                } catch (NumberFormatException e) {
-                    // ignore error
+            if (insideNode && level == 2) {
+                if (key.equals(ID)) {
+                    try {
+                        nodeId = Integer.parseInt(ctx.NUMBER().getText());
+                    } catch (NumberFormatException e) {
+                        // ignore error
+                    }
+                } else {
+                    attributes.put(key, parseNumberAttribute(ctx.NUMBER().getText()));
                 }
-            } else if (insideEdge && level == 2 && key.equals(SOURCE)) {
-                try {
-                    sourceId = Integer.parseInt(ctx.NUMBER().getText());
-                } catch (NumberFormatException e) {
-                    // ignore error
-                }
-            } else if (insideEdge && level == 2 && key.equals(TARGET)) {
-                try {
-                    targetId = Integer.parseInt(ctx.NUMBER().getText());
-                } catch (NumberFormatException e) {
-                    // ignore error
-                }
-            } else if (insideEdge && level == 2 && key.equals(WEIGHT)) {
-                try {
-                    weight = Double.parseDouble(ctx.NUMBER().getText());
-                } catch (NumberFormatException e) {
-                    // ignore error
+            } else if (insideEdge && level == 2) {
+                switch (key) {
+                case SOURCE:
+                    try {
+                        sourceId = Integer.parseInt(ctx.NUMBER().getText());
+                    } catch (NumberFormatException e) {
+                        // ignore error
+                    }
+                    break;
+                case TARGET:
+                    try {
+                        targetId = Integer.parseInt(ctx.NUMBER().getText());
+                    } catch (NumberFormatException e) {
+                        // ignore error
+                    }
+                    break;
+                case WEIGHT:
+                    try {
+                        weight = Double.parseDouble(ctx.NUMBER().getText());
+                    } catch (NumberFormatException e) {
+                        // ignore error
+                    }
+                    break;
+                default:
+                    attributes.put(key, parseNumberAttribute(ctx.NUMBER().getText()));
                 }
             }
         }
@@ -342,6 +354,26 @@ public class GmlImporter<V, E>
             String unescapedText = StringEscapeUtils.unescapeJava(noQuotes);
 
             attributes.put(key, DefaultAttribute.createAttribute(unescapedText));
+        }
+
+        private Attribute parseNumberAttribute(String value)
+        {
+            try {
+                return DefaultAttribute.createAttribute(Integer.parseInt(value, 10));
+            } catch (NumberFormatException e) {
+                // ignore
+            }
+            try {
+                return DefaultAttribute.createAttribute(Long.parseLong(value, 10));
+            } catch (NumberFormatException e) {
+                // ignore
+            }
+            try {
+                return DefaultAttribute.createAttribute(Double.parseDouble(value));
+            } catch (NumberFormatException e) {
+                // ignore
+            }
+            return DefaultAttribute.createAttribute(value);
         }
 
     }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/GmlImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/GmlImporter.java
@@ -177,7 +177,7 @@ public class GmlImporter<V, E>
         private Integer sourceId;
         private Integer targetId;
         private Double weight;
-        private Map<String, String> attributes;
+        private Map<String, Attribute> attributes;
 
         // collected nodes and edges
         private Map<Integer, Node> nodes;
@@ -341,16 +341,16 @@ public class GmlImporter<V, E>
             String noQuotes = text.subSequence(1, text.length() - 1).toString();
             String unescapedText = StringEscapeUtils.unescapeJava(noQuotes);
 
-            attributes.put(key, unescapedText);
+            attributes.put(key, DefaultAttribute.createAttribute(unescapedText));
         }
 
     }
 
     private class Node
     {
-        Map<String, String> attributes;
+        Map<String, Attribute> attributes;
 
-        public Node(Map<String, String> attributes)
+        public Node(Map<String, Attribute> attributes)
         {
             this.attributes = attributes;
         }
@@ -361,10 +361,10 @@ public class GmlImporter<V, E>
         Integer source;
         Integer target;
         Double weight;
-        Map<String, String> attributes;
+        Map<String, Attribute> attributes;
 
         public PartialEdge(
-            Integer source, Integer target, Double weight, Map<String, String> attributes)
+            Integer source, Integer target, Double weight, Map<String, Attribute> attributes)
         {
             this.source = source;
             this.target = target;

--- a/jgrapht-io/src/main/java/org/jgrapht/io/GraphMLExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/GraphMLExporter.java
@@ -59,9 +59,9 @@ public class GraphMLExporter<V, E>
     private int totalAttributes = 0;
 
     // special attributes
-    private static final String VERTEX_LABEL_DEFAULT_ATTRIBUTE_NAME = "Vertex Label";
+    private static final String VERTEX_LABEL_DEFAULT_ATTRIBUTE_NAME = "VertexLabel";
     private static final String EDGE_WEIGHT_DEFAULT_ATTRIBUTE_NAME = "weight";
-    private static final String EDGE_LABEL_DEFAULT_ATTRIBUTE_NAME = "Edge Label";
+    private static final String EDGE_LABEL_DEFAULT_ATTRIBUTE_NAME = "EdgeLabel";
 
     private String vertexLabelAttributeName = VERTEX_LABEL_DEFAULT_ATTRIBUTE_NAME;
     private String edgeWeightAttributeName = EDGE_WEIGHT_DEFAULT_ATTRIBUTE_NAME;

--- a/jgrapht-io/src/main/java/org/jgrapht/io/GraphMLExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/GraphMLExporter.java
@@ -158,37 +158,6 @@ public class GraphMLExporter<V, E>
     }
 
     /**
-     * Denotes the type of a GraphML-Attribute.
-     */
-    public enum AttributeType
-    {
-        BOOLEAN("boolean"),
-        INT("int"),
-        LONG("long"),
-        FLOAT("float"),
-        DOUBLE("double"),
-        STRING("string");
-
-        private String name;
-
-        private AttributeType(String name)
-        {
-            this.name = name;
-        }
-
-        /**
-         * Get a string representation of the attribute type
-         * 
-         * @return the string representation of the attribute type
-         */
-        public String toString()
-        {
-            return name;
-        }
-
-    }
-
-    /**
      * Register a GraphML-Attribute
      * 
      * @param name the attribute name
@@ -577,7 +546,7 @@ public class GraphMLExporter<V, E>
             }
 
             // find vertex attributes
-            Map<String, String> vertexAttributes = null;
+            Map<String, Attribute> vertexAttributes = null;
             if (vertexAttributeProvider != null) {
                 vertexAttributes = vertexAttributeProvider.getComponentAttributes(v);
             }
@@ -594,7 +563,8 @@ public class GraphMLExporter<V, E>
                     String name = e.getKey();
                     String defaultValue = details.defaultValue;
                     if (vertexAttributes.containsKey(name)) {
-                        String value = vertexAttributes.get(name);
+                        Attribute attribute = vertexAttributes.get(name);
+                        String value = attribute.getValue();
                         if (defaultValue == null || !defaultValue.equals(value)) {
                             if (value != null) {
                                 writeData(handler, details.key, value);
@@ -640,7 +610,7 @@ public class GraphMLExporter<V, E>
             }
 
             // find edge attributes
-            Map<String, String> edgeAttributes = null;
+            Map<String, Attribute> edgeAttributes = null;
             if (edgeAttributeProvider != null) {
                 edgeAttributes = edgeAttributeProvider.getComponentAttributes(e);
             }
@@ -657,7 +627,8 @@ public class GraphMLExporter<V, E>
                     String name = entry.getKey();
                     String defaultValue = details.defaultValue;
                     if (edgeAttributes.containsKey(name)) {
-                        String value = edgeAttributes.get(name);
+                        Attribute attribute = edgeAttributes.get(name);
+                        String value = attribute.getValue();
                         if (defaultValue == null || !defaultValue.equals(value)) {
                             if (value != null) {
                                 writeData(handler, details.key, value);

--- a/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
@@ -86,15 +86,15 @@ public class DOTExporterTest
             new ComponentAttributeProvider<String>()
             {
                 @Override
-                public Map<String, String> getComponentAttributes(String v)
+                public Map<String, Attribute> getComponentAttributes(String v)
                 {
-                    Map<String, String> map = new LinkedHashMap<>();
+                    Map<String, Attribute> map = new LinkedHashMap<>();
                     switch (v) {
                     case V1:
-                        map.put("label", "a");
+                        map.put("label", DefaultAttribute.createAttribute("a"));
                         break;
                     case V2:
-                        map.put("x", "y");
+                        map.put("x", DefaultAttribute.createAttribute("y"));
                         break;
                     default:
                         map = null;

--- a/jgrapht-io/src/test/java/org/jgrapht/io/DOTImporter2Test.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/DOTImporter2Test.java
@@ -318,7 +318,7 @@ public class DOTImporter2Test
         // @formatter:on
 
         VertexProvider<String> vp = (a, b) -> a;
-        Map<DefaultEdge, Map<String, String>> edgeAttributes = new HashMap<>();
+        Map<DefaultEdge, Map<String, Attribute>> edgeAttributes = new HashMap<>();
         EdgeProvider<String, DefaultEdge> ep = (f, t, l, a) -> {
             DefaultEdge e = new DefaultEdge();
             edgeAttributes.put(e, a);
@@ -340,7 +340,7 @@ public class DOTImporter2Test
         for (DefaultEdge e : edgeAttributes.keySet()) {
             String f = graph.getEdgeSource(e);
             String t = graph.getEdgeSource(e);
-            Map<String, String> attrs = edgeAttributes.get(e);
+            Map<String, Attribute> attrs = edgeAttributes.get(e);
             if (f.equals("a0") && t.equals("a1")) {
                 assertEquals("5.0", attrs.get("weight"));
             } else if (f.equals("a2") && t.equals("a3")) {
@@ -393,7 +393,7 @@ public class DOTImporter2Test
                        "}";
         // @formatter:on
 
-        Map<String, Map<String, String>> vertexAttributes = new HashMap<>();
+        Map<String, Map<String, Attribute>> vertexAttributes = new HashMap<>();
         VertexProvider<String> vp = (label, attrs) -> {
             vertexAttributes.put(label, attrs);
             return label;
@@ -412,12 +412,12 @@ public class DOTImporter2Test
         expected.addEdge("a4", "a5");
         assertEquals(expected.toString(), graph.toString());
 
-        assertEquals("gray", vertexAttributes.get("a0").get("color"));
-        assertEquals("gray", vertexAttributes.get("a1").get("color"));
-        assertEquals("black", vertexAttributes.get("a2").get("color"));
-        assertEquals("black", vertexAttributes.get("a3").get("color"));
-        assertEquals("white", vertexAttributes.get("a4").get("color"));
-        assertEquals("gray", vertexAttributes.get("a5").get("color"));
+        assertEquals("gray", vertexAttributes.get("a0").get("color").getValue());
+        assertEquals("gray", vertexAttributes.get("a1").get("color").getValue());
+        assertEquals("black", vertexAttributes.get("a2").get("color").getValue());
+        assertEquals("black", vertexAttributes.get("a3").get("color").getValue());
+        assertEquals("white", vertexAttributes.get("a4").get("color").getValue());
+        assertEquals("gray", vertexAttributes.get("a5").get("color").getValue());
     }
 
     @Test
@@ -440,7 +440,7 @@ public class DOTImporter2Test
                        "}";
         // @formatter:on
 
-        Map<String, Map<String, String>> vertexAttributes = new HashMap<>();
+        Map<String, Map<String, Attribute>> vertexAttributes = new HashMap<>();
         VertexProvider<String> vp = (label, attrs) -> {
             vertexAttributes.put(label, attrs);
             return label;
@@ -451,20 +451,22 @@ public class DOTImporter2Test
             new DirectedPseudograph<String, DefaultEdge>(DefaultEdge.class);
         importer.importGraph(graph, new StringReader(input));
 
-        assertEquals("myname", vertexAttributes.get("a0").get("name"));
-        assertEquals("name with ; semicolon", vertexAttributes.get("a1").get("name"));
-        assertEquals("myname", vertexAttributes.get("a3").get("name"));
-        assertEquals("name with \"internal\" quotes", vertexAttributes.get("a4").get("name"));
-        assertEquals("my\nname", vertexAttributes.get("a5").get("name"));
+        assertEquals("myname", vertexAttributes.get("a0").get("name").getValue());
+        assertEquals("name with ; semicolon", vertexAttributes.get("a1").get("name").getValue());
+        assertEquals("myname", vertexAttributes.get("a3").get("name").getValue());
         assertEquals(
-            "<a href=\"http:///www.jgrapht.org\"/>", vertexAttributes.get("a6").get("name"));
+            "name with \"internal\" quotes", vertexAttributes.get("a4").get("name").getValue());
+        assertEquals("my\nname", vertexAttributes.get("a5").get("name").getValue());
+        assertEquals(
+            "<a href=\"http:///www.jgrapht.org\"/>",
+            vertexAttributes.get("a6").get("name").getValue());
         assertEquals(
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>",
-            vertexAttributes.get("a7").get("name"));
-        assertEquals("<h2>name \u2705</h2>", vertexAttributes.get("a8").get("name"));
-        assertEquals("two\nlines", vertexAttributes.get("a9").get("name"));
-        assertEquals("", vertexAttributes.get("a10").get("name"));
-        assertEquals("\\\\\\\\", vertexAttributes.get("a11").get("name"));
+            vertexAttributes.get("a7").get("name").getValue());
+        assertEquals("<h2>name \u2705</h2>", vertexAttributes.get("a8").get("name").getValue());
+        assertEquals("two\nlines", vertexAttributes.get("a9").get("name").getValue());
+        assertEquals("", vertexAttributes.get("a10").get("name").getValue());
+        assertEquals("\\\\\\\\", vertexAttributes.get("a11").get("name").getValue());
     }
 
     @Test
@@ -477,7 +479,7 @@ public class DOTImporter2Test
                        "}";
         // @formatter:on
 
-        Map<String, Map<String, String>> vertexAttributes = new HashMap<>();
+        Map<String, Map<String, Attribute>> vertexAttributes = new HashMap<>();
         VertexProvider<String> vp = (label, attrs) -> {
             vertexAttributes.put(label, attrs);
             return label;
@@ -503,7 +505,7 @@ public class DOTImporter2Test
                        "}";
         // @formatter:on
 
-        Map<String, Map<String, String>> vertexAttributes = new HashMap<>();
+        Map<String, Map<String, Attribute>> vertexAttributes = new HashMap<>();
         VertexProvider<String> vp = (label, attrs) -> {
             vertexAttributes.put(label, attrs);
             return label;
@@ -514,7 +516,9 @@ public class DOTImporter2Test
             new DirectedPseudograph<String, DefaultEdge>(DefaultEdge.class);
         importer.importGraph(graph, new StringReader(input));
 
-        assertEquals("<h1/>", vertexAttributes.get("a0").get("name"));
+        Attribute attr = vertexAttributes.get("a0").get("name");
+        assertEquals("<h1/>", attr.getValue());
+        assertEquals(AttributeType.STRING, attr.getType());
     }
 
     @Test
@@ -534,7 +538,7 @@ public class DOTImporter2Test
         // @formatter:on
 
         VertexProvider<String> vp = (a, b) -> a;
-        Map<DefaultEdge, Map<String, String>> edgeAttributes = new HashMap<>();
+        Map<DefaultEdge, Map<String, Attribute>> edgeAttributes = new HashMap<>();
         EdgeProvider<String, DefaultEdge> ep = (f, t, l, a) -> {
             DefaultEdge e = new DefaultEdge();
             if (f.equals("a2") && t.equals("a3")) {

--- a/jgrapht-io/src/test/java/org/jgrapht/io/GmlImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/GmlImporterTest.java
@@ -647,16 +647,16 @@ public class GmlImporterTest
         VertexProvider<String> vp = (id, attributes) -> {
             assertNotNull(attributes);
             if (Integer.parseInt(id) >= 4) {
-                assertEquals("Node\t\t?", attributes.get("label"));
+                assertEquals("Node\t\t?", attributes.get("label").getValue());
             } else {
-                assertEquals("Node\t\t" + id, attributes.get("label"));
+                assertEquals("Node\t\t" + id, attributes.get("label").getValue());
             }
             return id;
         };
         EdgeProvider<String, DefaultEdge> ep = (from, to, label, attributes) -> {
             assertNotNull(attributes);
-            assertEquals("Edge " + from + "-" + to, attributes.get("label"));
-            assertEquals("Name " + from + to, attributes.get("name"));
+            assertEquals("Edge " + from + "-" + to, attributes.get("label").getValue());
+            assertEquals("Name " + from + to, attributes.get("name").getValue());
             return g.getEdgeFactory().createEdge(from, to);
         };
 

--- a/jgrapht-io/src/test/java/org/jgrapht/io/GmlImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/GmlImporterTest.java
@@ -674,6 +674,78 @@ public class GmlImporterTest
         assertTrue(g.containsEdge("3", "1"));
     }
 
+    @Test
+    public void testCustomNumberAttributesSupport()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "    frequency 6\n"
+                     + "    customweight 7.5\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "    frequency 2\n"
+                     + "    customweight 1.2\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "    frequency 3\n"
+                     + "    customweight 2.1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    frequency 5\n"
+                     + "    customweight 5.5\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = new DirectedWeightedPseudograph<>(DefaultEdge.class);
+
+        VertexProvider<String> vp = (id, attributes) -> {
+            assertNotNull(attributes);
+            if (Integer.parseInt(id) == 1) {
+                assertEquals("2", attributes.get("frequency").getValue());
+                assertEquals(AttributeType.INT, attributes.get("frequency").getType());
+                assertEquals("1.2", attributes.get("customweight").getValue());
+                assertEquals(AttributeType.DOUBLE, attributes.get("customweight").getType());
+            } else if (Integer.parseInt(id) == 2) {
+                assertEquals("3", attributes.get("frequency").getValue());
+                assertEquals(AttributeType.INT, attributes.get("frequency").getType());
+                assertEquals("2.1", attributes.get("customweight").getValue());
+                assertEquals(AttributeType.DOUBLE, attributes.get("customweight").getType());
+            } else {
+                assertEquals("5", attributes.get("frequency").getValue());
+                assertEquals(AttributeType.INT, attributes.get("frequency").getType());
+                assertEquals("5.5", attributes.get("customweight").getValue());
+                assertEquals(AttributeType.DOUBLE, attributes.get("customweight").getType());
+            }
+            return id;
+        };
+        EdgeProvider<String, DefaultEdge> ep = (from, to, label, attributes) -> {
+            assertNotNull(attributes);
+            assertEquals("6", attributes.get("frequency").getValue());
+            assertEquals(AttributeType.INT, attributes.get("frequency").getType());
+            assertEquals("7.5", attributes.get("customweight").getValue());
+            assertEquals(AttributeType.DOUBLE, attributes.get("customweight").getType());
+            return g.getEdgeFactory().createEdge(from, to);
+        };
+
+        GmlImporter<String, DefaultEdge> importer = new GmlImporter<String, DefaultEdge>(vp, ep);
+        importer.importGraph(g, new StringReader(input));
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(1, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsEdge("1", "2"));
+    }
+
     // ~ Private Methods ------------------------------------------------------
 
     private <E> Graph<String, E> readGraph(

--- a/jgrapht-io/src/test/java/org/jgrapht/io/GraphMLExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/GraphMLExporterTest.java
@@ -329,8 +329,8 @@ public class GraphMLExporterTest
 				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
 				+ "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\" "
 				+ "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">" + NL
-				+ "<key id=\"vertex_label_key\" for=\"node\" attr.name=\"Vertex Label\" attr.type=\"string\"/>" + NL
-				+ "<key id=\"edge_label_key\" for=\"edge\" attr.name=\"Edge Label\" attr.type=\"string\"/>" + NL
+				+ "<key id=\"vertex_label_key\" for=\"node\" attr.name=\"VertexLabel\" attr.type=\"string\"/>" + NL
+				+ "<key id=\"edge_label_key\" for=\"edge\" attr.name=\"EdgeLabel\" attr.type=\"string\"/>" + NL
 				+ "<key id=\"edge_weight_key\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\">" + NL
 				+ "<default>1.0</default>" + NL 
 				+ "</key>" + NL 

--- a/jgrapht-io/src/test/java/org/jgrapht/io/GraphMLExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/GraphMLExporterTest.java
@@ -29,7 +29,6 @@ import org.jgrapht.graph.SimpleDirectedGraph;
 import org.jgrapht.graph.SimpleGraph;
 import org.jgrapht.graph.SimpleWeightedGraph;
 import org.jgrapht.io.GraphMLExporter.AttributeCategory;
-import org.jgrapht.io.GraphMLExporter.AttributeType;
 
 import junit.framework.TestCase;
 
@@ -521,20 +520,20 @@ public class GraphMLExporterTest
             new ComponentAttributeProvider<String>()
             {
                 @Override
-                public Map<String, String> getComponentAttributes(String v)
+                public Map<String, Attribute> getComponentAttributes(String v)
                 {
-                    Map<String, String> map = new LinkedHashMap<>();
+                    Map<String, Attribute> map = new LinkedHashMap<>();
                     switch (v) {
                     case V1:
-                        map.put("color", "yellow");
-                        map.put("name", "V1");
+                        map.put("color", DefaultAttribute.createAttribute("yellow"));
+                        map.put("name", DefaultAttribute.createAttribute("V1"));
                         break;
                     case V2:
-                        map.put("color", "red");
-                        map.put("name", "V2");
+                        map.put("color", DefaultAttribute.createAttribute("red"));
+                        map.put("name", DefaultAttribute.createAttribute("V2"));
                         break;
                     case V3:
-                        map.put("name", "V3");
+                        map.put("name", DefaultAttribute.createAttribute("V3"));
                         break;
                     default:
                         break;
@@ -547,15 +546,15 @@ public class GraphMLExporterTest
             new ComponentAttributeProvider<DefaultWeightedEdge>()
             {
                 @Override
-                public Map<String, String> getComponentAttributes(DefaultWeightedEdge e)
+                public Map<String, Attribute> getComponentAttributes(DefaultWeightedEdge e)
                 {
-                    Map<String, String> map = new LinkedHashMap<>();
+                    Map<String, Attribute> map = new LinkedHashMap<>();
                     if (e.equals(g.getEdge(V1, V2))) {
-                        map.put("color", "what?");
-                        map.put("name", "e12");
+                        map.put("color", DefaultAttribute.createAttribute("what?"));
+                        map.put("name", DefaultAttribute.createAttribute("e12"));
                     } else if (e.equals(g.getEdge(V3, V1))) {
-                        map.put("color", "I have no color!");
-                        map.put("name", "e31");
+                        map.put("color", DefaultAttribute.createAttribute("I have no color!"));
+                        map.put("name", DefaultAttribute.createAttribute("e31"));
                     }
                     return map;
                 }
@@ -567,11 +566,9 @@ public class GraphMLExporterTest
                 new IntegerComponentNameProvider<>(), null, edgeAttributeProvider);
         exporter.setExportEdgeWeights(true);
         exporter.registerAttribute(
-            "color", GraphMLExporter.AttributeCategory.NODE, GraphMLExporter.AttributeType.STRING,
-            "yellow");
+            "color", GraphMLExporter.AttributeCategory.NODE, AttributeType.STRING, "yellow");
         exporter.registerAttribute(
-            "name", GraphMLExporter.AttributeCategory.ALL, GraphMLExporter.AttributeType.STRING,
-            "johndoe");
+            "name", GraphMLExporter.AttributeCategory.ALL, AttributeType.STRING, "johndoe");
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
@@ -618,37 +615,15 @@ public class GraphMLExporterTest
         g.addEdge(V3, V1);
         g.setEdgeWeight(g.getEdge(V1, V2), 3.0);
 
-        ComponentAttributeProvider<String> vertexAttributeProvider =
-            new ComponentAttributeProvider<String>()
-            {
-                @Override
-                public Map<String, String> getComponentAttributes(String v)
-                {
-                    return null;
-                }
-            };
-
-        ComponentAttributeProvider<DefaultWeightedEdge> edgeAttributeProvider =
-            new ComponentAttributeProvider<DefaultWeightedEdge>()
-            {
-                @Override
-                public Map<String, String> getComponentAttributes(DefaultWeightedEdge e)
-                {
-                    return null;
-                }
-            };
-
         GraphMLExporter<String,
             DefaultWeightedEdge> exporter = new GraphMLExporter<>(
-                new IntegerComponentNameProvider<>(), null, vertexAttributeProvider,
-                new IntegerComponentNameProvider<>(), null, edgeAttributeProvider);
+                new IntegerComponentNameProvider<>(), null, v->null,
+                new IntegerComponentNameProvider<>(), null, e->null);
         exporter.setExportEdgeWeights(true);
         exporter.registerAttribute(
-            "color", GraphMLExporter.AttributeCategory.NODE, GraphMLExporter.AttributeType.STRING,
-            "yellow");
+            "color", GraphMLExporter.AttributeCategory.NODE, AttributeType.STRING, "yellow");
         exporter.registerAttribute(
-            "name", GraphMLExporter.AttributeCategory.ALL, GraphMLExporter.AttributeType.STRING,
-            "johndoe");
+            "name", GraphMLExporter.AttributeCategory.ALL, AttributeType.STRING, "johndoe");
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");

--- a/jgrapht-io/src/test/java/org/jgrapht/io/GraphMLImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/GraphMLImporterTest.java
@@ -17,24 +17,35 @@
  */
 package org.jgrapht.io;
 
-import java.io.*;
-import java.nio.charset.*;
-import java.util.*;
+import static org.junit.Assert.*;
 
-import org.jgrapht.*;
-import org.jgrapht.graph.*;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
-import junit.framework.*;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.jgrapht.graph.Pseudograph;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.WeightedPseudograph;
+import org.junit.Test;
 
 /**
  * @author Dimitrios Michail
  */
 public class GraphMLImporterTest
-    extends TestCase
 {
 
     private static final String NL = System.getProperty("line.separator");
 
+    @Test
     public void testUndirectedUnweighted()
         throws ImportException
     {
@@ -68,6 +79,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("3", "1"));
     }
 
+    @Test
     public void testUndirectedUnweightedFromInputStream()
         throws ImportException
     {
@@ -104,6 +116,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("3", "1"));
     }
 
+    @Test
     public void testUndirectedUnweightedPseudoGraph()
         throws ImportException
     {
@@ -140,6 +153,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("1", "1"));
     }
 
+    @Test
     public void testUndirectedUnweightedStringKeys()
         throws ImportException
     {
@@ -175,6 +189,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("n1", "n1"));
     }
 
+    @Test
     public void testUndirectedUnweightedWrongOrder()
         throws ImportException
     {
@@ -208,6 +223,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("3", "1"));
     }
 
+    @Test
     public void testDirectedUnweighted()
         throws ImportException
     {
@@ -244,6 +260,7 @@ public class GraphMLImporterTest
         assertFalse(g.containsEdge("1", "3"));
     }
 
+    @Test
     public void testUndirectedUnweightedPrefix()
         throws ImportException
     {
@@ -277,6 +294,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("3", "1"));
     }
 
+    @Test
     public void testWithAttributes()
         throws ImportException
     {
@@ -322,6 +340,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("n1", "n2"));
     }
 
+    @Test
     public void testWithMapAttributes()
         throws ImportException
     {
@@ -385,6 +404,7 @@ public class GraphMLImporterTest
         assertFalse(eAttributes.get(g.getEdge("n1", "n2")).containsKey("weight"));
     }
 
+    @Test
     public void testWithAttributesWeightedGraphs()
         throws ImportException
     {
@@ -431,11 +451,12 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("n0", "n2"));
         assertTrue(g.containsEdge("n0", "n1"));
         assertTrue(g.containsEdge("n1", "n2"));
-        assertEquals(2.0, g.getEdgeWeight(g.getEdge("n0", "n2")));
-        assertEquals(1.0, g.getEdgeWeight(g.getEdge("n0", "n1")));
-        assertEquals(3.0, g.getEdgeWeight(g.getEdge("n1", "n2")));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("n0", "n2")), 1e-9);
+        assertEquals(1.0, g.getEdgeWeight(g.getEdge("n0", "n1")), 1e-9);
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("n1", "n2")), 1e-9);
     }
 
+    @Test
     public void testWithAttributesCustomNamedWeightedGraphs()
         throws ImportException
     {
@@ -491,11 +512,12 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("n0", "n2"));
         assertTrue(g.containsEdge("n0", "n1"));
         assertTrue(g.containsEdge("n1", "n2"));
-        assertEquals(2.0, g.getEdgeWeight(g.getEdge("n0", "n2")));
-        assertEquals(1.0, g.getEdgeWeight(g.getEdge("n0", "n1")));
-        assertEquals(3.0, g.getEdgeWeight(g.getEdge("n1", "n2")));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("n0", "n2")), 1e-9);
+        assertEquals(1.0, g.getEdgeWeight(g.getEdge("n0", "n1")), 1e-9);
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("n1", "n2")), 1e-9);
     }
 
+    @Test
     public void testWithAttributesCustomNamedWeightedForAllGraphs()
         throws ImportException
     {
@@ -554,9 +576,9 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("n0", "n2"));
         assertTrue(g.containsEdge("n0", "n1"));
         assertTrue(g.containsEdge("n1", "n2"));
-        assertEquals(2.0, g.getEdgeWeight(g.getEdge("n0", "n2")));
-        assertEquals(1.0, g.getEdgeWeight(g.getEdge("n0", "n1")));
-        assertEquals(3.0, g.getEdgeWeight(g.getEdge("n1", "n2")));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("n0", "n2")), 1e-9);
+        assertEquals(1.0, g.getEdgeWeight(g.getEdge("n0", "n1")), 1e-9);
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("n1", "n2")), 1e-9);
 
         assertEquals("3.0", vAttributes.get("n0").get("myvalue").getValue());
         assertEquals("3.0", vAttributes.get("n1").get("myvalue").getValue());
@@ -570,6 +592,7 @@ public class GraphMLImporterTest
         assertFalse(eAttributes.get(g.getEdge("n1", "n2")).containsKey("onemore"));
     }
 
+    @Test
     public void testWithHyperEdges()
         throws ImportException
     {
@@ -612,6 +635,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("n0", "n3"));
     }
 
+    @Test
     public void testValidate()
         throws ImportException
     {
@@ -637,6 +661,7 @@ public class GraphMLImporterTest
         }
     }
 
+    @Test
     public void testValidateNoNodeId()
         throws ImportException
     {
@@ -660,6 +685,7 @@ public class GraphMLImporterTest
         }
     }
 
+    @Test
     public void testValidateDuplicateNode()
         throws ImportException
     {
@@ -684,6 +710,7 @@ public class GraphMLImporterTest
         }
     }
 
+    @Test
     public void testValidWithXLinkNodeAttrib()
         throws ImportException
     {
@@ -718,6 +745,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("3", "1"));
     }
 
+    @Test
     public void testExportImport()
         throws Exception
     {
@@ -744,6 +772,7 @@ public class GraphMLImporterTest
         assertTrue(g2.containsEdge("3", "3"));
     }
 
+    @Test
     public void testWithAttributesAtGraphLevel()
         throws ImportException
     {
@@ -773,6 +802,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("n0", "n1"));
     }
 
+    @Test
     public void testWithAttributesAtGraphMLLevel()
         throws ImportException
     {
@@ -802,6 +832,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("n0", "n1"));
     }
 
+    @Test
     public void testNestedGraphs()
         throws ImportException
     {
@@ -858,6 +889,7 @@ public class GraphMLImporterTest
         assertTrue(g.containsEdge("n1", "n2"));
     }
 
+    @Test
     public void testUnsupportedGraph()
         throws ImportException
     {
@@ -894,6 +926,105 @@ public class GraphMLImporterTest
         } catch (Exception e) {
             // nothing
         }
+    }
+
+    @Test
+    public void testNonValidApoc()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL + 
+                 "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL + 
+                 "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<key id=\"name\" for=\"node\" attr.name=\"name\" attr.type=\"string\"/>" + NL +
+            "<key id=\"id\" for=\"node\" attr.name=\"id\" attr.type=\"long\"/>" + NL +
+            "<graph id=\"G\" edgedefault=\"directed\">" + NL +
+                "<node id=\"n45\" labels=\":Person:ENTITY\">" + NL + 
+                    "<data key=\"labels\">:Person:ENTITY</data>" + NL +
+                    "<data key=\"name\">Person1</data>" + NL +
+                    "<data key=\"id\">1</data>" + NL +
+                "</node>" + NL +
+                "<node id=\"n46\" labels=\":Person:ENTITY\">" + NL +
+                    "<data key=\"labels\">:Person:ENTITY</data>" + NL +
+                    "<data key=\"name\">Person2</data>" + NL +
+                    "<data key=\"id\">2</data>" + NL +
+                "</node>" + NL +
+                "<edge id=\"e34\" source=\"n45\" target=\"n46\" label=\"daughter\">" + NL +
+                    "<data key=\"label\">daughter</data>" + NL +
+                "</edge>" + NL +
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g =
+            new DirectedPseudograph<String, DefaultEdge>(DefaultEdge.class);
+
+        HashMap<String, Map<String, Attribute>> vertexAttributes = new HashMap<>();
+        HashMap<DefaultEdge, Map<String, Attribute>> edgeAttributes = new HashMap<>();
+
+        GraphMLImporter<String, DefaultEdge> importer =
+            createGraphImporter(g, (label, attributes) -> {
+                vertexAttributes.put(label, attributes);
+                return label;
+            }, (from, to, label, attributes) -> {
+                DefaultEdge e = g.getEdgeFactory().createEdge(from, to);
+                edgeAttributes.put(e, attributes);
+                return e;
+            });
+
+        importer.setSchemaValidation(false);
+
+        importer.importGraph(g, new StringReader(input));
+
+        assertEquals(2, g.vertexSet().size());
+        assertEquals(1, g.edgeSet().size());
+        for(Map<String, Attribute> va: vertexAttributes.values()) { 
+            assertTrue(va.containsKey("name"));
+            assertTrue(va.containsKey("id"));
+            assertFalse(va.containsKey("labels"));
+        }
+        for(Map<String, Attribute> ea: edgeAttributes.values()) { 
+            assertTrue(ea.isEmpty());
+        }
+    }
+
+    @Test(expected = ImportException.class)
+    public void testNonValidNoVertexId()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL +
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL + 
+                 "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL + 
+                 "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
+            "<graph id=\"G\" edgedefault=\"directed\">" + NL +
+                "<node />" + NL + 
+            "</graph>" + NL +
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g =
+            new DirectedPseudograph<String, DefaultEdge>(DefaultEdge.class);
+
+        HashMap<String, Map<String, Attribute>> vertexAttributes = new HashMap<>();
+        HashMap<DefaultEdge, Map<String, Attribute>> edgeAttributes = new HashMap<>();
+
+        GraphMLImporter<String, DefaultEdge> importer =
+            createGraphImporter(g, (label, attributes) -> {
+                vertexAttributes.put(label, attributes);
+                return label;
+            }, (from, to, label, attributes) -> {
+                DefaultEdge e = g.getEdgeFactory().createEdge(from, to);
+                edgeAttributes.put(e, attributes);
+                return e;
+            });
+
+        importer.setSchemaValidation(false);
+
+        importer.importGraph(g, new StringReader(input));
     }
 
     public <E> Graph<String, E> readGraph(


### PR DESCRIPTION
Upgraded org.jgrapht.io packages with an interface Attribute to be able to support importers that carry type information. 
 
I refrained from actually parsing the input, so that our interfaces are generic enough to support any type of importers. The user is free to use the value and the type information to do any additional transformation.

Resolves #435.