### PR TITLE
Refactored the k-shortest paths interface

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/KShortestPathAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/KShortestPathAlgorithm.java
@@ -55,20 +55,6 @@ public interface KShortestPathAlgorithm<V, E>
      * @param k the number of shortest paths to return
      * @return a list of the k-shortest paths
      */
-    default List<GraphPath<V, E>> getPaths(V source, V sink, int k) {
-        List<GraphPath<V, E>> paths = new ArrayList<>();
-        iterator(source, sink, k).forEachRemaining(paths::add);
-        return paths;
-    }
-    
-    /**
-     * Get an iterator over of k-shortest paths from a source vertex to a sink vertex.
-     * 
-     * @param source the source vertex
-     * @param sink the target vertex
-     * @param k the number of shortest paths to return
-     * @return an iterator over the k-shortest paths
-     */
-    Iterator<GraphPath<V, E>> iterator(V source, V sink, int k); 
+    List<GraphPath<V, E>> getPaths(V source, V sink, int k);
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/KShortestPathAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/KShortestPathAlgorithm.java
@@ -39,7 +39,36 @@ public interface KShortestPathAlgorithm<V, E>
      * @param source the source vertex
      * @param sink the target vertex
      * @return a list of shortest paths
+     * @deprecated In favor of providing k as a parameter.
      */
-    List<GraphPath<V, E>> getPaths(V source, V sink);
+    @Deprecated
+    default List<GraphPath<V, E>> getPaths(V source, V sink) { 
+        return getPaths(source, sink, Integer.MAX_VALUE);
+    }
+    
+    /**
+     * Get a list of k-shortest paths from a source vertex to a sink vertex. If no such paths exist
+     * this method returns an empty list.
+     * 
+     * @param source the source vertex
+     * @param sink the target vertex
+     * @param k the number of shortest paths to return
+     * @return a list of the k-shortest paths
+     */
+    default List<GraphPath<V, E>> getPaths(V source, V sink, int k) {
+        List<GraphPath<V, E>> paths = new ArrayList<>();
+        iterator(source, sink, k).forEachRemaining(paths::add);
+        return paths;
+    }
+    
+    /**
+     * Get an iterator over of k-shortest paths from a source vertex to a sink vertex.
+     * 
+     * @param source the source vertex
+     * @param sink the target vertex
+     * @param k the number of shortest paths to return
+     * @return an iterator over the k-shortest paths
+     */
+    Iterator<GraphPath<V, E>> iterator(V source, V sink, int k); 
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestPaths.java
@@ -177,11 +177,6 @@ public class KShortestPaths<V, E>
     }
 
     @Override
-    public Iterator<GraphPath<V, E>> iterator(V startVertex, V endVertex, int k) {
-        return getPaths(startVertex, endVertex, k).iterator();
-    }
-
-    @Override
     public List<GraphPath<V, E>> getPaths(V source, V sink, int k)
     {
         this.nPaths = k;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePaths.java
@@ -17,9 +17,11 @@
  */
 package org.jgrapht.alg.shortestpath;
 
+import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import org.jgrapht.Graph;
 import org.jgrapht.GraphPath;
@@ -114,7 +116,7 @@ public class KShortestSimplePaths<V, E>
     }
 
     /**
-     * Returns an iterator of the $k$ shortest simple paths in increasing order of weight.
+     * Returns a list of the $k$ shortest simple paths in increasing order of weight.
      *
      * @param startVertex source vertex of the calculated paths.
      * @param endVertex target vertex of the calculated paths.
@@ -126,7 +128,7 @@ public class KShortestSimplePaths<V, E>
      * @throws IllegalArgumentException if k is negative or zero
      */
     @Override
-    public Iterator<GraphPath<V, E>> iterator(V startVertex, V endVertex, int k)
+    public List<GraphPath<V, E>> getPaths(V startVertex, V endVertex, int k)
     {
         Objects.requireNonNull(startVertex, "Start vertex cannot be null");
         Objects.requireNonNull(endVertex, "End vertex cannot be null");
@@ -155,7 +157,7 @@ public class KShortestSimplePaths<V, E>
 
         RankingPathElementList<V, E> pathElements = iter.getPathElements(endVertex);
         if (pathElements == null) {
-            return Collections.<GraphPath<V, E>> emptyList().iterator();
+            return Collections.<GraphPath<V, E>> emptyList();
         } else {
             return pathElements
                 .stream()
@@ -163,7 +165,7 @@ public class KShortestSimplePaths<V, E>
                     e -> new GraphWalk<V, E>(
                         graph, startVertex, e.getVertex(), null, e.createEdgeListPath(),
                         e.getWeight()))
-                .map(w -> (GraphPath<V, E>) w).iterator();
+                .collect(Collectors.toCollection(ArrayList::new));
         }
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePathsIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePathsIterator.java
@@ -22,11 +22,11 @@ import java.util.*;
 import org.jgrapht.*;
 
 /**
- * Helper class for {@link KShortestPaths}.
+ * Helper class for {@link KShortestSimplePaths}.
  *
  * @since July 5, 2007
  */
-class KShortestPathsIterator<V, E>
+class KShortestSimplePathsIterator<V, E>
     implements Iterator<Set<V>>
 {
     /**
@@ -86,7 +86,7 @@ class KShortestPathsIterator<V, E>
      * @param endVertex end vertex of the calculated paths.
      * @param maxSize number of paths stored at end vertex of the graph.
      */
-    public KShortestPathsIterator(Graph<V, E> graph, V startVertex, V endVertex, int maxSize)
+    public KShortestSimplePathsIterator(Graph<V, E> graph, V startVertex, V endVertex, int maxSize)
     {
         this(graph, startVertex, endVertex, maxSize, null);
     }
@@ -98,7 +98,7 @@ class KShortestPathsIterator<V, E>
      * @param maxSize number of paths stored at end vertex of the graph.
      * @param pathValidator the path validator to use
      */
-    public KShortestPathsIterator(
+    public KShortestSimplePathsIterator(
         Graph<V, E> graph, V startVertex, V endVertex, int maxSize,
         PathValidator<V, E> pathValidator)
     {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPDiscardsValidPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPDiscardsValidPathsTest.java
@@ -35,7 +35,7 @@ public class KSPDiscardsValidPathsTest
     public void testNot3connectedGraph()
     {
         WeightedMultigraph<String, DefaultWeightedEdge> graph;
-        KShortestPaths<String, DefaultWeightedEdge> paths;
+        KShortestSimplePaths<String, DefaultWeightedEdge> paths;
 
         graph = new WeightedMultigraph<>(DefaultWeightedEdge.class);
         graph.addVertex("S");
@@ -73,9 +73,9 @@ public class KSPDiscardsValidPathsTest
         this.addGraphEdge(graph, "K", "L", 1.0);
         this.addGraphEdge(graph, "L", "S", 1.0);
 
-        paths = new KShortestPaths<>(graph, 3);
+        paths = new KShortestSimplePaths<>(graph);
 
-        assertTrue(paths.getPaths("S", "T").size() == 3);
+        assertTrue(paths.getPaths("S", "T", 3).size() == 3);
     }
 
     /**
@@ -87,7 +87,7 @@ public class KSPDiscardsValidPathsTest
     public void testBrunoMaoili()
     {
         WeightedMultigraph<String, DefaultWeightedEdge> graph;
-        KShortestPaths<String, DefaultWeightedEdge> paths;
+        KShortestSimplePaths<String, DefaultWeightedEdge> paths;
 
         graph = new WeightedMultigraph<>(DefaultWeightedEdge.class);
         graph.addVertex("A");
@@ -104,14 +104,14 @@ public class KSPDiscardsValidPathsTest
         this.addGraphEdge(graph, "B", "E", 1.0);
         this.addGraphEdge(graph, "C", "D", 1.0);
 
-        paths = new KShortestPaths<>(graph, 2);
-        assertTrue(paths.getPaths("A", "E").size() == 2);
+        paths = new KShortestSimplePaths<>(graph);
+        assertTrue(paths.getPaths("A", "E", 2).size() == 2);
 
-        paths = new KShortestPaths<>(graph, 3);
-        assertTrue(paths.getPaths("A", "E").size() == 3);
+        paths = new KShortestSimplePaths<>(graph);
+        assertTrue(paths.getPaths("A", "E", 3).size() == 3);
 
-        paths = new KShortestPaths<>(graph, 4);
-        assertTrue(paths.getPaths("A", "E").size() == 4);
+        paths = new KShortestSimplePaths<>(graph);
+        assertTrue(paths.getPaths("A", "E", 4).size() == 4);
     }
 
     private void addGraphEdge(

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPExampleTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPExampleTest.java
@@ -33,10 +33,10 @@ public class KSPExampleTest
         SimpleWeightedGraph<String, DefaultWeightedEdge> graph = new KSPExampleGraph();
 
         String sourceVertex = "S";
-        KShortestPaths<String, DefaultWeightedEdge> ksp = new KShortestPaths<>(graph, 4);
+        KShortestSimplePaths<String, DefaultWeightedEdge> ksp = new KShortestSimplePaths<>(graph);
 
         String targetVertex = "T";
-        assertEquals(3, ksp.getPaths(sourceVertex, targetVertex).size());
+        assertEquals(3, ksp.getPaths(sourceVertex, targetVertex, 4).size());
     }
 
     @Test
@@ -46,10 +46,10 @@ public class KSPExampleTest
 
         String sourceVertex = "S";
         int nbPaths = 3;
-        KShortestPaths<String, DefaultWeightedEdge> ksp = new KShortestPaths<>(graph, nbPaths);
+        KShortestSimplePaths<String, DefaultWeightedEdge> ksp = new KShortestSimplePaths<>(graph);
 
         String targetVertex = "T";
-        assertEquals(nbPaths, ksp.getPaths(sourceVertex, targetVertex).size());
+        assertEquals(nbPaths, ksp.getPaths(sourceVertex, targetVertex, nbPaths).size());
     }
 
     @Test
@@ -59,10 +59,10 @@ public class KSPExampleTest
 
         String sourceVertex = "S";
         int nbPaths = 2;
-        KShortestPaths<String, DefaultWeightedEdge> ksp = new KShortestPaths<>(graph, nbPaths);
+        KShortestSimplePaths<String, DefaultWeightedEdge> ksp = new KShortestSimplePaths<>(graph);
 
         String targetVertex = "T";
-        assertEquals(nbPaths, ksp.getPaths(sourceVertex, targetVertex).size());
+        assertEquals(nbPaths, ksp.getPaths(sourceVertex, targetVertex, nbPaths).size());
     }
 }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPPathValidatorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPPathValidatorTest.java
@@ -50,15 +50,16 @@ public class KSPPathValidatorTest
         int size = 5;
         SimpleGraph<String, DefaultEdge> clique = buildCliqueGraph(size);
         for (int i = 0; i < size; i++) {
-            KShortestPaths<String, DefaultEdge> ksp = new KShortestPaths<String, DefaultEdge>(
-                clique, 1, Integer.MAX_VALUE, (partialPath, edge) -> false);
+            KShortestSimplePaths<String, DefaultEdge> ksp = new KShortestSimplePaths<>(
+                clique, Integer.MAX_VALUE, (partialPath, edge) -> false);
 
             for (int j = 0; j < size; j++) {
                 if (j == i) {
                     continue;
                 }
+                int k = 1;
                 List<GraphPath<String, DefaultEdge>> paths =
-                    ksp.getPaths(String.valueOf(i), String.valueOf(j));
+                    ksp.getPaths(String.valueOf(i), String.valueOf(j), k);
                 assertTrue(paths.isEmpty());
             }
         }
@@ -73,15 +74,15 @@ public class KSPPathValidatorTest
         int size = 5;
         SimpleGraph<String, DefaultEdge> clique = buildCliqueGraph(size);
         for (int i = 0; i < size; i++) {
-            KShortestPaths<String, DefaultEdge> ksp = new KShortestPaths<String, DefaultEdge>(
-                clique, 30, Integer.MAX_VALUE, (partialPath, edge) -> true);
+            KShortestSimplePaths<String, DefaultEdge> ksp = new KShortestSimplePaths<>(
+                clique, Integer.MAX_VALUE, (partialPath, edge) -> true);
 
             for (int j = 0; j < size; j++) {
                 if (j == i) {
                     continue;
                 }
                 List<GraphPath<String, DefaultEdge>> paths =
-                    ksp.getPaths(String.valueOf(i), String.valueOf(j));
+                    ksp.getPaths(String.valueOf(i), String.valueOf(j), 30);
                 assertNotNull(paths);
                 assertEquals(16, paths.size());
             }
@@ -97,8 +98,8 @@ public class KSPPathValidatorTest
         int size = 10;
         SimpleGraph<Integer, DefaultEdge> ring = buildRingGraph(size);
         for (int i = 0; i < size; i++) {
-            KShortestPaths<Integer, DefaultEdge> ksp = new KShortestPaths<Integer, DefaultEdge>(
-                ring, 2, Integer.MAX_VALUE, (partialPath, edge) -> {
+            KShortestSimplePaths<Integer, DefaultEdge> ksp = new KShortestSimplePaths<>(
+                ring, Integer.MAX_VALUE, (partialPath, edge) -> {
                     if (partialPath == null) {
                         return true;
                     }
@@ -111,7 +112,7 @@ public class KSPPathValidatorTest
                 if (j == i) {
                     continue;
                 }
-                List<GraphPath<Integer, DefaultEdge>> paths = ksp.getPaths(i, j);
+                List<GraphPath<Integer, DefaultEdge>> paths = ksp.getPaths(i, j, 2);
                 assertNotNull(paths);
                 assertEquals(1, paths.size());
             }
@@ -129,8 +130,8 @@ public class KSPPathValidatorTest
         // generate graph of two cliques connected by single edge
         SimpleGraph<Integer, DefaultEdge> graph = buildGraphForTestDisconnected(cliqueSize);
         for (int i = 0; i < graph.vertexSet().size(); i++) {
-            KShortestPaths<Integer, DefaultEdge> ksp = new KShortestPaths<Integer, DefaultEdge>(
-                graph, 100, Integer.MAX_VALUE, (partialPath, edge) -> {
+            KShortestSimplePaths<Integer, DefaultEdge> ksp = new KShortestSimplePaths<>(
+                graph, Integer.MAX_VALUE, (partialPath, edge) -> {
                     // accept all requests but the one to pass through the edge connecting
                     // the two cliques.
                     DefaultEdge connectingEdge = graph.getEdge(cliqueSize - 1, cliqueSize);
@@ -141,7 +142,7 @@ public class KSPPathValidatorTest
                 if (j == i) {
                     continue;
                 }
-                List<GraphPath<Integer, DefaultEdge>> paths = ksp.getPaths(i, j);
+                List<GraphPath<Integer, DefaultEdge>> paths = ksp.getPaths(i, j, 100);
                 if ((i < cliqueSize && j < cliqueSize) || (i >= cliqueSize && j >= cliqueSize)) {
                     // within the clique - path should exist
                     assertNotNull(paths);
@@ -167,8 +168,8 @@ public class KSPPathValidatorTest
     public void testGraphPath()
     {
         SimpleDirectedGraph<Integer, DefaultEdge> line = buildLineGraph(10);
-        KShortestPaths<Integer, DefaultEdge> ksp = new KShortestPaths<Integer, DefaultEdge>(line, 
-            Integer.MAX_VALUE, new PathValidator<Integer, DefaultEdge>()
+        KShortestSimplePaths<Integer, DefaultEdge> ksp = new KShortestSimplePaths<>(line, 
+            new PathValidator<Integer, DefaultEdge>()
         {
 
             int index = 0;
@@ -207,7 +208,7 @@ public class KSPPathValidatorTest
             }
         });
 
-        ksp.getPaths(0, 9);
+        ksp.getPaths(0, 9, Integer.MAX_VALUE);
     }
 
     private SimpleGraph<String, DefaultEdge> buildCliqueGraph(int size)

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KShortestPathCostTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KShortestPathCostTest.java
@@ -45,9 +45,9 @@ public class KShortestPathCostTest
 
         KShortestPathCompleteGraph4 graph = new KShortestPathCompleteGraph4();
 
-        KShortestPaths<String, DefaultWeightedEdge> pathFinder =
-            new KShortestPaths<>(graph, nbPaths);
-        List<GraphPath<String, DefaultWeightedEdge>> pathElements = pathFinder.getPaths("vS", "v3");
+        KShortestSimplePaths<String, DefaultWeightedEdge> pathFinder =
+            new KShortestSimplePaths<>(graph);
+        List<GraphPath<String, DefaultWeightedEdge>> pathElements = pathFinder.getPaths("vS", "v3", nbPaths);
 
         assertEquals(
             "[[(vS : v1), (v1 : v3)], [(vS : v2), (v2 : v3)],"
@@ -70,12 +70,12 @@ public class KShortestPathCostTest
 
         int maxSize = 10;
 
-        KShortestPaths<String, DefaultWeightedEdge> pathFinder =
-            new KShortestPaths<>(picture1Graph, maxSize);
+        KShortestSimplePaths<String, DefaultWeightedEdge> pathFinder =
+            new KShortestSimplePaths<>(picture1Graph);
 
         // assertEquals(2, pathFinder.getPaths("v5").size());
 
-        List<GraphPath<String, DefaultWeightedEdge>> pathElements = pathFinder.getPaths("vS", "v5");
+        List<GraphPath<String, DefaultWeightedEdge>> pathElements = pathFinder.getPaths("vS", "v5", maxSize);
         GraphPath<String, DefaultWeightedEdge> pathElement = pathElements.get(0);
         assertEquals(
             Arrays.asList(new Object[] { picture1Graph.eS1, picture1Graph.e15 }),
@@ -92,7 +92,7 @@ public class KShortestPathCostTest
         vertices = pathElement.getVertexList();
         assertEquals(Arrays.asList(new Object[] { "vS", "v2", "v5" }), vertices);
 
-        pathElements = pathFinder.getPaths("vS", "v7");
+        pathElements = pathFinder.getPaths("vS", "v7", maxSize);
         pathElement = pathElements.get(0);
         double lastCost = pathElement.getWeight();
         for (int i = 0; i < pathElements.size(); i++) {
@@ -161,10 +161,10 @@ public class KShortestPathCostTest
         for (String sourceVertex : graph.vertexSet()) {
             for (String targetVertex : graph.vertexSet()) {
                 if (targetVertex != sourceVertex) {
-                    KShortestPaths<String, E> pathFinder = new KShortestPaths<>(graph, maxSize);
+                    KShortestSimplePaths<String, E> pathFinder = new KShortestSimplePaths<>(graph);
 
                     List<GraphPath<String, E>> pathElements =
-                        pathFinder.getPaths(sourceVertex, targetVertex);
+                        pathFinder.getPaths(sourceVertex, targetVertex, maxSize);
                     if (pathElements.isEmpty()) {
                         // no path exists between the start vertex and the end
                         // vertex
@@ -191,9 +191,9 @@ public class KShortestPathCostTest
         for (String sourceVertex : graph.vertexSet()) {
             for (String targetVertex : graph.vertexSet()) {
                 if (targetVertex != sourceVertex) {
-                    KShortestPaths<String, E> pathFinder = new KShortestPaths<>(graph, 1);
+                    KShortestSimplePaths<String, E> pathFinder = new KShortestSimplePaths<>(graph);
                     List<GraphPath<String, E>> prevPathElementsResults =
-                        pathFinder.getPaths(sourceVertex, targetVertex);
+                        pathFinder.getPaths(sourceVertex, targetVertex, 1);
 
                     if (prevPathElementsResults.isEmpty()) {
                         // no path exists between the start vertex and the
@@ -202,9 +202,9 @@ public class KShortestPathCostTest
                     }
 
                     for (int maxSize = 2; maxSize < maxSizeLimit; maxSize++) {
-                        pathFinder = new KShortestPaths<>(graph, maxSize);
+                        pathFinder = new KShortestSimplePaths<>(graph);
                         List<GraphPath<String, E>> pathElementsResults =
-                            pathFinder.getPaths(sourceVertex, targetVertex);
+                            pathFinder.getPaths(sourceVertex, targetVertex, maxSize);
 
                         verifyWeightsConsistency(prevPathElementsResults, pathElementsResults);
                     }
@@ -268,11 +268,11 @@ public class KShortestPathCostTest
 
         DefaultWeightedEdge src = graph.getEdge("M013", "M014");
 
-        KShortestPaths<String, DefaultWeightedEdge> kPaths = new KShortestPaths<>(graph, 5);
+        KShortestSimplePaths<String, DefaultWeightedEdge> kPaths = new KShortestSimplePaths<>(graph);
         List<GraphPath<String, DefaultWeightedEdge>> paths;
 
         try {
-            paths = kPaths.getPaths(graph.getEdgeSource(src), graph.getEdgeTarget(src));
+            paths = kPaths.getPaths(graph.getEdgeSource(src), graph.getEdgeTarget(src), 5);
             for (GraphPath<String, DefaultWeightedEdge> path : paths) {
                 for (DefaultWeightedEdge edge : path.getEdgeList()) {
                     System.out.print(

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KShortestPathKValuesTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KShortestPathKValuesTest.java
@@ -53,14 +53,14 @@ public class KShortestPathKValuesTest
         KShortestPathCompleteGraph6 graph = new KShortestPathCompleteGraph6();
 
         for (int maxSize = 1; maxSize <= calculateNbElementaryPathsForCompleteGraph(6); maxSize++) {
-            KShortestPaths<String, DefaultWeightedEdge> finder =
-                new KShortestPaths<>(graph, maxSize);
+            KShortestSimplePaths<String, DefaultWeightedEdge> finder =
+                new KShortestSimplePaths<>(graph);
 
-            assertEquals(finder.getPaths("vS", "v1").size(), maxSize);
-            assertEquals(finder.getPaths("vS", "v2").size(), maxSize);
-            assertEquals(finder.getPaths("vS", "v3").size(), maxSize);
-            assertEquals(finder.getPaths("vS", "v4").size(), maxSize);
-            assertEquals(finder.getPaths("vS", "v5").size(), maxSize);
+            assertEquals(finder.getPaths("vS", "v1", maxSize).size(), maxSize);
+            assertEquals(finder.getPaths("vS", "v2", maxSize).size(), maxSize);
+            assertEquals(finder.getPaths("vS", "v3", maxSize).size(), maxSize);
+            assertEquals(finder.getPaths("vS", "v4", maxSize).size(), maxSize);
+            assertEquals(finder.getPaths("vS", "v5", maxSize).size(), maxSize);
         }
     }
 
@@ -100,11 +100,11 @@ public class KShortestPathKValuesTest
         int maxSize = Integer.MAX_VALUE;
 
         for (String sourceVertex : graph.vertexSet()) {
-            KShortestPaths<String, DefaultWeightedEdge> finder =
-                new KShortestPaths<>(graph, maxSize);
+            KShortestSimplePaths<String, DefaultWeightedEdge> finder =
+                new KShortestSimplePaths<>(graph);
             for (String targetVertex : graph.vertexSet()) {
                 if (targetVertex != sourceVertex) {
-                    assertEquals(finder.getPaths(sourceVertex, targetVertex).size(), nbPaths);
+                    assertEquals(finder.getPaths(sourceVertex, targetVertex, maxSize).size(), nbPaths);
                 }
             }
         }


### PR DESCRIPTION
In an attempt to cleanup a little bit our k-shortest paths interfaces, I refactored the k shortest paths interface to accept the number of paths. Hopefully, this will also help in merging #413 before the next release.

- Changed the interface to accept k as a parameter (as suggested in #413)
- Added method which returns an iterator
- Due to deprecation procedures and compatibility, I renamed the class `KShortestPaths` to `KShortestSimplePaths` (it computes simple paths anyway, so this is likely a better name).

After the next release, we need to do a refactoring pass over the k-shortest path code.