### PR TITLE
Enhanced GML parser

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/AttributeType.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/AttributeType.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017-2017, by Dimitrios Michail and Contributors.
+ * (C) Copyright 2017-2018, by Dimitrios Michail and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -29,7 +29,8 @@ public enum AttributeType
     LONG("long"),
     FLOAT("float"),
     DOUBLE("double"),
-    STRING("string");
+    STRING("string"),
+    UNKNOWN("unknown");
 
     private String name;
 
@@ -69,6 +70,8 @@ public enum AttributeType
             return DOUBLE;
         case "string":
             return STRING;
+        case "unknown": 
+            return UNKNOWN;
         }
         throw new IllegalArgumentException("Type " + value + " is unknown");
     }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/GmlImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/GmlImporter.java
@@ -32,7 +32,7 @@ import org.jgrapht.io.GmlParser.*;
  * 
  * <p>
  * For a description of the format see <a href="http://www.infosun.fmi.uni-passau.de/Graphlet/GML/">
- * http://www. infosun.fmi.uni-passau.de/Graphlet/GML/</a>.
+ * http://www.infosun.fmi.uni-passau.de/Graphlet/GML/</a>.
  *
  * <p>
  * Below is small example of a graph in GML format.
@@ -68,7 +68,29 @@ import org.jgrapht.io.GmlParser.*;
  * In case the graph is weighted then the importer also reads edge weights. Otherwise edge weights
  * are ignored. The importer also supports reading additional string attributes such as label or
  * custom user attributes. String attributes are unescaped as if they are Java strings.
- *
+ * 
+ * <p>The parser completely ignores elements from the input that are not related to vertices or edges 
+ * of the graph. Moreover, complicated nested structures are simply returned as a whole. For example,
+ * in the following graph
+ * 
+ * <pre>
+ * graph [
+ *   node [ 
+ *     id 1
+ *   ]
+ *   node [ 
+ *     id 2
+ *   ]
+ *   edge [
+ *     source 1
+ *     target 2 
+ *     points [ x 1.0 y 2.0 ]
+ *   ]
+ * ]
+ * </pre>
+ * 
+ * the points attribute of the edge is returned as a string containing "[ x 1.0 y 2.0 ]". 
+ * 
  * @param <V> the vertex type
  * @param <E> the edge type
  * 
@@ -178,6 +200,7 @@ public class GmlImporter<V, E>
         private Integer targetId;
         private Double weight;
         private Map<String, Attribute> attributes;
+        private StringBuffer stringBuffer;
 
         // collected nodes and edges
         private Map<Integer, Node> nodes;
@@ -244,45 +267,70 @@ public class GmlImporter<V, E>
         @Override
         public void enterNumberKeyValue(GmlParser.NumberKeyValueContext ctx)
         {
-            String key = ctx.ID().getText();
-
-            if (insideNode && level == 2) {
-                if (key.equals(ID)) {
-                    try {
-                        nodeId = Integer.parseInt(ctx.NUMBER().getText());
-                    } catch (NumberFormatException e) {
-                        // ignore error
-                    }
-                } else {
-                    attributes.put(key, parseNumberAttribute(ctx.NUMBER().getText()));
-                }
-            } else if (insideEdge && level == 2) {
-                switch (key) {
-                case SOURCE:
-                    try {
-                        sourceId = Integer.parseInt(ctx.NUMBER().getText());
-                    } catch (NumberFormatException e) {
-                        // ignore error
-                    }
-                    break;
-                case TARGET:
-                    try {
-                        targetId = Integer.parseInt(ctx.NUMBER().getText());
-                    } catch (NumberFormatException e) {
-                        // ignore error
-                    }
-                    break;
-                case WEIGHT:
-                    try {
-                        weight = Double.parseDouble(ctx.NUMBER().getText());
-                    } catch (NumberFormatException e) {
-                        // ignore error
-                    }
-                    break;
-                default:
-                    attributes.put(key, parseNumberAttribute(ctx.NUMBER().getText()));
-                }
+            if (!insideNode && !insideEdge) { 
+                return;
             }
+            
+            if (level < 2) {
+                return;
+            }
+            
+            String key = ctx.ID().getText();
+            String value = ctx.NUMBER().getText();
+            
+            if (level == 2) { 
+                if (insideNode) { 
+                    if (key.equals(ID)) {
+                        try {
+                            nodeId = Integer.parseInt(value);
+                        } catch (NumberFormatException e) {
+                            // ignore error
+                        }
+                    } else {
+                        attributes.put(key, parseNumberAttribute(value));
+                    }    
+                } else {
+                    // insideEdge                    
+                    assert insideEdge;
+
+                    switch (key) {
+                    case SOURCE:
+                        try {
+                            sourceId = Integer.parseInt(value);
+                        } catch (NumberFormatException e) {
+                            // ignore error
+                        }
+                        break;
+                    case TARGET:
+                        try {
+                            targetId = Integer.parseInt(value);
+                        } catch (NumberFormatException e) {
+                            // ignore error
+                        }
+                        break;
+                    case WEIGHT:
+                        try {
+                            weight = Double.parseDouble(value);
+                        } catch (NumberFormatException e) {
+                            // ignore error
+                        }
+                        break;
+                    default:
+                        attributes.put(key, parseNumberAttribute(value));
+                    }
+                }
+            } else { 
+                assert level >= 3;
+                /*
+                 * Inside a list. We simply concatenate everything here to allow the user
+                 * to do something fancier in user-code. 
+                 */
+                stringBuffer.append(' ');
+                stringBuffer.append(key);
+                stringBuffer.append(' ');
+                stringBuffer.append(value);
+            }
+
         }
 
         @Override
@@ -302,6 +350,16 @@ public class GmlImporter<V, E>
                 targetId = null;
                 weight = null;
                 attributes = new HashMap<>();
+            } else if (insideNode || insideEdge) { 
+                if (level == 2) { 
+                    stringBuffer = new StringBuffer();
+                    stringBuffer.append('[');
+                } else if (level >= 3) { 
+                    stringBuffer.append(' ');
+                    stringBuffer.append(key);
+                    stringBuffer.append(' ');
+                    stringBuffer.append('[');
+                }
             }
             level++;
         }
@@ -327,33 +385,60 @@ public class GmlImporter<V, E>
                 }
                 insideEdge = false;
                 attributes = null;
+            }  else if (insideNode || insideEdge) {
+                if (level == 2) { 
+                    stringBuffer.append(' ');
+                    stringBuffer.append(']');
+                    attributes.put(key, new DefaultAttribute<>(stringBuffer.toString(), AttributeType.UNKNOWN));
+                    stringBuffer = null;
+                } else if (level >= 3) { 
+                    stringBuffer.append(' ');
+                    stringBuffer.append(']');
+                }
             }
         }
 
         @Override
         public void enterStringKeyValue(GmlParser.StringKeyValueContext ctx)
         {
-            if (!insideEdge && !insideNode && level != 2) {
+            if (!insideNode && !insideEdge) { 
                 return;
             }
-
-            String key = ctx.ID().getText();
-
-            if (key.equals(ID)) {
-                throw new IllegalArgumentException("Invalid type for attribute id: string");
-            } else if (key.equals(SOURCE)) {
-                throw new IllegalArgumentException("Invalid type for attribute source: string");
-            } else if (key.equals(TARGET)) {
-                throw new IllegalArgumentException("Invalid type for attribute target: string");
-            } else if (key.equals(WEIGHT)) {
-                throw new IllegalArgumentException("Invalid type for attribute weight: string");
+            
+            if (level < 2) {
+                return;
             }
-
+                
+            String key = ctx.ID().getText();
             String text = ctx.STRING().getText();
             String noQuotes = text.subSequence(1, text.length() - 1).toString();
             String unescapedText = StringEscapeUtils.unescapeJava(noQuotes);
+            
+            if (level == 2) {
+                /*
+                 * Store attribute 
+                 */
+                if (key.equals(ID)) {
+                    throw new IllegalArgumentException("Invalid type for attribute id: string");
+                } else if (key.equals(SOURCE)) {
+                    throw new IllegalArgumentException("Invalid type for attribute source: string");
+                } else if (key.equals(TARGET)) {
+                    throw new IllegalArgumentException("Invalid type for attribute target: string");
+                } else if (key.equals(WEIGHT)) {
+                    throw new IllegalArgumentException("Invalid type for attribute weight: string");
+                }
 
-            attributes.put(key, DefaultAttribute.createAttribute(unescapedText));
+                attributes.put(key, DefaultAttribute.createAttribute(unescapedText));
+            } else if (level >= 3) {
+                /*
+                 * Inside a list. We simply concatenate everything here to allow the user
+                 * to do something fancier in user-code.
+                 */
+                stringBuffer.append(' ');
+                stringBuffer.append(key);
+                stringBuffer.append(' ');
+                stringBuffer.append(text);
+            }
         }
 
         private Attribute parseNumberAttribute(String value)

--- a/jgrapht-io/src/test/java/org/jgrapht/io/GmlImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/GmlImporterTest.java
@@ -82,6 +82,8 @@ public class GmlImporterTest
         assertTrue(g.containsEdge("2", "3"));
         assertTrue(g.containsEdge("3", "1"));
     }
+    
+    
 
     @Test
     public void testIgnoreWeightsUndirectedUnweighted()
@@ -725,6 +727,99 @@ public class GmlImporterTest
             assertEquals(AttributeType.INT, attributes.get("frequency").getType());
             assertEquals("7.5", attributes.get("customweight").getValue());
             assertEquals(AttributeType.DOUBLE, attributes.get("customweight").getType());
+            return g.getEdgeFactory().createEdge(from, to);
+        };
+
+        GmlImporter<String, DefaultEdge> importer = new GmlImporter<String, DefaultEdge>(vp, ep);
+        importer.importGraph(g, new StringReader(input));
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(1, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsEdge("1", "2"));
+    }
+    
+    @Test
+    public void testNestedStructure()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  comment \"Sample Graph\"\n"
+                     + "  directed 1\n"
+                     + "  edge [\n"
+                     + "    source 1\n"
+                     + "    target 2\n"
+                     + "    frequency 6\n"
+                     + "    customweight 7.5\n"
+                     + "    points [ x 1.0 y 2.0 ]\n"
+                     + "    deep [ one [ one 1 two 2 ] two [ one 1 two 2 ] ]\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "    frequency 2\n"
+                     + "    customweight 1.2\n"
+                     + "    deep [ one [ one 1.0 two 2.0 ] two [ one \"1\" two \"2\" ] ]\n"                     
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 2\n"
+                     + "    frequency 3\n"
+                     + "    customweight 2.1\n"
+                     + "    points [ x 1.0 y 2.0 z 3.0 ]\n"
+                     + "    deep [ one [ one 1 two 2 ] two [ one 1 two 2 ] ]\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    frequency 5\n"
+                     + "    customweight 5.5\n"
+                     + "  ]\n"
+                     + "  deepignored [\n"
+                     + "    deep1 [ deep2 [ deep3 [ deep4 [ deep 5 ] ] ] ]\n"
+                     + "  ]\n"
+                     + "]\n"
+                     + "deepignored [\n"
+                     + "  deep1 [ deep2 [ deep3 [ deep4 [ deep 5 ] ] ] ]\n"
+                     + "]\n";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g = new DirectedWeightedPseudograph<>(DefaultEdge.class);
+
+        VertexProvider<String> vp = (id, attributes) -> {
+            assertNotNull(attributes);
+            if (Integer.parseInt(id) == 1) {
+                assertEquals("2", attributes.get("frequency").getValue());
+                assertEquals(AttributeType.INT, attributes.get("frequency").getType());
+                assertEquals("1.2", attributes.get("customweight").getValue());
+                assertEquals(AttributeType.DOUBLE, attributes.get("customweight").getType());
+                assertEquals(AttributeType.UNKNOWN, attributes.get("deep").getType());
+                assertEquals("[ one [ one 1.0 two 2.0 ] two [ one \"1\" two \"2\" ] ]", attributes.get("deep").getValue());                
+            } else if (Integer.parseInt(id) == 2) {
+                assertEquals("3", attributes.get("frequency").getValue());
+                assertEquals(AttributeType.INT, attributes.get("frequency").getType());
+                assertEquals("2.1", attributes.get("customweight").getValue());
+                assertEquals(AttributeType.DOUBLE, attributes.get("customweight").getType());
+                assertEquals(AttributeType.UNKNOWN, attributes.get("points").getType());
+                assertEquals("[ x 1.0 y 2.0 z 3.0 ]", attributes.get("points").getValue());
+                assertEquals(AttributeType.UNKNOWN, attributes.get("deep").getType());
+                assertEquals("[ one [ one 1 two 2 ] two [ one 1 two 2 ] ]", attributes.get("deep").getValue());
+            } else {
+                assertEquals("5", attributes.get("frequency").getValue());
+                assertEquals(AttributeType.INT, attributes.get("frequency").getType());
+                assertEquals("5.5", attributes.get("customweight").getValue());
+                assertEquals(AttributeType.DOUBLE, attributes.get("customweight").getType());
+            }
+            return id;
+        };
+        EdgeProvider<String, DefaultEdge> ep = (from, to, label, attributes) -> {
+            assertNotNull(attributes);
+            assertEquals("6", attributes.get("frequency").getValue());
+            assertEquals(AttributeType.INT, attributes.get("frequency").getType());
+            assertEquals("7.5", attributes.get("customweight").getValue());
+            assertEquals(AttributeType.DOUBLE, attributes.get("customweight").getType());
+            assertEquals(AttributeType.UNKNOWN, attributes.get("points").getType());
+            assertEquals("[ x 1.0 y 2.0 ]", attributes.get("points").getValue());
+            assertEquals(AttributeType.UNKNOWN, attributes.get("deep").getType());
+            assertEquals("[ one [ one 1 two 2 ] two [ one 1 two 2 ] ]", attributes.get("deep").getValue());
             return g.getEdgeFactory().createEdge(from, to);
         };
 


### PR DESCRIPTION
Minor changes in the GML Importer so that it does not throw away nested structures. Nested structures (lists, records, etc) are kept as a string and returned by the importer as an attribute.

For example, in the following edge
```
edge [
  source 1
  target 1
  weight 2.0
  points [ x 1.0 y 2.0 ]
]
```
the attribute points would be returned as "[ x 1.0 y 2.0 ]". This allows users to perform additional parsing in user-code. 

Resolves #543. Note that a full-blown parser of GML is out-of-scope. 


