### PR TITLE
Fix/double quoted ids

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
@@ -20,6 +20,7 @@ package org.jgrapht.io;
 import java.io.*;
 import java.util.*;
 import java.util.Map.*;
+import java.util.regex.Matcher;
 
 import org.jgrapht.*;
 import org.jgrapht.graph.*;
@@ -262,7 +263,7 @@ public class DOTExporter<V, E>
             }
         }
         if (labelName != null) {
-            out.print("label=\"" + labelName + "\" ");
+            out.print("label=\"" + escapeDoubleQuotes(labelName) + "\" ");
         }
         if (attributes != null) {
             for (Map.Entry<String, Attribute> entry : attributes.entrySet()) {
@@ -271,10 +272,14 @@ public class DOTExporter<V, E>
                     // already handled by special case above
                     continue;
                 }
-                out.print(name + "=\"" + entry.getValue().getValue() + "\" ");
+                out.print(name + "=\"" + escapeDoubleQuotes(entry.getValue().getValue()) + "\" ");
             }
         }
         out.print("]");
+    }
+
+    private static String escapeDoubleQuotes(String labelName) {
+        return labelName.replaceAll("\"", Matcher.quoteReplacement("\\\""));
     }
 
     /**

--- a/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
@@ -23,11 +23,12 @@ import java.util.*;
 import org.jgrapht.*;
 import org.jgrapht.graph.*;
 
-import junit.framework.*;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.CoreMatchers.containsString;
 
 /**
  * .
@@ -161,6 +162,23 @@ public class DOTExporterTest
                 // this is a negative test so exception is expected
             }
         }
+    }
+
+    @Test
+    public void testQuotedNodeIDs()
+    {
+        DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(
+            new StringComponentNameProvider<>(), new StringComponentNameProvider<>(), null);
+
+        StringWriter outputWriter = new StringWriter();
+
+        String quotedNodeId = "\"abc\"";
+
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex(quotedNodeId);
+        exporter.exportGraph(graph, outputWriter);
+
+        assertThat(outputWriter.toString(), containsString("label=\"\\\"abc\\\"\""));
     }
 
     @Test


### PR DESCRIPTION
Fix for 

```Expected: a string containing "label=\"abc\""
     but: was "strict digraph G {
  "abc" [ label=""abc"" ];
}```