### PR TITLE
added methods to query the search tree in BFS iterator

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
@@ -122,12 +122,13 @@ public class BreadthFirstIterator<V, E>
     }
 
     /**
-     * Returns the edge connecting vertex $v$ to its parent in the BFS search tree, or null if $v$ is the root node.
+     * Returns the edge connecting vertex $v$ to its parent in the spanning tree formed by the BFS search,
+     * or null if $v$ is a root node.
      * This method can only be invoked on a vertex $v$ once the iterator has visited vertex $v$!
      * @param v vertex
-     * @return parent node of vertex $v$ in the BFS search tree, or null if $v$ is a root node
+     * @return edge connecting vertex $v$ in the BFS search tree to its parent, or null if $v$ is a root node
      */
-    public E getParentEdge(V v){
+    public E getSpanningTreeEdge(V v){
         assert getSeenData(v) != null;
         return getSeenData(v).edge;
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
@@ -36,7 +36,7 @@ import org.jgrapht.*;
  * @since Jul 19, 2003
  */
 public class BreadthFirstIterator<V, E>
-    extends CrossComponentIterator<V, E, Object>
+    extends CrossComponentIterator<V, E, BreadthFirstIterator.SearchNodeData<E>>
 {
     private Deque<V> queue = new ArrayDeque<>();
 
@@ -93,7 +93,8 @@ public class BreadthFirstIterator<V, E>
     @Override
     protected void encounterVertex(V vertex, E edge)
     {
-        putSeenData(vertex, null);
+        int depth= (edge == null ? 0 : getSeenData(Graphs.getOppositeVertex(graph, edge, vertex)).depth+1);
+        putSeenData(vertex, new SearchNodeData<>(edge, depth));
         queue.add(vertex);
     }
 
@@ -106,12 +107,66 @@ public class BreadthFirstIterator<V, E>
     }
 
     /**
+     * Returns the parent node of vertex $v$ in the BFS search tree, or null if $v$ is the root node.
+     * This method can only be invoked on a vertex $v$ once the iterator has visited vertex $v$!
+     * @param v vertex
+     * @return parent node of vertex $v$ in the BFS search tree, or null if $v$ is a root node
+     */
+    public V getParent(V v){
+        assert getSeenData(v) != null;
+        E edge= getSeenData(v).edge;
+        if(edge == null)
+            return null;
+        else
+            return Graphs.getOppositeVertex(graph, edge, v);
+    }
+
+    /**
+     * Returns the edge connecting vertex $v$ to its parent in the BFS search tree, or null if $v$ is the root node.
+     * This method can only be invoked on a vertex $v$ once the iterator has visited vertex $v$!
+     * @param v vertex
+     * @return parent node of vertex $v$ in the BFS search tree, or null if $v$ is a root node
+     */
+    public E getParentEdge(V v){
+        assert getSeenData(v) != null;
+        return getSeenData(v).edge;
+    }
+
+    /**
+     * Returns the depth of vertex $v$ in the search tree. The depth of a vertex $v$ is defined as the number of edges
+     * traversed on the path from the root of the BFS tree to vertex $v$. The root of the search tree has depth 0.
+     * This method can only be invoked on a vertex $v$ once the iterator has visited vertex $v$!
+     * @param v vertex
+     * @return depth of vertex $v$ in the search tree
+     */
+    public int getDepth(V v){
+        assert getSeenData(v) != null;
+        return getSeenData(v).depth;
+    }
+
+    /**
      * @see CrossComponentIterator#provideNextVertex()
      */
     @Override
     protected V provideNextVertex()
     {
         return queue.removeFirst();
+    }
+
+    static class SearchNodeData<E>{
+        /**
+         * Edge to parent
+         */
+        final E edge;
+        /**
+         * Depth of node in search tree
+         */
+        final int depth;
+
+        SearchNodeData(E edge, int depth) {
+            this.edge = edge;
+            this.depth = depth;
+        }
     }
 }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/BreadthFirstIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/BreadthFirstIteratorTest.java
@@ -116,12 +116,12 @@ public class BreadthFirstIteratorTest
         assertEquals(3, bfs.getDepth("e"));
         assertEquals(2, bfs.getDepth("z"));
 
-        assertNull(bfs.getParentEdge("a"));
-        assertEquals(e1, bfs.getParentEdge("b"));
-        assertEquals(e2, bfs.getParentEdge("c"));
-        assertEquals(e4, bfs.getParentEdge("d"));
-        assertEquals(e5, bfs.getParentEdge("e"));
-        assertEquals(e3, bfs.getParentEdge("z"));
+        assertNull(bfs.getSpanningTreeEdge("a"));
+        assertEquals(e1, bfs.getSpanningTreeEdge("b"));
+        assertEquals(e2, bfs.getSpanningTreeEdge("c"));
+        assertEquals(e4, bfs.getSpanningTreeEdge("d"));
+        assertEquals(e5, bfs.getSpanningTreeEdge("e"));
+        assertEquals(e3, bfs.getSpanningTreeEdge("z"));
 
         assertNull(bfs.getParent("a"));
         assertEquals("a", bfs.getParent("b"));
@@ -148,10 +148,10 @@ public class BreadthFirstIteratorTest
         assertEquals(2, bfs.getDepth(2));
         assertEquals(3, bfs.getDepth(3));
 
-        assertNull(bfs.getParentEdge(0));
-        assertEquals(e1, bfs.getParentEdge(1));
-        assertEquals(e2, bfs.getParentEdge(2));
-        assertEquals(e3, bfs.getParentEdge(3));
+        assertNull(bfs.getSpanningTreeEdge(0));
+        assertEquals(e1, bfs.getSpanningTreeEdge(1));
+        assertEquals(e2, bfs.getSpanningTreeEdge(2));
+        assertEquals(e3, bfs.getSpanningTreeEdge(3));
 
         assertNull(bfs.getParent(0));
         assertEquals(new Integer(0), bfs.getParent(1));

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/BreadthFirstIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/BreadthFirstIteratorTest.java
@@ -19,6 +19,10 @@ package org.jgrapht.traverse;
 
 import org.jgrapht.*;
 import org.jgrapht.graph.*;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 /**
  * Tests for the {@link BreadthFirstIterator} class.
@@ -28,7 +32,8 @@ import org.jgrapht.graph.*;
  * the algorithm. This could cause false failures if the traversal implementation changes.
  * </p>
  *
- * @author Liviu Rau, Patrick Sharp
+ * @author Liviu Rau
+ * @author Patrick Sharp
  * @since Jul 30, 2003
  */
 public class BreadthFirstIteratorTest
@@ -82,6 +87,76 @@ public class BreadthFirstIteratorTest
         Graph<String, DefaultWeightedEdge> g, Iterable<String> startVertex)
     {
         return new BreadthFirstIterator<>(g, startVertex);
+    }
+
+    @Test
+    public void searchTreeTest(){
+        Graph<String, DefaultEdge> g =
+                new DefaultDirectedGraph<>(DefaultEdge.class);
+        g.addVertex("a");
+        g.addVertex("b");
+        g.addVertex("c");
+        g.addVertex("d");
+        g.addVertex("e");
+        g.addVertex("z");
+
+        DefaultEdge e1=g.addEdge("a", "b");
+        DefaultEdge e2=g.addEdge("b", "c");
+        DefaultEdge e3=g.addEdge("b", "z");
+        DefaultEdge e4=g.addEdge("b", "d");
+        DefaultEdge e5=g.addEdge("d", "e");
+
+        BreadthFirstIterator<String, DefaultEdge> bfs= new BreadthFirstIterator<>(g, "a");
+        while(bfs.hasNext()) bfs.next();
+
+        assertEquals(0, bfs.getDepth("a"));
+        assertEquals(1, bfs.getDepth("b"));
+        assertEquals(2, bfs.getDepth("c"));
+        assertEquals(2, bfs.getDepth("d"));
+        assertEquals(3, bfs.getDepth("e"));
+        assertEquals(2, bfs.getDepth("z"));
+
+        assertNull(bfs.getParentEdge("a"));
+        assertEquals(e1, bfs.getParentEdge("b"));
+        assertEquals(e2, bfs.getParentEdge("c"));
+        assertEquals(e4, bfs.getParentEdge("d"));
+        assertEquals(e5, bfs.getParentEdge("e"));
+        assertEquals(e3, bfs.getParentEdge("z"));
+
+        assertNull(bfs.getParent("a"));
+        assertEquals("a", bfs.getParent("b"));
+        assertEquals("b", bfs.getParent("c"));
+        assertEquals("b", bfs.getParent("d"));
+        assertEquals("d", bfs.getParent("e"));
+        assertEquals("b", bfs.getParent("z"));
+
+    }
+
+    @Test
+    public void searchTreeDirectedCycleTest(){
+        Graph<Integer,DefaultEdge> g= new SimpleDirectedGraph<>(DefaultEdge.class);
+        DefaultEdge e1=Graphs.addEdgeWithVertices(g, 0,1);
+        DefaultEdge e2=Graphs.addEdgeWithVertices(g, 1,2);
+        DefaultEdge e3=Graphs.addEdgeWithVertices(g, 2,3);
+        Graphs.addEdgeWithVertices(g, 3,0);
+
+        BreadthFirstIterator<Integer, DefaultEdge> bfs= new BreadthFirstIterator<>(g, 0);
+        while(bfs.hasNext()) bfs.next();
+
+        assertEquals(0, bfs.getDepth(0));
+        assertEquals(1, bfs.getDepth(1));
+        assertEquals(2, bfs.getDepth(2));
+        assertEquals(3, bfs.getDepth(3));
+
+        assertNull(bfs.getParentEdge(0));
+        assertEquals(e1, bfs.getParentEdge(1));
+        assertEquals(e2, bfs.getParentEdge(2));
+        assertEquals(e3, bfs.getParentEdge(3));
+
+        assertNull(bfs.getParent(0));
+        assertEquals(new Integer(0), bfs.getParent(1));
+        assertEquals(new Integer(1), bfs.getParent(2));
+        assertEquals(new Integer(2), bfs.getParent(3));
     }
 }
 


### PR DESCRIPTION
Added methods to query the search tree traversed by the BFS iterator. This feature was asked for [here](https://stackoverflow.com/questions/49948803/get-the-level-of-a-node-in-a-tree-using-jgrapht/49954762#49954762)
This change is equivalent to the change proposed in PR #423 (which I still have to finish)