### PR TITLE
Add a template for pull requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!-- describe the changes you have made here: what, why, …
+     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333).
+     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->
+
+----
+
+- [ ] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
+- [ ] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
+- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
+- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
+- [ ] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
+- [ ] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
+- [ ] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)


### PR DESCRIPTION
Seeing the mail by @jsichi https://sourceforge.net/p/jgrapht/mailman/message/36343401/ requesting newcomers to follow the coding guidelines, I thought, it is a good idea to add a pull request template.

In case this file is available, at each opened pull request, the content is shown in the description box. See https://help.github.com/articles/about-issue-and-pull-request-templates/#pull-request-templates for more details.

I think, this is a good way to remind contributors to check links. Not sure, if this is too harsh and would prevent newcomers to contribute. In JabRef, we made good experiences with it.

I used full markdown in the template. Not sure whether newbies really can click on the links. In the rendered preview, the links fully work.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [ ] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
