### PR TITLE
Faster GraphML importer

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/BaseListenableImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/BaseListenableImporter.java
@@ -17,11 +17,12 @@
  */
 package org.jgrapht.io;
 
-import org.jgrapht.*;
-import org.jgrapht.alg.util.Pair;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.function.BiConsumer;
+
+import org.jgrapht.Graph;
+import org.jgrapht.alg.util.Pair;
 
 /**
  * Base implementation for a graph importer which uses consumers for attributes.
@@ -121,7 +122,7 @@ class BaseListenableImporter<V, E>
      * @param key the attribute key
      * @param value the attribute
      */
-    public void notifyGraph(Graph<V, E> g, String key, Attribute value)
+    protected void notifyGraph(Graph<V, E> g, String key, Attribute value)
     {
         graphAttributeConsumers.forEach(c -> c.accept(Pair.of(g, key), value));
     }
@@ -133,7 +134,7 @@ class BaseListenableImporter<V, E>
      * @param key the attribute key
      * @param value the attribute
      */
-    public void notifyVertex(V v, String key, Attribute value)
+    protected void notifyVertex(V v, String key, Attribute value)
     {
         vertexAttributeConsumers.forEach(c -> c.accept(Pair.of(v, key), value));
     }
@@ -145,7 +146,7 @@ class BaseListenableImporter<V, E>
      * @param key the attribute key
      * @param value the attribute
      */
-    public void notifyEdge(E e, String key, Attribute value)
+    protected void notifyEdge(E e, String key, Attribute value)
     {
         edgeAttributeConsumers.forEach(c -> c.accept(Pair.of(e, key), value));
     }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/BaseListenableImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/BaseListenableImporter.java
@@ -1,0 +1,153 @@
+/*
+ * (C) Copyright 2018-2018, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.io;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.util.Pair;
+
+import java.util.*;
+import java.util.function.BiConsumer;
+
+/**
+ * Base implementation for a graph importer which uses consumers for attributes.
+ * 
+ * <p>
+ * The importer will notify the registered consumers in no particular order about any attributes it
+ * encounters in the input file.
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ *
+ * @author Dimitrios Michail
+ * @since May 2018
+ */
+class BaseListenableImporter<V, E>
+{
+
+    private List<BiConsumer<Pair<Graph<V, E>, String>, Attribute>> graphAttributeConsumers;
+    private List<BiConsumer<Pair<V, String>, Attribute>> vertexAttributeConsumers;
+    private List<BiConsumer<Pair<E, String>, Attribute>> edgeAttributeConsumers;
+
+    /**
+     * Constructor
+     */
+    public BaseListenableImporter()
+    {
+        this.graphAttributeConsumers = new ArrayList<>();
+        this.vertexAttributeConsumers = new ArrayList<>();
+        this.edgeAttributeConsumers = new ArrayList<>();
+    }
+
+    /**
+     * Add a graph attribute consumer.
+     * 
+     * @param consumer the consumer
+     */
+    public void addGraphAttributeConsumer(BiConsumer<Pair<Graph<V, E>, String>, Attribute> consumer)
+    {
+        graphAttributeConsumers.add(consumer);
+    }
+
+    /**
+     * Remove a graph attribute consumer.
+     * 
+     * @param consumer the consumer
+     */
+    public void removeGraphAttributeConsumer(
+        BiConsumer<Pair<Graph<V, E>, String>, Attribute> consumer)
+    {
+        graphAttributeConsumers.remove(consumer);
+    }
+
+    /**
+     * Add a vertex attribute consumer.
+     * 
+     * @param consumer the consumer
+     */
+    public void addVertexAttributeConsumer(BiConsumer<Pair<V, String>, Attribute> consumer)
+    {
+        vertexAttributeConsumers.add(consumer);
+    }
+
+    /**
+     * Remove a vertex attribute consumer.
+     * 
+     * @param consumer the consumer
+     */
+    public void removeVertexAttributeConsumer(BiConsumer<Pair<V, String>, Attribute> consumer)
+    {
+        vertexAttributeConsumers.remove(consumer);
+    }
+
+    /**
+     * Add an edge attribute consumer.
+     * 
+     * @param consumer the consumer
+     */
+    public void addEdgeAttributeConsumer(BiConsumer<Pair<E, String>, Attribute> consumer)
+    {
+        edgeAttributeConsumers.add(consumer);
+    }
+
+    /**
+     * Remove an edge attribute consumer.
+     * 
+     * @param consumer the consumer
+     */
+    public void removeEdgeAttributeConsumer(BiConsumer<Pair<E, String>, Attribute> consumer)
+    {
+        edgeAttributeConsumers.remove(consumer);
+    }
+
+    /**
+     * Notify for a graph attribute
+     * 
+     * @param g the graph
+     * @param key the attribute key
+     * @param value the attribute
+     */
+    public void notifyGraph(Graph<V, E> g, String key, Attribute value)
+    {
+        graphAttributeConsumers.forEach(c -> c.accept(Pair.of(g, key), value));
+    }
+
+    /**
+     * Notify for a vertex attribute
+     * 
+     * @param v the vertex
+     * @param key the attribute key
+     * @param value the attribute
+     */
+    public void notifyVertex(V v, String key, Attribute value)
+    {
+        vertexAttributeConsumers.forEach(c -> c.accept(Pair.of(v, key), value));
+    }
+
+    /**
+     * Notify for an edge attribute
+     * 
+     * @param e the edge
+     * @param key the attribute key
+     * @param value the attribute
+     */
+    public void notifyEdge(E e, String key, Attribute value)
+    {
+        edgeAttributeConsumers.forEach(c -> c.accept(Pair.of(e, key), value));
+    }
+
+}

--- a/jgrapht-io/src/main/java/org/jgrapht/io/BaseListenableImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/BaseListenableImporter.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiConsumer;
 
-import org.jgrapht.Graph;
 import org.jgrapht.alg.util.Pair;
 
 /**
@@ -40,7 +39,7 @@ import org.jgrapht.alg.util.Pair;
 class BaseListenableImporter<V, E>
 {
 
-    private List<BiConsumer<Pair<Graph<V, E>, String>, Attribute>> graphAttributeConsumers;
+    private List<BiConsumer<String, Attribute>> graphAttributeConsumers;
     private List<BiConsumer<Pair<V, String>, Attribute>> vertexAttributeConsumers;
     private List<BiConsumer<Pair<E, String>, Attribute>> edgeAttributeConsumers;
 
@@ -59,7 +58,7 @@ class BaseListenableImporter<V, E>
      * 
      * @param consumer the consumer
      */
-    public void addGraphAttributeConsumer(BiConsumer<Pair<Graph<V, E>, String>, Attribute> consumer)
+    public void addGraphAttributeConsumer(BiConsumer<String, Attribute> consumer)
     {
         graphAttributeConsumers.add(consumer);
     }
@@ -70,7 +69,7 @@ class BaseListenableImporter<V, E>
      * @param consumer the consumer
      */
     public void removeGraphAttributeConsumer(
-        BiConsumer<Pair<Graph<V, E>, String>, Attribute> consumer)
+        BiConsumer<String, Attribute> consumer)
     {
         graphAttributeConsumers.remove(consumer);
     }
@@ -118,13 +117,12 @@ class BaseListenableImporter<V, E>
     /**
      * Notify for a graph attribute
      * 
-     * @param g the graph
      * @param key the attribute key
      * @param value the attribute
      */
-    protected void notifyGraph(Graph<V, E> g, String key, Attribute value)
+    protected void notifyGraph(String key, Attribute value)
     {
-        graphAttributeConsumers.forEach(c -> c.accept(Pair.of(g, key), value));
+        graphAttributeConsumers.forEach(c -> c.accept(key, value));
     }
 
     /**

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DefaultAttribute.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DefaultAttribute.java
@@ -56,13 +56,13 @@ public class DefaultAttribute<T>
     @Override
     public String getValue()
     {
-        return value.toString();
+        return String.valueOf(value);
     }
 
     @Override
     public String toString()
     {
-        return value.toString();
+        return String.valueOf(value);
     }
 
     /**

--- a/jgrapht-io/src/main/java/org/jgrapht/io/SimpleGraphMLImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/SimpleGraphMLImporter.java
@@ -52,7 +52,8 @@ import org.xml.sax.helpers.DefaultHandler;
  * The importer uses the graph suppliers ({@link Graph#getVertexSupplier()} and
  * {@link Graph#getEdgeSupplier()}) in order to create new vertices and edges. Moreover, it notifies
  * lazily and completely out-of-order for any additional vertex, edge or graph attributes in the
- * input file. Finally, default attribute values are completely ignored.
+ * input file. Users can register consumers for vertex, edge and graph attributes after construction
+ * of the importer. Finally, default attribute values are completely ignored.
  * 
  * <p>
  * For a description of the format see <a href="http://en.wikipedia.org/wiki/GraphML">
@@ -172,9 +173,10 @@ public class SimpleGraphMLImporter<V, E>
      */
     public void setEdgeWeightAttributeName(String edgeWeightAttributeName)
     {
-        this.edgeWeightAttributeName = Objects.requireNonNull(edgeWeightAttributeName, "Edge weight attribute name cannot be null");
+        this.edgeWeightAttributeName = Objects
+            .requireNonNull(edgeWeightAttributeName, "Edge weight attribute name cannot be null");
     }
-    
+
     /**
      * Whether the importer validates the input
      * 
@@ -504,7 +506,7 @@ public class SimpleGraphMLImporter<V, E>
                     /*
                      * Handle special weight key
                      */
-                    if (isWeighted && key.attributeName.equals(edgeWeightAttributeName)) { 
+                    if (isWeighted && key.attributeName.equals(edgeWeightAttributeName)) {
                         try {
                             graph.setEdgeWeight(currentEdge, Double.parseDouble(currentDataValue));
                         } catch (NumberFormatException e) {

--- a/jgrapht-io/src/main/java/org/jgrapht/io/SimpleGraphMLImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/SimpleGraphMLImporter.java
@@ -1,0 +1,375 @@
+/*
+ * (C) Copyright 2016-2017, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.io;
+
+import java.io.InputStream;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.jgrapht.Graph;
+import org.jgrapht.alg.util.Pair;
+import org.xml.sax.Attributes;
+import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.XMLReader;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Imports a graph from a GraphML data source.
+ * 
+ * <p>
+ * This is a simple implementation with supports only a limited set of features of the GraphML
+ * specification. For a more rigorous parser use {@link GraphMLImporter}. This version is oriented
+ * towards parsing speed.
+ * 
+ * 
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ * 
+ * @author Dimitrios Michail
+ */
+public class SimpleGraphMLImporter<V, E>
+    implements
+    GraphImporter<V, E>
+{
+    private static final String GRAPHML_SCHEMA_FILENAME = "graphml.xsd";
+    private static final String XLINK_SCHEMA_FILENAME = "xlink.xsd";
+
+    private boolean schemaValidation;
+
+    private Optional<BiConsumer<Pair<V, String>, Attribute>> vertexAttributeConsumer;
+    private Optional<BiConsumer<Pair<E, String>, Attribute>> edgeAttributeConsumer;
+
+    /**
+     * Constructs a new importer.
+     */
+    public SimpleGraphMLImporter()
+    {
+        this(null, null);
+    }
+
+    /**
+     * Constructs a new importer.
+     * 
+     * @param vertexAttributeConsumer consumer for vertex attributes. The consumer will receive as a
+     *        first argument a composite containing the graph vertex together with the attribute
+     *        key. The second argument will be the actual attribute.
+     * @param edgeAttributeConsumer consumer for edge attributes. The consumer will receive as a
+     *        first argument a composite containing the graph vertex together with the attribute
+     *        key. The second argument will be the actual attribute.
+     */
+    public SimpleGraphMLImporter(
+        BiConsumer<Pair<V, String>, Attribute> vertexAttributeConsumer,
+        BiConsumer<Pair<E, String>, Attribute> edgeAttributeConsumer)
+    {
+        this.schemaValidation = true;
+        this.vertexAttributeConsumer = Optional.ofNullable(vertexAttributeConsumer);
+        this.edgeAttributeConsumer = Optional.ofNullable(edgeAttributeConsumer);
+    }
+
+    /**
+     * Whether the importer validates the input
+     * 
+     * @return true if the importer validates the input
+     */
+    public boolean isSchemaValidation()
+    {
+        return schemaValidation;
+    }
+
+    /**
+     * Set whether the importer should validate the input
+     * 
+     * @param schemaValidation value for schema validation
+     */
+    public void setSchemaValidation(boolean schemaValidation)
+    {
+        this.schemaValidation = schemaValidation;
+    }
+
+    /**
+     * Import a graph.
+     * 
+     * <p>
+     * The provided graph must be able to support the features of the graph that is read. For
+     * example if the GraphML file contains self-loops then the graph provided must also support
+     * self-loops. The same for multiple edges.
+     * 
+     * @param graph the output graph
+     * @param input the input reader
+     * @throws ImportException in case an error occurs, such as I/O or parse error
+     */
+    @Override
+    public void importGraph(Graph<V, E> graph, Reader input)
+        throws ImportException
+    {
+        try {
+            // parse
+            XMLReader xmlReader = createXMLReader();
+            GraphMLHandler handler = new GraphMLHandler(graph);
+            xmlReader.setContentHandler(handler);
+            xmlReader.setErrorHandler(handler);
+            xmlReader.parse(new InputSource(input));
+        } catch (Exception se) {
+            throw new ImportException("Failed to parse GraphML", se);
+        }
+    }
+
+    private XMLReader createXMLReader()
+        throws ImportException
+    {
+        try {
+            SchemaFactory schemaFactory =
+                SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+
+            // create parser
+            SAXParserFactory spf = SAXParserFactory.newInstance();
+            if (schemaValidation) {
+                // load schema
+                InputStream xsdStream =
+                    Thread.currentThread().getContextClassLoader().getResourceAsStream(
+                        GRAPHML_SCHEMA_FILENAME);
+                if (xsdStream == null) {
+                    throw new ImportException("Failed to locate GraphML xsd");
+                }
+                InputStream xlinkStream =
+                    Thread.currentThread().getContextClassLoader().getResourceAsStream(
+                        XLINK_SCHEMA_FILENAME);
+                if (xlinkStream == null) {
+                    throw new ImportException("Failed to locate XLink xsd");
+                }
+                Source[] sources = new Source[2];
+                sources[0] = new StreamSource(xlinkStream);
+                sources[1] = new StreamSource(xsdStream);
+                Schema schema = schemaFactory.newSchema(sources);
+
+                spf.setSchema(schema);
+            }
+            spf.setNamespaceAware(true);
+            SAXParser saxParser = spf.newSAXParser();
+
+            // create reader
+            return saxParser.getXMLReader();
+        } catch (Exception se) {
+            throw new ImportException("Failed to parse GraphML", se);
+        }
+    }
+
+    // content handler
+    private class GraphMLHandler
+        extends
+        DefaultHandler
+    {
+        private static final String GRAPH = "graph";
+        private static final String NODE = "node";
+        private static final String NODE_ID = "id";
+        private static final String EDGE = "edge";
+        private static final String EDGE_SOURCE = "source";
+        private static final String EDGE_TARGET = "target";
+        private static final String KEY = "key";
+        private static final String DEFAULT = "default";
+        private static final String DATA = "data";
+
+        private Graph<V, E> graph;
+        private Map<String, V> nodes;
+
+        // parser state
+        private int insideDefault;
+        private int insideKey;
+        private int insideData;
+        private int insideGraph;
+        private int insideNode;
+        private V currentNode;
+        private int insideEdge;
+        private E currentEdge;
+
+        public GraphMLHandler(Graph<V, E> graph)
+        {
+            this.graph = Objects.requireNonNull(graph);
+        }
+
+        @Override
+        public void startDocument()
+            throws SAXException
+        {
+            nodes = new HashMap<>();
+            insideDefault = 0;
+            insideKey = 0;
+            insideData = 0;
+            insideGraph = 0;
+            insideNode = 0;
+            currentNode = null;
+            insideEdge = 0;
+            currentEdge = null;
+        }
+
+        @Override
+        public void startElement(String uri, String localName, String qName, Attributes attributes)
+            throws SAXException
+        {
+            switch (localName) {
+            case GRAPH:
+                if (insideGraph > 0) {
+                    throw new IllegalArgumentException(
+                        "This importer does not support nested graphs");
+                }
+                insideGraph++;
+                break;
+            case NODE:
+                if (insideNode > 0 || insideEdge > 0) {
+                    throw new IllegalArgumentException(
+                        "Nodes cannot be inside other nodes or edges");
+                }
+                insideNode++;
+                String nodeId = Objects.requireNonNull(
+                    findAttribute(NODE_ID, attributes), "Node must have an identifier");
+                V vertex = nodes.get(nodeId);
+                if (vertex == null) {
+                    vertex = graph.addVertex();
+                    nodes.put(nodeId, vertex);
+                }
+                currentNode = vertex;
+                vertexAttributeConsumer.ifPresent(
+                    c -> c.accept(
+                        Pair.of(currentNode, NODE_ID), DefaultAttribute.createAttribute(nodeId)));
+                break;
+            case EDGE:
+                if (insideNode > 0 || insideEdge > 0) {
+                    throw new IllegalArgumentException(
+                        "Edges cannot be inside other nodes or edges");
+                }
+                insideEdge++;
+                String sourceId = Objects
+                    .requireNonNull(findAttribute(EDGE_SOURCE, attributes), "Edge source missing");
+                String targetId = Objects
+                    .requireNonNull(findAttribute(EDGE_TARGET, attributes), "Edge target missing");
+                V source = nodes.computeIfAbsent(sourceId, k -> graph.addVertex());
+                V target = nodes.computeIfAbsent(targetId, k -> graph.addVertex());
+                currentEdge = graph.addEdge(source, target);
+                edgeAttributeConsumer.ifPresent(
+                    c -> c.accept(
+                        Pair.of(currentEdge, EDGE_SOURCE),
+                        DefaultAttribute.createAttribute(sourceId)));
+                edgeAttributeConsumer.ifPresent(
+                    c -> c.accept(
+                        Pair.of(currentEdge, EDGE_TARGET),
+                        DefaultAttribute.createAttribute(targetId)));
+                break;
+            case KEY:
+                insideKey++;
+                // TODO
+                break;
+            case DEFAULT:
+                insideDefault++;
+                // TODO
+                break;
+            case DATA:
+                insideData++;
+                // TODO
+                break;
+            default:
+                break;
+            }
+        }
+
+        @Override
+        public void endElement(String uri, String localName, String qName)
+            throws SAXException
+        {
+            switch (localName) {
+            case GRAPH:
+                insideGraph--;
+                break;
+            case NODE:
+                currentNode = null;
+                insideNode--;
+                break;
+            case EDGE:
+                currentEdge = null;
+                insideEdge--;
+                break;
+            case KEY:
+                insideKey--;
+                break;
+            case DEFAULT:
+                insideDefault--;
+                break;
+            case DATA:
+                insideData--;
+                break;
+            default:
+                break;
+            }
+        }
+
+        @Override
+        public void characters(char ch[], int start, int length)
+            throws SAXException
+        {
+            /*
+             * if (insideDefault) { currentKey.defaultValue = new String(ch, start, length); } else
+             * if (insideData) { currentData.value = new String(ch, start, length); }
+             */
+        }
+
+        @Override
+        public void warning(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
+
+        public void error(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
+
+        public void fatalError(SAXParseException e)
+            throws SAXException
+        {
+            throw e;
+        }
+
+        private String findAttribute(String localName, Attributes attributes)
+        {
+            for (int i = 0; i < attributes.getLength(); i++) {
+                String attrLocalName = attributes.getLocalName(i);
+                if (attrLocalName.equals(localName)) {
+                    return attributes.getValue(i);
+                }
+            }
+            return null;
+        }
+
+    }
+
+}

--- a/jgrapht-io/src/main/java/org/jgrapht/io/SimpleGraphMLImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/SimpleGraphMLImporter.java
@@ -347,10 +347,10 @@ public class SimpleGraphMLImporter<V, E>
                 }
                 insideGraph++;
                 findAttribute(GRAPH_ID, attributes).ifPresent(
-                    value -> notifyGraph(graph, GRAPH_ID, DefaultAttribute.createAttribute(value)));
+                    value -> notifyGraph(GRAPH_ID, DefaultAttribute.createAttribute(value)));
                 findAttribute(GRAPH_EDGE_DEFAULT, attributes).ifPresent(
                     value -> notifyGraph(
-                        graph, GRAPH_EDGE_DEFAULT, DefaultAttribute.createAttribute(value)));
+                        GRAPH_EDGE_DEFAULT, DefaultAttribute.createAttribute(value)));
                 break;
             case NODE:
                 if (insideNode > 0 || insideEdge > 0) {
@@ -522,8 +522,7 @@ public class SimpleGraphMLImporter<V, E>
                 Key key = graphValidKeys.get(currentDataKey);
                 if (key != null) {
                     notifyGraph(
-                        graph, key.attributeName,
-                        new DefaultAttribute<>(currentDataValue, key.type));
+                        key.attributeName, new DefaultAttribute<>(currentDataValue, key.type));
                 }
             }
         }

--- a/jgrapht-io/src/test/java/org/jgrapht/io/Graph6Sparse6ExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/Graph6Sparse6ExporterTest.java
@@ -18,7 +18,6 @@
 package org.jgrapht.io;
 
 import org.jgrapht.*;
-import org.jgrapht.alg.util.*;
 import org.jgrapht.generate.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.util.SupplierUtil;

--- a/jgrapht-io/src/test/java/org/jgrapht/io/SimpleGraphMLImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/SimpleGraphMLImporterTest.java
@@ -216,7 +216,7 @@ public class SimpleGraphMLImporterTest
         assertEquals(1.0, g.getEdgeWeight(g.getEdge("1", "2")), 1e-9);
     }
 
-    @Test
+    @Test(expected = ImportException.class)
     public void testValidate()
         throws ImportException
     {
@@ -235,18 +235,14 @@ public class SimpleGraphMLImporterTest
             "</graphml>";
         // @formatter:on
 
-        try {
-            Graph<String,
-                DefaultEdge> g = GraphTypeBuilder
-                    .undirected().weighted(false).allowingMultipleEdges(true)
-                    .allowingSelfLoops(true).vertexSupplier(SupplierUtil.createStringSupplier())
-                    .edgeSupplier(SupplierUtil.createDefaultEdgeSupplier()).buildGraph();
+        Graph<String,
+            DefaultEdge> g = GraphTypeBuilder
+                .undirected().weighted(false).allowingMultipleEdges(true)
+                .allowingSelfLoops(true).vertexSupplier(SupplierUtil.createStringSupplier())
+                .edgeSupplier(SupplierUtil.createDefaultEdgeSupplier()).buildGraph();
 
-            new SimpleGraphMLImporter<String, DefaultEdge>()
-                .importGraph(g, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
-            fail("No!");
-        } catch (ImportException e) {
-        }
+        new SimpleGraphMLImporter<String, DefaultEdge>()
+            .importGraph(g, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
     }
 
     @Test(expected = ImportException.class)

--- a/jgrapht-io/src/test/java/org/jgrapht/io/SimpleGraphMLImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/SimpleGraphMLImporterTest.java
@@ -1,0 +1,191 @@
+/*
+ * (C) Copyright 2018-2018, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.io;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.*;
+import java.nio.charset.*;
+import java.util.*;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.graph.*;
+import org.jgrapht.graph.builder.GraphTypeBuilder;
+import org.jgrapht.util.SupplierUtil;
+import org.junit.*;
+
+/**
+ * @author Dimitrios Michail
+ */
+public class SimpleGraphMLImporterTest
+{
+
+    private static final String NL = System.getProperty("line.separator");
+
+    @Test
+    public void testUndirectedUnweighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL +  
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String,
+            DefaultEdge> g = GraphTypeBuilder
+                .undirected().weighted(false).allowingMultipleEdges(true).allowingSelfLoops(true)
+                .vertexSupplier(SupplierUtil.createStringSupplier())
+                .edgeSupplier(SupplierUtil.createDefaultEdgeSupplier()).buildGraph();
+
+        new SimpleGraphMLImporter<String, DefaultEdge>()
+            .importGraph(g, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("0"));
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsEdge("0", "1"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "0"));
+    }
+
+    @Test
+    public void testUndirectedUnweightedWithConsumers()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<edge source=\"v\" target=\"x\"/>" + NL + 
+            "<node id=\"u\"/>" + NL +
+            "<node id=\"v\"/>" + NL + 
+            "<node id=\"x\"/>" + NL +  
+            "<edge source=\"u\" target=\"v\"/>" + NL + 
+            "<edge source=\"x\" target=\"u\"/>"+ NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String,
+            DefaultEdge> g = GraphTypeBuilder
+                .undirected().weighted(false).allowingMultipleEdges(true).allowingSelfLoops(true)
+                .vertexSupplier(SupplierUtil.createStringSupplier())
+                .edgeSupplier(SupplierUtil.createDefaultEdgeSupplier()).buildGraph();
+
+        Map<Pair<String, String>, Attribute> vertexAttrs = new HashMap<>();
+        Map<Pair<DefaultEdge, String>, Attribute> edgeAttrs = new HashMap<>();
+
+        new SimpleGraphMLImporter<String, DefaultEdge>((k, v) -> {
+            vertexAttrs.put(k, v);
+        }, (k, v) -> {
+            edgeAttrs.put(k, v);
+        }).importGraph(g, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
+
+        // check graph
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("0"));
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsEdge("0", "1"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("2", "0"));
+
+        // check collected attributes
+        assertEquals(vertexAttrs.get(Pair.of("0", "id")), DefaultAttribute.createAttribute("v"));
+        assertEquals(vertexAttrs.get(Pair.of("1", "id")), DefaultAttribute.createAttribute("x"));
+        assertEquals(vertexAttrs.get(Pair.of("2", "id")), DefaultAttribute.createAttribute("u"));
+        assertEquals(
+            edgeAttrs.get(Pair.of(g.getEdge("0", "1"), "source")),
+            DefaultAttribute.createAttribute("v"));
+        assertEquals(
+            edgeAttrs.get(Pair.of(g.getEdge("0", "1"), "target")),
+            DefaultAttribute.createAttribute("x"));
+        assertEquals(
+            edgeAttrs.get(Pair.of(g.getEdge("1", "2"), "source")),
+            DefaultAttribute.createAttribute("x"));
+        assertEquals(
+            edgeAttrs.get(Pair.of(g.getEdge("1", "2"), "target")),
+            DefaultAttribute.createAttribute("u"));
+        assertEquals(
+            edgeAttrs.get(Pair.of(g.getEdge("2", "0"), "source")),
+            DefaultAttribute.createAttribute("u"));
+        assertEquals(
+            edgeAttrs.get(Pair.of(g.getEdge("2", "0"), "target")),
+            DefaultAttribute.createAttribute("v"));
+    }
+
+    @Test
+    public void testValidate()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<nOde id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<myedge source=\"1\" target=\"2\"/>" + NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        try {
+            Graph<String,
+                DefaultEdge> g = GraphTypeBuilder
+                    .undirected().weighted(false).allowingMultipleEdges(true)
+                    .allowingSelfLoops(true).vertexSupplier(SupplierUtil.createStringSupplier())
+                    .edgeSupplier(SupplierUtil.createDefaultEdgeSupplier()).buildGraph();
+
+            Map<Pair<String, String>, Attribute> vertexAttrs = new HashMap<>();
+            Map<Pair<DefaultEdge, String>, Attribute> edgeAttrs = new HashMap<>();
+
+            new SimpleGraphMLImporter<String, DefaultEdge>()
+                .importGraph(g, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
+            fail("No!");
+        } catch (ImportException e) {
+        }
+    }
+
+}

--- a/jgrapht-io/src/test/java/org/jgrapht/io/SimpleGraphMLImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/SimpleGraphMLImporterTest.java
@@ -111,11 +111,14 @@ public class SimpleGraphMLImporterTest
 
         Map<Pair<String, String>, Attribute> vertexAttrs = new HashMap<>();
         Map<Pair<DefaultEdge, String>, Attribute> edgeAttrs = new HashMap<>();
+        Map<Pair<Graph<String, DefaultEdge>, String>, Attribute> graphAttrs = new HashMap<>();
 
         new SimpleGraphMLImporter<String, DefaultEdge>((k, v) -> {
             vertexAttrs.put(k, v);
         }, (k, v) -> {
             edgeAttrs.put(k, v);
+        }, (k, v) -> {
+            graphAttrs.put(k, v);
         }).importGraph(g, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
 
         // check graph
@@ -177,9 +180,6 @@ public class SimpleGraphMLImporterTest
                     .undirected().weighted(false).allowingMultipleEdges(true)
                     .allowingSelfLoops(true).vertexSupplier(SupplierUtil.createStringSupplier())
                     .edgeSupplier(SupplierUtil.createDefaultEdgeSupplier()).buildGraph();
-
-            Map<Pair<String, String>, Attribute> vertexAttrs = new HashMap<>();
-            Map<Pair<DefaultEdge, String>, Attribute> edgeAttrs = new HashMap<>();
 
             new SimpleGraphMLImporter<String, DefaultEdge>()
                 .importGraph(g, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));


### PR DESCRIPTION
I have created a new GraphML importer which is a little bit more restricted but faster than our full-blown `GraphMLImporter`. This is related to #417.

A few points:
 - Our current importer is supporting a lot of features from the GraphML spec but is a little bit slow. It waits until is finds all available information about a vertex and then notifies the user. For this reason (and the fact that is supports nested graphs), it needs a lot of memory. 
 - Our current importer asks the user to provide vertex and edge objects, instead of using the suppliers.

The new importer is not a replacement for the old one. However,
 - It uses the edge and vertex suppliers in order to create edges and vertices.
 - It notifies the user regarding graph, vertex and edge attributes completely out-of-order which means that it keeps memory requirements low. The notification is done through the Java 8 `Consumer` interfaces.
- It does not support nested subgraphs and other complicated stuff, for the same reason.
- XML schema validation can again be disabled, in which case the speedup is significant.
 
----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
