### PR TITLE
Version upgrades for jdk9

### DIFF
--- a/jgrapht-core/pom.xml
+++ b/jgrapht-core/pom.xml
@@ -29,13 +29,13 @@
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
-			<version>1.10.3</version>
+			<version>1.19</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-generator-annprocess</artifactId>
-			<version>1.10.3</version>
+			<version>1.19</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/graph/GraphPerformanceTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/graph/GraphPerformanceTest.java
@@ -44,7 +44,8 @@ import junit.framework.*;
  * multiple graphs. Not sure how to achieve that through the JMH framework.
  */
 public class GraphPerformanceTest
-    extends TestCase
+    extends
+    TestCase
 {
 
     public static final int PERF_BENCHMARK_VERTICES_COUNT = 1000;
@@ -71,7 +72,8 @@ public class GraphPerformanceTest
         @Setup
         public void setup()
         {
-            blackhole = new Blackhole();
+            blackhole = new Blackhole(
+                "Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.");
         }
 
         /**
@@ -167,7 +169,8 @@ public class GraphPerformanceTest
      * optimized for low memory usage, but performs edge retrieval operations fairly slow.
      */
     public static class MemoryEfficientDirectedGraphBenchmark
-        extends DirectedGraphBenchmarkBase
+        extends
+        DirectedGraphBenchmarkBase
     {
         @Override
         SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> constructGraph()
@@ -184,7 +187,8 @@ public class GraphPerformanceTest
      * perform quick edge retrievals.
      */
     public static class FastLookupDirectedGraphBenchmark
-        extends DirectedGraphBenchmarkBase
+        extends
+        DirectedGraphBenchmarkBase
     {
         @Override
         SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> constructGraph()
@@ -219,7 +223,8 @@ public class GraphPerformanceTest
      * @param <E> the graph edge type
      */
     public static class MemoryEfficientDirectedWeightedGraph<V, E>
-        extends SimpleDirectedWeightedGraph<V, E>
+        extends
+        SimpleDirectedWeightedGraph<V, E>
     {
         private static final long serialVersionUID = -1826738982402033648L;
 

--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -110,10 +110,6 @@
 			<version>5.13.0.0</version>
 		</dependency>
 		<dependency>
-			<groupId>xmlunit</groupId>
-			<artifactId>xmlunit</artifactId>
-		</dependency>
-		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 		</dependency>

--- a/jgrapht-io/pom.xml
+++ b/jgrapht-io/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>org.jgrapht</groupId>
@@ -36,7 +37,8 @@
 				</executions>
 				<configuration>
 					<transformers>
-						<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+						<transformer
+							implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 							<manifestEntries>
 								<!-- Use unique OSGi bundle symbolic name for uber artifact. Otherwise 
 									e.g. jgrapht-io-x.y.z.jar and jgrapht-io-x.y.z-uber.jar could not be deployed 
@@ -169,8 +171,8 @@
 			<artifactId>jgrapht-core</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>xmlunit</groupId>
-			<artifactId>xmlunit</artifactId>
+			<groupId>org.xmlunit</groupId>
+			<artifactId>xmlunit-core</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/jgrapht-io/src/test/java/org/jgrapht/io/GraphMLExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/GraphMLExporterTest.java
@@ -17,22 +17,29 @@
  */
 package org.jgrapht.io;
 
-import java.io.*;
-import java.util.*;
+import java.io.ByteArrayOutputStream;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
-import org.custommonkey.xmlunit.*;
-import org.jgrapht.*;
-import org.jgrapht.graph.*;
-import org.jgrapht.io.GraphMLExporter.*;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleDirectedGraph;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.SimpleWeightedGraph;
+import org.jgrapht.io.GraphMLExporter.AttributeCategory;
+import org.xmlunit.builder.DiffBuilder;
+import org.xmlunit.diff.Diff;
 
-import junit.framework.*;
+import junit.framework.TestCase;
 
 /**
  * @author Trevor Harmon
  * @author Dimitrios Michail
  */
 public class GraphMLExporterTest
-    extends TestCase
+    extends
+    TestCase
 {
     // ~ Static fields/initializers
     // ---------------------------------------------
@@ -50,7 +57,7 @@ public class GraphMLExporterTest
         throws Exception
     {
         String output =
-            // @formatter:off
+        // @formatter:off
 				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
 				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
 				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
@@ -77,15 +84,17 @@ public class GraphMLExporterTest
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
-        XMLAssert.assertXMLEqual(output, res);
 
+        Diff diff = DiffBuilder
+            .compare(res).withTest(output).ignoreWhitespace().checkForIdentical().build();
+        assertFalse("XML identical " + diff.toString(), diff.hasDifferences());
     }
 
     public void testUndirectedWeighted()
         throws Exception
     {
         String output =
-            // @formatter:off
+        // @formatter:off
 				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
 				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
 				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
@@ -116,14 +125,17 @@ public class GraphMLExporterTest
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
-        XMLAssert.assertXMLEqual(output, res);
+        
+        Diff diff = DiffBuilder
+            .compare(res).withTest(output).ignoreWhitespace().checkForIdentical().build();
+        assertFalse("XML identical " + diff.toString(), diff.hasDifferences());
     }
 
     public void testDirected()
         throws Exception
     {
         String output =
-            // @formatter:off
+        // @formatter:off
 				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
 				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
 				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
@@ -151,14 +163,17 @@ public class GraphMLExporterTest
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
-        XMLAssert.assertXMLEqual(output, res);
+        
+        Diff diff = DiffBuilder
+            .compare(res).withTest(output).ignoreWhitespace().checkForIdentical().build();
+        assertFalse("XML identical " + diff.toString(), diff.hasDifferences());
     }
 
     public void testUndirectedUnweightedWithWeights()
         throws Exception
     {
         String output =
-            // @formatter:off
+        // @formatter:off
 				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
 				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
 				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
@@ -189,14 +204,17 @@ public class GraphMLExporterTest
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
-        XMLAssert.assertXMLEqual(output, res);
+        
+        Diff diff = DiffBuilder
+            .compare(res).withTest(output).ignoreWhitespace().checkForIdentical().build();
+        assertFalse("XML identical " + diff.toString(), diff.hasDifferences());
     }
 
     public void testUndirectedWeightedWithWeights()
         throws Exception
     {
         String output =
-            // @formatter:off
+        // @formatter:off
 				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
 				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
 				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
@@ -230,14 +248,17 @@ public class GraphMLExporterTest
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
-        XMLAssert.assertXMLEqual(output, res);
+        
+        Diff diff = DiffBuilder
+            .compare(res).withTest(output).ignoreWhitespace().checkForIdentical().build();
+        assertFalse("XML identical " + diff.toString(), diff.hasDifferences());
     }
 
     public void testUndirectedWeightedWithCustomNameWeights()
         throws Exception
     {
         String output =
-            // @formatter:off
+        // @formatter:off
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
                 + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
                 + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
@@ -273,7 +294,10 @@ public class GraphMLExporterTest
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
-        XMLAssert.assertXMLEqual(output, res);
+        
+        Diff diff = DiffBuilder
+            .compare(res).withTest(output).ignoreWhitespace().checkForIdentical().build();
+        assertFalse("XML identical " + diff.toString(), diff.hasDifferences());
     }
 
     public void testNoRegisterWeightAttribute()
@@ -318,7 +342,7 @@ public class GraphMLExporterTest
         throws Exception
     {
         String output =
-            // @formatter:off
+        // @formatter:off
 				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
 				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
 				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
@@ -383,14 +407,17 @@ public class GraphMLExporterTest
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
-        XMLAssert.assertXMLEqual(output, res);
+        
+        Diff diff = DiffBuilder
+            .compare(res).withTest(output).ignoreWhitespace().checkForIdentical().build();
+        assertFalse("XML identical " + diff.toString(), diff.hasDifferences());        
     }
 
     public void testUndirectedWeightedWithWeightsAndLabelsAndCustomNames()
         throws Exception
     {
         String output =
-            // @formatter:off
+        // @formatter:off
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
                 + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
                 + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
@@ -457,15 +484,17 @@ public class GraphMLExporterTest
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
-        XMLAssert.assertXMLEqual(output, res);
-
+        
+        Diff diff = DiffBuilder
+            .compare(res).withTest(output).ignoreWhitespace().checkForIdentical().build();
+        assertFalse("XML identical " + diff.toString(), diff.hasDifferences());        
     }
 
     public void testUndirectedWeightedWithWeightsAndColor()
         throws Exception
     {
         String output =
-            // @formatter:off
+        // @formatter:off
 				"<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
 				+ "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
 				+ "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
@@ -567,14 +596,17 @@ public class GraphMLExporterTest
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
-        XMLAssert.assertXMLEqual(output, res);
+
+        Diff diff = DiffBuilder
+            .compare(res).withTest(output).ignoreWhitespace().checkForIdentical().build();
+        assertFalse("XML identical " + diff.toString(), diff.hasDifferences());        
     }
 
     public void testUndirectedWeightedWithNullComponentProvider()
         throws Exception
     {
         String output =
-            // @formatter:off
+        // @formatter:off
                 "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL
                 + "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\" "
                 + "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns "
@@ -612,8 +644,8 @@ public class GraphMLExporterTest
 
         GraphMLExporter<String,
             DefaultWeightedEdge> exporter = new GraphMLExporter<>(
-                new IntegerComponentNameProvider<>(), null, v->null,
-                new IntegerComponentNameProvider<>(), null, e->null);
+                new IntegerComponentNameProvider<>(), null, v -> null,
+                new IntegerComponentNameProvider<>(), null, e -> null);
         exporter.setExportEdgeWeights(true);
         exporter.registerAttribute(
             "color", GraphMLExporter.AttributeCategory.NODE, AttributeType.STRING, "yellow");
@@ -622,7 +654,10 @@ public class GraphMLExporterTest
         ByteArrayOutputStream os = new ByteArrayOutputStream();
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
-        XMLAssert.assertXMLEqual(output, res);
+        
+        Diff diff = DiffBuilder
+            .compare(res).withTest(output).ignoreWhitespace().checkForIdentical().build();
+        assertFalse("XML identical " + diff.toString(), diff.hasDifferences());
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,10 @@
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>xmlunit</groupId>
-				<artifactId>xmlunit</artifactId>
-				<version>1.3</version>
-				<scope>test</scope>
+			    <groupId>org.xmlunit</groupId>
+			    <artifactId>xmlunit-core</artifactId>
+			    <version>2.5.1</version>
+			    <scope>test</scope>
 			</dependency>
 			<dependency>
 				<groupId>junit</groupId>


### PR DESCRIPTION
- Updated jmh version to a version that is compatible with jdk9 (does not use the old Generated annotation). 
- Updated xmlunit to 2.x