### PR TITLE
Specifics strategy

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/BaseIntrusiveEdgesSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/BaseIntrusiveEdgesSpecifics.java
@@ -44,10 +44,12 @@ public abstract class BaseIntrusiveEdgesSpecifics<V, E, IE extends IntrusiveEdge
 
     /**
      * Constructor
+     * 
+     * @param edgeMap the map to use for storage
      */
-    public BaseIntrusiveEdgesSpecifics()
+    public BaseIntrusiveEdgesSpecifics(Map<E, IE> edgeMap)
     {
-        this.edgeMap = new LinkedHashMap<>();
+        this.edgeMap = Objects.requireNonNull(edgeMap);
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultDirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultDirectedGraph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultDirectedWeightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultDirectedWeightedGraph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphSpecificsStrategy.java
@@ -43,10 +43,10 @@ public class DefaultGraphSpecificsStrategy<V, E>
         return (Function<GraphType, IntrusiveEdgesSpecifics<V, E>> & Serializable) (type) -> {
             if (type.isWeighted()) {
                 return new WeightedIntrusiveEdgesSpecifics<V, E>(
-                    this.<E, IntrusiveWeightedEdge> getPredictableOrderIterationMapFactory().get());
+                    this.<E, IntrusiveWeightedEdge> getPredictableOrderMapFactory().get());
             } else {
                 return new UniformIntrusiveEdgesSpecifics<>(
-                    this.<E, IntrusiveEdge> getPredictableOrderIterationMapFactory().get());
+                    this.<E, IntrusiveEdge> getPredictableOrderMapFactory().get());
             }
         };
     }
@@ -64,11 +64,11 @@ public class DefaultGraphSpecificsStrategy<V, E>
             Specifics<V, E>> & Serializable) (graph, type) -> {
                 if (type.isDirected()) {
                     return new DirectedSpecifics<>(graph, this
-                        .<V, DirectedEdgeContainer<V, E>> getPredictableOrderIterationMapFactory()
+                        .<V, DirectedEdgeContainer<V, E>> getPredictableOrderMapFactory()
                         .get(), getEdgeSetFactory());
                 } else {
                     return new UndirectedSpecifics<>(graph, this
-                        .<V, UndirectedEdgeContainer<V, E>> getPredictableOrderIterationMapFactory()
+                        .<V, UndirectedEdgeContainer<V, E>> getPredictableOrderMapFactory()
                         .get(), getEdgeSetFactory());
                 }
             };

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphSpecificsStrategy.java
@@ -1,0 +1,77 @@
+package org.jgrapht.graph;
+
+import java.io.Serializable;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphType;
+import org.jgrapht.graph.specifics.DirectedEdgeContainer;
+import org.jgrapht.graph.specifics.DirectedSpecifics;
+import org.jgrapht.graph.specifics.Specifics;
+import org.jgrapht.graph.specifics.UndirectedEdgeContainer;
+import org.jgrapht.graph.specifics.UndirectedSpecifics;
+
+/**
+ * A default lookup specifics strategy implementation.
+ * 
+ * <p>
+ * Graphs constructed using this strategy require the least amount of memory, at the expense of slow
+ * edge retrievals. Methods which depend on edge retrievals, e.g. getEdge(V u, V v), containsEdge(V
+ * u, V v), addEdge(V u, V v), etc may be relatively slow when the average degree of a vertex is
+ * high (dense graphs). For a fast implementation, use {@link FastLookupGraphSpecificsStrategy}.
+ * 
+ * @author Dimitrios Michail
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ */
+public class DefaultGraphSpecificsStrategy<V, E>
+    implements GraphSpecificsStrategy<V, E>
+{
+    private static final long serialVersionUID = 7615319421753562075L;
+
+    /**
+     * Get a function which creates the intrusive edges specifics. The factory will accept the graph
+     * type as a parameter.
+     * 
+     * @return a function which creates intrusive edges specifics.
+     */
+    @Override
+    public Function<GraphType, IntrusiveEdgesSpecifics<V, E>> getIntrusiveEdgesSpecificsFactory()
+    {
+        return (Function<GraphType, IntrusiveEdgesSpecifics<V, E>> & Serializable) (type) -> {
+            if (type.isWeighted()) {
+                return new WeightedIntrusiveEdgesSpecifics<V, E>(
+                    this.<E, IntrusiveWeightedEdge> getPredictableOrderIterationMapFactory().get());
+            } else {
+                return new UniformIntrusiveEdgesSpecifics<>(
+                    this.<E, IntrusiveEdge> getPredictableOrderIterationMapFactory().get());
+            }
+        };
+    }
+
+    /**
+     * Get a function which creates the specifics. The factory will accept the graph type as a
+     * parameter.
+     * 
+     * @return a function which creates intrusive edges specifics.
+     */
+    @Override
+    public BiFunction<Graph<V, E>, GraphType, Specifics<V, E>> getSpecificsFactory()
+    {
+        return (BiFunction<Graph<V, E>, GraphType,
+            Specifics<V, E>> & Serializable) (graph, type) -> {
+                if (type.isDirected()) {
+                    return new DirectedSpecifics<>(graph, this
+                        .<V, DirectedEdgeContainer<V, E>> getPredictableOrderIterationMapFactory()
+                        .get(), getEdgeSetFactory());
+                } else {
+                    return new UndirectedSpecifics<>(graph, this
+                        .<V, UndirectedEdgeContainer<V, E>> getPredictableOrderIterationMapFactory()
+                        .get(), getEdgeSetFactory());
+                }
+            };
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultUndirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultUndirectedGraph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultUndirectedWeightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultUndirectedWeightedGraph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedMultigraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedMultigraph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedPseudograph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedPseudograph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedWeightedMultigraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedWeightedMultigraph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedWeightedPseudograph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedWeightedPseudograph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/FastLookupGraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/FastLookupGraphSpecificsStrategy.java
@@ -1,0 +1,81 @@
+package org.jgrapht.graph;
+
+import java.io.Serializable;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphType;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.graph.specifics.DirectedEdgeContainer;
+import org.jgrapht.graph.specifics.FastLookupDirectedSpecifics;
+import org.jgrapht.graph.specifics.FastLookupUndirectedSpecifics;
+import org.jgrapht.graph.specifics.Specifics;
+import org.jgrapht.graph.specifics.UndirectedEdgeContainer;
+import org.jgrapht.util.ArrayUnenforcedSet;
+
+/**
+ * The fast lookup specifics strategy implementation.
+ * 
+ * <p>
+ * Graphs constructed using this strategy use additional data structures to improve the performance
+ * of methods which depend on edge retrievals, e.g. getEdge(V u, V v), containsEdge(V u, V
+ * v),addEdge(V u, V v). A disadvantage is an increase in memory consumption. If memory utilization
+ * is an issue, use the {@link DefaultGraphSpecificsStrategy} instead.
+ * 
+ * @author Dimitrios Michail
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ */
+public class FastLookupGraphSpecificsStrategy<V, E>
+    implements GraphSpecificsStrategy<V, E>
+{
+    private static final long serialVersionUID = -5490869870275054280L;
+
+    /**
+     * Get a function which creates the intrusive edges specifics. The factory will accept the graph
+     * type as a parameter.
+     * 
+     * @return a function which creates intrusive edges specifics.
+     */
+    @Override
+    public Function<GraphType, IntrusiveEdgesSpecifics<V, E>> getIntrusiveEdgesSpecificsFactory()
+    {
+        return (Function<GraphType, IntrusiveEdgesSpecifics<V, E>> & Serializable) (type) -> {
+            if (type.isWeighted()) {
+                return new WeightedIntrusiveEdgesSpecifics<V, E>(
+                    this.<E, IntrusiveWeightedEdge> getPredictableOrderIterationMapFactory().get());
+            } else {
+                return new UniformIntrusiveEdgesSpecifics<>(
+                    this.<E, IntrusiveEdge> getPredictableOrderIterationMapFactory().get());
+            }
+        };
+    }
+
+    /**
+     * Get a function which creates the specifics. The factory will accept the graph type as a
+     * parameter.
+     * 
+     * @return a function which creates intrusive edges specifics.
+     */
+    @Override
+    public BiFunction<Graph<V, E>, GraphType, Specifics<V, E>> getSpecificsFactory()
+    {
+        return (BiFunction<Graph<V, E>, GraphType,
+            Specifics<V, E>> & Serializable) (graph, type) -> {
+                if (type.isDirected()) {
+                    return new FastLookupDirectedSpecifics<>(graph, this
+                        .<V, DirectedEdgeContainer<V, E>> getPredictableOrderIterationMapFactory()
+                        .get(), this.<Pair<V, V>, ArrayUnenforcedSet<E>> getMapFactory().get(),
+                        getEdgeSetFactory());
+                } else {
+                    return new FastLookupUndirectedSpecifics<>(graph, this
+                        .<V, UndirectedEdgeContainer<V, E>> getPredictableOrderIterationMapFactory()
+                        .get(), this.<Pair<V, V>, ArrayUnenforcedSet<E>> getMapFactory().get(),
+                        getEdgeSetFactory());
+                }
+            };
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/FastLookupGraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/FastLookupGraphSpecificsStrategy.java
@@ -1,6 +1,7 @@
 package org.jgrapht.graph;
 
 import java.io.Serializable;
+import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -12,7 +13,6 @@ import org.jgrapht.graph.specifics.FastLookupDirectedSpecifics;
 import org.jgrapht.graph.specifics.FastLookupUndirectedSpecifics;
 import org.jgrapht.graph.specifics.Specifics;
 import org.jgrapht.graph.specifics.UndirectedEdgeContainer;
-import org.jgrapht.util.ArrayUnenforcedSet;
 
 /**
  * The fast lookup specifics strategy implementation.
@@ -67,12 +67,12 @@ public class FastLookupGraphSpecificsStrategy<V, E>
                 if (type.isDirected()) {
                     return new FastLookupDirectedSpecifics<>(graph, this
                         .<V, DirectedEdgeContainer<V, E>> getPredictableOrderIterationMapFactory()
-                        .get(), this.<Pair<V, V>, ArrayUnenforcedSet<E>> getMapFactory().get(),
+                        .get(), this.<Pair<V, V>, Set<E>> getMapFactory().get(),
                         getEdgeSetFactory());
                 } else {
                     return new FastLookupUndirectedSpecifics<>(graph, this
                         .<V, UndirectedEdgeContainer<V, E>> getPredictableOrderIterationMapFactory()
-                        .get(), this.<Pair<V, V>, ArrayUnenforcedSet<E>> getMapFactory().get(),
+                        .get(), this.<Pair<V, V>, Set<E>> getMapFactory().get(),
                         getEdgeSetFactory());
                 }
             };

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/FastLookupGraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/FastLookupGraphSpecificsStrategy.java
@@ -45,10 +45,10 @@ public class FastLookupGraphSpecificsStrategy<V, E>
         return (Function<GraphType, IntrusiveEdgesSpecifics<V, E>> & Serializable) (type) -> {
             if (type.isWeighted()) {
                 return new WeightedIntrusiveEdgesSpecifics<V, E>(
-                    this.<E, IntrusiveWeightedEdge> getPredictableOrderIterationMapFactory().get());
+                    this.<E, IntrusiveWeightedEdge> getPredictableOrderMapFactory().get());
             } else {
                 return new UniformIntrusiveEdgesSpecifics<>(
-                    this.<E, IntrusiveEdge> getPredictableOrderIterationMapFactory().get());
+                    this.<E, IntrusiveEdge> getPredictableOrderMapFactory().get());
             }
         };
     }
@@ -66,12 +66,12 @@ public class FastLookupGraphSpecificsStrategy<V, E>
             Specifics<V, E>> & Serializable) (graph, type) -> {
                 if (type.isDirected()) {
                     return new FastLookupDirectedSpecifics<>(graph, this
-                        .<V, DirectedEdgeContainer<V, E>> getPredictableOrderIterationMapFactory()
+                        .<V, DirectedEdgeContainer<V, E>> getPredictableOrderMapFactory()
                         .get(), this.<Pair<V, V>, Set<E>> getMapFactory().get(),
                         getEdgeSetFactory());
                 } else {
                     return new FastLookupUndirectedSpecifics<>(graph, this
-                        .<V, UndirectedEdgeContainer<V, E>> getPredictableOrderIterationMapFactory()
+                        .<V, UndirectedEdgeContainer<V, E>> getPredictableOrderMapFactory()
                         .get(), this.<Pair<V, V>, Set<E>> getMapFactory().get(),
                         getEdgeSetFactory());
                 }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphSpecificsStrategy.java
@@ -1,0 +1,80 @@
+package org.jgrapht.graph;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphType;
+import org.jgrapht.graph.specifics.ArrayUnenforcedSetEdgeSetFactory;
+import org.jgrapht.graph.specifics.Specifics;
+
+/**
+ * A graph specifics construction factory.
+ * 
+ * <p>Such a strategy can be used to adjust the internals of the default graph implementations. 
+ * 
+ * @author Dimitrios Michail
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ * 
+ * @see FastLookupGraphSpecificsStrategy
+ */
+public interface GraphSpecificsStrategy<V, E> extends Serializable
+{
+    /**
+     * Get a function which creates the intrusive edges specifics. The factory will accept the graph
+     * type as a parameter.
+     * 
+     * @return a function which creates intrusive edges specifics.
+     */
+    Function<GraphType, IntrusiveEdgesSpecifics<V, E>> getIntrusiveEdgesSpecificsFactory();
+    
+    /**
+     * Get a function which creates the specifics. The factory will accept the graph type as a
+     * parameter.
+     * 
+     * @return a function which creates intrusive edges specifics.
+     */
+    BiFunction<Graph<V, E>, GraphType, Specifics<V, E>> getSpecificsFactory();
+
+    /**
+     * Get a supplier of maps with a predictable iteration order.
+     * 
+     * @return a supplier of maps with a predictable iteration order.
+     * @param <K1> the key type
+     * @param <V1> the value type 
+     */
+    default <K1, V1> Supplier<Map<K1, V1>> getPredictableOrderIterationMapFactory()
+    {
+        return (Supplier<Map<K1, V1>> & Serializable)() -> new LinkedHashMap<>();
+    }
+
+    /**
+     * Get a supplier of maps.
+     * 
+     * @return a supplier of maps.
+     * @param <K1> the key type
+     * @param <V1> the value type 
+     */
+    default <K1, V1> Supplier<Map<K1, V1>> getMapFactory()
+    {
+        return (Supplier<Map<K1, V1>> & Serializable)() -> new HashMap<>();
+    }
+
+    /**
+     * Get an edge set factory.
+     * 
+     * @return an edge set factory
+     */
+    default EdgeSetFactory<V, E> getEdgeSetFactory()
+    {
+        return new ArrayUnenforcedSetEdgeSetFactory<>();
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphSpecificsStrategy.java
@@ -24,6 +24,7 @@ import org.jgrapht.graph.specifics.Specifics;
  * @param <E> the graph edge type
  * 
  * @see FastLookupGraphSpecificsStrategy
+ * @see DefaultGraphSpecificsStrategy
  */
 public interface GraphSpecificsStrategy<V, E> extends Serializable
 {
@@ -50,7 +51,7 @@ public interface GraphSpecificsStrategy<V, E> extends Serializable
      * @param <K1> the key type
      * @param <V1> the value type 
      */
-    default <K1, V1> Supplier<Map<K1, V1>> getPredictableOrderIterationMapFactory()
+    default <K1, V1> Supplier<Map<K1, V1>> getPredictableOrderMapFactory()
     {
         return (Supplier<Map<K1, V1>> & Serializable)() -> new LinkedHashMap<>();
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/Multigraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/Multigraph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/Pseudograph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/Pseudograph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleDirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleDirectedGraph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleGraph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleWeightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/SimpleWeightedGraph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/UniformIntrusiveEdgesSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/UniformIntrusiveEdgesSpecifics.java
@@ -17,6 +17,9 @@
  */
 package org.jgrapht.graph;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * An uniform weights variant of the intrusive edges specifics.
  * 
@@ -40,10 +43,23 @@ public class UniformIntrusiveEdgesSpecifics<V, E>
 
     /**
      * Constructor
+     * 
+     * @deprecated Since, default strategies should be decided at a higher level.
      */
+    @Deprecated
     public UniformIntrusiveEdgesSpecifics()
     {
-        super();
+        this(new LinkedHashMap<>());
+    }
+    
+    /**
+     * Constructor
+     * 
+     * @param map the map to use for storage
+     */
+    public UniformIntrusiveEdgesSpecifics(Map<E, IntrusiveEdge> map)
+    {
+        super(map);
     }
 
     @Override

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/WeightedIntrusiveEdgesSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/WeightedIntrusiveEdgesSpecifics.java
@@ -17,6 +17,9 @@
  */
 package org.jgrapht.graph;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 /**
  * A weighted variant of the intrusive edges specifics.
  * 
@@ -40,10 +43,23 @@ public class WeightedIntrusiveEdgesSpecifics<V, E>
 
     /**
      * Constructor
+     * 
+     * @deprecated Since default strategies should be decided at a higher level.
      */
+    @Deprecated
     public WeightedIntrusiveEdgesSpecifics()
     {
-        super();
+        this(new LinkedHashMap<>());
+    }
+    
+    /**
+     * Constructor
+     * 
+     * @param map the map to use for storage
+     */
+    public WeightedIntrusiveEdgesSpecifics(Map<E, IntrusiveWeightedEdge> map)
+    {
+        super(map);
     }
 
     @Override

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/WeightedMultigraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/WeightedMultigraph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/WeightedPseudograph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/WeightedPseudograph.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -42,7 +42,7 @@ public class DirectedSpecifics<V, E>
     Specifics<V, E>,
     Serializable
 {
-    private static final long serialVersionUID = 8971725103718958232L;
+    private static final long serialVersionUID = 5964807709682219859L;
 
     protected Graph<V, E> graph;
     protected Map<V, DirectedEdgeContainer<V, E>> vertexMap;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -17,6 +17,7 @@
  */
 package org.jgrapht.graph.specifics;
 
+import org.jgrapht.Graph;
 import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
 
@@ -43,46 +44,51 @@ public class DirectedSpecifics<V, E>
 {
     private static final long serialVersionUID = 8971725103718958232L;
 
-    protected AbstractBaseGraph<V, E> abstractBaseGraph;
-    protected Map<V, DirectedEdgeContainer<V, E>> vertexMapDirected;
+    protected Graph<V, E> graph;
+    protected Map<V, DirectedEdgeContainer<V, E>> vertexMap;
     protected EdgeSetFactory<V, E> edgeSetFactory;
 
     /**
      * Construct a new directed specifics.
      * 
-     * @param abstractBaseGraph the graph for which these specifics are for
+     * @param graph the graph for which these specifics are for
+     * @deprecated Since default strategies should be decided at a higher level. 
      */
-    public DirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph)
+    @Deprecated
+    public DirectedSpecifics(Graph<V, E> graph)
     {
-        this(abstractBaseGraph, new LinkedHashMap<>(), new ArrayUnenforcedSetEdgeSetFactory<>());
+        this(graph, new LinkedHashMap<>(), new ArrayUnenforcedSetEdgeSetFactory<>());
     }
 
     /**
      * Construct a new directed specifics.
      * 
-     * @param abstractBaseGraph the graph for which these specifics are for
+     * @param graph the graph for which these specifics are for
      * @param vertexMap map for the storage of vertex edge sets
+     * @deprecated Since default strategies should be decided at a higher level.
      */
+    @Deprecated    
     public DirectedSpecifics(
-        AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, DirectedEdgeContainer<V, E>> vertexMap)
+        Graph<V, E> graph, Map<V, DirectedEdgeContainer<V, E>> vertexMap)
     {
-        this(abstractBaseGraph, vertexMap, new ArrayUnenforcedSetEdgeSetFactory<>());
+        this(graph, vertexMap, new ArrayUnenforcedSetEdgeSetFactory<>());
     }
 
     /**
      * Construct a new directed specifics.
      * 
-     * @param abstractBaseGraph the graph for which these specifics are for
-     * @param vertexMap map for the storage of vertex edge sets
+     * @param graph the graph for which these specifics are for
+     * @param vertexMap map for the storage of vertex edge sets. Needs to have a predictable
+     *        iteration order.
      * @param edgeSetFactory factory for the creation of vertex edge sets
      */
     public DirectedSpecifics(
-        AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, DirectedEdgeContainer<V, E>> vertexMap,
+        Graph<V, E> graph, Map<V, DirectedEdgeContainer<V, E>> vertexMap,
         EdgeSetFactory<V, E> edgeSetFactory)
     {
-        this.abstractBaseGraph = abstractBaseGraph;
-        this.vertexMapDirected = vertexMap;
-        this.edgeSetFactory = edgeSetFactory;
+        this.graph = Objects.requireNonNull(graph);
+        this.vertexMap = Objects.requireNonNull(vertexMap);
+        this.edgeSetFactory = Objects.requireNonNull(edgeSetFactory);
     }
 
     /**
@@ -91,9 +97,9 @@ public class DirectedSpecifics<V, E>
     @Override
     public boolean addVertex(V v)
     {
-        DirectedEdgeContainer<V, E> ec = vertexMapDirected.get(v);
+        DirectedEdgeContainer<V, E> ec = vertexMap.get(v);
         if (ec == null) {
-            vertexMapDirected.put(v, new DirectedEdgeContainer<>(edgeSetFactory, v));
+            vertexMap.put(v, new DirectedEdgeContainer<>(edgeSetFactory, v));
             return true;
         }
         return false;
@@ -105,7 +111,7 @@ public class DirectedSpecifics<V, E>
     @Override
     public Set<V> getVertexSet()
     {
-        return vertexMapDirected.keySet();
+        return vertexMap.keySet();
     }
 
     /**
@@ -116,15 +122,15 @@ public class DirectedSpecifics<V, E>
     {
         Set<E> edges = null;
 
-        if (abstractBaseGraph.containsVertex(sourceVertex)
-            && abstractBaseGraph.containsVertex(targetVertex))
+        if (graph.containsVertex(sourceVertex)
+            && graph.containsVertex(targetVertex))
         {
             edges = new ArrayUnenforcedSet<>();
 
             DirectedEdgeContainer<V, E> ec = getEdgeContainer(sourceVertex);
 
             for (E e : ec.outgoing) {
-                if (abstractBaseGraph.getEdgeTarget(e).equals(targetVertex)) {
+                if (graph.getEdgeTarget(e).equals(targetVertex)) {
                     edges.add(e);
                 }
             }
@@ -139,13 +145,13 @@ public class DirectedSpecifics<V, E>
     @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
-        if (abstractBaseGraph.containsVertex(sourceVertex)
-            && abstractBaseGraph.containsVertex(targetVertex))
+        if (graph.containsVertex(sourceVertex)
+            && graph.containsVertex(targetVertex))
         {
             DirectedEdgeContainer<V, E> ec = getEdgeContainer(sourceVertex);
 
             for (E e : ec.outgoing) {
-                if (abstractBaseGraph.getEdgeTarget(e).equals(targetVertex)) {
+                if (graph.getEdgeTarget(e).equals(targetVertex)) {
                     return e;
                 }
             }
@@ -160,8 +166,8 @@ public class DirectedSpecifics<V, E>
     @Override
     public void addEdgeToTouchingVertices(E e)
     {
-        V source = abstractBaseGraph.getEdgeSource(e);
-        V target = abstractBaseGraph.getEdgeTarget(e);
+        V source = graph.getEdgeSource(e);
+        V target = graph.getEdgeTarget(e);
 
         getEdgeContainer(source).addOutgoingEdge(e);
         getEdgeContainer(target).addIncomingEdge(e);
@@ -187,7 +193,7 @@ public class DirectedSpecifics<V, E>
         inAndOut.addAll(getEdgeContainer(vertex).outgoing);
 
         // we have two copies for each self-loop - remove one of them.
-        if (abstractBaseGraph.getType().isAllowingSelfLoops()) {
+        if (graph.getType().isAllowingSelfLoops()) {
             Set<E> loops = getAllEdges(vertex, vertex);
 
             for (int i = 0; i < inAndOut.size();) {
@@ -247,8 +253,8 @@ public class DirectedSpecifics<V, E>
     @Override
     public void removeEdgeFromTouchingVertices(E e)
     {
-        V source = abstractBaseGraph.getEdgeSource(e);
-        V target = abstractBaseGraph.getEdgeTarget(e);
+        V source = graph.getEdgeSource(e);
+        V target = graph.getEdgeTarget(e);
 
         getEdgeContainer(source).removeOutgoingEdge(e);
         getEdgeContainer(target).removeIncomingEdge(e);
@@ -263,11 +269,11 @@ public class DirectedSpecifics<V, E>
      */
     protected DirectedEdgeContainer<V, E> getEdgeContainer(V vertex)
     {
-        DirectedEdgeContainer<V, E> ec = vertexMapDirected.get(vertex);
+        DirectedEdgeContainer<V, E> ec = vertexMap.get(vertex);
 
         if (ec == null) {
             ec = new DirectedEdgeContainer<>(edgeSetFactory, vertex);
-            vertexMapDirected.put(vertex, ec);
+            vertexMap.put(vertex, ec);
         }
 
         return ec;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
@@ -35,13 +35,14 @@ import java.util.*;
  * @author Joris Kinable
  */
 public class FastLookupDirectedSpecifics<V, E>
-    extends DirectedSpecifics<V, E>
+    extends
+    DirectedSpecifics<V, E>
 {
     private static final long serialVersionUID = 4089085208843722263L;
 
     /**
-     * Maps a pair of vertices &lt;u,v&gt; to a set of edges {(u,v)}. In case of a multigraph, all edges
-     * which touch both u and v are included in the set.
+     * Maps a pair of vertices &lt;u,v&gt; to a set of edges {(u,v)}. In case of a multigraph, all
+     * edges which touch both u and v are included in the set.
      */
     protected Map<Pair<V, V>, Set<E>> touchingVerticesToEdgeMap;
 
@@ -78,7 +79,7 @@ public class FastLookupDirectedSpecifics<V, E>
      * @param vertexMap map for the storage of vertex edge sets. Needs to have a predictable
      *        iteration order.
      * @param edgeSetFactory factory for the creation of vertex edge sets
-     * @deprecated Since default strategies should be decided at a higher level. 
+     * @deprecated Since default strategies should be decided at a higher level.
      */
     @Deprecated
     public FastLookupDirectedSpecifics(
@@ -87,21 +88,20 @@ public class FastLookupDirectedSpecifics<V, E>
     {
         this(graph, vertexMap, new HashMap<>(), edgeSetFactory);
     }
-    
+
     /**
      * Construct a new fast lookup directed specifics.
      * 
      * @param graph the graph for which these specifics are for
      * @param vertexMap map for the storage of vertex edge sets. Needs to have a predictable
      *        iteration order.
-     * @param touchingVerticesToEdgeMap Additional map for caching. No need for a predictable iteration order.
+     * @param touchingVerticesToEdgeMap Additional map for caching. No need for a predictable
+     *        iteration order.
      * @param edgeSetFactory factory for the creation of vertex edge sets
      */
     public FastLookupDirectedSpecifics(
-        Graph<V, E> graph, 
-        Map<V, DirectedEdgeContainer<V, E>> vertexMap,
-        Map<Pair<V, V>, Set<E>> touchingVerticesToEdgeMap,
-        EdgeSetFactory<V, E> edgeSetFactory)
+        Graph<V, E> graph, Map<V, DirectedEdgeContainer<V, E>> vertexMap,
+        Map<Pair<V, V>, Set<E>> touchingVerticesToEdgeMap, EdgeSetFactory<V, E> edgeSetFactory)
     {
         super(graph, vertexMap, edgeSetFactory);
         this.touchingVerticesToEdgeMap = Objects.requireNonNull(touchingVerticesToEdgeMap);
@@ -115,9 +115,9 @@ public class FastLookupDirectedSpecifics<V, E>
     {
         if (graph.containsVertex(sourceVertex) && graph.containsVertex(targetVertex)) {
             Set<E> edges = touchingVerticesToEdgeMap.get(new Pair<>(sourceVertex, targetVertex));
-            if (edges == null) { 
+            if (edges == null) {
                 return Collections.emptySet();
-            } else { 
+            } else {
                 Set<E> edgeSet = edgeSetFactory.createEdgeSet(sourceVertex);
                 edgeSet.addAll(edges);
                 return edgeSet;
@@ -136,8 +136,8 @@ public class FastLookupDirectedSpecifics<V, E>
         Set<E> edges = touchingVerticesToEdgeMap.get(new Pair<>(sourceVertex, targetVertex));
         if (edges == null || edges.isEmpty())
             return null;
-        else { 
-            return edges.stream().findFirst().orElse(null);
+        else {
+            return edges.iterator().next();
         }
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
@@ -138,7 +138,7 @@ public class FastLookupUndirectedSpecifics<V, E>
         if (edges == null || edges.isEmpty())
             return null;
         else
-            return edges.stream().findFirst().orElse(null);
+            return edges.iterator().next();
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
@@ -42,7 +42,7 @@ public class UndirectedSpecifics<V, E>
     Specifics<V, E>,
     Serializable
 {
-    private static final long serialVersionUID = 6494588405178655873L;
+    private static final long serialVersionUID = 4206026440450450992L;
 
     protected Graph<V, E> graph;
     protected Map<V, UndirectedEdgeContainer<V, E>> vertexMap;
@@ -65,11 +65,10 @@ public class UndirectedSpecifics<V, E>
      * 
      * @param graph the graph for which these specifics are for
      * @param vertexMap map for the storage of vertex edge sets
-     * @deprecated Since default strategies should be decided at a higher level. 
+     * @deprecated Since default strategies should be decided at a higher level.
      */
     @Deprecated
-    public UndirectedSpecifics(
-        Graph<V, E> graph, Map<V, UndirectedEdgeContainer<V, E>> vertexMap)
+    public UndirectedSpecifics(Graph<V, E> graph, Map<V, UndirectedEdgeContainer<V, E>> vertexMap)
     {
         this(graph, vertexMap, new ArrayUnenforcedSetEdgeSetFactory<>());
     }
@@ -122,9 +121,7 @@ public class UndirectedSpecifics<V, E>
     {
         Set<E> edges = null;
 
-        if (graph.containsVertex(sourceVertex)
-            && graph.containsVertex(targetVertex))
-        {
+        if (graph.containsVertex(sourceVertex) && graph.containsVertex(targetVertex)) {
             edges = new ArrayUnenforcedSet<>();
 
             for (E e : getEdgeContainer(sourceVertex).vertexEdges) {
@@ -145,9 +142,7 @@ public class UndirectedSpecifics<V, E>
     @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
-        if (graph.containsVertex(sourceVertex)
-            && graph.containsVertex(targetVertex))
-        {
+        if (graph.containsVertex(sourceVertex) && graph.containsVertex(targetVertex)) {
 
             for (E e : getEdgeContainer(sourceVertex).vertexEdges) {
                 boolean equal = isEqualsStraightOrInverted(sourceVertex, targetVertex, e);
@@ -193,8 +188,8 @@ public class UndirectedSpecifics<V, E>
     @Override
     public int degreeOf(V vertex)
     {
-        if (graph.getType().isAllowingSelfLoops()) { 
-            /* 
+        if (graph.getType().isAllowingSelfLoops()) {
+            /*
              * Then we must count, and add loops twice
              */
             int degree = 0;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
@@ -17,6 +17,7 @@
  */
 package org.jgrapht.graph.specifics;
 
+import org.jgrapht.Graph;
 import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
 
@@ -43,46 +44,51 @@ public class UndirectedSpecifics<V, E>
 {
     private static final long serialVersionUID = 6494588405178655873L;
 
-    protected AbstractBaseGraph<V, E> abstractBaseGraph;
-    protected Map<V, UndirectedEdgeContainer<V, E>> vertexMapUndirected;
+    protected Graph<V, E> graph;
+    protected Map<V, UndirectedEdgeContainer<V, E>> vertexMap;
     protected EdgeSetFactory<V, E> edgeSetFactory;
 
     /**
      * Construct a new undirected specifics.
      * 
-     * @param abstractBaseGraph the graph for which these specifics are for
+     * @param graph the graph for which these specifics are for
+     * @deprecated Since default strategies should be decided at a higher level.
      */
-    public UndirectedSpecifics(AbstractBaseGraph<V, E> abstractBaseGraph)
+    @Deprecated
+    public UndirectedSpecifics(Graph<V, E> graph)
     {
-        this(abstractBaseGraph, new LinkedHashMap<>(), new ArrayUnenforcedSetEdgeSetFactory<>());
+        this(graph, new LinkedHashMap<>(), new ArrayUnenforcedSetEdgeSetFactory<>());
     }
 
     /**
      * Construct a new undirected specifics.
      * 
-     * @param abstractBaseGraph the graph for which these specifics are for
+     * @param graph the graph for which these specifics are for
      * @param vertexMap map for the storage of vertex edge sets
+     * @deprecated Since default strategies should be decided at a higher level. 
      */
+    @Deprecated
     public UndirectedSpecifics(
-        AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, UndirectedEdgeContainer<V, E>> vertexMap)
+        Graph<V, E> graph, Map<V, UndirectedEdgeContainer<V, E>> vertexMap)
     {
-        this(abstractBaseGraph, vertexMap, new ArrayUnenforcedSetEdgeSetFactory<>());
+        this(graph, vertexMap, new ArrayUnenforcedSetEdgeSetFactory<>());
     }
 
     /**
      * Construct a new undirected specifics.
      * 
-     * @param abstractBaseGraph the graph for which these specifics are for
-     * @param vertexMap map for the storage of vertex edge sets
+     * @param graph the graph for which these specifics are for
+     * @param vertexMap map for the storage of vertex edge sets. Needs to have a predictable
+     *        iteration order.
      * @param edgeSetFactory factory for the creation of vertex edge sets
      */
     public UndirectedSpecifics(
-        AbstractBaseGraph<V, E> abstractBaseGraph, Map<V, UndirectedEdgeContainer<V, E>> vertexMap,
+        Graph<V, E> graph, Map<V, UndirectedEdgeContainer<V, E>> vertexMap,
         EdgeSetFactory<V, E> edgeSetFactory)
     {
-        this.abstractBaseGraph = abstractBaseGraph;
-        this.vertexMapUndirected = vertexMap;
-        this.edgeSetFactory = edgeSetFactory;
+        this.graph = Objects.requireNonNull(graph);
+        this.vertexMap = Objects.requireNonNull(vertexMap);
+        this.edgeSetFactory = Objects.requireNonNull(edgeSetFactory);
     }
 
     /**
@@ -91,9 +97,9 @@ public class UndirectedSpecifics<V, E>
     @Override
     public boolean addVertex(V v)
     {
-        UndirectedEdgeContainer<V, E> ec = vertexMapUndirected.get(v);
+        UndirectedEdgeContainer<V, E> ec = vertexMap.get(v);
         if (ec == null) {
-            vertexMapUndirected.put(v, new UndirectedEdgeContainer<>(edgeSetFactory, v));
+            vertexMap.put(v, new UndirectedEdgeContainer<>(edgeSetFactory, v));
             return true;
         }
         return false;
@@ -105,7 +111,7 @@ public class UndirectedSpecifics<V, E>
     @Override
     public Set<V> getVertexSet()
     {
-        return vertexMapUndirected.keySet();
+        return vertexMap.keySet();
     }
 
     /**
@@ -116,8 +122,8 @@ public class UndirectedSpecifics<V, E>
     {
         Set<E> edges = null;
 
-        if (abstractBaseGraph.containsVertex(sourceVertex)
-            && abstractBaseGraph.containsVertex(targetVertex))
+        if (graph.containsVertex(sourceVertex)
+            && graph.containsVertex(targetVertex))
         {
             edges = new ArrayUnenforcedSet<>();
 
@@ -139,8 +145,8 @@ public class UndirectedSpecifics<V, E>
     @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
-        if (abstractBaseGraph.containsVertex(sourceVertex)
-            && abstractBaseGraph.containsVertex(targetVertex))
+        if (graph.containsVertex(sourceVertex)
+            && graph.containsVertex(targetVertex))
         {
 
             for (E e : getEdgeContainer(sourceVertex).vertexEdges) {
@@ -157,11 +163,11 @@ public class UndirectedSpecifics<V, E>
 
     private boolean isEqualsStraightOrInverted(Object sourceVertex, Object targetVertex, E e)
     {
-        boolean equalStraight = sourceVertex.equals(abstractBaseGraph.getEdgeSource(e))
-            && targetVertex.equals(abstractBaseGraph.getEdgeTarget(e));
+        boolean equalStraight = sourceVertex.equals(graph.getEdgeSource(e))
+            && targetVertex.equals(graph.getEdgeTarget(e));
 
-        boolean equalInverted = sourceVertex.equals(abstractBaseGraph.getEdgeTarget(e))
-            && targetVertex.equals(abstractBaseGraph.getEdgeSource(e));
+        boolean equalInverted = sourceVertex.equals(graph.getEdgeTarget(e))
+            && targetVertex.equals(graph.getEdgeSource(e));
         return equalStraight || equalInverted;
     }
 
@@ -171,8 +177,8 @@ public class UndirectedSpecifics<V, E>
     @Override
     public void addEdgeToTouchingVertices(E e)
     {
-        V source = abstractBaseGraph.getEdgeSource(e);
-        V target = abstractBaseGraph.getEdgeTarget(e);
+        V source = graph.getEdgeSource(e);
+        V target = graph.getEdgeTarget(e);
 
         getEdgeContainer(source).addEdge(e);
 
@@ -187,13 +193,15 @@ public class UndirectedSpecifics<V, E>
     @Override
     public int degreeOf(V vertex)
     {
-        if (abstractBaseGraph.getType().isAllowingSelfLoops()) { // then we must count, and add
-                                                                 // loops twice
+        if (graph.getType().isAllowingSelfLoops()) { 
+            /* 
+             * Then we must count, and add loops twice
+             */
             int degree = 0;
             Set<E> edges = getEdgeContainer(vertex).vertexEdges;
 
             for (E e : edges) {
-                if (abstractBaseGraph.getEdgeSource(e).equals(abstractBaseGraph.getEdgeTarget(e))) {
+                if (graph.getEdgeSource(e).equals(graph.getEdgeTarget(e))) {
                     degree += 2;
                 } else {
                     degree += 1;
@@ -257,8 +265,8 @@ public class UndirectedSpecifics<V, E>
     @Override
     public void removeEdgeFromTouchingVertices(E e)
     {
-        V source = abstractBaseGraph.getEdgeSource(e);
-        V target = abstractBaseGraph.getEdgeTarget(e);
+        V source = graph.getEdgeSource(e);
+        V target = graph.getEdgeTarget(e);
 
         getEdgeContainer(source).removeEdge(e);
 
@@ -276,11 +284,11 @@ public class UndirectedSpecifics<V, E>
      */
     protected UndirectedEdgeContainer<V, E> getEdgeContainer(V vertex)
     {
-        UndirectedEdgeContainer<V, E> ec = vertexMapUndirected.get(vertex);
+        UndirectedEdgeContainer<V, E> ec = vertexMap.get(vertex);
 
         if (ec == null) {
             ec = new UndirectedEdgeContainer<>(edgeSetFactory, vertex);
-            vertexMapUndirected.put(vertex, ec);
+            vertexMap.put(vertex, ec);
         }
 
         return ec;

--- a/jgrapht-io/src/test/java/org/jgrapht/io/DOTImporter1Test.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/DOTImporter1Test.java
@@ -523,7 +523,7 @@ public class DOTImporter1Test
     }
 
     private void testGarbageGraph(
-        String input, String expected, AbstractBaseGraph<String, DefaultEdge> graph)
+        String input, String expected, Graph<String, DefaultEdge> graph)
     {
         GraphImporter<String, DefaultEdge> importer = buildImporter();
         try {


### PR DESCRIPTION
This PR continues the discussion at #459 by introducing a `GraphSpecificsStrategy` interface, which is provided to the graph on construction time. The strategy object contains all factories that are needed in order to build all internal data structures (maps, etc.).

I have also cleaned up all places where default values were used, and delegated all calls to the strategy. Moreover, I fixed the issues where the fast lookup specifics were not using the same edge factory as the base specifics class.

After this one, we can go forward and add a separate `opt` package with specialized graph implementations. It should be straightforward to replace all maps, etc.

