### PR TITLE
Fixed bug in JohnsonSimpleCycles with custom edge types

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/DirectedSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/DirectedSimpleCycles.java
@@ -36,7 +36,9 @@ public interface DirectedSimpleCycles<V, E>
      * Returns the graph on which the simple cycle search algorithm is executed by this object.
      *
      * @return The graph.
+     * @deprecated Since not really needed on the interface.
      */
+    @Deprecated
     Graph<V, E> getGraph();
 
     /**
@@ -44,17 +46,15 @@ public interface DirectedSimpleCycles<V, E>
      *
      * @param graph the graph.
      * @throws IllegalArgumentException if the argument is <code>null</code>.
+     * @deprecated Since not really needed on the interface. 
      */
+    @Deprecated
     void setGraph(Graph<V, E> graph);
 
     /**
-     * Finds the simple cycles of the graph.<br>
-     * Note that the full algorithm is executed on every call since the graph may have changed
-     * between calls.
+     * Find the simple cycles of the graph.
      *
-     * @return The list of all simple cycles. Possibly empty but never <code>
-     * null</code>.
-     * @throws IllegalArgumentException if the current graph is null.
+     * @return The list of all simple cycles. Possibly empty but never <code>null</code>.
      */
     List<List<V>> findSimpleCycles();
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/JohnsonSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/JohnsonSimpleCycles.java
@@ -37,7 +37,8 @@ import org.jgrapht.graph.*;
  * @author Nikolay Ognyanov
  */
 public class JohnsonSimpleCycles<V, E>
-    implements DirectedSimpleCycles<V, E>
+    implements
+    DirectedSimpleCycles<V, E>
 {
     // The graph.
     private Graph<V, E> graph;
@@ -79,6 +80,9 @@ public class JohnsonSimpleCycles<V, E>
     public JohnsonSimpleCycles(Graph<V, E> graph)
     {
         this.graph = GraphTests.requireDirected(graph, "Graph must be directed");
+        if (GraphTests.hasMultipleEdges(graph)) {
+            throw new IllegalArgumentException("Graph should not have multiple (parallel) edges");
+        }
     }
 
     /**
@@ -103,6 +107,9 @@ public class JohnsonSimpleCycles<V, E>
     public void setGraph(Graph<V, E> graph)
     {
         this.graph = GraphTests.requireDirected(graph, "Graph must be directed");
+        if (GraphTests.hasMultipleEdges(graph)) {
+            throw new IllegalArgumentException("Graph should not have multiple (parallel) edges");
+        }
     }
 
     /**
@@ -176,8 +183,9 @@ public class JohnsonSimpleCycles<V, E>
         }
         for (V v : minSCC) {
             for (V w : minSCC) {
-                if (graph.containsEdge(v, w)) {
-                    resultGraph.addEdge(v, w);
+                E edge = graph.getEdge(v, w);
+                if (edge != null) {
+                    resultGraph.addEdge(v, w, edge);
                 }
             }
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/JohnsonSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/JohnsonSimpleCycles.java
@@ -132,7 +132,6 @@ public class JohnsonSimpleCycles<V, E>
         return result;
     }
 
-    @SuppressWarnings("unchecked")
     private Object[] findMinSCSG(int startIndex)
     {
         // Per Johnson : "adjacency structure of strong
@@ -165,8 +164,7 @@ public class JohnsonSimpleCycles<V, E>
         }
 
         // build a graph for the SCC found
-        Graph<V, E> resultGraph = new DefaultDirectedGraph<>(
-            new ClassBasedEdgeFactory<>((Class<? extends E>) DefaultEdge.class));
+        Graph<V, E> resultGraph = new DefaultDirectedGraph<>(graph.getEdgeFactory());
         for (V v : minSCC) {
             resultGraph.addVertex(v);
         }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/DirectedSimpleCyclesTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/DirectedSimpleCyclesTest.java
@@ -1,6 +1,5 @@
 /*
- * (C) Copyright 2013-2018, by Nikolay Ognyanov
- and Contributors.
+ * (C) Copyright 2013-2017, by Nikolay Ognyanov and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -16,10 +15,11 @@
  * (b) the terms of the Eclipse Public License v1.0 as published by
  * the Eclipse Foundation.
  */
-
 package org.jgrapht.alg.cycle;
 
 import static org.junit.Assert.assertTrue;
+
+import java.util.function.Function;
 
 import org.jgrapht.*;
 import org.jgrapht.graph.*;
@@ -33,61 +33,46 @@ public class DirectedSimpleCyclesTest
     @Test
     public void test()
     {
-        TiernanSimpleCycles<Integer, DefaultEdge> tiernanFinder = new TiernanSimpleCycles<>();
-        TarjanSimpleCycles<Integer, DefaultEdge> tarjanFinder = new TarjanSimpleCycles<>();
-        JohnsonSimpleCycles<Integer, DefaultEdge> johnsonFinder = new JohnsonSimpleCycles<>();
-        SzwarcfiterLauerSimpleCycles<Integer, DefaultEdge> szwarcfiterLauerFinder =
-            new SzwarcfiterLauerSimpleCycles<>();
-        HawickJamesSimpleCycles<Integer, DefaultEdge> hawickJamesFinder =
-            new HawickJamesSimpleCycles<>();
+        testAlgorithm(g -> new TiernanSimpleCycles<Integer, DefaultEdge>(g));
+        testAlgorithm(g -> new TarjanSimpleCycles<Integer, DefaultEdge>(g));
+        testAlgorithm(g -> new JohnsonSimpleCycles<Integer, DefaultEdge>(g));
+        testAlgorithm(g -> new SzwarcfiterLauerSimpleCycles<Integer, DefaultEdge>(g));
+        testAlgorithm(g -> new HawickJamesSimpleCycles<Integer, DefaultEdge>(g));
 
-        testAlgorithm(tiernanFinder);
-        testAlgorithm(tarjanFinder);
-        testAlgorithm(johnsonFinder);
-        testAlgorithm(szwarcfiterLauerFinder);
-        testAlgorithm(hawickJamesFinder);
+        testAlgorithmWithWeightedGraph(
+            g -> new TiernanSimpleCycles<Integer, DefaultWeightedEdge>(g));
+        testAlgorithmWithWeightedGraph(
+            g -> new TarjanSimpleCycles<Integer, DefaultWeightedEdge>(g));
+        testAlgorithmWithWeightedGraph(
+            g -> new JohnsonSimpleCycles<Integer, DefaultWeightedEdge>(g));
+        testAlgorithmWithWeightedGraph(
+            g -> new SzwarcfiterLauerSimpleCycles<Integer, DefaultWeightedEdge>(g));
+        testAlgorithmWithWeightedGraph(
+            g -> new HawickJamesSimpleCycles<Integer, DefaultWeightedEdge>(g));
     }
 
-    @Test
-    public void testWeightedGraph()
-    {
-        TiernanSimpleCycles<Integer, DefaultWeightedEdge> tiernanFinder =
-            new TiernanSimpleCycles<>();
-        TarjanSimpleCycles<Integer, DefaultWeightedEdge> tarjanFinder = new TarjanSimpleCycles<>();
-        JohnsonSimpleCycles<Integer, DefaultWeightedEdge> johnsonFinder =
-            new JohnsonSimpleCycles<>();
-        SzwarcfiterLauerSimpleCycles<Integer, DefaultWeightedEdge> szwarcfiterLauerFinder =
-            new SzwarcfiterLauerSimpleCycles<>();
-        HawickJamesSimpleCycles<Integer, DefaultWeightedEdge> hawickJamesFinder =
-            new HawickJamesSimpleCycles<>();
-
-        testAlgorithmWithWeightedGraph(tiernanFinder);
-        testAlgorithmWithWeightedGraph(tarjanFinder);
-        testAlgorithmWithWeightedGraph(johnsonFinder);
-        testAlgorithmWithWeightedGraph(szwarcfiterLauerFinder);
-        testAlgorithmWithWeightedGraph(hawickJamesFinder);
-    }
-
-    private void testAlgorithm(DirectedSimpleCycles<Integer, DefaultEdge> finder)
+    private void testAlgorithm(
+        Function<Graph<Integer, DefaultEdge>,
+            DirectedSimpleCycles<Integer, DefaultEdge>> algProvider)
     {
         Graph<Integer, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
         for (int i = 0; i < 7; i++) {
             graph.addVertex(i);
         }
-        finder.setGraph(graph);
+        DirectedSimpleCycles<Integer, DefaultEdge> alg = algProvider.apply(graph);
         graph.addEdge(0, 0);
-        checkResult(finder, 1);
+        assertTrue(alg.findSimpleCycles().size() == 1);
         graph.addEdge(1, 1);
-        checkResult(finder, 2);
+        assertTrue(alg.findSimpleCycles().size() == 2);
         graph.addEdge(0, 1);
         graph.addEdge(1, 0);
-        checkResult(finder, 3);
+        assertTrue(alg.findSimpleCycles().size() == 3);
         graph.addEdge(1, 2);
         graph.addEdge(2, 3);
         graph.addEdge(3, 0);
-        checkResult(finder, 4);
+        assertTrue(alg.findSimpleCycles().size() == 4);
         graph.addEdge(6, 6);
-        checkResult(finder, 5);
+        assertTrue(alg.findSimpleCycles().size() == 5);
 
         for (int size = 1; size <= MAX_SIZE; size++) {
             graph = new DefaultDirectedGraph<>(DefaultEdge.class);
@@ -99,33 +84,34 @@ public class DirectedSimpleCyclesTest
                     graph.addEdge(i, j);
                 }
             }
-            finder.setGraph(graph);
-            checkResult(finder, RESULTS[size]);
+            alg = algProvider.apply(graph);
+            assertTrue(alg.findSimpleCycles().size() == RESULTS[size]);
         }
     }
 
     private void testAlgorithmWithWeightedGraph(
-        DirectedSimpleCycles<Integer, DefaultWeightedEdge> finder)
+        Function<Graph<Integer, DefaultWeightedEdge>,
+            DirectedSimpleCycles<Integer, DefaultWeightedEdge>> algProvider)
     {
         Graph<Integer, DefaultWeightedEdge> graph =
             new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
         for (int i = 0; i < 7; i++) {
             graph.addVertex(i);
         }
-        finder.setGraph(graph);
+        DirectedSimpleCycles<Integer, DefaultWeightedEdge> alg = algProvider.apply(graph);
         graph.addEdge(0, 0);
-        checkResult(finder, 1);
+        assertTrue(alg.findSimpleCycles().size() == 1);
         graph.addEdge(1, 1);
-        checkResult(finder, 2);
+        assertTrue(alg.findSimpleCycles().size() == 2);
         graph.addEdge(0, 1);
         graph.addEdge(1, 0);
-        checkResult(finder, 3);
+        assertTrue(alg.findSimpleCycles().size() == 3);
         graph.addEdge(1, 2);
         graph.addEdge(2, 3);
         graph.addEdge(3, 0);
-        checkResult(finder, 4);
+        assertTrue(alg.findSimpleCycles().size() == 4);
         graph.addEdge(6, 6);
-        checkResult(finder, 5);
+        assertTrue(alg.findSimpleCycles().size() == 5);
 
         for (int size = 1; size <= MAX_SIZE; size++) {
             graph = new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
@@ -137,13 +123,9 @@ public class DirectedSimpleCyclesTest
                     graph.addEdge(i, j);
                 }
             }
-            finder.setGraph(graph);
-            checkResult(finder, RESULTS[size]);
+            alg = algProvider.apply(graph);
+            assertTrue(alg.findSimpleCycles().size() == RESULTS[size]);
         }
     }
 
-    private <E> void checkResult(DirectedSimpleCycles<Integer, E> finder, int size)
-    {
-        assertTrue(finder.findSimpleCycles().size() == size);
-    }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/DirectedSimpleCyclesTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/DirectedSimpleCyclesTest.java
@@ -48,10 +48,29 @@ public class DirectedSimpleCyclesTest
         testAlgorithm(hawickJamesFinder);
     }
 
+    @Test
+    public void testWeightedGraph()
+    {
+        TiernanSimpleCycles<Integer, DefaultWeightedEdge> tiernanFinder =
+            new TiernanSimpleCycles<>();
+        TarjanSimpleCycles<Integer, DefaultWeightedEdge> tarjanFinder = new TarjanSimpleCycles<>();
+        JohnsonSimpleCycles<Integer, DefaultWeightedEdge> johnsonFinder =
+            new JohnsonSimpleCycles<>();
+        SzwarcfiterLauerSimpleCycles<Integer, DefaultWeightedEdge> szwarcfiterLauerFinder =
+            new SzwarcfiterLauerSimpleCycles<>();
+        HawickJamesSimpleCycles<Integer, DefaultWeightedEdge> hawickJamesFinder =
+            new HawickJamesSimpleCycles<>();
+
+        testAlgorithmWithWeightedGraph(tiernanFinder);
+        testAlgorithmWithWeightedGraph(tarjanFinder);
+        testAlgorithmWithWeightedGraph(johnsonFinder);
+        testAlgorithmWithWeightedGraph(szwarcfiterLauerFinder);
+        testAlgorithmWithWeightedGraph(hawickJamesFinder);
+    }
+
     private void testAlgorithm(DirectedSimpleCycles<Integer, DefaultEdge> finder)
     {
-        Graph<Integer, DefaultEdge> graph =
-            new DefaultDirectedGraph<>(new ClassBasedEdgeFactory<>(DefaultEdge.class));
+        Graph<Integer, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
         for (int i = 0; i < 7; i++) {
             graph.addVertex(i);
         }
@@ -71,7 +90,7 @@ public class DirectedSimpleCyclesTest
         checkResult(finder, 5);
 
         for (int size = 1; size <= MAX_SIZE; size++) {
-            graph = new DefaultDirectedGraph<>(new ClassBasedEdgeFactory<>(DefaultEdge.class));
+            graph = new DefaultDirectedGraph<>(DefaultEdge.class);
             for (int i = 0; i < size; i++) {
                 graph.addVertex(i);
             }
@@ -85,7 +104,45 @@ public class DirectedSimpleCyclesTest
         }
     }
 
-    private void checkResult(DirectedSimpleCycles<Integer, DefaultEdge> finder, int size)
+    private void testAlgorithmWithWeightedGraph(
+        DirectedSimpleCycles<Integer, DefaultWeightedEdge> finder)
+    {
+        Graph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int i = 0; i < 7; i++) {
+            graph.addVertex(i);
+        }
+        finder.setGraph(graph);
+        graph.addEdge(0, 0);
+        checkResult(finder, 1);
+        graph.addEdge(1, 1);
+        checkResult(finder, 2);
+        graph.addEdge(0, 1);
+        graph.addEdge(1, 0);
+        checkResult(finder, 3);
+        graph.addEdge(1, 2);
+        graph.addEdge(2, 3);
+        graph.addEdge(3, 0);
+        checkResult(finder, 4);
+        graph.addEdge(6, 6);
+        checkResult(finder, 5);
+
+        for (int size = 1; size <= MAX_SIZE; size++) {
+            graph = new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+            for (int i = 0; i < size; i++) {
+                graph.addVertex(i);
+            }
+            for (int i = 0; i < size; i++) {
+                for (int j = 0; j < size; j++) {
+                    graph.addEdge(i, j);
+                }
+            }
+            finder.setGraph(graph);
+            checkResult(finder, RESULTS[size]);
+        }
+    }
+
+    private <E> void checkResult(DirectedSimpleCycles<Integer, E> finder, int size)
     {
         assertTrue(finder.findSimpleCycles().size() == size);
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/JohnsonSimpleCyclesTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/JohnsonSimpleCyclesTest.java
@@ -1,0 +1,62 @@
+/*
+ * (C) Copyright 2018-2018, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+
+package org.jgrapht.alg.cycle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.jgrapht.*;
+import org.jgrapht.graph.*;
+import org.junit.*;
+
+/**
+ * Simple tests for JohnsonSimpleCycles.
+ * 
+ * @author Dimitrios Michail
+ */
+public class JohnsonSimpleCyclesTest
+{
+    @Test
+    public void testSmallExample()
+    {
+        Graph<Integer, DefaultEdge> g = new DefaultDirectedGraph<>(DefaultEdge.class);
+        Graphs.addAllVertices(g, Arrays.asList(1, 2, 3, 4, 5, 6));
+        g.addEdge(1, 2);
+        g.addEdge(2, 3);
+        g.addEdge(2, 5);
+        g.addEdge(3, 4);
+        g.addEdge(4, 5);
+        g.addEdge(5, 6);
+        g.addEdge(6, 1);
+
+        List<List<Integer>> cycles = new JohnsonSimpleCycles<>(g).findSimpleCycles();
+
+        assertTrue(cycles.size() == 2);
+
+        List<Integer> cycle0 = cycles.get(0);
+        assertEquals(cycle0, Arrays.asList(1, 2, 3, 4, 5, 6));
+
+        List<Integer> cycle1 = cycles.get(1);
+        assertEquals(cycle1, Arrays.asList(1, 2, 5, 6));
+    }
+
+}


### PR DESCRIPTION
The solution is to create new graphs using the original graph's edge factory. Fixes #474.

Update: 
I had the time to do a bit of cleaning up with the following changes: 
 - Cleaned up `JohnsonSimpleCycles` to use proper type checking
 - Fixed `JohnsonSimpleCycles` to return cycles in proper edge direction (instead of the reverse)
 - Removed `getGraph()` and `setGraph()` from the `DirectedSimpleCycles` interface.
 - Added one more test for `JohnsonSimpleCycles`.
