### PR TITLE
Bhandari K Shortest paths: Improved findOverlappingEdges efficiency.

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BhandariKDisjointShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BhandariKDisjointShortestPaths.java
@@ -249,23 +249,23 @@ public class BhandariKDisjointShortestPaths<V, E>
      */
     private void findOverlappingEdges()
     {
-        Map<UnorderedPair<V, V>, Integer> edgeOccurenceCount = new HashMap<>();
+        Map<UnorderedPair<V, V>, Integer> edgeOccurrenceCount = new HashMap<>();
         for (List<E> path : pathList) {
             for (E e : path) {                
                 V v = this.workingGraph.getEdgeSource(e);
                 V u = this.workingGraph.getEdgeTarget(e);                
                 UnorderedPair<V, V> edgePair = new UnorderedPair<>(v, u);
                 
-                if (edgeOccurenceCount.containsKey(edgePair)) {
-                    edgeOccurenceCount.put(edgePair, 2);
+                if (edgeOccurrenceCount.containsKey(edgePair)) {
+                    edgeOccurrenceCount.put(edgePair, 2);
                 } else {
-                    edgeOccurenceCount.put(edgePair, 1);
+                    edgeOccurrenceCount.put(edgePair, 1);
                 }
             }
         }
 
         this.overlappingEdges = pathList.stream().flatMap(List::stream).filter(
-            e -> edgeOccurenceCount.get(new UnorderedPair<>(
+            e -> edgeOccurrenceCount.get(new UnorderedPair<>(
                 this.workingGraph.getEdgeSource(e), 
                 this.workingGraph.getEdgeTarget(e))) > 1)
             .collect(Collectors.toSet());

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BhandariKDisjointShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BhandariKDisjointShortestPaths.java
@@ -239,8 +239,9 @@ public class BhandariKDisjointShortestPaths<V, E>
     }
 
     /**
-     * Iterating over all paths to removes overlapping edges (contained in more than single path).
-     * Edges are considered as overlapping in case both resides between the same ends 
+     * Iterate over all paths to remove overlapping edges (i.e. those edges contained in more than 
+     * one path).
+     * Two edges are considered as overlapping in case both edges connect the same vertex pair, 
      * disregarding direction.
      * At the end of this method, each path contains unique edges but not necessarily connecting the
      * start to end vertex.
@@ -248,23 +249,23 @@ public class BhandariKDisjointShortestPaths<V, E>
      */
     private void findOverlappingEdges()
     {
-        Map<UnorderedPair<V, V>, Integer> edgeOccuranceCount = new HashMap<>();
+        Map<UnorderedPair<V, V>, Integer> edgeOccurenceCount = new HashMap<>();
         for (List<E> path : pathList) {
             for (E e : path) {                
                 V v = this.workingGraph.getEdgeSource(e);
                 V u = this.workingGraph.getEdgeTarget(e);                
                 UnorderedPair<V, V> edgePair = new UnorderedPair<>(v, u);
                 
-                if (edgeOccuranceCount.containsKey(edgePair)) {
-                    edgeOccuranceCount.put(edgePair, 2);
+                if (edgeOccurenceCount.containsKey(edgePair)) {
+                    edgeOccurenceCount.put(edgePair, 2);
                 } else {
-                    edgeOccuranceCount.put(edgePair, 1);
+                    edgeOccurenceCount.put(edgePair, 1);
                 }
             }
         }
 
         this.overlappingEdges = pathList.stream().flatMap(List::stream).filter(
-            e -> edgeOccuranceCount.get(new UnorderedPair<>(
+            e -> edgeOccurenceCount.get(new UnorderedPair<>(
                 this.workingGraph.getEdgeSource(e), 
                 this.workingGraph.getEdgeTarget(e))) > 1)
             .collect(Collectors.toSet());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BhandariKDisjointShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BhandariKDisjointShortestPathsTest.java
@@ -434,13 +434,14 @@ public class BhandariKDisjointShortestPathsTest
     }
 
     /**
-     * Tests three joint paths from 1 to 5 Edges expected in path 1 ---------------
-     * {@literal 1 --> 4}, w=4 {@literal 4 --> 5}, w=1
-     * 
+     * Tests three joint paths from 1 to 5. 
+     * <p>
+     * Edges expected in path 1 --------------- {@literal 1 --> 4}, w=4 {@literal 4 --> 5}, w=1
+     * <p>
      * Edges expected in path 2 --------------- {@literal 1 --> 2}, w=1 {@literal 2 --> 5}, w=6
-     * 
+     * <p>
      * Edges expected in path 3 --------------- {@literal 1 --> 3}, w=4 {@literal 3 --> 5}, w=5
-     * 
+     * <p>
      * Edges expected in no path --------------- {@literal 2 --> 3}, w=1 {@literal 3 --> 4}, w=1
      */
     @Test


### PR DESCRIPTION
This is fixing issue #577. I took different approach than suggested there as the working graph cannot be reference for the existence of an edge, nor the edge `hashCode `case it exist indeed. Two edges are considered as overlapping case both resides between the same ends disregarding direction. Due to the transformations the graph is going through at the `prepare `method (edges are added and removed) the `hashCode `may be different for two overlapping edges so cannot be used as the criterion. That's why I used edge to edge comparison in the first implementation. 
Current implementation is building a Multigraph from all paths edges and then identifies all overlapping edges so doing pratically the same while having the linear running time suggested in #577.