### PR TITLE
fixed init edge container capacity to 1 in FastLookup specifics

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
@@ -128,7 +128,7 @@ public class FastLookupDirectedSpecifics<V, E>
         if (edgeSet != null)
             edgeSet.add(e);
         else {
-            edgeSet = new ArrayUnenforcedSet<>();
+            edgeSet = new ArrayUnenforcedSet<>(1);
             edgeSet.add(e);
             touchingVerticesToEdgeMap.put(vertexPair, edgeSet);
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
@@ -130,7 +130,7 @@ public class FastLookupUndirectedSpecifics<V, E>
         if (edgeSet != null)
             edgeSet.add(e);
         else {
-            edgeSet = new ArrayUnenforcedSet<>();
+            edgeSet = new ArrayUnenforcedSet<>(1);
             edgeSet.add(e);
             touchingVerticesToEdgeMap.put(vertexPair, edgeSet);
         }


### PR DESCRIPTION
Fixes issue #459 
Memory improvement: This fix sets the initial capacity of an edge container which stores the edges between a pair of vertices to 1. This is the most common case for simple graphs.
These containers are used to store edges associated with a pair of vertices; hence, the `ArrayUnenforcedSetEdgeSetFactory` could not be used. 