### PR TITLE
added assertions to NeighborCache

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/NeighborCache.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/NeighborCache.java
@@ -125,9 +125,10 @@ public class NeighborCache<V, E>
     @Override
     public void edgeAdded(GraphEdgeChangeEvent<V, E> e)
     {
-        E edge = e.getEdge();
-        V source = graph.getEdgeSource(edge);
-        V target = graph.getEdgeTarget(edge);
+        assert e.getSource()==this.graph : "This NeighborCache is added as a listener to a graph other than the one specified during the construction of this NeighborCache!";
+
+        V source = e.getEdgeSource();
+        V target = e.getEdgeTarget();
 
         if (successors.containsKey(source)) {
             successors.get(source).addNeighbor(target);
@@ -149,6 +150,8 @@ public class NeighborCache<V, E>
     @Override
     public void edgeRemoved(GraphEdgeChangeEvent<V, E> e)
     {
+        assert e.getSource()==this.graph : "This NeighborCache is added as a listener to a graph other than the one specified during the construction of this NeighborCache!";
+
         V source = e.getEdgeSource();
         V target = e.getEdgeTarget();
 
@@ -178,6 +181,8 @@ public class NeighborCache<V, E>
     @Override
     public void vertexRemoved(GraphVertexChangeEvent<V> e)
     {
+        assert e.getSource()==this.graph : "This NeighborCache is added as a listener to a graph other than the one specified during the construction of this NeighborCache!";
+
         successors.remove(e.getVertex());
         predecessors.remove(e.getVertex());
         neighbors.remove(e.getVertex());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/util/NeighborCacheTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/util/NeighborCacheTest.java
@@ -222,6 +222,7 @@ public class NeighborCacheTest
         exception.expectMessage("no such vertex");
         cache.neighborListOf(B);
     }
+
 }
 
 // End NeighborCacheTest.java


### PR DESCRIPTION
Tiny pull request which fixes issue #10. It seemed overkill to throw an explicit exception.
An assertion error is thrown whenever the NeighborCache is added as a listener to a graph other than the one specified during the construction of the NeighborCache.