### PR TITLE
Removed lazy instantiation of containers

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/concurrent/AsSynchronizedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/concurrent/AsSynchronizedGraph.java
@@ -18,7 +18,6 @@
 package org.jgrapht.graph.concurrent;
 
 import java.io.*;
-import java.lang.*;
 import java.util.*;
 import java.util.concurrent.*;
 import java.util.concurrent.locks.*;
@@ -967,12 +966,12 @@ public class AsSynchronizedGraph<V, E>
         {
             readWriteLock.readLock().lock();
             try {
-                Set tempCopy = copy;
+                Set<E> tempCopy = copy;
                 if (tempCopy == null) {
                     synchronized (this) {
                         tempCopy = copy;
                         if (tempCopy == null) {
-                            copy = tempCopy = new LinkedHashSet(set);
+                            copy = tempCopy = new LinkedHashSet<>(set);
                         }
                     }
                 }
@@ -1297,9 +1296,12 @@ public class AsSynchronizedGraph<V, E>
     /**
      * A builder for {@link AsSynchronizedGraph}.
      *
+     * @param <V> the graph vertex type
+     * @param <E> the graph edge type
+     *
      * @author CHEN Kui
      */
-    public static class Builder
+    public static class Builder<V, E>
     {
         private boolean cacheEnable;
         private boolean fair;
@@ -1318,7 +1320,7 @@ public class AsSynchronizedGraph<V, E>
          *
          * @param graph the graph on which to base the builder
          */
-        public Builder(AsSynchronizedGraph graph)
+        public Builder(AsSynchronizedGraph<V, E> graph)
         {
             this.cacheEnable = graph.isCacheEnabled();
             this.fair = graph.isFair();
@@ -1329,7 +1331,7 @@ public class AsSynchronizedGraph<V, E>
          *
          * @return the Builder
          */
-        public Builder cacheDisable()
+        public Builder<V,E> cacheDisable()
         {
             cacheEnable = false;
             return this;
@@ -1340,7 +1342,7 @@ public class AsSynchronizedGraph<V, E>
          *
          * @return the Builder
          */
-        public Builder cacheEnable()
+        public Builder<V,E> cacheEnable()
         {
             cacheEnable = true;
             return this;
@@ -1360,7 +1362,7 @@ public class AsSynchronizedGraph<V, E>
          *
          * @return the SynchronizedGraphParams
          */
-        public Builder setFair()
+        public Builder<V,E> setFair()
         {
             fair = true;
             return this;
@@ -1371,7 +1373,7 @@ public class AsSynchronizedGraph<V, E>
          *
          * @return the SynchronizedGraphParams
          */
-        public Builder setNonfair()
+        public Builder<V,E> setNonfair()
         {
             fair = false;
             return this;
@@ -1391,11 +1393,9 @@ public class AsSynchronizedGraph<V, E>
          * Build the AsSynchronizedGraph.
          *
          * @param graph the backing graph (the delegate)
-         * @param <V> the graph vertex type
-         * @param <E> the graph edge type
          * @return the AsSynchronizedGraph
          */
-        public <V, E> AsSynchronizedGraph build(Graph<V, E> graph)
+        public AsSynchronizedGraph<V,E> build(Graph<V, E> graph)
         {
             return new AsSynchronizedGraph<>(graph, cacheEnable, fair);
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -89,8 +89,7 @@ public class DirectedSpecifics<V, E>
     @Override
     public void addVertex(V v)
     {
-        // add with a lazy edge container entry
-        vertexMapDirected.put(v, null);
+        getEdgeContainer(v);
     }
 
     /**
@@ -249,7 +248,7 @@ public class DirectedSpecifics<V, E>
     }
 
     /**
-     * A lazy build of edge container for specified vertex.
+     * Get the edge container for specified vertex.
      *
      * @param vertex a vertex in this graph.
      *

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
@@ -89,8 +89,7 @@ public class UndirectedSpecifics<V, E>
     @Override
     public void addVertex(V v)
     {
-        // add with a lazy edge container entry
-        vertexMapUndirected.put(v, null);
+        getEdgeContainer(v);
     }
 
     /**
@@ -261,7 +260,7 @@ public class UndirectedSpecifics<V, E>
     }
 
     /**
-     * A lazy build of edge container for specified vertex.
+     * Get the edge container for a specified vertex.
      *
      * @param vertex a vertex in this graph
      *

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/concurrent/AsSynchronizedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/concurrent/AsSynchronizedGraphTest.java
@@ -40,7 +40,7 @@ public class AsSynchronizedGraphTest
     @Test
     public void testAddVertex()
     {
-        g = new AsSynchronizedGraph.Builder().build(new SimpleGraph<>(DefaultEdge.class));
+        g = new AsSynchronizedGraph.Builder<Integer, DefaultEdge>().build(new SimpleGraph<>(DefaultEdge.class));
         ordersList = new Vector<>();
         for (int i = 0; i < 20; i++) {
             ordersList.add(new ArrayList<>());
@@ -66,7 +66,7 @@ public class AsSynchronizedGraphTest
     @Test
     public void testAddEdge()
     {
-        g = new AsSynchronizedGraph.Builder().cacheEnable().build(new SimpleGraph<>(DefaultEdge.class));
+        g = new AsSynchronizedGraph.Builder<Integer, DefaultEdge>().cacheEnable().build(new SimpleGraph<>(DefaultEdge.class));
         ArrayList<DefaultEdge> list = new ArrayList<>();
         for (int i = 0; i < 1000; i++)
             g.addVertex(i);
@@ -102,7 +102,7 @@ public class AsSynchronizedGraphTest
     @Test
     public void testRemoveEdge()
     {
-        g = new AsSynchronizedGraph.Builder().cacheEnable().build(new SimpleGraph<>(DefaultEdge.class));
+        g = new AsSynchronizedGraph.Builder<Integer, DefaultEdge>().cacheEnable().build(new SimpleGraph<>(DefaultEdge.class));
         edges = new ArrayList<>();
         TestSuite ts = new ActiveTestSuite();
         for (int i = 0; i < 1000; i++) {
@@ -128,7 +128,7 @@ public class AsSynchronizedGraphTest
     @Test
     public void testRemoveVertex()
     {
-        g = new AsSynchronizedGraph.Builder().cacheEnable().build(new DirectedPseudograph<>(DefaultEdge.class));
+        g = new AsSynchronizedGraph.Builder<Integer, DefaultEdge>().cacheEnable().build(new DirectedPseudograph<>(DefaultEdge.class));
         vertices = new ArrayList<>();
         TestSuite ts = new ActiveTestSuite();
         for (int i = 0; i < 100; i++) {
@@ -162,7 +162,7 @@ public class AsSynchronizedGraphTest
     @Test
     public void testOthers()
     {
-        g = new AsSynchronizedGraph.Builder().cacheDisable().build(new Pseudograph<>(DefaultEdge.class));
+        g = new AsSynchronizedGraph.Builder<Integer, DefaultEdge>().cacheDisable().build(new Pseudograph<>(DefaultEdge.class));
         Set<Integer> vertSet = g.vertexSet();
         Set<DefaultEdge> edgeSet = g.edgeSet();
         g.addVertex(1);
@@ -293,14 +293,17 @@ public class AsSynchronizedGraphTest
             }
         }
     }
+    
     private interface Order
     {
         void execute();
     }
+    
     private class AddV
         implements Order
     {
         int vertex;
+        
         public AddV(int v)
         {
             vertex = v;
@@ -311,11 +314,13 @@ public class AsSynchronizedGraphTest
             g.addVertex(vertex);
         }
     }
+    
     private class AddE
         implements Order
     {
         DefaultEdge e;
         int s, t;
+        
         public AddE(int s, int t, DefaultEdge e)
         {
             this.e = e;
@@ -329,6 +334,7 @@ public class AsSynchronizedGraphTest
             g.addEdge(s, t, e);
         }
     }
+    
     private class SetCache
         implements Order
     {
@@ -338,10 +344,12 @@ public class AsSynchronizedGraphTest
             g.setCache(!g.isCacheEnabled());
         }
     }
+    
     private class RmV
         implements Order
     {
         int v;
+        
         public RmV(int v)
         {
             this.v = v;
@@ -353,10 +361,12 @@ public class AsSynchronizedGraphTest
             g.removeVertex(v);
         }
     }
+    
     private class RmE
         implements Order
     {
         int s, t;
+        
         public RmE(int s, int t)
         {
             this.s = s;
@@ -369,7 +379,8 @@ public class AsSynchronizedGraphTest
             g.removeEdge(s, t);
         }
     }
-    private int iteratorCnt(Iterator it)
+    
+    private <K> int iteratorCnt(Iterator<K> it)
     {
         int count = 0;
         while (it.hasNext()) {
@@ -378,6 +389,7 @@ public class AsSynchronizedGraphTest
         }
         return count;
     }
+    
     public class TestThread
         extends TestCase
     {
@@ -385,6 +397,7 @@ public class AsSynchronizedGraphTest
         {
             super(s);
         }
+        
         public void addVertex()
         {
             while (true) {
@@ -398,6 +411,7 @@ public class AsSynchronizedGraphTest
                 g.addVertex(id);
             }
         }
+        
         public void removeEdge()
         {
             while (true) {
@@ -411,6 +425,7 @@ public class AsSynchronizedGraphTest
                 g.removeEdge(e);
             }
         }
+        
         public void removeVertex()
         {
             while (true) {
@@ -423,6 +438,7 @@ public class AsSynchronizedGraphTest
                 g.removeVertex(c);
             }
         }
+        
         public void runAsThread()
         {
             List<Order> orders = ordersList.remove(0);


### PR DESCRIPTION
Follow up of #500 as discussed in #520 to disable lazy instantiation of vertex containers. Also contains a minor type warnings cleanup.