### PR TITLE
Fix #461 and optimize Push-Relabel

### DIFF
--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMFImplTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMFImplTest.java
@@ -17,9 +17,12 @@
  */
 package org.jgrapht.alg.flow;
 
-import org.jgrapht.*;
-import org.jgrapht.alg.interfaces.*;
-import org.jgrapht.graph.*;
+import org.jgrapht.Graph;
+import org.jgrapht.alg.interfaces.MaximumFlowAlgorithm;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedWeightedMultigraph;
+import org.jgrapht.graph.SimpleDirectedGraph;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -27,6 +30,47 @@ import static org.junit.Assert.assertEquals;
 public class PushRelabelMFImplTest
     extends MaximumFlowAlgorithmTest
 {
+    public static void testPushRelabelMFImpl(int graphSize){
+        int outWeight = 3;
+        int inWeight = 4;
+
+        DirectedWeightedMultigraph<Integer, DefaultWeightedEdge> g = new DirectedWeightedMultigraph<>(DefaultWeightedEdge.class);
+        for (int i = 0; i<graphSize; i++){
+            g.addVertex(i);
+        }
+
+        for(int i = 1; i < graphSize; i++) {
+            if(i%2 == 0){
+                DefaultWeightedEdge eOut = g.addEdge(0, i);
+                g.setEdgeWeight(eOut, outWeight);
+
+                DefaultWeightedEdge eInt = g.addEdge(i, 0);
+                g.setEdgeWeight(eInt, inWeight);
+            }else{
+                DefaultWeightedEdge e = g.addEdge(0,i);
+                g.setEdgeWeight(e, 0);
+            }
+        }
+
+        //System.out.println("Graph constructed... Size = " + graphSize);
+
+        long startTime = System.nanoTime();
+        PushRelabelMFImpl<Integer, DefaultWeightedEdge> algorithm = new PushRelabelMFImpl<>(g);
+        algorithm.getMaximumFlow(2,1);
+
+        double time = (System.nanoTime() - startTime)/1e9;
+
+        //System.out.println("Finished. Time used: " + time + "s.");
+    }
+
+    @Test
+    public void testSize(){
+        /*
+            See https://github.com/jgrapht/jgrapht/issues/461
+         */
+
+        testPushRelabelMFImpl(1000);
+    }
 
     @Override
     MaximumFlowAlgorithm<Integer, DefaultWeightedEdge> createSolver(

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMFImplTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PushRelabelMFImplTest.java
@@ -21,7 +21,6 @@ import org.jgrapht.Graph;
 import org.jgrapht.alg.interfaces.MaximumFlowAlgorithm;
 import org.jgrapht.graph.DefaultEdge;
 import org.jgrapht.graph.DefaultWeightedEdge;
-import org.jgrapht.graph.DirectedWeightedMultigraph;
 import org.jgrapht.graph.SimpleDirectedGraph;
 import org.junit.Test;
 
@@ -30,48 +29,6 @@ import static org.junit.Assert.assertEquals;
 public class PushRelabelMFImplTest
     extends MaximumFlowAlgorithmTest
 {
-    public static void testPushRelabelMFImpl(int graphSize){
-        int outWeight = 3;
-        int inWeight = 4;
-
-        DirectedWeightedMultigraph<Integer, DefaultWeightedEdge> g = new DirectedWeightedMultigraph<>(DefaultWeightedEdge.class);
-        for (int i = 0; i<graphSize; i++){
-            g.addVertex(i);
-        }
-
-        for(int i = 1; i < graphSize; i++) {
-            if(i%2 == 0){
-                DefaultWeightedEdge eOut = g.addEdge(0, i);
-                g.setEdgeWeight(eOut, outWeight);
-
-                DefaultWeightedEdge eInt = g.addEdge(i, 0);
-                g.setEdgeWeight(eInt, inWeight);
-            }else{
-                DefaultWeightedEdge e = g.addEdge(0,i);
-                g.setEdgeWeight(e, 0);
-            }
-        }
-
-        //System.out.println("Graph constructed... Size = " + graphSize);
-
-        long startTime = System.nanoTime();
-        PushRelabelMFImpl<Integer, DefaultWeightedEdge> algorithm = new PushRelabelMFImpl<>(g);
-        algorithm.getMaximumFlow(2,1);
-
-        double time = (System.nanoTime() - startTime)/1e9;
-
-        //System.out.println("Finished. Time used: " + time + "s.");
-    }
-
-    @Test
-    public void testSize(){
-        /*
-            See https://github.com/jgrapht/jgrapht/issues/461
-         */
-
-        testPushRelabelMFImpl(1000);
-    }
-
     @Override
     MaximumFlowAlgorithm<Integer, DefaultWeightedEdge> createSolver(
         Graph<Integer, DefaultWeightedEdge> network)


### PR DESCRIPTION
I have fixed #461.

I also made a little optimization: `labeling` is now a simple array instead of a HashMap. According to `Lemma 26.20` (Introduction to Algorithm, 3rd ed, page 744) all vertices will have labels ```< 2|V|``` so we can store `labeling` in an array.