### PR TITLE
fixed typo in TreeSingleSourcePathsImpl

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DijkstraClosestFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DijkstraClosestFirstIterator.java
@@ -187,11 +187,9 @@ class DijkstraClosestFirstIterator<V, E>
             node = new FibonacciHeapNode<>(new QueueEntry(e, v));
             heap.insert(node, distance);
             seen.put(v, node);
-        } else {
-            if (distance < node.getKey()) {
-                heap.decreaseKey(node, distance);
-                node.getData().e = e;
-            }
+        } else if (distance < node.getKey()) {
+            heap.decreaseKey(node, distance);
+            node.getData().e = e;            
         }
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TreeSingleSourcePathsImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TreeSingleSourcePathsImpl.java
@@ -135,7 +135,7 @@ public class TreeSingleSourcePathsImpl<V, E>
         }
 
         double weight = 0d;
-        while (p != null && !p.equals(source)) {
+        while (p != null && !cur.equals(source)) {
             E e = p.getSecond();
             if (e == null) {
                 break;


### PR DESCRIPTION
Variable `p` has type `Pair`, while `source` has type of a vertex. It seems, like `cur` should be used instead. 