### PR TITLE
Add an abstract class for the union-find data structure and an implementation that can undo/redo the last operation(s)

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/AbstractUnionFind.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/AbstractUnionFind.java
@@ -1,0 +1,149 @@
+/*
+ * (C) Copyright 2017-2017, by Alexandru Valeanu and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.util;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * A skeletal implementation of a data structure that keeps track of a set of
+ * elements partitioned into a number of disjoint (non-overlapping) subsets.
+ *
+ * @param <T> element type
+ *
+ * @author Alexandru Valeanu
+ */
+public abstract class AbstractUnionFind<T> {
+    protected final Map<T, T> parentMap;
+    protected final Map<T, Integer> rankMap;
+    protected int count; // number of components
+
+    /**
+     * Create a new UnionFind instance.
+     */
+    protected AbstractUnionFind() {
+        parentMap = new HashMap<>();
+        rankMap = new HashMap<>();
+        count = 0;
+    }
+
+    /**
+     * Adds a new element to the data structure in its own set.
+     *
+     * @param element The element to add.
+     */
+    public abstract void addElement(T element);
+
+    /**
+     * Returns the representative element of the set that element is in.
+     *
+     * @param element The element to find.
+     *
+     * @return The element representing the set the element is in.
+     */
+    public abstract T find(final T element);
+
+    /**
+     * Merges the sets which contain element1 and element2. No guarantees are given as to which
+     * element becomes the representative of the resulting (merged) set: this can be either
+     * find(element1) or find(element2).
+     *
+     * @param element1 The first element to union.
+     * @param element2 The second element to union.
+     */
+    public abstract void union(T element1, T element2);
+
+    /**
+     * Resets the UnionFind data structure: each element is placed in its own singleton set.
+     */
+    public abstract void reset();
+
+    /**
+     * Tests whether two elements are contained in the same set.
+     *
+     * @param element1 first element
+     * @param element2 second element
+     * @return true if element1 and element2 are contained in the same set, false otherwise.
+     */
+    public boolean inSameSet(T element1, T element2)
+    {
+        return find(element1).equals(find(element2));
+    }
+
+    /**
+     * Returns the number of sets. Initially, all items are in their own set. The smallest number of
+     * sets equals one.
+     *
+     * @return the number of sets
+     */
+    public int numberOfSets()
+    {
+        assert count >= 1 && count <= parentMap.keySet().size();
+        return count;
+    }
+
+    /**
+     * Returns the total number of elements in this data structure.
+     *
+     * @return the total number of elements in this data structure.
+     */
+    public int size()
+    {
+        return parentMap.size();
+    }
+
+    /**
+     * @return map from element to parent element
+     */
+    protected Map<T, T> getParentMap()
+    {
+        return parentMap;
+    }
+
+    /**
+     * @return map from element to rank
+     */
+    protected Map<T, Integer> getRankMap()
+    {
+        return rankMap;
+    }
+
+    /**
+     * Returns a string representation of this data structure. Each component is represented as
+     * {v_i:v_1,v_2,v_3,...v_n}, where v_i is the representative of the set.
+     *
+     * @return string representation of this data structure
+     */
+    public String toString()
+    {
+        Map<T, Set<T>> setRep = new LinkedHashMap<>();
+        for (T t : parentMap.keySet()) {
+            T representative = find(t);
+            if (!setRep.containsKey(representative))
+                setRep.put(representative, new LinkedHashSet<>());
+            setRep.get(representative).add(t);
+        }
+
+        return setRep
+                .keySet().stream()
+                .map(
+                        key -> "{" + key + ":" + setRep.get(key).stream().map(Objects::toString).collect(
+                                Collectors.joining(",")) + "}")
+                .collect(Collectors.joining(", ", "{", "}"));
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/UnionFind.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/UnionFind.java
@@ -17,8 +17,8 @@
  */
 package org.jgrapht.alg.util;
 
-import java.util.*;
-import java.util.stream.*;
+import java.util.Objects;
+import java.util.Set;
 
 /**
  * An implementation of <a href="http://en.wikipedia.org/wiki/Disjoint-set_data_structure">Union
@@ -33,12 +33,7 @@ import java.util.stream.*;
  * @author Tom Conerly
  * @since Feb 10, 2010
  */
-public class UnionFind<T>
-{
-    private final Map<T, T> parentMap;
-    private final Map<T, Integer> rankMap;
-    private int count; // number of components
-
+public class UnionFind<T> extends AbstractUnionFind<T> {
     /**
      * Creates a UnionFind instance with all the elements in separate sets.
      * 
@@ -46,58 +41,48 @@ public class UnionFind<T>
      */
     public UnionFind(Set<T> elements)
     {
-        parentMap = new LinkedHashMap<>();
-        rankMap = new HashMap<>();
-        for (T element : elements) {
-            parentMap.put(element, element);
-            rankMap.put(element, 0);
+        super();
+
+        if (Objects.nonNull(elements)){
+            for (T element : elements) {
+                parentMap.put(element, element);
+                rankMap.put(element, 0);
+            }
+            count = elements.size();
         }
-        count = elements.size();
     }
 
     /**
-     * Adds a new element to the data structure in its own set.
-     *
-     * @param element The element to add.
+     * Creates a UnionFind instance with no elements.
      */
+    public UnionFind()
+    {
+        this(null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void addElement(T element)
     {
         if (parentMap.containsKey(element))
             throw new IllegalArgumentException(
-                "element is already contained in UnionFind: " + element);
+                    "element is already contained in UnionFind: " + element);
         parentMap.put(element, element);
         rankMap.put(element, 0);
         count++;
     }
 
     /**
-     * @return map from element to parent element
+     * {@inheritDoc}
      */
-    protected Map<T, T> getParentMap()
-    {
-        return parentMap;
-    }
-
-    /**
-     * @return map from element to rank
-     */
-    protected Map<T, Integer> getRankMap()
-    {
-        return rankMap;
-    }
-
-    /**
-     * Returns the representative element of the set that element is in.
-     *
-     * @param element The element to find.
-     *
-     * @return The element representing the set the element is in.
-     */
+    @Override
     public T find(final T element)
     {
         if (!parentMap.containsKey(element)) {
             throw new IllegalArgumentException(
-                "element is not contained in this UnionFind data structure: " + element);
+                    "element is not contained in this UnionFind data structure: " + element);
         }
 
         T current = element;
@@ -121,13 +106,9 @@ public class UnionFind<T>
     }
 
     /**
-     * Merges the sets which contain element1 and element2. No guarantees are given as to which
-     * element becomes the representative of the resulting (merged) set: this can be either
-     * find(element1) or find(element2).
-     *
-     * @param element1 The first element to union.
-     * @param element2 The second element to union.
+     * {@inheritDoc}
      */
+    @Override
     public void union(T element1, T element2)
     {
         if (!parentMap.containsKey(element1) || !parentMap.containsKey(element2)) {
@@ -156,42 +137,9 @@ public class UnionFind<T>
     }
 
     /**
-     * Tests whether two elements are contained in the same set.
-     * 
-     * @param element1 first element
-     * @param element2 second element
-     * @return true if element1 and element2 are contained in the same set, false otherwise.
+     * {@inheritDoc}
      */
-    public boolean inSameSet(T element1, T element2)
-    {
-        return find(element1).equals(find(element2));
-    }
-
-    /**
-     * Returns the number of sets. Initially, all items are in their own set. The smallest number of
-     * sets equals one.
-     * 
-     * @return the number of sets
-     */
-    public int numberOfSets()
-    {
-        assert count >= 1 && count <= parentMap.keySet().size();
-        return count;
-    }
-
-    /**
-     * Returns the total number of elements in this data structure.
-     * 
-     * @return the total number of elements in this data structure.
-     */
-    public int size()
-    {
-        return parentMap.size();
-    }
-
-    /**
-     * Resets the UnionFind data structure: each element is placed in its own singleton set.
-     */
+    @Override
     public void reset()
     {
         for (T element : parentMap.keySet()) {
@@ -199,30 +147,6 @@ public class UnionFind<T>
             rankMap.put(element, 0);
         }
         count = parentMap.size();
-    }
-
-    /**
-     * Returns a string representation of this data structure. Each component is represented as
-     * {v_i:v_1,v_2,v_3,...v_n}, where v_i is the representative of the set.
-     * 
-     * @return string representation of this data structure
-     */
-    public String toString()
-    {
-        Map<T, Set<T>> setRep = new LinkedHashMap<>();
-        for (T t : parentMap.keySet()) {
-            T representative = find(t);
-            if (!setRep.containsKey(representative))
-                setRep.put(representative, new LinkedHashSet<>());
-            setRep.get(representative).add(t);
-        }
-
-        return setRep
-            .keySet().stream()
-            .map(
-                key -> "{" + key + ":" + setRep.get(key).stream().map(Objects::toString).collect(
-                    Collectors.joining(",")) + "}")
-            .collect(Collectors.joining(", ", "{", "}"));
     }
 }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/UnionFindUndo.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/UnionFindUndo.java
@@ -30,6 +30,9 @@ import java.util.Set;
  * rank to achieve an amortized cost of O(log n) per operation.
  * UnionFindUndo uses the hashCode and equals method of the elements it operates on.
  *
+ * <p>
+ * Note: Only {@link #addElement(Object)} and {@link #union(Object, Object)} can be undone/redone.
+ *
  * @param <T> element type
  *
  * @author Alexandru Valeanu

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/UnionFindUndo.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/UnionFindUndo.java
@@ -1,0 +1,291 @@
+/*
+ * (C) Copyright 2017-2017, by Alexandru Valeanu and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * An implementation of <a href="http://en.wikipedia.org/wiki/Disjoint-set_data_structure">Union
+ * Find</a> data structure that can also undo or redo the last performed operation.
+ * Union Find is a disjoint-set data structure. It supports two operations:
+ * finding the set a specific element is in, and merging two sets. The implementation uses union by
+ * rank to achieve an amortized cost of O(log n) per operation.
+ * UnionFindUndo uses the hashCode and equals method of the elements it operates on.
+ *
+ * @param <T> element type
+ *
+ * @author Alexandru Valeanu
+ */
+public class UnionFindUndo<T> extends AbstractUnionFind<T>
+{
+    /** An element of the undo history. */
+    private static abstract class Change {
+        /**
+         * Reset the subject to its previous state.
+         */
+        abstract void undo(); // abstract
+
+        /**
+         * Reset the subject to the state after the change.
+         */
+        abstract void redo(); // abstract
+    }
+
+    private class AddElementChange extends Change{
+        final T element;
+
+        private AddElementChange(T element) {
+            this.element = element;
+        }
+
+        @Override
+        void undo() {
+            parentMap.remove(element);
+            rankMap.remove(element);
+            count--;
+        }
+
+        @Override
+        void redo() {
+            parentMap.put(element, element);
+            rankMap.put(element, 1);
+            count++;
+        }
+    }
+
+    private class UnionChange extends Change{
+        final T child;
+        final T parent;
+
+        private UnionChange(T child, T parent) {
+            this.child = child;
+            this.parent = parent;
+        }
+
+        @Override
+        void undo() {
+            cut(child, parent, rankMap.get(parent) - rankMap.get(child));
+        }
+
+        @Override
+        void redo() {
+            link(child, parent, rankMap.get(parent) + rankMap.get(child));
+        }
+    }
+
+    /** A stack of undo changes from executed actions. */
+    private final List<Change> history = new ArrayList<>();
+
+    /** Index into undo stack.  Elements history[0..u) have been executed
+     but not undone, and elements history[u..) have been undone. */
+    private int undoPointer = 0;
+
+    /**
+     * Creates a UnionFindUndo instance with all the elements in separate sets.
+     *
+     * @param elements the initial elements to include (each element in a singleton set).
+     */
+    public UnionFindUndo(Set<T> elements)
+    {
+        super();
+
+        if (Objects.nonNull(elements)){
+            for (T element : elements) {
+                parentMap.put(element, element);
+                rankMap.put(element, 0);
+            }
+            count = elements.size();
+        }
+    }
+
+    /**
+     * Creates a UnionFindUndo instance with no elements.
+     */
+    public UnionFindUndo()
+    {
+        this(null);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void addElement(T element)
+    {
+        if (parentMap.containsKey(element))
+            throw new IllegalArgumentException("element is already contained in UnionFindUndo: " + element);
+
+        // Update the UFU data-structure
+        parentMap.put(element, element);
+        rankMap.put(element, 1);
+        count++;
+
+        // Record undo info (AddElementChange)
+        addChange(new AddElementChange(element));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public T find(final T element)
+    {
+        if (!parentMap.containsKey(element)) {
+            throw new IllegalArgumentException(
+                "element is not contained in this UnionFindUndo data structure: " + element);
+        }
+
+        T current = element;
+        while (true) {
+            T parent = parentMap.get(current);
+            if (parent.equals(current)) {
+                break;
+            }
+            current = parent;
+        }
+
+        return current;
+    }
+
+    private void link(T child, T parent, int totalSize){
+        parentMap.put(child, parent);
+        rankMap.put(parent, totalSize);
+        count--;
+    }
+
+    private void cut(T child, T parent, int totalSize){
+        parentMap.put(child, child);
+        rankMap.put(parent, totalSize);
+        count++;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void union(T element1, T element2)
+    {
+        if (!parentMap.containsKey(element1) || !parentMap.containsKey(element2)) {
+            throw new IllegalArgumentException("elements must be contained in given set");
+        }
+
+        T parent1 = find(element1);
+        T parent2 = find(element2);
+
+        Change change = null;
+
+        // check if the elements are not already in the same set
+        if (!parent1.equals(parent2)) {
+            int size1 = rankMap.get(parent1);
+            int size2 = rankMap.get(parent2);
+
+            if (size1 >= size2) {
+                link(parent2, parent1, size1 + size2);
+                change = new UnionChange(parent2, parent1);
+            } else {
+                link(parent1, parent2, size1 + size2);
+                change = new UnionChange(parent1, parent2);
+            }
+        }
+
+        // Record undo info (UnionChange)
+        addChange(change);
+    }
+
+    /**
+     * Resets the UnionFindUndo data structure: each element is placed in its own singleton set.
+     */
+    @Override
+    public void reset()
+    {
+        for (T element : parentMap.keySet()) {
+            parentMap.put(element, element);
+            rankMap.put(element, 1);
+        }
+        count = parentMap.size();
+
+        // clear the stack of performed changes
+        history.clear();
+        undoPointer = 0;
+    }
+
+    /*
+        Add change to history
+     */
+    private void addChange(Change change){
+        while (history.size() > undoPointer){
+            history.remove(history.size() - 1);
+        }
+
+        history.add(change);
+        undoPointer++;
+    }
+
+    /**
+     * Undo the latest operation. If there is no operation to be undone, nothing happens.
+     */
+    public void undo() {
+        if (undoPointer != 0){
+            undoPointer -= 1;
+            Change change = history.get(undoPointer);
+
+            if (change != null)
+                change.undo();
+        }
+    }
+
+    /**
+     * Undo the latest k operations.
+     *
+     * @param k number of operations to undo
+     */
+    public void undo(int k){
+        while (k > 0){
+            undo();
+            k--;
+        }
+    }
+
+    /**
+     * Redo the latest undone operation. If there is no operation to be redone, nothing happens.
+     */
+    public void redo() {
+        if (undoPointer < history.size()){
+            Change change = history.get(undoPointer);
+            undoPointer += 1;
+
+            if (change != null)
+                change.redo();
+        }
+    }
+
+    /**
+     * Redo the latest k undone operations.
+     *
+     * @param k number of operations to redo
+     */
+    public void redo(int k){
+        while (k > 0){
+            redo();
+            k--;
+        }
+    }
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/util/UnionFindTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/util/UnionFindTest.java
@@ -17,23 +17,21 @@
  */
 package org.jgrapht.alg.util;
 
-import java.util.*;
+import org.junit.Test;
 
-import junit.framework.*;
+import java.util.ArrayList;
+import java.util.TreeSet;
+
+import static org.junit.Assert.*;
 
 /**
- * .
+ * Test {@link UnionFind} class
  *
  * @author Tom Conerly
  */
 public class UnionFindTest
-    extends TestCase
 {
-    // ~ Methods ----------------------------------------------------------------
-
-    /**
-     * .
-     */
+    @Test
     public void testUnionFind()
     {
         TreeSet<String> set = new TreeSet<String>();
@@ -83,9 +81,9 @@ public class UnionFindTest
         assertEquals(6, uf.numberOfSets());
     }
 
-    private void union(ArrayList<ArrayList<String>> sets, String a, String b)
+    static <E> void union(ArrayList<ArrayList<E>> sets, E a, E b)
     {
-        ArrayList<String> toAdd = new ArrayList<String>();
+        ArrayList<E> toAdd = new ArrayList<E>();
         for (int i = 0; i < sets.size(); i++) {
             if (sets.get(i).contains(a)) {
                 toAdd.addAll(sets.get(i));
@@ -103,9 +101,9 @@ public class UnionFindTest
         sets.add(toAdd);
     }
 
-    private boolean same(ArrayList<ArrayList<String>> sets, String a, String b)
+    static <E> boolean same(ArrayList<ArrayList<E>> sets, E a, E b)
     {
-        for (ArrayList<String> set : sets) {
+        for (ArrayList<E> set : sets) {
             if (set.contains(a) && set.contains(b)) {
                 return true;
             }
@@ -113,11 +111,11 @@ public class UnionFindTest
         return false;
     }
 
-    private void testIdentical(
-        String[] universe, ArrayList<ArrayList<String>> sets, UnionFind<String> uf)
+    static <E> void testIdentical(
+        E[] universe, ArrayList<ArrayList<E>> sets, AbstractUnionFind<E> uf)
     {
-        for (String a : universe) {
-            for (String b : universe) {
+        for (E a : universe) {
+            for (E b : universe) {
                 boolean same1 = uf.find(a).equals(uf.find(b));
                 boolean same2 = same(sets, a, b);
                 assertEquals(same1, same2);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/util/UnionFindUndoTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/util/UnionFindUndoTest.java
@@ -1,0 +1,267 @@
+/*
+ * (C) Copyright 2017-2017, by Alexandru Valeanu and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.util;
+
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.jgrapht.alg.util.UnionFindTest.testIdentical;
+import static org.jgrapht.alg.util.UnionFindTest.union;
+import static org.junit.Assert.*;
+
+/**
+ * Test {@link UnionFindUndo} class
+ *
+ * @author Alexandru Valeanu
+ */
+public class UnionFindUndoTest {
+    private static class DisjointSets<E> extends AbstractUnionFind<E>{
+
+        DisjointSets(){
+        }
+
+        DisjointSets(Map<E, E> map){
+            map.forEach(parentMap::put);
+        }
+
+        @Override
+        public void addElement(E element) {
+            assert !parentMap.containsKey(element);
+            parentMap.put(element, element);
+            count++;
+        }
+
+        @Override
+        public E find(E element) {
+            E parent = parentMap.get(element);
+            assert parent != null;
+            return parent;
+        }
+
+        @Override
+        public void union(E element1, E element2) {
+            Map<E, E> newMap = new HashMap<>();
+            element1 = find(element1);
+            element2 = find(element2);
+
+            for (Map.Entry<E, E> entry: parentMap.entrySet()){
+                if (entry.getValue().equals(element1)){
+                    newMap.put(entry.getKey(), element2);
+                }
+                else{
+                    newMap.put(entry.getKey(), entry.getValue());
+                }
+            }
+
+            parentMap.clear();
+            newMap.forEach(parentMap::put);
+            count = new HashSet<>(parentMap.values()).size();
+        }
+
+        @Override
+        public void reset() {
+            throw new UnsupportedOperationException("not implemented");
+        }
+
+        DisjointSets<E> deepCopy(){
+            return new DisjointSets<>(parentMap);
+        }
+    }
+
+    @Test
+    public void testSimple(){
+        UnionFindUndo<String> ufu = new UnionFindUndo<>();
+        ufu.addElement("alex");
+        ufu.addElement("ben");
+        ufu.addElement("charlie");
+        ufu.addElement("dan");
+        assertEquals(ufu.size(), 4);
+        ufu.undo();
+        ufu.undo();
+        assertEquals(ufu.size(), 2);
+        ufu.redo();
+        assertEquals(ufu.size(), 3);
+        ufu.addElement("earl");
+        ufu.union("alex", "ben");
+        assertEquals(ufu.find("alex"), ufu.find("ben"));
+        ufu.undo(1);
+        assertNotEquals(ufu.find("alex"), ufu.find("ben"));
+    }
+
+    @Test
+    public void testSimple2(){
+        UnionFindUndo<Integer> ufu = new UnionFindUndo<>();
+
+        for (int i = 0; i < 10; i++) {
+            ufu.addElement(i);
+        }
+
+        assertEquals(ufu.size(), 10);
+        assertEquals(ufu.numberOfSets(), 10);
+
+        ufu.undo(); // nothing should happen
+        ufu.redo(); // nothing should happen
+
+        ufu.union(4, 5);
+        ufu.union(1, 2);
+        ufu.union(5, 7);
+
+        assertTrue(ufu.inSameSet(4, 7));
+        ufu.undo();
+        assertFalse(ufu.inSameSet(4, 7));
+        ufu.redo();
+        assertTrue(ufu.inSameSet(4, 7));
+
+        ufu.undo(2);
+        assertTrue(ufu.inSameSet(4, 5));
+        assertFalse(ufu.inSameSet(1, 2));
+        assertFalse(ufu.inSameSet(4, 7));
+        ufu.redo(1);
+        assertTrue(ufu.inSameSet(1, 2));
+        assertFalse(ufu.inSameSet(5, 7));
+
+        ufu.union(5, 8);
+        assertFalse(ufu.inSameSet(4, 7));
+        assertTrue(ufu.inSameSet(4, 8));
+        ufu.undo(2);
+        assertEquals(ufu.numberOfSets(), 9);
+        ufu.redo(1);
+        assertEquals(ufu.numberOfSets(), 8);
+
+        ufu.addElement(11);
+        assertEquals(ufu.size(), 11);
+        ufu.undo();
+        assertEquals(ufu.size(), 10);
+
+        ufu.undo(1000);
+        assertEquals(ufu.size(), 0);
+    }
+
+    @Test
+    public void testRandom(){
+        Random random = new Random(121212);
+        DisjointSets<Integer> dsu = new DisjointSets<>();
+        UnionFindUndo<Integer> ufu = new UnionFindUndo<>();
+
+        int N = 0;
+        for (int i = 0; i < 5; i++) {
+            dsu.addElement(N);
+            ufu.addElement(N);
+            N++;
+        }
+
+        assertEquals(dsu.numberOfSets(), ufu.numberOfSets());
+        assertEquals(dsu.size(), ufu.size());
+
+        final int NUM_OPS = 15_000;
+        for (int i = 0; i < NUM_OPS; i++) {
+            int t = random.nextInt(2);
+
+            if (t == 0){
+                dsu.addElement(N);
+                ufu.addElement(N);
+                N++;
+            } else if (t == 1){
+                int u = random.nextInt(N);
+                int v = random.nextInt(N);
+                dsu.union(u, v);
+                ufu.union(u, v);
+            }
+
+            assertEquals(dsu.numberOfSets(), ufu.numberOfSets());
+            assertEquals(dsu.size(), ufu.size());
+
+            for (int j = 0; j < 100; j++) {
+                int u = random.nextInt(N);
+                int v = random.nextInt(N);
+                assertEquals(dsu.inSameSet(u, v), ufu.inSameSet(u, v));
+            }
+        }
+    }
+
+    @Test
+    public void testSpeed(){
+        final int N = 100_000;
+        UnionFindUndo<Integer> ufu = new UnionFindUndo<>();
+
+        for (int i = 0; i < N; i++) {
+            ufu.addElement(i);
+        }
+
+        for (int i = 1; i < N; i++) {
+            ufu.union(0, i);
+        }
+
+        assertEquals(ufu.numberOfSets(), 1);
+        ufu.undo(N - 1);
+        assertEquals(ufu.numberOfSets(), N);
+        ufu.redo(N - 1);
+        assertEquals(ufu.numberOfSets(), 1);
+    }
+
+    @Test
+    public void testUnionFind()
+    {
+        TreeSet<String> set = new TreeSet<String>();
+        String[] strs = { "aaa", "bbb", "ccc", "ddd", "eee" };
+        ArrayList<ArrayList<String>> sets = new ArrayList<>();
+        for (String str : strs) {
+            set.add(str);
+            sets.add(new ArrayList<>());
+            sets.get(sets.size() - 1).add(str);
+        }
+        UnionFindUndo<String> uf = new UnionFindUndo<>(set);
+        assertEquals(5, uf.size());
+        assertEquals(5, uf.numberOfSets());
+        testIdentical(strs, sets, uf);
+
+        uf.union(strs[0], strs[1]);
+        assertEquals(4, uf.numberOfSets());
+        union(sets, strs[0], strs[1]);
+        testIdentical(strs, sets, uf);
+        assertTrue(uf.inSameSet("aaa", "bbb"));
+        assertFalse(uf.inSameSet("bbb", "ccc"));
+
+        uf.union(strs[2], strs[3]);
+        assertEquals(3, uf.numberOfSets());
+        union(sets, strs[2], strs[3]);
+        testIdentical(strs, sets, uf);
+
+        uf.union(strs[2], strs[4]);
+        assertEquals(2, uf.numberOfSets());
+        union(sets, strs[2], strs[4]);
+        testIdentical(strs, sets, uf);
+
+        uf.union(strs[2], strs[4]);
+        assertEquals(2, uf.numberOfSets());
+        union(sets, strs[2], strs[4]);
+        testIdentical(strs, sets, uf);
+
+        uf.union(strs[0], strs[4]);
+        assertEquals(1, uf.numberOfSets());
+        union(sets, strs[0], strs[4]);
+        testIdentical(strs, sets, uf);
+
+        uf.addElement("fff");
+        assertEquals(2, uf.numberOfSets());
+        assertEquals(6, uf.size());
+        uf.reset();
+        assertEquals(6, uf.numberOfSets());
+    }
+}


### PR DESCRIPTION
I have implemented a variation of the classical union-find data structure that is also capable of undoing/redoing the last operation(s) efficiently. This variation only uses union by rank (size of subtree in this case) to achieve O(log n) per operation.

In order to undo/redo operations, all changes to the data-structure are kept in a list and updated/queried when needed. `undo` and `redo` both take O(1).

I have also added an abstract class that implements some functions, commonly supported by union-find implementations. 