### PR TITLE
O(V^2) implementation of Prim's algorithm

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/PrimMinimumSpanningTree.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/PrimMinimumSpanningTree.java
@@ -17,10 +17,10 @@
  */
 package org.jgrapht.alg.spanning;
 
-import java.util.*;
+import org.jgrapht.Graph;
+import org.jgrapht.alg.interfaces.SpanningTreeAlgorithm;
 
-import org.jgrapht.*;
-import org.jgrapht.alg.interfaces.*;
+import java.util.*;
 
 /**
  * An implementation of <a href="http://en.wikipedia.org/wiki/Prim's_algorithm"> Prim's
@@ -72,7 +72,7 @@ public class PrimMinimumSpanningTree<V, E>
 
             PriorityQueue<E> dangling = new PriorityQueue<>(
                 g.edgeSet().size(),
-                (lop, rop) -> Double.valueOf(g.getEdgeWeight(lop)).compareTo(g.getEdgeWeight(rop)));
+                    Comparator.comparingDouble(g::getEdgeWeight));
 
             dangling.addAll(g.edgesOf(root));
 
@@ -97,6 +97,91 @@ public class PrimMinimumSpanningTree<V, E>
                     {
                         dangling.add(e);
                     }
+                }
+            }
+        }
+
+        return new SpanningTreeImpl<>(minimumSpanningTreeEdgeSet, spanningTreeWeight);
+    }
+
+
+    /**
+     * Computes a spanning tree in $O(|V|^2)$ time.
+     *
+     * Note: This method is only recommended for dense graphs.
+     *
+     * @return a spanning tree
+     */
+    @SuppressWarnings("unchecked")
+    public SpanningTree<E> getSpanningTreeDense(){
+        Set<E> minimumSpanningTreeEdgeSet = new HashSet<>(g.vertexSet().size());
+        double spanningTreeWeight = 0d;
+
+        final int N = g.vertexSet().size();
+
+        /*
+         * Normalize the graph
+         *   map each vertex to an integer (using a HashMap)
+         *   keep the reverse mapping  (using an ArrayList)
+         */
+        Map<V, Integer> vertexMap = new HashMap<>();
+        List<V> indexList = new ArrayList<>();
+        for (E e: g.edgeSet()){
+            V source = g.getEdgeSource(e);
+            V target = g.getEdgeTarget(e);
+
+            // map 'source' if no mapping exists
+            if (!vertexMap.containsKey(source)){
+                vertexMap.put(source, vertexMap.size());
+                indexList.add(source);
+            }
+
+            // map 'target' if no mapping exists
+            if (!vertexMap.containsKey(target)){
+                vertexMap.put(target, vertexMap.size());
+                indexList.add(target);
+            }
+        }
+
+        boolean[] spanned = new boolean[N];
+        double[] distance = new double[N];
+        E[] edgeFromParent = (E[]) new Object[N];
+
+        Arrays.fill(distance, Double.MAX_VALUE);
+        distance[0] = 0;
+
+        for (int step = 0; step < N; step++) {
+            int u = -1;
+
+            for (int i = 0; i < N; i++) {
+                if (!spanned[i] && (u == -1 || distance[i] < distance[u]))
+                    u = i;
+            }
+
+            if (u == -1)
+                break;
+
+
+            V root = indexList.get(u);
+            spanned[u] = true;
+
+            if (edgeFromParent[u] != null) {
+                minimumSpanningTreeEdgeSet.add(edgeFromParent[u]);
+                spanningTreeWeight += g.getEdgeWeight(edgeFromParent[u]);
+            }
+
+            for (E e : g.edgesOf(root)) {
+                V target = g.getEdgeTarget(e);
+
+                if (target.equals(root))
+                    target = g.getEdgeSource(e);
+
+                int id = vertexMap.get(target);
+                double cost = g.getEdgeWeight(e);
+
+                if (!spanned[id] && distance[id] > cost) {
+                    distance[id] = cost;
+                    edgeFromParent[id] = e;
                 }
             }
         }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/MinimumSpanningTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/MinimumSpanningTreeTest.java
@@ -17,17 +17,21 @@
  */
 package org.jgrapht.alg.spanning;
 
-import java.util.*;
-
-import org.jgrapht.*;
-import org.jgrapht.alg.interfaces.*;
-import org.jgrapht.alg.interfaces.SpanningTreeAlgorithm.*;
-import org.jgrapht.alg.util.*;
-import org.jgrapht.generate.*;
-import org.jgrapht.graph.*;
-
-import junit.framework.*;
+import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.interfaces.SpanningTreeAlgorithm;
+import org.jgrapht.alg.interfaces.SpanningTreeAlgorithm.SpanningTree;
+import org.jgrapht.alg.util.IntegerVertexFactory;
+import org.jgrapht.generate.GnpRandomGraphGenerator;
+import org.jgrapht.generate.GraphGenerator;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleWeightedGraph;
+import org.jgrapht.graph.WeightedPseudograph;
 import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Random;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -36,24 +40,24 @@ public class MinimumSpanningTreeTest
 {
     // ~ Static fields/initializers ---------------------------------------------
 
-    private static final String A = "A";
-    private static final String B = "B";
-    private static final String C = "C";
-    private static final String D = "D";
-    private static final String E = "E";
-    private static final String F = "F";
-    private static final String G = "G";
-    private static final String H = "H";
+    public static final String A = "A";
+    public static final String B = "B";
+    public static final String C = "C";
+    public static final String D = "D";
+    public static final String E = "E";
+    public static final String F = "F";
+    public static final String G = "G";
+    public static final String H = "H";
 
     // ~ Instance fields --------------------------------------------------------
 
-    private DefaultWeightedEdge AB;
-    private DefaultWeightedEdge AC;
-    private DefaultWeightedEdge BD;
-    private DefaultWeightedEdge DE;
-    private DefaultWeightedEdge EG;
-    private DefaultWeightedEdge GH;
-    private DefaultWeightedEdge FH;
+    public static DefaultWeightedEdge AB;
+    public static DefaultWeightedEdge AC;
+    public static DefaultWeightedEdge BD;
+    public static DefaultWeightedEdge DE;
+    public static DefaultWeightedEdge EG;
+    public static DefaultWeightedEdge GH;
+    public static DefaultWeightedEdge FH;
 
     // ~ Methods ----------------------------------------------------------------
 
@@ -68,20 +72,6 @@ public class MinimumSpanningTreeTest
 
         testMinimumSpanningTreeBuilding(
             new KruskalMinimumSpanningTree<String, DefaultWeightedEdge>(
-                createSimpleDisconnectedWeightedGraph()).getSpanningTree(),
-            Arrays.asList(AB, AC, BD, EG, GH, FH), 60.0);
-    }
-
-    @Test
-    public void testPrim()
-    {
-        testMinimumSpanningTreeBuilding(
-            new PrimMinimumSpanningTree<String, DefaultWeightedEdge>(
-                createSimpleConnectedWeightedGraph()).getSpanningTree(),
-            Arrays.asList(AB, AC, BD, DE), 15.0);
-
-        testMinimumSpanningTreeBuilding(
-            new PrimMinimumSpanningTree<String, DefaultWeightedEdge>(
                 createSimpleDisconnectedWeightedGraph()).getSpanningTree(),
             Arrays.asList(AB, AC, BD, EG, GH, FH), 60.0);
     }
@@ -133,14 +123,14 @@ public class MinimumSpanningTreeTest
         }
     }
 
-    protected <V, E> void testMinimumSpanningTreeBuilding(
+    public static <V, E>  void testMinimumSpanningTreeBuilding(
         final SpanningTree<E> mst, final Collection<E> edgeSet, final double weight)
     {
         assertEquals(weight, mst.getWeight(),0);
         assertTrue(mst.getEdges().containsAll(edgeSet));
     }
 
-    protected Graph<String, DefaultWeightedEdge> createSimpleDisconnectedWeightedGraph()
+    public static Graph<String, DefaultWeightedEdge> createSimpleDisconnectedWeightedGraph()
     {
 
         Graph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
@@ -174,7 +164,7 @@ public class MinimumSpanningTreeTest
         return g;
     }
 
-    protected Graph<String, DefaultWeightedEdge> createSimpleConnectedWeightedGraph()
+    public static Graph<String, DefaultWeightedEdge> createSimpleConnectedWeightedGraph()
     {
 
         Graph<String, DefaultWeightedEdge> g = new SimpleWeightedGraph<>(DefaultWeightedEdge.class);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/PrimMinimumSpanningTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/PrimMinimumSpanningTreeTest.java
@@ -1,0 +1,115 @@
+package org.jgrapht.alg.spanning;
+
+import org.jgrapht.Graph;
+import org.jgrapht.alg.interfaces.SpanningTreeAlgorithm;
+import org.jgrapht.alg.util.IntegerVertexFactory;
+import org.jgrapht.generate.GnpRandomGraphGenerator;
+import org.jgrapht.generate.GraphGenerator;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleWeightedGraph;
+import org.jgrapht.graph.WeightedPseudograph;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Random;
+
+import static org.jgrapht.alg.spanning.MinimumSpanningTreeTest.*;
+import static org.junit.Assert.assertEquals;
+
+public class PrimMinimumSpanningTreeTest {
+
+    @Test
+    public void testRandomInstances()
+    {
+        final Random rng = new Random(33);
+        final double edgeProbability = 0.5;
+        final int numberVertices = 100;
+        final int repeat = 200;
+
+        GraphGenerator<Integer, DefaultWeightedEdge, Integer> gg =
+                new GnpRandomGraphGenerator<>(
+                        numberVertices, edgeProbability, rng, false);
+
+        for (int i = 0; i < repeat; i++) {
+            WeightedPseudograph<Integer, DefaultWeightedEdge> g =
+                    new WeightedPseudograph<>(DefaultWeightedEdge.class);
+            gg.generateGraph(g, new IntegerVertexFactory(), null);
+
+            for (DefaultWeightedEdge e : g.edgeSet()) {
+                g.setEdgeWeight(e, rng.nextDouble());
+            }
+
+            PrimMinimumSpanningTree<Integer, DefaultWeightedEdge> alg = new PrimMinimumSpanningTree<>(g);
+
+            SpanningTreeAlgorithm.SpanningTree<DefaultWeightedEdge> tree1 = alg.getSpanningTreeDense();
+            SpanningTreeAlgorithm.SpanningTree<DefaultWeightedEdge> tree2 = new KruskalMinimumSpanningTree<>(g).getSpanningTree();
+            SpanningTreeAlgorithm.SpanningTree<DefaultWeightedEdge> tree3 = alg.getSpanningTree();
+
+            assertEquals(tree1.getWeight(), tree2.getWeight(), 1e-9);
+            assertEquals(tree2.getWeight(), tree3.getWeight(), 1e-9);
+        }
+    }
+
+    @Test
+    public void testPrim()
+    {
+        testMinimumSpanningTreeBuilding(
+                new PrimMinimumSpanningTree<>(
+                        MinimumSpanningTreeTest.createSimpleConnectedWeightedGraph()).getSpanningTree(),
+                Arrays.asList(AB, AC, BD, DE), 15.0);
+
+        testMinimumSpanningTreeBuilding(
+                new PrimMinimumSpanningTree<>(
+                        MinimumSpanningTreeTest.createSimpleConnectedWeightedGraph()).getSpanningTreeDense(),
+                Arrays.asList(AB, AC, BD, DE), 15.0);
+
+        testMinimumSpanningTreeBuilding(
+                new PrimMinimumSpanningTree<>(
+                        createSimpleDisconnectedWeightedGraph()).getSpanningTree(),
+                Arrays.asList(AB, AC, BD, EG, GH, FH), 60.0);
+
+        testMinimumSpanningTreeBuilding(
+                new PrimMinimumSpanningTree<>(
+                        createSimpleDisconnectedWeightedGraph()).getSpanningTreeDense(),
+                Arrays.asList(AB, AC, BD, EG, GH, FH), 60.0);
+    }
+
+    /*
+        The above code is to test time diff between getSpanningTree and getSpanningTreeDense
+     */
+
+    private static Graph<Integer, DefaultWeightedEdge> bigGraph;
+
+    @BeforeClass
+    public static void generateBigGraph(){
+        Random random = new Random(991199);
+        bigGraph = new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
+
+        final int N = 2_000;
+
+        for (int i = 0; i < N; i++) {
+            bigGraph.addVertex(i);
+        }
+
+        int P = 70;
+
+        for (int i = 0; i < N; i++) {
+            for (int j = i + 1; j < N; j++) {
+                if (1 + random.nextInt(100) <= P){
+                    bigGraph.setEdgeWeight(bigGraph.addEdge(i, j), 1 + random.nextInt(100));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testDenseGraphNormal(){
+        assertEquals(new PrimMinimumSpanningTree<>(bigGraph).getSpanningTree().getWeight(), 1999, 1e-9);
+    }
+
+    @Test
+    public void testDenseGraphSpecial(){
+        assertEquals(new PrimMinimumSpanningTree<>(bigGraph).getSpanningTreeDense().getWeight(), 1999, 1e-9);
+    }
+}


### PR DESCRIPTION
I have implemented the naive O(V^2) version of Prim's algorithm. This implementation is suited for dense graphs. Simple tests using graphs with over 1000 vertices and ~70% density show that `getSpanningTreeDense` works 6-10x better than the original `getSpanningTree`.

I have also done some refactoring to `MinimumSpanningTreeTest` and created `PrimMinimumSpanningTreeTest`.

Let me know what you think.