### PR TITLE
Expose lock as public for AsSynchronizedGraph, and add copyless access mode

### DIFF
--- a/jgrapht-core/src/test/java/org/jgrapht/graph/concurrent/AsSynchronizedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/concurrent/AsSynchronizedGraphTest.java
@@ -463,10 +463,8 @@ public class AsSynchronizedGraphTest
                 }
                 g.getLock().readLock().lock();
                 try {
-                    int x = 0;
                     for (DefaultEdge e : g.edgesOf(c)) {
                         assertTrue(g.containsEdge(e));
-                        x++;
                     }
                 } finally {
                     g.getLock().readLock().unlock();


### PR DESCRIPTION
@Yimismi, when we originally discussed AsSynchronizedGraph, you suggested exposing a way to explicitly synchronize on the graph in order to allow a compound sequence of operations to be made atomic.  At the time, I said we could just use Java's built in synchronized primitive.  That was true then, since we were using a simple mutex in the design, but later we changed the design to use a ReentrantReadWriteLock.

This change exposes the lock to allow for explicit synchronization in application code.

Given this, I've also added a "copyless" mode so that applications which are going to the trouble to explicitly synchronize can choose to optimize away collection copies as well.

Let me know what you think.
