### PR TITLE
Add Automatic-Module-Name values

### DIFF
--- a/jgrapht-core/pom.xml
+++ b/jgrapht-core/pom.xml
@@ -79,6 +79,7 @@
 				</executions>
 				<configuration>
 					<instructions>
+						<Automatic-Module-Name>org.jgrapht.core</Automatic-Module-Name>
 						<Bundle-Vendor>Barak Naveh, John V. Sichi and contributors (see
 							http://sourceforge.net/projects/jgrapht/)</Bundle-Vendor>
 					</instructions>

--- a/jgrapht-demo/pom.xml
+++ b/jgrapht-demo/pom.xml
@@ -32,6 +32,9 @@
 							<mainClass>org.jgrapht.demo.JGraphAdapterDemo</mainClass>
 							<addClasspath>true</addClasspath>
 						</manifest>
+						<manifestEntries>
+							<Automatic-Module-Name>org.jgrapht.demo</Automatic-Module-Name>
+						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>

--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -79,6 +79,7 @@
 				</executions>
 				<configuration>
 					<instructions>
+						<Automatic-Module-Name>org.jgrapht.ext</Automatic-Module-Name>
 						<Bundle-Vendor>Barak Naveh, John V. Sichi and contributors (see
 							http://sourceforge.net/projects/jgrapht/)</Bundle-Vendor>
 						<!-- JGraph (source code at https://github.com/jgraph/legacy-jgraph5.git) 

--- a/jgrapht-io/pom.xml
+++ b/jgrapht-io/pom.xml
@@ -79,6 +79,7 @@
 				</executions>
 				<configuration>
 					<instructions>
+						<Automatic-Module-Name>org.jgrapht.io</Automatic-Module-Name>
 						<Bundle-Vendor>Barak Naveh, John V. Sichi and contributors (see
 							http://sourceforge.net/projects/jgrapht/)</Bundle-Vendor>
 					</instructions>

--- a/jgrapht-touchgraph/pom.xml
+++ b/jgrapht-touchgraph/pom.xml
@@ -26,6 +26,18 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<archive>
+						<manifestEntries>
+							<Automatic-Module-Name>org.jgrapht.demo</Automatic-Module-Name>
+						</manifestEntries>
+					</archive>
+				</configuration>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-shade-plugin</artifactId>
 				<version>1.5</version>
 				<executions>


### PR DESCRIPTION
This sets the following module names:

  jgrapht-core → org.jgrapht.core
  jgrapht-ext  → org.jgrapht.ext
  jgrapht-io   → org.jgrapht.io

This gives the modules stable names in preparation for possible full
modularization.

Affects #448