### PR TITLE
Handle maxPathLength=1 case correctly in AllDirectedPaths

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
@@ -226,9 +226,9 @@ public class AllDirectedPaths<V, E>
             }
         }
 
-	if (maxPathLength != null && maxPathLength == 0) {
-	    return completePaths;
-	}
+        if (maxPathLength != null && maxPathLength == 0) {
+            return completePaths;
+        }
 
         // Walk through the queue of incomplete paths
         for (List<E> incompletePath; (incompletePath = incompletePaths.poll()) != null;) {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
@@ -29,7 +29,7 @@ import org.jgrapht.graph.*;
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
  *
- * @author Andrew Gainer-Dewar
+ * @author Andrew Gainer-Dewar, Google LLC
  * @since Feb, 2016
  */
 public class AllDirectedPaths<V, E>
@@ -38,7 +38,7 @@ public class AllDirectedPaths<V, E>
 
     /**
      * Create a new instance
-     * 
+     *
      * @param graph the input graph
      * @throws IllegalArgumentException if the graph is not directed
      */
@@ -202,13 +202,8 @@ public class AllDirectedPaths<V, E>
         Deque<List<E>> incompletePaths = new LinkedList<>();
 
         // Input sanity checking
-        if (maxPathLength != null) {
-            if (maxPathLength < 0) {
-                throw new IllegalArgumentException("maxPathLength must be non-negative if defined");
-            }
-            if (maxPathLength == 0) {
-                return completePaths;
-            }
+        if (maxPathLength != null && maxPathLength < 0) {
+            throw new IllegalArgumentException("maxPathLength must be non-negative if defined");
         }
 
         // Bootstrap the search with the source vertices
@@ -224,12 +219,16 @@ public class AllDirectedPaths<V, E>
                     completePaths.add(makePath(Collections.singletonList(edge)));
                 }
 
-                if (edgeMinDistancesFromTargets.containsKey(edge)) {
+                if (edgeMinDistancesFromTargets.containsKey(edge) && (maxPathLength == null || maxPathLength > 1)) {
                     List<E> path = Collections.singletonList(edge);
                     incompletePaths.add(path);
                 }
             }
         }
+
+	if (maxPathLength != null && maxPathLength == 0) {
+	    return completePaths;
+	}
 
         // Walk through the queue of incomplete paths
         for (List<E> incompletePath; (incompletePath = incompletePaths.poll()) != null;) {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/AllDirectedPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/AllDirectedPathsTest.java
@@ -69,11 +69,11 @@ public class AllDirectedPathsTest
     @Test
     public void testTrivialPaths()
     {
+        // Verify fix for http://github.com/jgrapht/jgrapht/issues/234.
         AllDirectedPaths<String, DefaultEdge> pathFindingAlg = new AllDirectedPaths<>(toyGraph());
 
         Set<String> sources = new HashSet<>();
         sources.add(I1);
-	sources.add(A);
 
         Set<String> targets = new HashSet<>();
         targets.add(I1);
@@ -83,10 +83,29 @@ public class AllDirectedPathsTest
             pathFindingAlg.getAllPaths(sources, targets, true, 1);
 
         assertEquals(
-            "Toy network should have correct number of trivial simple paths", 3, allPaths.size());
-	assertEquals(Arrays.asList(A), allPaths.get(0).getVertexList());
-	assertEquals(Arrays.asList(I1), allPaths.get(1).getVertexList());
-	assertEquals(Arrays.asList(I1, A), allPaths.get(2).getVertexList());
+            "Toy network should have correct number of trivial simple paths", 2, allPaths.size());
+	assertEquals(Arrays.asList(I1), allPaths.get(0).getVertexList());
+	assertEquals(Arrays.asList(I1, A), allPaths.get(1).getVertexList());
+    }
+
+    @Test
+    public void testLengthOnePaths()
+    {
+        // Verify fix for http://github.com/jgrapht/jgrapht/issues/441.
+        DefaultDirectedGraph<String, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+	graph.addVertex("A");
+	graph.addVertex("B");
+	graph.addEdge("B", "A");
+
+	AllDirectedPaths<String, DefaultEdge> all = new AllDirectedPaths<>(graph);
+	List<GraphPath<String, DefaultEdge>> allPaths =
+	    all.getAllPaths(graph.vertexSet(), graph.vertexSet(), true, graph.edgeSet().size());
+
+        assertEquals(3, allPaths.size());
+	assertEquals(Arrays.asList("A"), allPaths.get(0).getVertexList());
+	assertEquals(Arrays.asList("B"), allPaths.get(1).getVertexList());
+	assertEquals(Arrays.asList("B", "A"), allPaths.get(2).getVertexList());
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/AllDirectedPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/AllDirectedPathsTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.fail;
 /**
  * Test cases for the AllDirectedPaths algorithm.
  *
- * @author Andrew Gainer-Dewar
+ * @author Andrew Gainer-Dewar, Google LLC
  **/
 
 public class AllDirectedPathsTest
@@ -73,16 +73,20 @@ public class AllDirectedPathsTest
 
         Set<String> sources = new HashSet<>();
         sources.add(I1);
+	sources.add(A);
 
         Set<String> targets = new HashSet<>();
         targets.add(I1);
         targets.add(A);
 
         List<GraphPath<String, DefaultEdge>> allPaths =
-            pathFindingAlg.getAllPaths(sources, targets, true, null);
+            pathFindingAlg.getAllPaths(sources, targets, true, 1);
 
         assertEquals(
-            "Toy network should have correct number of trivial simple paths", 2, allPaths.size());
+            "Toy network should have correct number of trivial simple paths", 3, allPaths.size());
+	assertEquals(Arrays.asList(A), allPaths.get(0).getVertexList());
+	assertEquals(Arrays.asList(I1), allPaths.get(1).getVertexList());
+	assertEquals(Arrays.asList(I1, A), allPaths.get(2).getVertexList());
     }
 
     @Test


### PR DESCRIPTION
Fixes an edge case in initializing the algorithm when maxPathLength=1, resolving #441.