### PR TITLE
Nice tree decomposition for chordal graph

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/ChordalNiceDecompositionBuilder.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/ChordalNiceDecompositionBuilder.java
@@ -1,0 +1,225 @@
+/*
+ * (C) Copyright 2018-2018, by Ira Justus Fesefeldt and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.decomposition;
+
+import java.util.*;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.cycle.*;
+
+/**
+ * A builder for a nice decomposition for chordal graphs. See {@link NiceDecompositionBuilder} for
+ * an explanation of nice decomposition.
+ * <p>
+ * This builder uses the perfect elimination order from {@link ChordalityInspector} to iterate over
+ * the graph. For every node it generates a node for the predecessors of the current node according
+ * to the perfect elimination order and builds a path to such a node from the node where the
+ * greatest predecessor was introduced.
+ * <p>
+ * The complexity of this algorithm is in $\mathcal{O}(|V|(|V|+|E|))$.<br>
+ * Consider the every node in the nice tree decomposition: There are exactly $|V|$ many forget
+ * nodes. There are at most $2|V|$ additionally nodes because of a join nodes. Every join node
+ * creates one additional path from root to a leaf, every such path can contain for every vertex at
+ * most one introduce node, which yields $|V|^2$ introduce nodes. Now considering the bags of the
+ * introduce nodes. On a path from root to a leaf we have at most one introduce node for every
+ * introduced vertex. Since this introduced vertex is part of the clique of the least ancestor
+ * forget node, the corresponding bag of the introduce node is smaller than the set of neighbors of
+ * this vertex. Thus the time complexity is in $\mathcal{O}(|V|(|V|+|E|))$.
+ * <p>
+ * This is a non-recursive adaption for nice tree decomposition of algorithm 2 from here: <br>
+ * Hans L. Bodlaender, Arie M.C.A. Koster, Treewidth computations I. Upper bounds, Information and
+ * Computation, Volume 208, Issue 3, 2010, Pages 259-275,
+ * 
+ * @author Ira Justus Fesefeldt (PhoenixIra)
+ * @author Timofey Chudakov
+ *
+ * @since June 2018
+ *
+ * @param <V> the vertex type of the graph
+ * @param <E> the edge type of the graph
+ */
+public class ChordalNiceDecompositionBuilder<V, E>
+    extends
+    NiceDecompositionBuilder<V>
+{
+    // the chordal graph
+    Graph<V, E> graph;
+
+    // the perfect elimination order of graph
+    List<V> perfectOrder;
+
+    // another representation of the perfect elimination order of graph
+    Map<V, Integer> vertexInOrder;
+
+    /**
+     * Factory method for the nice decomposition builder of chordal graphs. Returns null, if the
+     * graph is not chordal.
+     * 
+     * @param <V> the vertex type of graph
+     * @param <E> the edge type of graph
+     * @param graph the chordal graph for which a decomposition should be created
+     * @return a nice decomposition builder for the graph if the graph was chordal, else null
+     */
+    public static <V, E> ChordalNiceDecompositionBuilder<V, E> create(Graph<V, E> graph)
+    {
+        ChordalityInspector<V, E> inspec = new ChordalityInspector<V, E>(graph);
+        if (!inspec.isChordal())
+            return null;
+        ChordalNiceDecompositionBuilder<V, E> builder =
+            new ChordalNiceDecompositionBuilder<>(graph, inspec.getPerfectEliminationOrder());
+        builder.computeNiceDecomposition();
+        return builder;
+
+    }
+
+    /**
+     * Factory method for the nice decomposition builder of chordal graphs. This method needs the
+     * perfect elimination order. It does not check whether the order is correct. This method may
+     * behave arbitrary if the perfect elimination order is incorrect.
+     * 
+     * @param <V> the vertex type of graph
+     * @param <E> the edge type of graph
+     * @param graph the chordal graph for which a decomposition should be created
+     * @param perfectEliminationOrder the perfect elimination order of the graph
+     * @return a nice decomposition builder for the graph if the graph was chordal, else null
+     */
+    public static <V, E> ChordalNiceDecompositionBuilder<V, E> create(
+        Graph<V, E> graph, List<V> perfectEliminationOrder)
+    {
+        ChordalNiceDecompositionBuilder<V, E> builder =
+            new ChordalNiceDecompositionBuilder<>(graph, perfectEliminationOrder);
+        builder.computeNiceDecomposition();
+        return builder;
+
+    }
+
+    /**
+     * Creates a nice decomposition builder for chordal graphs.
+     * 
+     * @param graph the chordal graph
+     * @param perfectOrder the perfect elimination order of graph
+     */
+    private ChordalNiceDecompositionBuilder(Graph<V, E> graph, List<V> perfectOrder)
+    {
+        super();
+        this.graph = graph;
+        this.perfectOrder = perfectOrder;
+        vertexInOrder = getVertexInOrder();
+    }
+
+    /**
+     * Computes the nice decomposition of the graph. We iterate over the perfect elimination order
+     * of the chordal graph and try to add a node containing the predecessors regarding the
+     * perfect elimination as a bag to the tree
+     */
+    private void computeNiceDecomposition()
+    {
+
+        // map from vertices to decomposition-nodes where the decomposition-node has all its
+        // predecessors
+        Map<V, Integer> forgetNodeMap = new HashMap<V, Integer>(graph.vertexSet().size());
+
+        // set current node to the root
+        Integer decompNode = getRoot();
+
+        // iterate over the perfect elimination order
+        for (V vertex : perfectOrder) {
+
+            // get the predecessors regarding the perfect elimination order
+            Set<V> predecessors = getOrderPredecessors(vertexInOrder, vertex);
+
+            // calculate nearest successors according to perfect elimination order
+            V lastVertex = null;
+            for (V predecessor : predecessors) {
+                if (lastVertex == null)
+                    lastVertex = predecessor;
+                if (vertexInOrder.get(predecessor) > vertexInOrder.get(lastVertex))
+                    lastVertex = predecessor;
+            }
+
+            // get node with clique of last vertex, else we use the last node
+            if (lastVertex != null)
+                decompNode = forgetNodeMap.get(lastVertex);
+
+            // if this node is not a leaf node, create a join node
+            if (Graphs.vertexHasSuccessors(decomposition, decompNode)) {
+                decompNode = addJoin(decompNode).getFirst();
+            }
+
+            // calculate vertices of nearest successor, which needs to be handled
+            Set<V> clique = new HashSet<V>(predecessors);
+            clique.add(vertex);
+            Set<V> toIntroduce = new HashSet<V>(decompositionMap.get(decompNode));
+            toIntroduce.removeAll(clique);
+
+            // first remove unnecessary nodes
+            for (V introduce : toIntroduce) {
+                decompNode = addIntroduce(introduce, decompNode);
+            }
+            // now add new node!
+            decompNode = addForget(vertex, decompNode);
+            forgetNodeMap.put(vertex, decompNode);
+
+        }
+        //finish all unfinished paths
+        leafClosure();
+
+    }
+
+    /**
+     * Returns a map containing vertices from the {@code vertexOrder} mapped to their indices in
+     * {@code vertexOrder}.
+     *
+     * @param vertexOrder a list with vertices.
+     * @return a mapping of vertices from {@code vertexOrder} to their indices in
+     *         {@code vertexOrder}.
+     */
+    private Map<V, Integer> getVertexInOrder()
+    {
+        Map<V, Integer> vertexInOrder = new HashMap<>(perfectOrder.size());
+        int i = 0;
+        for (V vertex : perfectOrder) {
+            vertexInOrder.put(vertex, i++);
+        }
+        return vertexInOrder;
+    }
+
+    /**
+     * Returns the predecessors of {@code vertex} in the perfect elimination order defined by
+     * {@code map}. More precisely, returns those of {@code vertex}, whose mapped index in
+     * {@code map} is less then the index of {@code vertex}.
+     *
+     * @param map defines the mapping of vertices in {@code graph} to their indices in order.
+     * @param vertex the vertex whose predecessors in order are to be returned.
+     * @return the predecessors of {@code vertex} in order defines by {@code map}.
+     */
+    private Set<V> getOrderPredecessors(Map<V, Integer> map, V vertex)
+    {
+        Set<V> predecessors = new HashSet<>();
+        Integer vertexPosition = map.get(vertex);
+        Set<E> edges = graph.edgesOf(vertex);
+        for (E edge : edges) {
+            V oppositeVertex = Graphs.getOppositeVertex(graph, edge, vertex);
+            Integer destPosition = map.get(oppositeVertex);
+            if (destPosition < vertexPosition) {
+                predecessors.add(oppositeVertex);
+            }
+        }
+        return predecessors;
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/NiceDecompositionBuilder.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/NiceDecompositionBuilder.java
@@ -1,0 +1,266 @@
+/*
+ * (C) Copyright 2018-2018, by Ira Justus Fesefeldt and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.decomposition;
+
+import java.util.*;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.util.*;
+import org.jgrapht.graph.*;
+
+/**
+ * An abstract builder class for nice tree decompositions, which builds the tree decomposition in a
+ * top-down manner.
+ * <p>
+ * A tree decomposition of a graph $G$ is a tree $T$ and a map $b:V(T) \rightarrow Set&lt;V(G)&gt;$,
+ * which satisfies the properties:
+ * <ul>
+ * <li>for every edge $e \in E(G)$, there is a node $t \in V(T)$ with $e \subseteq b(v)$</li>
+ * <li>for all vertices $v \in V(G)$ the set $\{t \in V(T) | v \in b(t)\}$ is non-empty and
+ * connected in $T$</li>
+ * </ul>
+ * <br>
+ * A nice tree decomposition is a special tree decomposition, which satisfies the properties:
+ * <ul>
+ * <li>for root $r \in V(T)$ and leaf $l \in V(T): b(r)=b(t)=\emptyset$</li>
+ * <li>every non-leaf node $t \in V(T)$ is of one of the following three types:
+ * <ul>
+ * <li>forget node: $t$ has exactly one child $d$ and $b(t) \cup \{ w\} = b(d)$ for some $w \in
+ * V(G)\setminus b(t)$</li>
+ * <li>introduce node: $t$ has exactly one child $d$ and $b(t) = b(d) \cup \{ w\}$ for some $w \in
+ * V(G)\setminus b(d)$</li>
+ * <li>join node: $t$ has exactly two children $d_1$, $d_2$ and $b(t)=b(d_1)=b(d_2)$</li>
+ * </ul>
+ * </ul>
+ * <p>
+ * See:<br>
+ * Bodlaender, Hans &amp; Kloks, Ton. (1991). Better Algorithms for the Pathwidth and Treewidth of
+ * Graphs. 544-555. 10.1007/3-540-54233-7_162.
+ * 
+ * @author Ira Justus Fesefeldt (PhoenixIra)
+ *
+ * @param <V> the vertices of the graph
+ */
+abstract public class NiceDecompositionBuilder<V>
+{
+
+    // resulting decomposition
+    protected Graph<Integer, DefaultEdge> decomposition;
+
+    // map from decomposition nodes to the vertex sets
+    protected Map<Integer, Set<V>> decompositionMap;
+
+    // the root of the tree
+    protected Integer root;
+
+    // next integer for vertex generation
+    private Integer nextInteger;
+
+    /**
+     * Constructor for all methods used in the abstract method. This constructor instantiates the
+     * tree of the decomposition, the map from tree vertices to vertex sets and adds the root to the
+     * tree.
+     */
+    protected NiceDecompositionBuilder()
+    {
+        // creating objects
+        decomposition = new DefaultDirectedGraph<Integer, DefaultEdge>(DefaultEdge.class);
+        decompositionMap = new HashMap<Integer, Set<V>>();
+
+        // create root
+        root = 0;
+        nextInteger = 1;
+        decompositionMap.put(root, new HashSet<V>());
+        decomposition.addVertex(root);
+    }
+
+    /**
+     * Getter for the next free Integer. Supplies the add vertex methods with new vertices
+     * 
+     * @return unused integer
+     */
+    private Integer getNextInteger()
+    {
+        return nextInteger++;
+    }
+
+    /**
+     * Method for adding a new join node.<br>
+     * {@code node} is copied two times jLeft and jRight. {@code node} afterwards becomes the root
+     * of the subtree. jRight becomes the child of {@code node} and has the children of {@code node}
+     * as children. jLeft becomes a leaf and the child of {@code node}. This can be used to make a
+     * join node retrospectively to branch of this node. jRight continues the path while jLeft adds
+     * another path.<br>
+     * The time complexity of this method is in $\mathcal{O}(|b(node)|)$.
+     * 
+     * @param node which nodes should become a join node
+     * @return the new children of the join node; first/left element has no children, second/right
+     *         element has the children of {@code node}
+     */
+    protected Pair<Integer, Integer> addJoin(Integer node)
+    {
+        Set<V> currentVertexBag = null;
+
+        // create first/left new child of node
+        Integer vertexChildLeft = getNextInteger();
+        decomposition.addVertex(vertexChildLeft);
+        currentVertexBag = new HashSet<V>(decompositionMap.get(node));
+        decompositionMap.put(vertexChildLeft, currentVertexBag);
+
+        // create second/right new child of node
+        Integer vertexChildRight = getNextInteger();
+        decomposition.addVertex(vertexChildRight);
+        currentVertexBag = new HashSet<V>(decompositionMap.get(node));
+        decompositionMap.put(vertexChildRight, currentVertexBag);
+
+        // redirect all edges to new parent, the second/right element
+        for (Integer successor : Graphs.successorListOf(decomposition, node)) {
+            decomposition.removeEdge(node, successor);
+            decomposition.addEdge(vertexChildRight, successor);
+        }
+        // make edge from node to left and right vertex
+        decomposition.addEdge(node, vertexChildLeft);
+        decomposition.addEdge(node, vertexChildRight);
+
+        return new Pair<Integer, Integer>(vertexChildLeft, vertexChildRight);
+    }
+
+    /**
+     * Method for adding forget nodes. It is only usable if {@code node} is a leaf. It then adds the
+     * new node as the child of {@code node} with the set of {@code node} plus
+     * {@code forgottenElement}.<br>
+     * The time complexity of this method is in $\mathcal{O}(|b(node)|)$.
+     * 
+     * @param forgottenElement the element, which gets forgotten
+     * @param node the node of the tree decomposition, which becomes a forget node
+     * @return the newly created node; or null and no change if either {@code forgottenElement} is
+     *         in b({@code node}) or {@code node} is not a leaf.
+     */
+    protected Integer addForget(V forgottenElement, Integer node)
+    {
+        //check precondition
+        if (!Graphs.successorListOf(decomposition, node).isEmpty())
+            return null;
+        if (decompositionMap.get(node).contains(forgottenElement))
+            return null;
+
+        //add new child
+        Set<V> nextVertexBag = new HashSet<>(decompositionMap.get(node));
+        nextVertexBag.add(forgottenElement);
+        Integer nextVertex = getNextInteger();
+        decomposition.addVertex(nextVertex);
+        decomposition.addEdge(node, nextVertex);
+        decompositionMap.put(nextVertex, nextVertexBag);
+
+        //return child
+        return nextVertex;
+    }
+
+    /**
+     * Method for adding introduce nodes. It is only usable if {@code node} is a leaf. It then adds
+     * the new node as the child of {@code node} with the set of {@code node} minus
+     * {@code introducedElement}.<br>
+     * The time complexity of this method is in $\mathcal{O}(|b(node)|)$.
+     * 
+     * @param introducedElement the element, which is introduced
+     * @param node the node, which becomes an introduce node
+     * @return the newly created node; or null and no change if either {@code introducedElement} is
+     *         in b({@code node}) or {@code node} is not a leaf.
+     */
+    protected Integer addIntroduce(V introducedElement, Integer node)
+    {
+        //check precondition
+        if (!Graphs.successorListOf(decomposition, node).isEmpty())
+            return null;
+        if (!decompositionMap.get(node).contains(introducedElement))
+            return null;
+
+        //add new child
+        Set<V> nextVertexBag = new HashSet<>(decompositionMap.get(node));
+        nextVertexBag.remove(introducedElement);
+        Integer nextVertex = getNextInteger();
+        decomposition.addVertex(nextVertex);
+        decomposition.addEdge(node, nextVertex);
+        decompositionMap.put(nextVertex, nextVertexBag);
+
+        //return child
+        return nextVertex;
+    }
+
+    /**
+     * Adds to all current leaves in the decomposition introduce nodes until only empty sets
+     * are leaves.
+     */
+    protected void leafClosure()
+    {
+        Set<Integer> vertices = new HashSet<Integer>(decomposition.vertexSet());
+        // make leaf nodes
+        for (Integer leaf : vertices) {
+            // node is not a leaf
+            if (Graphs.vertexHasSuccessors(decomposition, leaf))
+                continue;
+
+            // otherwise add nodes until empty set
+            Set<V> vertexSet = decompositionMap.get(leaf);
+            Integer current = leaf;
+            for (V forget : vertexSet) {
+                current = addIntroduce(forget, current);
+            }
+        }
+    }
+
+    /**
+     * Returns the tree of the decomposition as an unmodifiable, directed graph
+     * 
+     * @return the computed tree decomposition graph
+     */
+    public Graph<Integer, DefaultEdge> getDecomposition()
+    {
+        return new AsUnmodifiableGraph<>(decomposition);
+    }
+
+    /**
+     * Returns the map from integer nodes of the tree decomposition {@code getDecomposition()} to
+     * the sets of the vertices from the graph as an unmodifiable map
+     * 
+     * @return the nodes of decomposition to sets of vertices map
+     */
+    public Map<Integer, Set<V>> getMap()
+    {
+        return Collections.unmodifiableMap(decompositionMap);
+    }
+
+    /**
+     * Returns the root of the decomposition {@code getDecomposition()}
+     * 
+     * @return the root the decomposition
+     */
+    public Integer getRoot()
+    {
+        return root;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString()
+    {
+        return getDecomposition() + "\n " + getMap();
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/package-info.java
@@ -1,0 +1,6 @@
+
+/**
+ * Tree Decomposition related algorithms
+ *
+ */
+package org.jgrapht.alg.decomposition;

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/decompostion/ChordalityNiceDecompositionBuilderTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/decompostion/ChordalityNiceDecompositionBuilderTest.java
@@ -1,0 +1,130 @@
+package org.jgrapht.alg.decompostion;
+
+import java.util.function.Supplier;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.decomposition.*;
+import org.jgrapht.alg.util.*;
+import org.jgrapht.generate.*;
+import org.jgrapht.graph.*;
+import org.jgrapht.graph.builder.*;
+import org.jgrapht.util.SupplierUtil;
+import org.junit.*;
+
+public class ChordalityNiceDecompositionBuilderTest
+{
+
+    private Graph<Integer, DefaultEdge> makeCompleteGraph(int n)
+    {
+        Graph<Integer, DefaultEdge> graph =
+            new SimpleGraph<Integer, DefaultEdge>(SupplierUtil.createIntegerSupplier(), 
+                                                  SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        CompleteGraphGenerator<Integer, DefaultEdge> cgGen = new CompleteGraphGenerator<>(n);
+        cgGen.generateGraph(graph);
+        return graph;
+    }
+
+    @Test
+    public void testCompleteGraph()
+    {
+        for (int i = 0; i < 10; i++) {
+            Graph<Integer, DefaultEdge> graph = makeCompleteGraph(i);
+            ChordalNiceDecompositionBuilder<Integer, DefaultEdge> decompBuild =
+                ChordalNiceDecompositionBuilder.create(graph);
+            NiceDecompositionBuilderTestUtil
+                .testDecomposition(graph, decompBuild.getDecomposition(), decompBuild.getMap());
+            NiceDecompositionBuilderTestUtil.testNiceDecomposition(
+                decompBuild.getDecomposition(), decompBuild.getMap(), decompBuild.getRoot());
+        }
+    }
+
+    private Graph<Integer, DefaultEdge> makeGraphsWithTriangles(int n)
+    {
+        Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(), 
+                                                              SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        if (n == 0)
+            return graph;
+        int freeVertex = 1;
+        graph.addVertex(freeVertex++);
+        graph.addVertex(freeVertex++);
+        graph.addVertex(freeVertex++);
+        graph.addEdge(1, 2);
+        graph.addEdge(2, 3);
+        graph.addEdge(3, 1);
+        for (int i = 1; i < n; i++) {
+            graph.addVertex(freeVertex++);
+            graph.addEdge(freeVertex - 3, freeVertex - 1);
+            graph.addEdge(freeVertex - 2, freeVertex - 1);
+        }
+        return graph;
+    }
+
+    @Test
+    public void testGraphsWithTriangles()
+    {
+        for (int i = 0; i < 10; i++) {
+            Graph<Integer, DefaultEdge> graph = makeGraphsWithTriangles(i);
+            ChordalNiceDecompositionBuilder<Integer, DefaultEdge> decompBuild =
+                ChordalNiceDecompositionBuilder.create(graph);
+            NiceDecompositionBuilderTestUtil
+                .testDecomposition(graph, decompBuild.getDecomposition(), decompBuild.getMap());
+            NiceDecompositionBuilderTestUtil.testNiceDecomposition(
+                decompBuild.getDecomposition(), decompBuild.getMap(), decompBuild.getRoot());
+        }
+    }
+
+    private Graph<Integer, DefaultEdge> makeUnconnectedGraph(int n)
+    {
+        Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(), 
+                                                              SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        for (int i = 0; i < n; i++)
+            graph.addVertex(i);
+        return graph;
+    }
+
+    @Test
+    public void testUnconnectedGraph()
+    {
+        for (int i = 0; i < 10; i++) {
+            Graph<Integer, DefaultEdge> graph = makeUnconnectedGraph(i);
+            ChordalNiceDecompositionBuilder<Integer, DefaultEdge> decompBuild =
+                ChordalNiceDecompositionBuilder.create(graph);
+            NiceDecompositionBuilderTestUtil
+                .testDecomposition(graph, decompBuild.getDecomposition(), decompBuild.getMap());
+            NiceDecompositionBuilderTestUtil.testNiceDecomposition(
+                decompBuild.getDecomposition(), decompBuild.getMap(), decompBuild.getRoot());
+        }
+    }
+
+    public Graph<Integer, DefaultEdge> makeLekkerkerkerBolandFamily(int n)
+    {
+        GraphBuilder<Integer, DefaultEdge, ? extends SimpleGraph<Integer, DefaultEdge>> builder =
+            SimpleGraph.createBuilder(SupplierUtil.DEFAULT_EDGE_SUPPLIER);
+
+        builder.addEdge(0, 1);
+
+        for (int i = 3; i < n; i++) {
+            builder.addEdge(1, i);
+            builder.addEdge(i - 1, i);
+        }
+
+        builder.addEdge(n - 1, n);
+
+        return builder.build();
+    }
+
+    @Test
+    public void testLekkerkerkerBolandFamily()
+    {
+        for (int i = 0; i < 10; i++) {
+            Graph<Integer, DefaultEdge> graph = makeLekkerkerkerBolandFamily(i);
+            ChordalNiceDecompositionBuilder<Integer, DefaultEdge> decompBuild =
+                ChordalNiceDecompositionBuilder.create(graph);
+            NiceDecompositionBuilderTestUtil
+                .testDecomposition(graph, decompBuild.getDecomposition(), decompBuild.getMap());
+            NiceDecompositionBuilderTestUtil.testNiceDecomposition(
+                decompBuild.getDecomposition(), decompBuild.getMap(), decompBuild.getRoot());
+        }
+    }
+
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/decompostion/NiceDecompositionBuilderTestUtil.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/decompostion/NiceDecompositionBuilderTestUtil.java
@@ -1,0 +1,115 @@
+package org.jgrapht.alg.decompostion;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.*;
+import java.util.Map.*;
+
+import org.jgrapht.*;
+import org.jgrapht.graph.*;
+
+public final class NiceDecompositionBuilderTestUtil
+{
+    //static class
+    private NiceDecompositionBuilderTestUtil() {}
+    
+    /**
+     * tests whether the tree decomposition (decomposition, map) with root is nice
+     * 
+     * @param decomposition the tree decomposition to check
+     * @param map the map of the tree decomposition
+     * @param root the root of the tree decomposition
+     */
+    public static <V,E,W> void testNiceDecomposition(Graph<V,E> decomposition, Map<V,Set<W>> map, V root){
+        
+        Queue<V> queue = new LinkedList<V>();
+        
+        //test and add root
+        assertTrue(root+" is no valid root"
+                + "\n in decomposition "+decomposition
+                + "\n and map"+map, map.get(root).isEmpty());
+       queue.add(root);
+        
+        while(!queue.isEmpty())
+        {
+            V current = queue.poll();
+            List<V> successor = Graphs.successorListOf(decomposition, current);
+            if(successor.size() == 0 && map.get(current).isEmpty()) continue; //leaf node
+            if(successor.size() == 1) //forget or introduce
+            {
+                V next = successor.get(0);
+                queue.add(next);
+                Set<W> union = new HashSet<W>(map.get(current));
+                union.addAll(map.get(next));
+                if(union.size() == map.get(next).size() || union.size() == map.get(current).size())
+                {
+                    if(map.get(current).size() == map.get(next).size()-1) continue; //introduce
+                    else if(map.get(current).size()-1 == map.get(next).size()) continue; //forget
+                }
+            }
+            if(successor.size() == 2) //join
+            {
+                V first = successor.get(0);
+                V second = successor.get(1);
+                queue.add(first);
+                queue.add(second);
+                Set<W> union = new HashSet<W>(map.get(current));
+                union.addAll(map.get(first));
+                union.addAll(map.get(second));
+                if(union.size() == map.get(current).size() 
+                && union.size() == map.get(first).size() 
+                && union.size() == map.get(second).size()) 
+                    continue; //join node!
+            }
+            assertFalse("Vertex Set "+current+" is not a valid node for a nice decomposition"
+                + "\nin decomposition "+decomposition
+                + "\nwith map "+map, true); //no valid node!
+        }
+        assertTrue(true);
+    }
+    
+    /**
+     * Test whether (decomposition, map) a tree decomposition of oldGraph is
+     * 
+     * @param oldGraph the graph of the tree decomposition
+     * @param decomposition the tree decomposition
+     * @param map the map from vertices to the tree decomposition to the sets of the tree decomposition
+     */
+    public static <V,E,W,F> void testDecomposition(Graph<W,F> oldGraph, Graph<V,E> decomposition, Map<V,Set<W>> map){
+        Set<F> edgeSet = oldGraph.edgeSet();
+        Set<V> vertexSet = decomposition.vertexSet();
+        //Every edge is represented
+        for(F e : edgeSet)
+        {
+            boolean hasVertex = false;
+            for(V v : vertexSet)
+            {
+                if(map.get(v).contains(oldGraph.getEdgeSource(e)) && map.get(v).contains(oldGraph.getEdgeTarget(e))) {
+                    hasVertex = true;
+                    break; 
+                }
+            }
+            assertTrue("Edge "+e+" is not found"
+                + "\nin graph "+decomposition
+                + "\nwith map "+map, hasVertex);
+        }
+        //every vertex has non-empty connected set of vertex sets
+        Set<W> oldVertexSet = oldGraph.vertexSet();
+        for(W w : oldVertexSet)
+        {
+            Set<V> keySet = new HashSet<V>();
+            for(Entry<V,Set<W>> entry : map.entrySet())
+            {
+                if(entry.getValue().contains(w))
+                    keySet.add(entry.getKey());
+            }
+            //not empty
+            assertFalse("Vertex "+w+" is not represented\n in decomposition "+decomposition+"\n and map "+map, keySet.isEmpty());
+            //connected
+            Graph<V,E> subgraph = new AsSubgraph<V,E>(decomposition,keySet);
+            assertTrue("Vertex "+w+" is not connected\n in decomposition "+decomposition+"\n and map "+map,GraphTests.isConnected(subgraph));
+        }
+    }
+    
+}


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, …
     Link issues by using the following pattern: [#333](https://github.com/JabRef/jabref/issues/333).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->
Regarding the issue [#586](https://github.com/jgrapht/jgrapht/issues/586) we created also a nice tree decomposition builder for chordal graphs, which computes a nice tree decomposition with size and time complexity in O(|V|(|V|+|E|)).
We used the idea of an algorithm which outputs a non-nice tree decomposition of size and time complexity in O(|V|+|E|), but adapting it to nice tree decomposition gives here an additional cost (which we do not get for interval graphs).

We also squashed the commit history for a cleaner history and with better readable commits.


----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
