### PR TITLE
Fixes issue with multiple characters() method calls in some SAX parsers.

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/GraphMLImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/GraphMLImporter.java
@@ -549,9 +549,17 @@ public class GraphMLImporter<V, E>
             throws SAXException
         {
             if (insideDefault) {
-                currentKey.defaultValue = new String(ch, start, length);
+                if (currentKey.defaultValue != null) {
+                    currentKey.defaultValue += new String(ch, start, length);
+                } else {
+                    currentKey.defaultValue = new String(ch, start, length);
+                }
             } else if (insideData) {
-                currentData.value = new String(ch, start, length);
+                if (currentData.value != null) {
+                    currentData.value += new String(ch, start, length);
+                } else {
+                    currentData.value = new String(ch, start, length);
+                }
             }
         }
 

--- a/jgrapht-io/src/main/java/org/jgrapht/io/SimpleGraphMLImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/SimpleGraphMLImporter.java
@@ -303,7 +303,7 @@ public class SimpleGraphMLImporter<V, E>
         private E currentEdge;
         private Key currentKey;
         private String currentDataKey;
-        private String currentDataValue;
+        private StringBuilder currentDataValue;
         private Map<String, Key> nodeValidKeys;
         private Map<String, Key> edgeValidKeys;
         private Map<String, Key> graphValidKeys;
@@ -329,7 +329,7 @@ public class SimpleGraphMLImporter<V, E>
             currentEdge = null;
             currentKey = null;
             currentDataKey = null;
-            currentDataValue = null;
+            currentDataValue = new StringBuilder();
             nodeValidKeys = new HashMap<>();
             edgeValidKeys = new HashMap<>();
             graphValidKeys = new HashMap<>();
@@ -438,7 +438,7 @@ public class SimpleGraphMLImporter<V, E>
             case DATA:
                 if (--insideData == 0) {
                     notifyData();
-                    currentDataValue = null;
+                    currentDataValue.setLength(0);
                     currentDataKey = null;
                 }
                 break;
@@ -452,7 +452,7 @@ public class SimpleGraphMLImporter<V, E>
             throws SAXException
         {
             if (insideData == 1) {
-                currentDataValue = new String(ch, start, length);
+                currentDataValue.append(new String(ch, start, length));
             }
         }
 
@@ -488,7 +488,7 @@ public class SimpleGraphMLImporter<V, E>
 
         private void notifyData()
         {
-            if (currentDataKey == null || currentDataValue == null) {
+            if (currentDataKey == null || currentDataValue.length() == 0) {
                 return;
             }
 
@@ -497,7 +497,7 @@ public class SimpleGraphMLImporter<V, E>
                 if (key != null) {
                     notifyVertex(
                         currentNode, key.attributeName,
-                        new DefaultAttribute<>(currentDataValue, key.type));
+                        new DefaultAttribute<>(currentDataValue.toString(), key.type));
                 }
             }
             if (currentEdge != null) {
@@ -508,21 +508,21 @@ public class SimpleGraphMLImporter<V, E>
                      */
                     if (isWeighted && key.attributeName.equals(edgeWeightAttributeName)) {
                         try {
-                            graph.setEdgeWeight(currentEdge, Double.parseDouble(currentDataValue));
+                            graph.setEdgeWeight(currentEdge, Double.parseDouble(currentDataValue.toString()));
                         } catch (NumberFormatException e) {
                             // ignore
                         }
                     }
                     notifyEdge(
                         currentEdge, key.attributeName,
-                        new DefaultAttribute<>(currentDataValue, key.type));
+                        new DefaultAttribute<>(currentDataValue.toString(), key.type));
                 }
             }
             if (graph != null) {
                 Key key = graphValidKeys.get(currentDataKey);
                 if (key != null) {
                     notifyGraph(
-                        key.attributeName, new DefaultAttribute<>(currentDataValue, key.type));
+                        key.attributeName, new DefaultAttribute<>(currentDataValue.toString(), key.type));
                 }
             }
         }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/SimpleGraphMLImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/SimpleGraphMLImporter.java
@@ -452,7 +452,7 @@ public class SimpleGraphMLImporter<V, E>
             throws SAXException
         {
             if (insideData == 1) {
-                currentDataValue.append(new String(ch, start, length));
+                currentDataValue.append(ch, start, length);
             }
         }
 

--- a/jgrapht-io/src/test/java/org/jgrapht/io/SimpleGraphMLImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/SimpleGraphMLImporterTest.java
@@ -19,7 +19,6 @@ package org.jgrapht.io;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.io.*;
 import java.nio.charset.*;


### PR DESCRIPTION
Fix for #644.

Some SAX parsers call method `characters()` multiple times. The fix accumulates the data. Documentation can be found at https://docs.oracle.com/javase/tutorial/jaxp/sax/parsing.html.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
