### PR TITLE
Changed Johnson's result representation into a 2-dimensional array

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/FloydWarshallShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/FloydWarshallShortestPaths.java
@@ -17,11 +17,17 @@
  */
 package org.jgrapht.alg.shortestpath;
 
-import org.jgrapht.*;
-import org.jgrapht.graph.*;
-import org.jgrapht.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import java.util.*;
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.Graphs;
+import org.jgrapht.graph.GraphWalk;
+import org.jgrapht.util.TypeUtil;
 
 /**
  * The Floyd-Warshall algorithm.
@@ -42,8 +48,7 @@ import java.util.*;
  * @author Dimitrios Michail
  */
 public class FloydWarshallShortestPaths<V, E>
-    extends
-    BaseShortestPathAlgorithm<V, E>
+    extends BaseShortestPathAlgorithm<V, E>
 {
     private final List<V> vertices;
     private final Map<V, Integer> vertexIndices;
@@ -318,8 +323,7 @@ public class FloydWarshallShortestPaths<V, E>
     }
 
     class FloydWarshallSingleSourcePaths
-        implements
-        SingleSourcePaths<V, E>
+        implements SingleSourcePaths<V, E>
     {
         private V source;
 
@@ -343,49 +347,14 @@ public class FloydWarshallShortestPaths<V, E>
         @Override
         public double getWeight(V sink)
         {
-            if (!graph.containsVertex(source)) {
-                throw new IllegalArgumentException(GRAPH_MUST_CONTAIN_THE_SOURCE_VERTEX);
-            }
-            if (!graph.containsVertex(sink)) {
-                throw new IllegalArgumentException(GRAPH_MUST_CONTAIN_THE_SINK_VERTEX);
-            }
-
-            lazyCalculateMatrix();
-
-            return d[vertexIndices.get(source)][vertexIndices.get(sink)];
+            return FloydWarshallShortestPaths.this.getPathWeight(source, sink);
         }
 
         @Override
         public GraphPath<V, E> getPath(V sink)
         {
-            if (!graph.containsVertex(source)) {
-                throw new IllegalArgumentException(GRAPH_MUST_CONTAIN_THE_SOURCE_VERTEX);
-            }
-            if (!graph.containsVertex(sink)) {
-                throw new IllegalArgumentException(GRAPH_MUST_CONTAIN_THE_SINK_VERTEX);
-            }
-
-            lazyCalculateMatrix();
-
-            int v_a = vertexIndices.get(source);
-            int v_b = vertexIndices.get(sink);
-
-            if (backtrace[v_a][v_b] == null) { // No path exists
-                return createEmptyPath(source, sink);
-            }
-
-            // Reconstruct the path
-            List<E> edges = new ArrayList<>();
-            V u = source;
-            while (!u.equals(sink)) {
-                int v_u = vertexIndices.get(u);
-                E e = TypeUtil.uncheckedCast(backtrace[v_u][v_b]);
-                edges.add(e);
-                u = Graphs.getOppositeVertex(graph, e, u);
-            }
-            return new GraphWalk<>(graph, source, sink, null, edges, d[v_a][v_b]);
+            return FloydWarshallShortestPaths.this.getPath(source, sink);
         }
-
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/JohnsonShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/JohnsonShortestPaths.java
@@ -60,7 +60,7 @@ public class JohnsonShortestPaths<V, E>
     extends BaseShortestPathAlgorithm<V, E>
 {
     private double[][] distance;
-    private Object[][] pred;
+    private E [][] pred;
     private Map<V, Integer> vertexIndices;
 
     private final Comparator<Double> comparator;
@@ -113,7 +113,7 @@ public class JohnsonShortestPaths<V, E>
         int vSink = vertexIndices.get(sink);
         
         V cur = sink;
-        E e = TypeUtil.uncheckedCast(pred[vSource][vSink]);
+        E e = pred[vSource][vSink];
         if (e == null) { 
             return null;
         }
@@ -122,7 +122,7 @@ public class JohnsonShortestPaths<V, E>
         while(e != null) { 
             edgeList.addFirst(e);
             cur = Graphs.getOppositeVertex(graph, e, cur);
-            e = TypeUtil.uncheckedCast(pred[vSource][vertexIndices.get(cur)]);
+            e = pred[vSource][vertexIndices.get(cur)];
         }
 
         return new GraphWalk<>(graph, source, sink, null, edgeList, distance[vSource][vSink]);
@@ -202,7 +202,7 @@ public class JohnsonShortestPaths<V, E>
         vertexIndices = computeVertexIndices(g);
         final int n = g.vertexSet().size();
         distance = new double[n][n];
-        pred = new Object[n][n];
+        pred = TypeUtil.uncheckedCast(new Object[n][n]);
 
         /*
          * Execute Dijkstra multiple times
@@ -260,7 +260,7 @@ public class JohnsonShortestPaths<V, E>
         vertexIndices = computeVertexIndices(g);
         final int n = g.vertexSet().size();
         distance = new double[n][n];
-        pred = new Object[n][n];
+        pred = TypeUtil.uncheckedCast(new Object[n][n]);
 
         /*
          * Run Dijkstra using new weights for all vertices

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/JohnsonShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/JohnsonShortestPaths.java
@@ -17,12 +17,22 @@
  */
 package org.jgrapht.alg.shortestpath;
 
-import org.jgrapht.*;
-import org.jgrapht.alg.util.*;
-import org.jgrapht.graph.*;
-import org.jgrapht.graph.builder.*;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Map;
 
-import java.util.*;
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.GraphTests;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.alg.util.ToleranceDoubleComparator;
+import org.jgrapht.graph.AsGraphUnion;
+import org.jgrapht.graph.AsWeightedGraph;
+import org.jgrapht.graph.GraphWalk;
+import org.jgrapht.graph.builder.GraphTypeBuilder;
+import org.jgrapht.util.TypeUtil;
 
 /**
  * Johnson's all pairs shortest paths algorithm.
@@ -47,12 +57,13 @@ import java.util.*;
  * @since February 2017
  */
 public class JohnsonShortestPaths<V, E>
-    extends
-    BaseShortestPathAlgorithm<V, E>
+    extends BaseShortestPathAlgorithm<V, E>
 {
-    private Map<V, SingleSourcePaths<V, E>> paths;
-    private final Comparator<Double> comparator;
+    private double[][] distance;
+    private Object[][] pred;
+    private Map<V, Integer> vertexIndices;
 
+    private final Comparator<Double> comparator;
 
     /**
      * Construct a new instance.
@@ -91,8 +102,30 @@ public class JohnsonShortestPaths<V, E>
         if (!graph.containsVertex(sink)) {
             throw new IllegalArgumentException(GRAPH_MUST_CONTAIN_THE_SINK_VERTEX);
         }
+        
         run();
-        return paths.get(source).getPath(sink);
+        
+        if (source.equals(sink)) {
+            return GraphWalk.singletonWalk(graph, source, 0d);
+        }
+        
+        int vSource = vertexIndices.get(source);
+        int vSink = vertexIndices.get(sink);
+        
+        V cur = sink;
+        E e = TypeUtil.uncheckedCast(pred[vSource][vSink]);
+        if (e == null) { 
+            return null;
+        }
+        
+        LinkedList<E> edgeList = new LinkedList<>();
+        while(e != null) { 
+            edgeList.addFirst(e);
+            cur = Graphs.getOppositeVertex(graph, e, cur);
+            e = TypeUtil.uncheckedCast(pred[vSource][vertexIndices.get(cur)]);
+        }
+
+        return new GraphWalk<>(graph, source, sink, null, edgeList, distance[vSource][vSink]);
     }
 
     /**
@@ -111,7 +144,7 @@ public class JohnsonShortestPaths<V, E>
             throw new IllegalArgumentException(GRAPH_MUST_CONTAIN_THE_SINK_VERTEX);
         }
         run();
-        return paths.get(source).getWeight(sink);
+        return distance[vertexIndices.get(source)][vertexIndices.get(sink)];
     }
 
     /**
@@ -124,7 +157,7 @@ public class JohnsonShortestPaths<V, E>
     public SingleSourcePaths<V, E> getPaths(V source)
     {
         run();
-        return paths.get(source);
+        return new JohnsonSingleSourcePaths(source);
     }
 
     /**
@@ -132,24 +165,27 @@ public class JohnsonShortestPaths<V, E>
      */
     private void run()
     {
-        if (paths != null) {
+        if (pred != null) {
             return;
         }
         GraphTests.requireDirectedOrUndirected(graph);
 
         boolean graphHasNegativeEdgeWeights = false;
-        for (E e : graph.edgeSet())
+        for (E e : graph.edgeSet()) {
             if (comparator.compare(graph.getEdgeWeight(e), 0.0) < 0) {
                 graphHasNegativeEdgeWeights = true;
                 break;
             }
+        }
 
         if (graphHasNegativeEdgeWeights) {
-            if (graph.getType().isUndirected())
+            if (graph.getType().isUndirected()) {
                 throw new RuntimeException(GRAPH_CONTAINS_A_NEGATIVE_WEIGHT_CYCLE);
+            }
             runWithNegativeEdgeWeights(graph);
-        } else
+        } else {
             runWithPositiveEdgeWeights(graph);
+        }
     }
 
     /**
@@ -161,12 +197,31 @@ public class JohnsonShortestPaths<V, E>
     private void runWithPositiveEdgeWeights(Graph<V, E> g)
     {
         /*
-         * Run Dijkstra for all vertices.
+         * Create vertex numbering for array representation of results.
          */
-        paths = new HashMap<>();
-        DijkstraShortestPath<V, E> dijkstraAlg = new DijkstraShortestPath<>(g);
+        vertexIndices = computeVertexIndices(g);
+        final int n = g.vertexSet().size();
+        distance = new double[n][n];
+        pred = new Object[n][n];
+
+        /*
+         * Execute Dijkstra multiple times
+         */
         for (V v : g.vertexSet()) {
-            paths.put(v, dijkstraAlg.getPaths(v));
+            DijkstraClosestFirstIterator<V, E> it =
+                new DijkstraClosestFirstIterator<>(g, v, Double.POSITIVE_INFINITY);
+            while (it.hasNext()) {
+                it.next();
+            }
+            Map<V, Pair<Double, E>> distanceAndPredecessorMap = it.getDistanceAndPredecessorMap();
+
+            // transform result
+            for (V u : g.vertexSet()) {
+                Pair<Double, E> pair = distanceAndPredecessorMap
+                    .getOrDefault(u, Pair.of(Double.POSITIVE_INFINITY, null));
+                distance[vertexIndices.get(v)][vertexIndices.get(u)] = pair.getFirst();
+                pred[vertexIndices.get(v)][vertexIndices.get(u)] = pair.getSecond();
+            }
         }
     }
 
@@ -200,11 +255,17 @@ public class JohnsonShortestPaths<V, E>
         Graph<V, E> newEdgeWeightsGraph = new AsWeightedGraph<>(g, newEdgeWeights);
 
         /*
+         * Create vertex numbering, for array representation of results
+         */
+        vertexIndices = computeVertexIndices(g);
+        final int n = g.vertexSet().size();
+        distance = new double[n][n];
+        pred = new Object[n][n];
+
+        /*
          * Run Dijkstra using new weights for all vertices
          */
-        paths = new HashMap<>();
         for (V v : g.vertexSet()) {
-            // execute Dijkstra
             DijkstraClosestFirstIterator<V, E> it = new DijkstraClosestFirstIterator<>(
                 newEdgeWeightsGraph, v, Double.POSITIVE_INFINITY);
             while (it.hasNext()) {
@@ -213,20 +274,21 @@ public class JohnsonShortestPaths<V, E>
             Map<V, Pair<Double, E>> distanceAndPredecessorMap = it.getDistanceAndPredecessorMap();
 
             // transform distances to original weights
-            Map<V, Pair<Double, E>> newDistanceAndPredecessorMap = new HashMap<>();
             for (V u : g.vertexSet()) {
                 Pair<Double, E> oldPair = distanceAndPredecessorMap.get(u);
-                if (oldPair != null) {
-                    Pair<Double,
-                        E> newPair = Pair.of(
-                            oldPair.getFirst() - vertexWeights.get(v) + vertexWeights.get(u),
-                            oldPair.getSecond());
-                    newDistanceAndPredecessorMap.put(u, newPair);
-                }
-            }
 
-            // store shortest path tree
-            paths.put(v, new TreeSingleSourcePathsImpl<>(g, v, newDistanceAndPredecessorMap));
+                Pair<Double, E> newPair;
+                if (oldPair != null) {
+                    newPair = Pair.of(
+                        oldPair.getFirst() - vertexWeights.get(v) + vertexWeights.get(u),
+                        oldPair.getSecond());
+                } else {
+                    newPair = Pair.of(Double.POSITIVE_INFINITY, null);
+                }
+
+                distance[vertexIndices.get(v)][vertexIndices.get(u)] = newPair.getFirst();
+                pred[vertexIndices.get(v)][vertexIndices.get(u)] = newPair.getSecond();
+            }
         }
 
     }
@@ -277,6 +339,58 @@ public class JohnsonShortestPaths<V, E>
             weights.put(v, paths.getWeight(v));
         }
         return weights;
+    }
+
+    /**
+     * Compute a unique integer for each vertex of the graph
+     * 
+     * @param g the graph
+     * @return a map with the result
+     */
+    private Map<V, Integer> computeVertexIndices(Graph<V, E> g)
+    {
+        Map<V, Integer> numbering = new HashMap<>();
+        int num = 0;
+        for (V v : g.vertexSet()) {
+            numbering.put(v, num++);
+        }
+        return numbering;
+    }
+
+    class JohnsonSingleSourcePaths
+        implements SingleSourcePaths<V, E>
+    {
+        private V source;
+
+        public JohnsonSingleSourcePaths(V source)
+        {
+            this.source = source;
+        }
+
+        @Override
+        public Graph<V, E> getGraph()
+        {
+            return graph;
+        }
+
+        @Override
+        public V getSourceVertex()
+        {
+            return source;
+        }
+
+        @Override
+        public double getWeight(V sink)
+        {
+            return JohnsonShortestPaths.this.getPathWeight(source, sink);
+        }
+
+        @Override
+        public GraphPath<V, E> getPath(V sink)
+        {
+            return JohnsonShortestPaths.this.getPath(source, sink);
+        }
+
     }
 
 }


### PR DESCRIPTION
Change the representation of the result of Johnson's algorithm to be the same as with Floyd-Warshall
Fixes #626.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
