### PR TITLE
Use POSIX tar files

### DIFF
--- a/jgrapht-dist/pom.xml
+++ b/jgrapht-dist/pom.xml
@@ -80,6 +80,7 @@
 							<finalName>jgrapht-${project.version}</finalName>
 							<descriptorSourceDirectory>${basedir}/src/assembly</descriptorSourceDirectory>
 							<appendAssemblyId>false</appendAssemblyId>
+							<tarLongFileMode>posix</tarLongFileMode>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
When building `jgrapht` as a user with a high user or group ID value
(`1919775341` on my system, for example), the `maven-assembly-plugin`
will produce an error message:

  group id '1919775341` is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit

This commit configures the assembly plugin to use POSIX extensions
in order to be able to store larger gid/uid values.