### PR TITLE
Tree generator based on Prufer sequences

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/generate/BarabasiAlbertForestGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/BarabasiAlbertForestGenerator.java
@@ -101,17 +101,24 @@ public class BarabasiAlbertForestGenerator<V, E> implements GraphGenerator<V, E,
     /**
      * Generates an instance.
      *
-     * Note: All existing vertices and edges of the target graph will be removed.
+     * <p>
+     * Note: An exception will be thrown if the target graph is not empty (i.e. contains
+     * at least one vertex)
+     * </p>
      *
      * @param target the target graph
      * @param resultMap not used by this generator, can be null
+     * @throws NullPointerException if {@code target} is {@code null}
+     * @throws IllegalArgumentException if {@code target} is not undirected
+     * @throws IllegalArgumentException if {@code target} is not empty
      */
     @Override
     public void generateGraph(Graph<V, E> target, Map<String, V> resultMap) {
         GraphTests.requireUndirected(target);
 
-        // remove old vertices and edges
-        target.removeAllVertices(new HashSet<>(target.vertexSet()));
+        if (!target.vertexSet().isEmpty()){
+            throw new IllegalArgumentException("target graph is not empty");
+        }
 
         assert target.vertexSet().isEmpty();
         assert target.edgeSet().isEmpty();

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/BarabasiAlbertForestGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/BarabasiAlbertForestGenerator.java
@@ -110,8 +110,8 @@ public class BarabasiAlbertForestGenerator<V, E> implements GraphGenerator<V, E,
     public void generateGraph(Graph<V, E> target, Map<String, V> resultMap) {
         GraphTests.requireUndirected(target);
 
-        // remove old vertices and edges ???
-        target.removeAllVertices(target.vertexSet());
+        // remove old vertices and edges
+        target.removeAllVertices(new HashSet<>(target.vertexSet()));
 
         assert target.vertexSet().isEmpty();
         assert target.edgeSet().isEmpty();

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/PruferTreeGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/PruferTreeGenerator.java
@@ -1,0 +1,179 @@
+/*
+ * (C) Copyright 2018-2018, by Alexandru Valeanu and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.generate;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphTests;
+
+import java.util.*;
+
+/**
+ * Generates a random tree using Prüfer sequences.
+ * 
+ * <p>
+ *  A Prüfer sequence of length $n$ is randomly generated and converted into the corresponding tree.
+ * </p>
+ *
+ * <p>
+ *  This implementation is inspired by "X. Wang, L. Wang and Y. Wu, "An Optimal Algorithm for Prufer Codes," Journal
+ *  of Software Engineering and Applications, Vol. 2 No. 2, 2009, pp. 111-115. doi: 10.4236/jsea.2009.22016."
+ *  and has a running time of $O(n)$.
+ * </p>
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ *
+ * @author Alexandru Valeanu
+ */
+public class PruferTreeGenerator<V, E> implements GraphGenerator<V, E, V> {
+
+    // number of vertices
+    private int n;
+
+    // random number generator
+    private Random rng;
+
+    /**
+     * Construct a new PruferTreeGenerator.
+     *
+     * @param n number of vertices to be generated
+     * @throws IllegalArgumentException if {@code n} is &le; 0
+     */
+    public PruferTreeGenerator(int n) {
+        this(n, new Random());
+    }
+
+    /**
+     * Construct a new PruferTreeGenerator.
+     *
+     * @param n number of vertices to be generated
+     * @param seed seed for the random number generator
+     * @throws IllegalArgumentException if {@code n} is &le; 0
+     */
+    public PruferTreeGenerator(int n, long seed) {
+        this(n, new Random(seed));
+    }
+
+    /**
+     * Construct a new PruferTreeGenerator
+     *
+     * @param n number of vertices to be generated
+     * @param rng the random number generator to use
+     * @throws IllegalArgumentException if {@code n} is &le; 0
+     * @throws NullPointerException if {@code rng} is {@code null}
+     */
+    public PruferTreeGenerator(int n, Random rng) {
+        if (n <= 0){
+            throw new IllegalArgumentException("n must be greater than 0");
+        }
+
+        this.n = n;
+        this.rng = Objects.requireNonNull(rng, "Random number generator cannot be null");
+    }
+
+    /**
+     * Generates a tree.
+     *
+     * Note: All existing vertices and edges of the target graph will be removed.
+     *
+     * @param target the target graph
+     * @param resultMap not used by this generator, can be null
+     * @throws NullPointerException if {@code target} is {@code null}
+     * @throws IllegalArgumentException if {@code target} is not undirected
+     */
+    @Override
+    public void generateGraph(Graph<V, E> target, Map<String, V> resultMap) {
+        GraphTests.requireUndirected(target);
+
+        // remove old vertices and edges
+        target.removeAllVertices(new HashSet<>(target.vertexSet()));
+
+        // base case
+        if (n == 1){
+            if (target.addVertex() == null) {
+                throw new IllegalArgumentException("Invalid vertex supplier");
+            }
+
+            return;
+        }
+
+        List<V> vertexList = new ArrayList<>(n);
+
+        // add vertices
+        for (int i = 0; i < n; i++) {
+            V newVertex = target.addVertex();
+
+            if (newVertex == null) {
+                throw new IllegalArgumentException("Invalid vertex supplier");
+            }
+
+            vertexList.add(newVertex);
+        }
+
+        // degree stores the remaining degree (plus one) for each node. The
+        // degree of a node in the decoded tree is one more than the number
+        // of times it appears in the code.
+        int[] degree = new int[n];
+        Arrays.fill(degree, 1);
+
+        int[] pruferSeq = new int[n - 2];
+        for (int i = 0; i < n - 2; i++) {
+            pruferSeq[i] = rng.nextInt(n);
+            ++degree[pruferSeq[i]];
+        }
+
+        int index = -1, x = -1;
+
+        for (int k = 0; k < n; k++){
+            if (degree[k] == 1){
+                index = x = k;
+                break;
+            }
+        }
+
+        assert index != -1;
+
+        // set of nodes without a parent
+        Set<V> orphans = new HashSet<>(target.vertexSet());
+
+        for (int i = 0; i < n - 2; i++){
+            int y = pruferSeq[i];
+            orphans.remove(vertexList.get(x));
+            target.addEdge(vertexList.get(x), vertexList.get(y));
+            --degree[y];
+
+            if (y < index && degree[y] == 1){
+                x = y;
+            }
+            else{
+                for (int k = index + 1; k < n; k++) {
+                    if (degree[k] == 1){
+                        index = x = k;
+                        break;
+                    }
+                }
+            }
+        }
+
+        assert orphans.size() == 2;
+        Iterator<V> iterator = orphans.iterator();
+        V u = iterator.next();
+        V v = iterator.next();
+        target.addEdge(u, v);
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/PruferTreeGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/PruferTreeGenerator.java
@@ -53,7 +53,7 @@ public class PruferTreeGenerator<V, E> implements GraphGenerator<V, E, V> {
 
     /**
      * Construct a new PruferTreeGenerator from an input Prüfer sequence. Note that
-     * the size of the generated tree will $l+2$ where $l$ is the length of the input
+     * the size of the generated tree will be $l+2$ where $l$ is the length of the input
      * sequence. The Prüfer sequence must contain integers between $0$ and $l+1$ (inclusive).
      *
      * Note: In this case, the same tree will be generated every time.

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/BarabasiAlbertForestGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/BarabasiAlbertForestGeneratorTest.java
@@ -124,7 +124,7 @@ public class BarabasiAlbertForestGeneratorTest {
         assertEquals(20, g.vertexSet().size());
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testUndirectedWithGraphWhichAlreadyHasSomeVertices() {
         final long seed = 5;
 

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/PruferTreeGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/PruferTreeGeneratorTest.java
@@ -26,6 +26,7 @@ import org.jgrapht.util.SupplierUtil;
 import org.junit.Assert;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.Random;
 
 /**
@@ -76,6 +77,11 @@ public class PruferTreeGeneratorTest {
         generator.generateGraph(tree);
 
         Assert.assertEquals(6, tree.vertexSet().size());
+
+        int[] degrees = tree.vertexSet().stream().mapToInt(tree::degreeOf).toArray();
+        Arrays.sort(degrees);
+
+        Assert.assertArrayEquals(new int[]{1, 1, 1, 1, 2, 4}, degrees);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/PruferTreeGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/PruferTreeGeneratorTest.java
@@ -36,6 +36,49 @@ import java.util.Random;
 public class PruferTreeGeneratorTest {
 
     @Test(expected = IllegalArgumentException.class)
+    public void testNullPruferSequence(){
+        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(1),
+                SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+
+        PruferTreeGenerator<Integer, DefaultEdge> generator =
+                new PruferTreeGenerator<>(null);
+    }
+
+    @Test
+    public void testEmptyPruferSequence(){
+        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(1),
+                SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+
+        PruferTreeGenerator<Integer, DefaultEdge> generator =
+                new PruferTreeGenerator<>(new int[]{});
+
+        generator.generateGraph(tree);
+        Assert.assertEquals(2, tree.vertexSet().size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInvalidPruferSequence(){
+        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(1),
+                SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+
+        PruferTreeGenerator<Integer, DefaultEdge> generator =
+                new PruferTreeGenerator<>(new int[]{10});
+    }
+
+    @Test
+    public void testPruferSequence(){
+        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(1),
+                SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+
+        PruferTreeGenerator<Integer, DefaultEdge> generator =
+                new PruferTreeGenerator<>(new int[]{4, 4, 4, 5});
+
+        generator.generateGraph(tree);
+
+        Assert.assertEquals(6, tree.vertexSet().size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
     public void testZeroVertices(){
         Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(1),
                 SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
@@ -84,7 +127,7 @@ public class PruferTreeGeneratorTest {
         Assert.assertTrue(GraphTests.isTree(tree));
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testExistingVertices(){
         Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(),
                 SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
@@ -98,8 +141,6 @@ public class PruferTreeGeneratorTest {
                 new PruferTreeGenerator<>(100, 0x99);
 
         generator.generateGraph(tree);
-        Assert.assertEquals(100, tree.vertexSet().size());
-        Assert.assertTrue(GraphTests.isTree(tree));
     }
 
 

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/PruferTreeGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/PruferTreeGeneratorTest.java
@@ -1,0 +1,134 @@
+/*
+ * (C) Copyright 2018-2018, by Alexandru Valeanu and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.generate;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphTests;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DirectedAcyclicGraph;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.util.SupplierUtil;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Random;
+
+/**
+ * Tests for {@link PruferTreeGenerator}
+ *
+ * @author Alexandru Valeanu
+ */
+public class PruferTreeGeneratorTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testZeroVertices(){
+        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(1),
+                SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+
+        PruferTreeGenerator<Integer, DefaultEdge> generator =
+                new PruferTreeGenerator<>(0);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullRNG(){
+        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(1),
+                SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+
+        PruferTreeGenerator<Integer, DefaultEdge> generator =
+                new PruferTreeGenerator<>(100, null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDirectedGraph(){
+        Graph<Integer, DefaultEdge> tree = new DirectedAcyclicGraph<>(SupplierUtil.createIntegerSupplier(1),
+                SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+
+        PruferTreeGenerator<Integer, DefaultEdge> generator =
+                new PruferTreeGenerator<>(10);
+
+        generator.generateGraph(tree);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testNullGraph(){
+        PruferTreeGenerator<Integer, DefaultEdge> generator =
+                new PruferTreeGenerator<>(10);
+
+        generator.generateGraph(null);
+    }
+
+    @Test
+    public void testOneVertex(){
+        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(),
+                SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+
+        PruferTreeGenerator<Integer, DefaultEdge> generator =
+                new PruferTreeGenerator<>(1, 0x99);
+
+        generator.generateGraph(tree);
+        Assert.assertTrue(GraphTests.isTree(tree));
+    }
+
+    @Test
+    public void testExistingVertices(){
+        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(),
+                SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+
+        CompleteGraphGenerator<Integer, DefaultEdge> completeGraphGenerator =
+                new CompleteGraphGenerator<>(10);
+
+        completeGraphGenerator.generateGraph(tree);
+
+        PruferTreeGenerator<Integer, DefaultEdge> generator =
+                new PruferTreeGenerator<>(100, 0x99);
+
+        generator.generateGraph(tree);
+        Assert.assertEquals(100, tree.vertexSet().size());
+        Assert.assertTrue(GraphTests.isTree(tree));
+    }
+
+
+    @Test
+    public void testRandomSizes(){
+        Random random = new Random(0x88);
+        final int NUM_TESTS = 500;
+
+        for (int test = 0; test < NUM_TESTS; test++) {
+            Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(1),
+                    SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+
+            PruferTreeGenerator<Integer, DefaultEdge> generator =
+                    new PruferTreeGenerator<>(1 + random.nextInt(5000), random);
+
+            generator.generateGraph(tree);
+            Assert.assertTrue(GraphTests.isTree(tree));
+        }
+    }
+
+    @Test
+    public void testHugeSize(){
+        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(SupplierUtil.createIntegerSupplier(),
+                SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+
+        PruferTreeGenerator<Integer, DefaultEdge> generator =
+                new PruferTreeGenerator<>(100_000, 0x99);
+
+        generator.generateGraph(tree);
+        Assert.assertTrue(GraphTests.isTree(tree));
+    }
+}


### PR DESCRIPTION
Inspired by [networkx's implementation of from_prufer_sequence],(https://networkx.github.io/documentation/stable/reference/algorithms/generated/networkx.algorithms.tree.coding.from_prufer_sequence.html) I implemented a tree generator based on Prufer codes. It randomly generator a Prufer code and then converts it into the corresponding tree in linear time. 

Note: I also fixed a small bug in `BarabasiAlbertForestGenerator`. The old version removed the vertex set while iterating over it.

Note 2.0: After all other tree PR's are merged I'll create a new one that adds (for each tree-related class) tests with this generator.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
