### PR TITLE
Minor refactoring of the DOT Exporter

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
@@ -17,13 +17,16 @@
  */
 package org.jgrapht.io;
 
-import java.io.*;
-import java.util.*;
-import java.util.Map.*;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.regex.Matcher;
 
-import org.jgrapht.*;
-import org.jgrapht.graph.*;
+import org.jgrapht.Graph;
 
 /**
  * Exports a graph into a DOT file.
@@ -32,6 +35,9 @@ import org.jgrapht.graph.*;
  * For a description of the format see <a href="http://en.wikipedia.org/wiki/DOT_language">
  * http://en.wikipedia.org/wiki/DOT_language</a>.
  * </p>
+ * 
+ * The user can adjust the behavior using {@link ComponentNameProvider} and {@link ComponentAttributeProvider} instances
+ * given through the constructor.   
  * 
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -47,12 +53,15 @@ public class DOTExporter<V, E>
      */
     public static final String DEFAULT_GRAPH_ID = "G";
 
-    private ComponentNameProvider<Graph<V, E>> graphIDProvider;
-    private ComponentNameProvider<V> vertexLabelProvider;
-    private ComponentNameProvider<E> edgeLabelProvider;
-    private ComponentAttributeProvider<V> vertexAttributeProvider;
-    private ComponentAttributeProvider<E> edgeAttributeProvider;
-    private Map<String, String> graphAttributes;
+    private final ComponentNameProvider<Graph<V, E>> graphIDProvider;
+    private final ComponentNameProvider<V> vertexLabelProvider;
+    private final ComponentNameProvider<E> edgeLabelProvider;
+    private final ComponentAttributeProvider<V> vertexAttributeProvider;
+    private final ComponentAttributeProvider<E> edgeAttributeProvider;
+    private final Map<String, String> graphAttributes;
+    private final Map<V, String> vertexIds;
+
+    private static final String INDENT = "  ";
 
     /**
      * Constructs a new DOTExporter object with an integer name provider for the vertex IDs and null
@@ -139,6 +148,7 @@ public class DOTExporter<V, E>
         this.graphIDProvider =
             (graphIDProvider == null) ? any -> DEFAULT_GRAPH_ID : graphIDProvider;
         this.graphAttributes = new LinkedHashMap<>();
+        this.vertexIds = new HashMap<>();
     }
 
     /**
@@ -151,33 +161,12 @@ public class DOTExporter<V, E>
     public void exportGraph(Graph<V, E> g, Writer writer)
     {
         PrintWriter out = new PrintWriter(writer);
-        String indent = "  ";
-        String connector;
-        String header = (g instanceof AbstractBaseGraph
-            && !((AbstractBaseGraph<V, E>) g).isAllowingMultipleEdges())
-                ? DOTUtils.DONT_ALLOW_MULTIPLE_EDGES_KEYWORD + " " : "";
-        String graphId = graphIDProvider.getName(g);
-        if (graphId == null || graphId.trim().isEmpty()) {
-            graphId = DEFAULT_GRAPH_ID;
-        }
-        if (!DOTUtils.isValidID(graphId)) {
-            throw new RuntimeException(
-                "Generated graph ID '" + graphId
-                    + "' is not valid with respect to the .dot language");
-        }
-        if (g.getType().isDirected()) {
-            header += DOTUtils.DIRECTED_GRAPH_KEYWORD;
-            connector = " " + DOTUtils.DIRECTED_GRAPH_EDGEOP + " ";
-        } else {
-            header += DOTUtils.UNDIRECTED_GRAPH_KEYWORD;
-            connector = " " + DOTUtils.UNDIRECTED_GRAPH_EDGEOP + " ";
-        }
-        header += " " + graphId + " {";
-        out.println(header);
+
+        out.println(computeHeader(g));
 
         // graph attributes
-        for(Entry<String, String> attr: graphAttributes.entrySet()) {
-            out.print(indent);
+        for (Entry<String, String> attr : graphAttributes.entrySet()) {
+            out.print(INDENT);
             out.print(attr.getKey());
             out.print('=');
             out.print(attr.getValue());
@@ -186,7 +175,8 @@ public class DOTExporter<V, E>
 
         // vertex set
         for (V v : g.vertexSet()) {
-            out.print(indent + getVertexID(v));
+            out.print(INDENT);
+            out.print(getVertexID(v));
 
             String labelName = null;
             if (vertexLabelProvider != null) {
@@ -201,12 +191,17 @@ public class DOTExporter<V, E>
             out.println(";");
         }
 
+        String connector = computeConnector(g);
+
         // edge set
         for (E e : g.edgeSet()) {
             String source = getVertexID(g.getEdgeSource(e));
             String target = getVertexID(g.getEdgeTarget(e));
 
-            out.print(indent + source + connector + target);
+            out.print(INDENT);
+            out.print(source);
+            out.print(connector);
+            out.print(target);
 
             String labelName = null;
             if (edgeLabelProvider != null) {
@@ -221,9 +216,30 @@ public class DOTExporter<V, E>
             out.println(";");
         }
 
-        out.println("}");
+        out.println(computeFooter(g));
 
         out.flush();
+    }
+
+    /**
+     * Compute the header
+     * 
+     * @param graph the graph
+     * @return the header
+     */
+    private String computeHeader(Graph<V, E> graph)
+    {
+        StringBuilder headerBuilder = new StringBuilder();
+        if (!graph.getType().isAllowingMultipleEdges()) {
+            headerBuilder.append(DOTUtils.DONT_ALLOW_MULTIPLE_EDGES_KEYWORD).append(" ");
+        }
+        if (graph.getType().isDirected()) {
+            headerBuilder.append(DOTUtils.DIRECTED_GRAPH_KEYWORD);
+        } else {
+            headerBuilder.append(DOTUtils.UNDIRECTED_GRAPH_KEYWORD);
+        }
+        headerBuilder.append(" ").append(computeGraphId(graph)).append(" {");
+        return headerBuilder.toString();
     }
 
     /**
@@ -250,7 +266,56 @@ public class DOTExporter<V, E>
         graphAttributes.put(key, value);
     }
 
-    private void renderAttributes(PrintWriter out, String labelName, Map<String, Attribute> attributes)
+    /**
+     * Compute the footer
+     * 
+     * @param graph the graph
+     * @return the footer
+     */
+    private String computeFooter(Graph<V, E> graph)
+    {
+        return "}";
+    }
+
+    /**
+     * Compute the connector
+     * 
+     * @param graph the graph
+     * @return the connector
+     */
+    private String computeConnector(Graph<V, E> graph)
+    {
+        StringBuilder connectorBuilder = new StringBuilder();
+        if (graph.getType().isDirected()) {
+            connectorBuilder.append(" ").append(DOTUtils.DIRECTED_GRAPH_EDGEOP).append(" ");
+        } else {
+            connectorBuilder.append(" ").append(DOTUtils.UNDIRECTED_GRAPH_EDGEOP).append(" ");
+        }
+        return connectorBuilder.toString();
+    }
+
+    /**
+     * Get the id of the graph.
+     * 
+     * @param graph the graph
+     * @return the graph id
+     */
+    private String computeGraphId(Graph<V, E> graph)
+    {
+        String graphId = graphIDProvider.getName(graph);
+        if (graphId == null || graphId.trim().isEmpty()) {
+            graphId = DEFAULT_GRAPH_ID;
+        }
+        if (!DOTUtils.isValidID(graphId)) {
+            throw new RuntimeException(
+                "Generated graph ID '" + graphId
+                    + "' is not valid with respect to the .dot language");
+        }
+        return graphId;
+    }
+
+    private void renderAttributes(
+        PrintWriter out, String labelName, Map<String, Attribute> attributes)
     {
         if (labelName == null && attributes == null) {
             return;
@@ -258,7 +323,7 @@ public class DOTExporter<V, E>
         out.print(" [ ");
         if (labelName == null) {
             Attribute labelAttribute = attributes.get("label");
-            if (labelAttribute != null) { 
+            if (labelAttribute != null) {
                 labelName = labelAttribute.getValue();
             }
         }
@@ -278,7 +343,8 @@ public class DOTExporter<V, E>
         out.print("]");
     }
 
-    private static String escapeDoubleQuotes(String labelName) {
+    private static String escapeDoubleQuotes(String labelName)
+    {
         return labelName.replaceAll("\"", Matcher.quoteReplacement("\\\""));
     }
 
@@ -299,20 +365,26 @@ public class DOTExporter<V, E>
      */
     private String getVertexID(V v)
     {
-        // TODO jvs 28-Jun-2008: possible optimizations here are
-        // (a) only validate once per vertex
-
-        // use the associated id provider for an ID of the given vertex
-        String idCandidate = vertexIDProvider.getName(v);
-
-        // test if it is a valid ID
-        if (DOTUtils.isValidID(idCandidate)) {
-            return idCandidate;
+        String vertexId = vertexIds.get(v);
+        if (vertexId == null) { 
+            /* 
+             *  use the associated id provider for an ID of the given vertex
+             */
+            String idCandidate = vertexIDProvider.getName(v);
+            
+            /* 
+             * test if it is a valid ID
+             */
+            if (!DOTUtils.isValidID(idCandidate)) {
+                throw new RuntimeException(
+                    "Generated id '" + idCandidate + "'for vertex '" + v
+                        + "' is not valid with respect to the .dot language");
+            }
+            
+            vertexIds.put(v, idCandidate);
+            vertexId = idCandidate;
         }
-
-        throw new RuntimeException(
-            "Generated id '" + idCandidate + "'for vertex '" + v
-                + "' is not valid with respect to the .dot language");
+        return vertexId;
     }
 
 }


### PR DESCRIPTION
 - Removed `instanceof AbstractBaseGraph` no longer needed due to dynamic graph type information
 - Added caching of vertex identifiers (removed one very old TODO comment!)
 - Used `StringBuilder` instead of string addition