### PR TITLE
Added jheaps dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,12 +130,13 @@ A local copy of the Javadoc HTML files is included in the distribution. The late
 ## Dependencies ##
 
 - JGraphT requires JDK 1.8 or later to build starting with version 1.0.0.
+- [JHeaps](http://www.jheaps.org/) is a library with priority queues. JHeaps is licensed under the terms of the Apache License, Version 2.0.
 - [JUnit](http://www.junit.org) is a unit testing framework. You need JUnit only if you want to run the unit tests.  JUnit is licensed under the terms of the IBM Common Public License.  The JUnit tests included with JGraphT have been created using JUnit 4.
 - [XMLUnit](http://xmlunit.sourceforge.net) extends JUnit with XML capabilities. You need XMLUnit only if you want to run the unit tests.  XMLUnit is licensed under the terms of the BSD License.
 - [JGraphX](http://www.jgraph.com/jgraph.html) is a graph visualizations and editing component (the successor to the older JGraph library). You need JGraphX only if you want to use the JGraphXAdapter to visualize the JGraphT graph interactively via JGraphX. JGraphX is licensed under the terms of the BSD license.
 - [Touchgraph](http://sourceforge.net/projects/touchgraph) is a graph visualization and layout component. You need Touchgraph only if you want to create graph visualizations using the JGraphT-to-Touchgraph converter. Touchgraph is licensed under the terms of an Apache-style License.
 - [ANTLR](http://www.antlr.org) is a parser generator.  It is used for reading text files containing graph representations, and is only required by the jgrapht-io module.  ANTLR v4 is licensed under the terms of the [BSD license](http://www.antlr.org/license.html).
-- [Guava](https://github.com/google/guava) is Google's core libraries for Java. You need Guava only if you are already using Guava's graph data-structures and wish to use our adapter classes in order to execute JGraphT's algorithms.
+- [Guava](https://github.com/google/guava) is Google's core libraries for Java. You need Guava only if you are already using Guava's graph data-structures and wish to use our adapter classes in order to execute JGraphT's algorithms. Only required by the jgrapht-guava module.
 
 ## Online Resources ##
 

--- a/jgrapht-core/pom.xml
+++ b/jgrapht-core/pom.xml
@@ -26,6 +26,11 @@
 	</licenses>
 	<dependencies>
 		<dependency>
+			<groupId>org.jheaps</groupId>
+			<artifactId>jheaps</artifactId>
+			<version>0.8</version>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
@@ -33,7 +38,7 @@
 		<dependency>
 			<groupId>com.googlecode.junit-toolbox</groupId>
 			<artifactId>junit-toolbox</artifactId>
-                        <version>2.4</version>
+			<version>2.4</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -51,6 +56,41 @@
 	</dependencies>
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<transformers>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+							<manifestEntries>
+								<!-- Use unique OSGi bundle symbolic name for uber artifact. Otherwise 
+									e.g. jgrapht-core-x.y.z.jar and jgrapht-core-x.y.z-uber.jar could not be deployed 
+									to the same P2 repository. -->
+								<Bundle-SymbolicName>org.jgrapht.core.uber</Bundle-SymbolicName>
+							</manifestEntries>
+						</transformer>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+							<resource>META-INF/jheaps-license</resource>
+							<file>${main.basedir}/etc/licenses/apache-license-2.0.txt</file>
+						</transformer>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer">
+                			</transformer>
+						<transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+							<addHeader>false</addHeader>
+						</transformer>
+					</transformers>
+					<shadedArtifactAttached>true</shadedArtifactAttached>
+					<shadedClassifierName>uber</shadedClassifierName>
+				</configuration>
+			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/MartinShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/MartinShortestPath.java
@@ -17,13 +17,24 @@
  */
 package org.jgrapht.alg.shortestpath;
 
-import org.jgrapht.*;
-import org.jgrapht.graph.*;
-import org.jgrapht.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
-import java.util.*;
-import java.util.function.*;
-import java.util.stream.*;
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.Graphs;
+import org.jgrapht.graph.GraphWalk;
+import org.jheaps.Heap;
+import org.jheaps.array.DaryArrayHeap;
 
 /**
  * Martin's algorithm for the multi-objective shortest paths problem.
@@ -52,8 +63,8 @@ public class MartinShortestPath<V, E>
     // final labels for each node
     private final Map<V, LinkedList<Label>> nodeLabels;
     // temporary labels ordered lexicographically
-    private final GenericFibonacciHeap<Label, Void> heap;
-
+    private final Heap<Label> heap;
+    
     /**
      * Create a new shortest path algorithm
      * 
@@ -67,9 +78,9 @@ public class MartinShortestPath<V, E>
             Objects.requireNonNull(edgeWeightFunction, "Function cannot be null");
         this.objectives = validateEdgeWeightFunction(edgeWeightFunction);
         this.nodeLabels = new HashMap<>();
-        this.heap = new GenericFibonacciHeap<>(new LabelComparator());
+        this.heap = new DaryArrayHeap<>(3, new LabelComparator());
     }
-
+    
     @Override
     public List<GraphPath<V, E>> getPaths(V source, V sink)
     {
@@ -107,10 +118,10 @@ public class MartinShortestPath<V, E>
             nodeLabels.put(v, new LinkedList<>());
         }
         nodeLabels.get(source).add(sourceLabel);
-        heap.insert(sourceLabel, null);
+        heap.insert(sourceLabel);
 
         while (!heap.isEmpty()) {
-            Label curLabel = heap.removeMin().getKey();
+            Label curLabel = heap.deleteMin();
             V v = curLabel.node;
             for (E e : graph.outgoingEdgesOf(v)) {
                 V u = Graphs.getOppositeVertex(graph, e, v);
@@ -132,7 +143,7 @@ public class MartinShortestPath<V, E>
                 }
                 if (!isDominated) {
                     uLabels.add(newLabel);
-                    heap.insert(newLabel, null);
+                    heap.insert(newLabel);
                 }
             }
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/GenericFibonacciHeap.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/GenericFibonacciHeap.java
@@ -41,7 +41,10 @@ import java.util.*;
  *
  * @author Nathan Fiedler
  * @author Dimitrios Michail
+ * 
+ * @deprecated In favor of using data structures from the jheaps library. 
  */
+@Deprecated
 public class GenericFibonacciHeap<K, T>
 {
     private static final double ONEOVERLOGPHI = 1.0 / Math.log((1.0 + Math.sqrt(5.0)) / 2.0);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/MartinShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/MartinShortestPathTest.java
@@ -17,15 +17,17 @@
  */
 package org.jgrapht.alg.shortestpath;
 
-import org.jgrapht.*;
-import org.jgrapht.alg.interfaces.MultiObjectiveShortestPathAlgorithm.*;
-import org.jgrapht.graph.*;
-import org.junit.*;
+import static org.junit.Assert.assertEquals;
 
-import java.util.*;
-import java.util.stream.*;
+import java.util.List;
+import java.util.stream.IntStream;
 
-import static org.junit.Assert.*;
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.interfaces.MultiObjectiveShortestPathAlgorithm.MultiObjectiveSingleSourcePaths;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultEdgeFunction;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.junit.Test;
 
 /**
  * Test {@link MartinShortestPath}.
@@ -105,5 +107,5 @@ public class MartinShortestPathTest
         List<GraphPath<Integer, DefaultEdge>> paths22 = paths2.getPaths(2);
         assertEquals(1, paths22.size());
     }
-
+    
 }

--- a/jgrapht-dist/pom.xml
+++ b/jgrapht-dist/pom.xml
@@ -30,6 +30,12 @@
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
+			<artifactId>jgrapht-core</artifactId>
+			<classifier>uber</classifier>
+			<version>${project.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
 			<artifactId>jgrapht-io</artifactId>
 		</dependency>
 		<dependency>

--- a/jgrapht-dist/src/assembly/assembly.xml
+++ b/jgrapht-dist/src/assembly/assembly.xml
@@ -66,6 +66,11 @@
 			<outputDirectory>3rd-party-licenses</outputDirectory>
 			<destName>commons-lang3-license.txt</destName>
 		</file>
+		<file>
+			<source>${main.basedir}/etc/licenses/apache-license-2.0.txt</source>
+			<outputDirectory>3rd-party-licenses</outputDirectory>
+			<destName>jheaps-license.txt</destName>
+		</file>
 	</files>
 
 	<fileSets>


### PR DESCRIPTION
Added the jheaps dependency and deprecated the `GenericFibonacciHeap` class. This affects the implementation of the maximum weight bipartite matching algorithm and Martin's shortest path algorithm.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
