### PR TITLE
Simplify TypeUtil.uncheckedCast

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HierholzerEulerianCycle.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HierholzerEulerianCycle.java
@@ -492,7 +492,7 @@ public class HierholzerEulerianCycle<V, E>
                 return false;
             if (getClass() != obj.getClass())
                 return false;
-            VertexNode other = TypeUtil.uncheckedCast(obj, null);
+            VertexNode other = TypeUtil.uncheckedCast(obj);
             return Objects.equals(this.v, other.v);
         }
 
@@ -552,7 +552,7 @@ public class HierholzerEulerianCycle<V, E>
                 return false;
             if (getClass() != obj.getClass())
                 return false;
-            EdgeNode other = TypeUtil.uncheckedCast(obj, null);
+            EdgeNode other = TypeUtil.uncheckedCast(obj);
             return Objects.equals(this.e, other.e);
         }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/FloydWarshallShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/FloydWarshallShortestPaths.java
@@ -117,7 +117,7 @@ public class FloydWarshallShortestPaths<V, E>
         V u = a;
         while (!u.equals(b)) {
             int v_u = vertexIndices.get(u);
-            E e = TypeUtil.uncheckedCast(backtrace[v_u][v_b], null);
+            E e = TypeUtil.uncheckedCast(backtrace[v_u][v_b]);
             edges.add(e);
             u = Graphs.getOppositeVertex(graph, e, u);
         }
@@ -173,7 +173,7 @@ public class FloydWarshallShortestPaths<V, E>
         if (backtrace[v_a][v_b] == null) { // No path exists
             return null;
         } else {
-            E e = TypeUtil.uncheckedCast(backtrace[v_a][v_b], null);
+            E e = TypeUtil.uncheckedCast(backtrace[v_a][v_b]);
             return Graphs.getOppositeVertex(graph, e, a);
         }
     }
@@ -202,7 +202,7 @@ public class FloydWarshallShortestPaths<V, E>
             return null;
         } else {
             populateLastHopMatrix();
-            E e = TypeUtil.uncheckedCast(lastHopMatrix[v_a][v_b], null);
+            E e = TypeUtil.uncheckedCast(lastHopMatrix[v_a][v_b]);
             return Graphs.getOppositeVertex(graph, e, b);
         }
     }
@@ -307,7 +307,7 @@ public class FloydWarshallShortestPaths<V, E>
                 V b = vertices.get(j);
                 while (!u.equals(b)) {
                     int v_u = vertexIndices.get(u);
-                    E e = TypeUtil.uncheckedCast(backtrace[v_u][j], null);
+                    E e = TypeUtil.uncheckedCast(backtrace[v_u][j]);
                     V other = Graphs.getOppositeVertex(graph, e, u);
                     lastHopMatrix[i][vertexIndices.get(other)] = e;
                     u = other;
@@ -377,7 +377,7 @@ public class FloydWarshallShortestPaths<V, E>
             V u = source;
             while (!u.equals(sink)) {
                 int v_u = vertexIndices.get(u);
-                E e = TypeUtil.uncheckedCast(backtrace[v_u][v_b], null);
+                E e = TypeUtil.uncheckedCast(backtrace[v_u][v_b]);
                 edges.add(e);
                 u = Graphs.getOppositeVertex(graph, e, u);
             }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/util/RatioVertex.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/util/RatioVertex.java
@@ -134,7 +134,7 @@ public class RatioVertex<V>
             return true;
         else if (!(o instanceof RatioVertex))
             return false;
-        RatioVertex<V> other = TypeUtil.uncheckedCast(o, null);
+        RatioVertex<V> other = TypeUtil.uncheckedCast(o);
         return this.ID == other.ID;
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -268,7 +268,7 @@ public abstract class AbstractBaseGraph<V, E>
     public Object clone()
     {
         try {
-            AbstractBaseGraph<V, E> newGraph = TypeUtil.uncheckedCast(super.clone(), null);
+            AbstractBaseGraph<V, E> newGraph = TypeUtil.uncheckedCast(super.clone());
 
             newGraph.edgeFactory = this.edgeFactory;
             newGraph.unmodifiableVertexSet = null;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractGraph.java
@@ -253,7 +253,7 @@ public abstract class AbstractGraph<V, E>
             return false;
         }
 
-        Graph<V, E> g = TypeUtil.uncheckedCast(obj, null);
+        Graph<V, E> g = TypeUtil.uncheckedCast(obj);
 
         if (!vertexSet().equals(g.vertexSet())) {
             return false;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/BaseIntrusiveEdgesSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/BaseIntrusiveEdgesSpecifics.java
@@ -96,7 +96,7 @@ public abstract class BaseIntrusiveEdgesSpecifics<V, E, IE extends IntrusiveEdge
         if (ie == null) {
             throw new IllegalArgumentException("no such edge in graph: " + e.toString());
         }
-        return TypeUtil.uncheckedCast(ie.source, null);
+        return TypeUtil.uncheckedCast(ie.source);
     }
 
     /**
@@ -111,7 +111,7 @@ public abstract class BaseIntrusiveEdgesSpecifics<V, E, IE extends IntrusiveEdge
         if (ie == null) {
             throw new IllegalArgumentException("no such edge in graph: " + e.toString());
         }
-        return TypeUtil.uncheckedCast(ie.target, null);
+        return TypeUtil.uncheckedCast(ie.target);
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultListenableGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultListenableGraph.java
@@ -185,7 +185,7 @@ public class DefaultListenableGraph<V, E>
     public Object clone()
     {
         try {
-            DefaultListenableGraph<V, E> g = TypeUtil.uncheckedCast(super.clone(), null);
+            DefaultListenableGraph<V, E> g = TypeUtil.uncheckedCast(super.clone());
             g.graphListeners = new ArrayList<>();
             g.vertexSetListeners = new ArrayList<>();
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/MaskEdgeSet.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/MaskEdgeSet.java
@@ -58,7 +58,7 @@ class MaskEdgeSet<V, E>
         if (!edgeSet.contains(o)) {
             return false;
         }
-        E e = TypeUtil.uncheckedCast(o, null);
+        E e = TypeUtil.uncheckedCast(o);
 
         return !edgeMask.test(e) && !vertexMask.test(graph.getEdgeSource(e))
             && !vertexMask.test(graph.getEdgeTarget(e));

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/MaskVertexSet.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/MaskVertexSet.java
@@ -52,7 +52,7 @@ class MaskVertexSet<V>
         if (!vertexSet.contains(o)) {
             return false;
         }
-        V v = TypeUtil.uncheckedCast(o, null);
+        V v = TypeUtil.uncheckedCast(o);
         return !mask.test(v);
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/builder/GraphTypeBuilder.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/builder/GraphTypeBuilder.java
@@ -206,7 +206,7 @@ public final class GraphTypeBuilder<V, E>
     public <V1 extends V,
         E1 extends E> GraphTypeBuilder<V1, E1> edgeFactory(EdgeFactory<V1, E1> edgeFactory)
     {
-        GraphTypeBuilder<V1, E1> newBuilder = TypeUtil.uncheckedCast(this, null);
+        GraphTypeBuilder<V1, E1> newBuilder = TypeUtil.uncheckedCast(this);
         newBuilder.edgeFactory = edgeFactory;
         return newBuilder;
     }
@@ -220,7 +220,7 @@ public final class GraphTypeBuilder<V, E>
      */
     public <V1 extends V> GraphTypeBuilder<V1, E> vertexClass(Class<V1> vertexClass)
     {
-        GraphTypeBuilder<V1, E> newBuilder = TypeUtil.uncheckedCast(this, null);
+        GraphTypeBuilder<V1, E> newBuilder = TypeUtil.uncheckedCast(this);
         return newBuilder;
     }
 
@@ -233,7 +233,7 @@ public final class GraphTypeBuilder<V, E>
      */
     public <E1 extends E> GraphTypeBuilder<V, E1> edgeClass(Class<E1> edgeClass)
     {
-        GraphTypeBuilder<V, E1> newBuilder = TypeUtil.uncheckedCast(this, null);
+        GraphTypeBuilder<V, E1> newBuilder = TypeUtil.uncheckedCast(this);
         newBuilder.edgeFactory = new ClassBasedEdgeFactory<>(edgeClass);
         return newBuilder;
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/DepthFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/DepthFirstIterator.java
@@ -171,7 +171,7 @@ public class DepthFirstIterator<V, E>
                 // Now carry on with another pop until we find a non-sentinel
             } else {
                 // Got a real vertex to start working on
-                v = TypeUtil.uncheckedCast(o, null);
+                v = TypeUtil.uncheckedCast(o);
                 break;
             }
         }
@@ -186,7 +186,7 @@ public class DepthFirstIterator<V, E>
 
     private void recordFinish()
     {
-        V v = TypeUtil.uncheckedCast(stack.removeLast(), null);
+        V v = TypeUtil.uncheckedCast(stack.removeLast());
         putSeenData(v, VisitColor.BLACK);
         finishVertex(v);
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/TypeUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/TypeUtil.java
@@ -38,6 +38,23 @@ public class TypeUtil
     {
         return (T) o;
     }
+
+    /**
+     * Casts an object to a type.
+     *
+     * @param o object to be cast
+     * @param <T> the type of the result
+     * @param typeDecl conveys the target type information; the actual value is unused and can be
+     *        null since this is all just stupid compiler tricks
+     *
+     * @return the result of the cast
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public static <T> T uncheckedCast(Object o, Object typeDecl)
+    {
+        return (T) o;
+    }
 }
 
 // End TypeUtil.java

--- a/jgrapht-core/src/main/java/org/jgrapht/util/TypeUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/TypeUtil.java
@@ -21,24 +21,20 @@ package org.jgrapht.util;
  * TypeUtil isolates type-unsafety so that code which uses it for legitimate reasons can stay
  * warning-free.
  *
- * @param <T> the type of the result
- *
  * @author John V. Sichi
  */
-public class TypeUtil<T>
+public class TypeUtil
 {
     /**
      * Casts an object to a type.
      *
      * @param o object to be cast
-     * @param typeDecl conveys the target type information; the actual value is unused and can be
-     *        null since this is all just stupid compiler tricks
      * @param <T> the type of the result
      *
      * @return the result of the cast
      */
     @SuppressWarnings("unchecked")
-    public static <T> T uncheckedCast(Object o, TypeUtil<T> typeDecl)
+    public static <T> T uncheckedCast(Object o)
     {
         return (T) o;
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/TypeUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/TypeUtil.java
@@ -40,6 +40,7 @@ public class TypeUtil
     }
 
     /**
+     * @deprecated Use {@link #uncheckedCast(Object)} instead.
      * Casts an object to a type.
      *
      * @param o object to be cast

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/GnmRandomGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/GnmRandomGraphGeneratorTest.java
@@ -616,7 +616,7 @@ public class GnmRandomGraphGeneratorTest
                     return true;
                 else if (!(obj instanceof VertexOrdering.LabelsEdge))
                     return false;
-                LabelsEdge otherEdge = TypeUtil.uncheckedCast(obj, null);
+                LabelsEdge otherEdge = TypeUtil.uncheckedCast(obj);
                 return (this.source == otherEdge.source) && (this.target == otherEdge.target);
             }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleIdentityDirectedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleIdentityDirectedGraphTest.java
@@ -61,7 +61,7 @@ public class SimpleIdentityDirectedGraphTest
             if (o == null || getClass() != o.getClass())
                 return false;
 
-            Holder<T> holder = TypeUtil.uncheckedCast(o, null);
+            Holder<T> holder = TypeUtil.uncheckedCast(o);
 
             return !(t != null ? !t.equals(holder.t) : holder.t != null);
 


### PR DESCRIPTION
Maybe we should keep the old signature with a deprecated annotation.