### PR TITLE
Detection of all minimal vertex separators of a chordal graph with their multiplicities

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinder.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinder.java
@@ -1,0 +1,166 @@
+/*
+ * (C) Copyright 2018-2018, by Timofey Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.cycle;
+
+import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
+
+import java.util.*;
+
+/**
+ * Allows obtaining a mapping of all minimal vertex separators of a graph to their multiplicities
+ * <p>
+ * In the context of this implementation following definitions are used:
+ * <ul>
+ * <li>A set of vertices $S$ of a graph $G=(V, E)$ is called a <i>u-v separator</i>, if vertices $u$ and
+ * $v$ in the induced graph on vertices $V(G) - S$ are in different connected components.</li>
+ * <li>A set $S$ is called a <i>minimal u-v separator</i> if it is a u-v separator and no proper subset of $S$ is
+ * a u-v separator.</li>
+ * <li> A set $S$ is called a <i>minimal vertex separator</i> if it is minimal u-v separator for some
+ * vertices $u$ and $v$ of the graph $G$.</li>
+ * <li>A set of vertices $S$ is called a <i>minimal separator</i> if no proper subset of $S$ is
+ * a separator of the graph $G$.</li>
+ * </ul>
+ * <p>
+ * Let $\sigma = (v_1, v_2, \dots, v_n)$ be some perfect elimination order (peo) of the graph $G = (V, E)$.
+ * The induced graph on vertices $(v_1, v_2, \dots, v_i)$ with respect to peo $\sigma$ is denoted as $G_i$.
+ * The predecessors set of vertex $v$ with respect to peo $\sigma$ is denoted as $N(v, \sigma)$.
+ * A set $B$ is called a <i>base set</i> with respect to $\sigma$, is there exist some vertex $v$ with
+ * $t = \sigma(v)$ such that $N(v, \sigma) = B$ and B is not a maximal clique in $G_{t-1}$.
+ * The vertices which satisfy conditions described above are called <i>dependent vertices</i>
+ * with respect to $\sigma$. The cardinality of the set of dependent vertices is called a multiplicity
+ * of the base set $B$. The definitions of a base set and a minimal vertex separator in the context of
+ * chordal graphs are equivalent.
+ * <p>
+ * For more information on the topic see: Kumar, P.Sreenivasa & Madhavan, C.E.Veni. (1998).
+ * <a href="https://www.sciencedirect.com/science/article/pii/S0166218X98001231?via%3Dihub">
+ * Minimal vertex separators of chordal graphs</a>. Discrete Applied Mathematics.
+ * 89. 155-168. 10.1016/S0166-218X(98)00123-1.
+ * <p>
+ * The running time of the algorithm is $\mathcal{O}(\omega(G)(|V| + |E|))$, where $\omega(G)$
+ * is the size of the cardinality of a maximum clique of the graph $G$.
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ * @author Timofey Chudakov
+ * @see ChordalityInspector
+ * @since April 2018
+ */
+public class ChordalGraphMinimalVertexSeparatorFinder<V, E> {
+    /**
+     * The graph in which minimal vertex separators to searched in
+     */
+    private final Graph<V, E> graph;
+    /**
+     * {@link ChordalityInspector} for testing chordality of the {@code graph}
+     */
+    private final ChordalityInspector<V, E> chordalityInspector;
+    /**
+     * A mapping of minimal separators to their multiplicities
+     */
+    private Map<Set<V>, Integer> minimalSeparators;
+
+    /**
+     * Creates new {@code ChordalGraphMinimalVertexSeparatorFinder} instance. The {@link ChordalityInspector}
+     * used in this implementation uses the default {@link org.jgrapht.traverse.MaximumCardinalityIterator}
+     * iterator
+     *
+     * @param graph the graph minimal separators to search in
+     */
+    public ChordalGraphMinimalVertexSeparatorFinder(Graph<V, E> graph) {
+        this.graph = Objects.requireNonNull(graph);
+        chordalityInspector = new ChordalityInspector<>(graph, ChordalityInspector.IterationOrder.MCS);
+    }
+
+    /**
+     * Computes and returns a mapping of all minimal vertex separators of the {@code graph}
+     * and returns it. Returns null if the {@code graph} isn't chordal.
+     *
+     * @return computed mapping of all minimal separators to their multiplicities, or null if
+     * the {@code graph} isn't chordal
+     */
+    public Map<Set<V>, Integer> getMinimalSeparators() {
+        lazyComputeMinimalSeparators();
+        return minimalSeparators;
+    }
+
+    /**
+     * Lazy computes a mapping of all minimal vertex separators of the {@code graph}
+     * to their multiplicities
+     */
+    private void lazyComputeMinimalSeparators() {
+        if (minimalSeparators == null && chordalityInspector.isChordal()) {
+            minimalSeparators = new HashMap<>();
+            List<V> perfectEliminationOrder = chordalityInspector.getPerfectEliminationOrder();
+            Map<V, Integer> vertexInOrder = getVertexInOrder(perfectEliminationOrder);
+            Set<V> previous;
+            Set<V> current = new HashSet<>();
+            for (int i = 1; i < perfectEliminationOrder.size(); i++) {
+                previous = current;
+                current = getPredecessors(vertexInOrder, perfectEliminationOrder.get(i));
+                if (current.size() <= previous.size()) {
+                    // current set is a minimal separator
+                    if (minimalSeparators.containsKey(current)) {
+                        // found another vertex dependent on current set
+                        minimalSeparators.put(current, minimalSeparators.get(current) + 1);
+                    } else {
+                        // vertex at position i is the first vertex dependent on current set
+                        minimalSeparators.put(current, 1);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Returns a map containing vertices from the {@code vertexOrder} mapped to their
+     * indices in {@code vertexOrder}.
+     *
+     * @param vertexOrder a list with vertices.
+     * @return a mapping of vertices from {@code vertexOrder} to their indices in {@code vertexOrder}.
+     */
+    private Map<V, Integer> getVertexInOrder(List<V> vertexOrder) {
+        Map<V, Integer> vertexInOrder = new HashMap<>(vertexOrder.size());
+        int i = 0;
+        for (V vertex : vertexOrder) {
+            vertexInOrder.put(vertex, i++);
+        }
+        return vertexInOrder;
+    }
+
+    /**
+     * Returns the predecessors of {@code vertex} in the order defined by {@code map}. More precisely,
+     * returns those of {@code vertex}, whose mapped index in {@code map} is less then the index of {@code vertex}.
+     *
+     * @param vertexInOrder defines the mapping of vertices in {@code graph} to their indices in order.
+     * @param vertex        the vertex whose predecessors in order are to be returned.
+     * @return the predecessors of {@code vertex} in order defines by {@code map}.
+     */
+    private Set<V> getPredecessors(Map<V, Integer> vertexInOrder, V vertex) {
+        Set<V> predecessors = new HashSet<>();
+        Integer vertexPosition = vertexInOrder.get(vertex);
+        Set<E> edges = graph.edgesOf(vertex);
+        for (E edge : edges) {
+            V oppositeVertex = Graphs.getOppositeVertex(graph, edge, vertex);
+            Integer destPosition = vertexInOrder.get(oppositeVertex);
+            if (destPosition < vertexPosition)
+                predecessors.add(oppositeVertex);
+        }
+        return predecessors;
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinder.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinder.java
@@ -23,7 +23,8 @@ import org.jgrapht.Graphs;
 import java.util.*;
 
 /**
- * Allows obtaining a mapping of all minimal vertex separators of a graph to their multiplicities
+ * Allows obtaining a mapping of all <a href="https://en.wikipedia.org/wiki/Chordal_graph#Minimal_separators">
+ * minimal vertex separators</a> of a graph to their multiplicities
  * <p>
  * In the context of this implementation following definitions are used:
  * <ul>

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinder.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinder.java
@@ -76,10 +76,6 @@ public class ChordalGraphMinimalVertexSeparatorFinder<V, E> {
      * A mapping of minimal separators to their multiplicities
      */
     private Map<Set<V>, Integer> minimalSeparatorsWithMultiplicities;
-    /**
-     * Set of minimal separators
-     */
-    private Set<Set<V>> minimalSeparators;
 
     /**
      * Creates new {@code ChordalGraphMinimalVertexSeparatorFinder} instance. The {@link ChordalityInspector}
@@ -100,7 +96,7 @@ public class ChordalGraphMinimalVertexSeparatorFinder<V, E> {
      */
     public Set<Set<V>> getMinimalSeparators() {
         lazyComputeMinimalSeparatorsWithMultiplicities();
-        return minimalSeparators;
+        return minimalSeparatorsWithMultiplicities == null ? null : minimalSeparatorsWithMultiplicities.keySet();
     }
 
     /**
@@ -122,7 +118,6 @@ public class ChordalGraphMinimalVertexSeparatorFinder<V, E> {
     private void lazyComputeMinimalSeparatorsWithMultiplicities() {
         if (minimalSeparatorsWithMultiplicities == null && chordalityInspector.isChordal()) {
             minimalSeparatorsWithMultiplicities = new HashMap<>();
-            minimalSeparators = new HashSet<>();
             List<V> perfectEliminationOrder = chordalityInspector.getPerfectEliminationOrder();
             Map<V, Integer> vertexInOrder = getVertexInOrder(perfectEliminationOrder);
             Set<V> previous;
@@ -137,7 +132,6 @@ public class ChordalGraphMinimalVertexSeparatorFinder<V, E> {
                         minimalSeparatorsWithMultiplicities.put(current, minimalSeparatorsWithMultiplicities.get(current) + 1);
                     } else {
                         // vertex at position i is the first vertex dependent on current set
-                        minimalSeparators.add(current);
                         minimalSeparatorsWithMultiplicities.put(current, 1);
                     }
                 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinder.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinder.java
@@ -47,7 +47,7 @@ import java.util.*;
  * of the base set $B$. The definitions of a base set and a minimal vertex separator in the context of
  * chordal graphs are equivalent.
  * <p>
- * For more information on the topic see: Kumar, P.Sreenivasa & Madhavan, C.E.Veni. (1998).
+ * For more information on the topic see: Kumar, P.Sreenivasa &amp; Madhavan, C.E.Veni. (1998).
  * <a href="https://www.sciencedirect.com/science/article/pii/S0166218X98001231?via%3Dihub">
  * Minimal vertex separators of chordal graphs</a>. Discrete Applied Mathematics.
  * 89. 155-168. 10.1016/S0166-218X(98)00123-1.

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinderTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinderTest.java
@@ -1,0 +1,183 @@
+/*
+ * (C) Copyright 2018-2018, by Timofey Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.cycle;
+
+import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultUndirectedGraph;
+import org.jgrapht.graph.Pseudograph;
+import org.junit.Test;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the {@link ChordalGraphMinimalVertexSeparatorFinder}
+ *
+ * @author Timofey Chudakov
+ */
+public class ChordalGraphMinimalVertexSeparatorFinderTest {
+
+    /**
+     * Test on empty graph
+     */
+    @Test
+    public void testGetMinimalSeparators1() {
+        Graph<Integer, DefaultEdge> graph = new DefaultUndirectedGraph<>(DefaultEdge.class);
+        ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
+        Map<Set<Integer>, Integer> separators = finder.getMinimalSeparators();
+        assertEquals(0, separators.size());
+    }
+
+    /**
+     * Test on small chordal graph
+     */
+    @Test
+    public void testGetMinimalSeparators2() {
+        Graph<Integer, DefaultEdge> graph = new DefaultUndirectedGraph<>(DefaultEdge.class);
+        Graphs.addEdgeWithVertices(graph, 1, 2);
+        Graphs.addEdgeWithVertices(graph, 1, 3);
+        Graphs.addEdgeWithVertices(graph, 2, 3);
+        Graphs.addEdgeWithVertices(graph, 2, 4);
+        Graphs.addEdgeWithVertices(graph, 3, 4);
+        ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
+        Map<Set<Integer>, Integer> separators = finder.getMinimalSeparators();
+        assertEquals(1, separators.size());
+        assertTrue(separators.containsKey(new HashSet<>(Arrays.asList(2, 3))));
+    }
+
+    /**
+     * Test on big chordal graph (example from original article)
+     */
+    @Test
+    public void testGetMinimalSeparators3() {
+        Graph<Integer, DefaultEdge> graph = new DefaultUndirectedGraph<>(DefaultEdge.class);
+        Graphs.addEdgeWithVertices(graph, 1, 2);
+        Graphs.addEdgeWithVertices(graph, 1, 3);
+        Graphs.addEdgeWithVertices(graph, 2, 3);
+        Graphs.addEdgeWithVertices(graph, 3, 4);
+        Graphs.addEdgeWithVertices(graph, 3, 5);
+        Graphs.addEdgeWithVertices(graph, 3, 6);
+        Graphs.addEdgeWithVertices(graph, 3, 8);
+        Graphs.addEdgeWithVertices(graph, 3, 10);
+        Graphs.addEdgeWithVertices(graph, 3, 11);
+        Graphs.addEdgeWithVertices(graph, 4, 5);
+        Graphs.addEdgeWithVertices(graph, 4, 6);
+        Graphs.addEdgeWithVertices(graph, 5, 6);
+        Graphs.addEdgeWithVertices(graph, 6, 7);
+        Graphs.addEdgeWithVertices(graph, 6, 8);
+        Graphs.addEdgeWithVertices(graph, 6, 10);
+        Graphs.addEdgeWithVertices(graph, 6, 11);
+        Graphs.addEdgeWithVertices(graph, 7, 8);
+        Graphs.addEdgeWithVertices(graph, 7, 10);
+        Graphs.addEdgeWithVertices(graph, 8, 9);
+        Graphs.addEdgeWithVertices(graph, 8, 10);
+        Graphs.addEdgeWithVertices(graph, 9, 10);
+        ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
+        Map<Set<Integer>, Integer> actual = finder.getMinimalSeparators();
+        Map<Set<Integer>, Integer> expected = new HashMap<>();
+        expected.put(new HashSet<>(Collections.singletonList(3)), 1);
+        expected.put(new HashSet<>(new HashSet<>(Arrays.asList(3, 6))), 2);
+        expected.put(new HashSet<>(new HashSet<>(Arrays.asList(8, 10))), 1);
+        expected.put(new HashSet<>(new HashSet<>(Arrays.asList(6, 8, 10))), 1);
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Test on big chordal graph (example from original article)
+     */
+    @Test
+    public void testGetMinimalSeparators4() {
+        Graph<Integer, DefaultEdge> graph = new DefaultUndirectedGraph<>(DefaultEdge.class);
+        Graphs.addEdgeWithVertices(graph, 1, 2);
+        Graphs.addEdgeWithVertices(graph, 2, 8);
+        Graphs.addEdgeWithVertices(graph, 2, 9);
+        Graphs.addEdgeWithVertices(graph, 3, 8);
+        Graphs.addEdgeWithVertices(graph, 3, 9);
+        Graphs.addEdgeWithVertices(graph, 4, 6);
+        Graphs.addEdgeWithVertices(graph, 4, 8);
+        Graphs.addEdgeWithVertices(graph, 5, 6);
+        Graphs.addEdgeWithVertices(graph, 5, 8);
+        Graphs.addEdgeWithVertices(graph, 6, 7);
+        Graphs.addEdgeWithVertices(graph, 6, 8);
+        Graphs.addEdgeWithVertices(graph, 6, 9);
+        Graphs.addEdgeWithVertices(graph, 7, 8);
+        Graphs.addEdgeWithVertices(graph, 7, 9);
+        Graphs.addEdgeWithVertices(graph, 8, 9);
+        Graphs.addEdgeWithVertices(graph, 8, 10);
+        Graphs.addEdgeWithVertices(graph, 8, 11);
+        Graphs.addEdgeWithVertices(graph, 8, 12);
+        Graphs.addEdgeWithVertices(graph, 9, 10);
+        Graphs.addEdgeWithVertices(graph, 9, 11);
+        Graphs.addEdgeWithVertices(graph, 9, 12);
+        Graphs.addEdgeWithVertices(graph, 10, 11);
+        Graphs.addEdgeWithVertices(graph, 11, 12);
+        ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
+        Map<Set<Integer>, Integer> actual = finder.getMinimalSeparators();
+        Map<Set<Integer>, Integer> expected = new HashMap<>();
+        expected.put(new HashSet<>(Collections.singletonList(2)), 1);
+        expected.put(new HashSet<>(Arrays.asList(6, 8)), 2);
+        expected.put(new HashSet<>(Arrays.asList(8, 9)), 3);
+        expected.put(new HashSet<>(Arrays.asList(8, 9, 11)), 1);
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Test on not chordal graph
+     */
+    @Test
+    public void testGetMinimalSeparators5() {
+        Graph<Integer, DefaultEdge> graph = new DefaultUndirectedGraph<>(DefaultEdge.class);
+        Graphs.addEdgeWithVertices(graph, 1, 2);
+        Graphs.addEdgeWithVertices(graph, 1, 3);
+        Graphs.addEdgeWithVertices(graph, 2, 4);
+        Graphs.addEdgeWithVertices(graph, 3, 4);
+        ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
+        Map<Set<Integer>, Integer> actual = finder.getMinimalSeparators();
+        assertNull(actual);
+    }
+
+    /**
+     * Test on pseudograph
+     */
+    @Test
+    public void testGetMinimalSeparators6() {
+        Graph<Integer, DefaultEdge> graph = new Pseudograph<>(DefaultEdge.class);
+        Graphs.addEdgeWithVertices(graph, 1, 1);
+        Graphs.addEdgeWithVertices(graph, 1, 1);
+        Graphs.addEdgeWithVertices(graph, 1, 2);
+        Graphs.addEdgeWithVertices(graph, 2, 3);
+        Graphs.addEdgeWithVertices(graph, 2, 3);
+        Graphs.addEdgeWithVertices(graph, 2, 3);
+        Graphs.addEdgeWithVertices(graph, 2, 5);
+        Graphs.addEdgeWithVertices(graph, 3, 3);
+        Graphs.addEdgeWithVertices(graph, 3, 4);
+        Graphs.addEdgeWithVertices(graph, 5, 3);
+        Graphs.addEdgeWithVertices(graph, 5, 3);
+        Graphs.addEdgeWithVertices(graph, 5, 4);
+        ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
+        Map<Set<Integer>, Integer> actual = finder.getMinimalSeparators();
+        Map<Set<Integer>, Integer> expected = new HashMap<>();
+        expected.put(new HashSet<>(Collections.singletonList(2)), 1);
+        expected.put(new HashSet<>(Arrays.asList(3, 5)), 1);
+        assertEquals(expected, actual);
+    }
+
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinderTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinderTest.java
@@ -26,7 +26,8 @@ import org.junit.Test;
 
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for the {@link ChordalGraphMinimalVertexSeparatorFinder}
@@ -42,8 +43,10 @@ public class ChordalGraphMinimalVertexSeparatorFinderTest {
     public void testGetMinimalSeparators1() {
         Graph<Integer, DefaultEdge> graph = new DefaultUndirectedGraph<>(DefaultEdge.class);
         ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
-        Map<Set<Integer>, Integer> separators = finder.getMinimalSeparators();
+        Set<Set<Integer>> separators = finder.getMinimalSeparators();
+        Map<Set<Integer>, Integer> separatorsAndMultiplicities = finder.getMinimalSeparatorsWithMultiplicities();
         assertEquals(0, separators.size());
+        assertEquals(0, separatorsAndMultiplicities.size());
     }
 
     /**
@@ -58,9 +61,12 @@ public class ChordalGraphMinimalVertexSeparatorFinderTest {
         Graphs.addEdgeWithVertices(graph, 2, 4);
         Graphs.addEdgeWithVertices(graph, 3, 4);
         ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
-        Map<Set<Integer>, Integer> separators = finder.getMinimalSeparators();
-        assertEquals(1, separators.size());
-        assertTrue(separators.containsKey(new HashSet<>(Arrays.asList(2, 3))));
+        Set<Set<Integer>> separators = finder.getMinimalSeparators();
+        Map<Set<Integer>, Integer> separatorsAndMultiplicities = finder.getMinimalSeparatorsWithMultiplicities();
+        Map<Set<Integer>, Integer> expected = new HashMap<>();
+        expected.put(new HashSet<>(Arrays.asList(2, 3)), 1);
+        assertEquals(expected.keySet(), separators);
+        assertEquals(expected, separatorsAndMultiplicities);
     }
 
     /**
@@ -91,13 +97,15 @@ public class ChordalGraphMinimalVertexSeparatorFinderTest {
         Graphs.addEdgeWithVertices(graph, 8, 10);
         Graphs.addEdgeWithVertices(graph, 9, 10);
         ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
-        Map<Set<Integer>, Integer> actual = finder.getMinimalSeparators();
+        Set<Set<Integer>> separators = finder.getMinimalSeparators();
+        Map<Set<Integer>, Integer> separatorsAndMultiplicities = finder.getMinimalSeparatorsWithMultiplicities();
         Map<Set<Integer>, Integer> expected = new HashMap<>();
         expected.put(new HashSet<>(Collections.singletonList(3)), 1);
-        expected.put(new HashSet<>(new HashSet<>(Arrays.asList(3, 6))), 2);
-        expected.put(new HashSet<>(new HashSet<>(Arrays.asList(8, 10))), 1);
-        expected.put(new HashSet<>(new HashSet<>(Arrays.asList(6, 8, 10))), 1);
-        assertEquals(expected, actual);
+        expected.put(new HashSet<>(Arrays.asList(3, 6)), 2);
+        expected.put(new HashSet<>(Arrays.asList(8, 10)), 1);
+        expected.put(new HashSet<>(Arrays.asList(6, 8, 10)), 1);
+        assertEquals(expected.keySet(), separators);
+        assertEquals(expected, separatorsAndMultiplicities);
     }
 
     /**
@@ -130,13 +138,15 @@ public class ChordalGraphMinimalVertexSeparatorFinderTest {
         Graphs.addEdgeWithVertices(graph, 10, 11);
         Graphs.addEdgeWithVertices(graph, 11, 12);
         ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
-        Map<Set<Integer>, Integer> actual = finder.getMinimalSeparators();
+        Set<Set<Integer>> separators = finder.getMinimalSeparators();
+        Map<Set<Integer>, Integer> separatorsAndMultiplicities = finder.getMinimalSeparatorsWithMultiplicities();
         Map<Set<Integer>, Integer> expected = new HashMap<>();
         expected.put(new HashSet<>(Collections.singletonList(2)), 1);
         expected.put(new HashSet<>(Arrays.asList(6, 8)), 2);
         expected.put(new HashSet<>(Arrays.asList(8, 9)), 3);
         expected.put(new HashSet<>(Arrays.asList(8, 9, 11)), 1);
-        assertEquals(expected, actual);
+        assertEquals(expected.keySet(), separators);
+        assertEquals(expected, separatorsAndMultiplicities);
     }
 
     /**
@@ -150,8 +160,10 @@ public class ChordalGraphMinimalVertexSeparatorFinderTest {
         Graphs.addEdgeWithVertices(graph, 2, 4);
         Graphs.addEdgeWithVertices(graph, 3, 4);
         ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
-        Map<Set<Integer>, Integer> actual = finder.getMinimalSeparators();
-        assertNull(actual);
+        Set<Set<Integer>> separators = finder.getMinimalSeparators();
+        Map<Set<Integer>, Integer> separatorsAndMultiplicities = finder.getMinimalSeparatorsWithMultiplicities();
+        assertNull(separators);
+        assertNull(separatorsAndMultiplicities);
     }
 
     /**
@@ -173,11 +185,13 @@ public class ChordalGraphMinimalVertexSeparatorFinderTest {
         Graphs.addEdgeWithVertices(graph, 5, 3);
         Graphs.addEdgeWithVertices(graph, 5, 4);
         ChordalGraphMinimalVertexSeparatorFinder<Integer, DefaultEdge> finder = new ChordalGraphMinimalVertexSeparatorFinder<>(graph);
-        Map<Set<Integer>, Integer> actual = finder.getMinimalSeparators();
+        Set<Set<Integer>> separators = finder.getMinimalSeparators();
+        Map<Set<Integer>, Integer> separatorsAndMultiplicities = finder.getMinimalSeparatorsWithMultiplicities();
         Map<Set<Integer>, Integer> expected = new HashMap<>();
         expected.put(new HashSet<>(Collections.singletonList(2)), 1);
         expected.put(new HashSet<>(Arrays.asList(3, 5)), 1);
-        assertEquals(expected, actual);
+        assertEquals(expected.keySet(), separators);
+        assertEquals(expected, separatorsAndMultiplicities);
     }
 
 }


### PR DESCRIPTION
Further class for chordal graphs support. ChordalGraphMinimalVertexSeparatorFinder allows obtaining a mapping of all minimal vertex separators of a chordal graph to their multiplicities. 

*Minimal vertex separator* is defined as a vertex set of a graph G = (V, E), which is a *minimal u-v separator* for some vertices u and v in the graph G. I've put other relevant definitions in the class Javadoc.

The implementation is based on [this article](https://www.sciencedirect.com/science/article/pii/S0166218X98001231?via%3Dihub). The running time complexity is O(w(G)(|E|+|V|)), where w(G) denotes the cardinality of a maximum clique of a graph G.