### PR TITLE
Add suites for fast tests, integration tests, and performance tests.

### DIFF
--- a/jgrapht-core/pom.xml
+++ b/jgrapht-core/pom.xml
@@ -30,6 +30,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.googlecode.junit-toolbox</groupId>
+			<artifactId>junit-toolbox</artifactId>
+                        <version>2.4</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
 			<version>1.19</version>

--- a/jgrapht-core/src/test/java/org/jgrapht/FastTestSuite.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/FastTestSuite.java
@@ -1,0 +1,34 @@
+/*
+ * (C) Copyright 2018-2018, by John Sichi and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht;
+
+import org.junit.runner.*;
+import org.junit.experimental.categories.*;
+import com.googlecode.junittoolbox.*;
+
+/**
+ * Suite of fast unit tests only (as run by mvn test).
+ * 
+ * @author John Sichi
+ */
+@RunWith(ParallelSuite.class)
+@Categories.ExcludeCategory(SlowTests.class)
+@SuiteClasses({"**/*Test.class", "!**/perf/**"})
+public class FastTestSuite
+{
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/IntegrationTestSuite.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/IntegrationTestSuite.java
@@ -1,0 +1,32 @@
+/*
+ * (C) Copyright 2018-2018, by John Sichi and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht;
+
+import org.junit.runner.*;
+import com.googlecode.junittoolbox.*;
+
+/**
+ * Suite of all unit and integration tests (as run by mvn verify).  Excludes performance tests.
+ * 
+ * @author John Sichi
+ */
+@RunWith(ParallelSuite.class)
+@SuiteClasses({"**/*Test.class", "!**/perf/**"})
+public class IntegrationTestSuite
+{
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/PerformanceTestSuite.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/PerformanceTestSuite.java
@@ -1,0 +1,33 @@
+/*
+ * (C) Copyright 2018-2018, by John Sichi and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht;
+
+import org.junit.runner.*;
+import com.googlecode.junittoolbox.*;
+
+/**
+ * Suite of performance tests only.  We use WildcardPatternSuite instead
+ * of ParallelSuite to avoid running multiple benchmark tests simultaneously.
+ * 
+ * @author John Sichi
+ */
+@RunWith(WildcardPatternSuite.class)
+@SuiteClasses({"**/perf/**/*Test.class"})
+public class PerformanceTestSuite
+{
+}


### PR DESCRIPTION
These suites give control over which tests to run from an IDE such as Eclipse.  Unfortunately, at least for Eclipse, there does not seem to be a way to designate the default suite to use except via manual configuration, so instead I will update our wiki developer setup instructions after this gets merged.

These can also be used from the command line, e.g.

mvn -Dtest=PerformanceTestSuite test

For FastTestSuite and IntegrationTestSuite, we use ParallelSuite, which speeds things up when multiple cores are available.  For PerformanceTestSuite, we use sequential execution.
