### PR TITLE
Clustering coefficient

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClusteringCoefficient.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClusteringCoefficient.java
@@ -24,12 +24,12 @@ import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
 
 /**
- * Clusteing coefficient.
+ * Clustering coefficient.
  * 
  * <p>
  * Computes the clustering coefficient of each vertex of a graph. The clustering coefficient of a
  * node $v$ in a directed graph is given by the expression: $C_i = \frac{|\{e_{jk}: v_j,v_k \in N_i, e_{jk} \in E\}|}{k_i(k_i-1)}$
- * where $N_i$ is the vertex neighbourhood: $N_i = \{v_j : e_{ij} \in E \or e_{ji} \in E\}$. For undirected graphs,
+ * where $N_i$ is the vertex neighborhood: $N_i = \{v_j : e_{ij} \in E \or e_{ji} \in E\}$. For undirected graphs,
  * $e_{ij}$ and $e_{ji}$ are considered identical hence the clustering coefficient is given by:
  * $C_i = \frac{2|\{e_{jk}: v_j,v_k \in N_i, e_{jk} \in E\}|}{k_i(k_i-1)}$. 
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClusteringCoefficient.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClusteringCoefficient.java
@@ -27,8 +27,8 @@ import org.jgrapht.alg.interfaces.*;
  * Clustering coefficient.
  * 
  * <p>
- * Computes the clustering coefficient of each vertex of a graph. The clustering coefficient of a
- * node $v$ in a directed graph is given by the expression: $C_i = \frac{|\{e_{jk}: v_j,v_k \in N_i, e_{jk} \in E\}|}{k_i(k_i-1)}$
+ * Computes the local clustering coefficient of a vertex of a graph. The clustering coefficient of a
+ * vertex $v$ in a directed graph is given by the expression: $C_i = \frac{|\{e_{jk}: v_j,v_k \in N_i, e_{jk} \in E\}|}{k_i(k_i-1)}$
  * where $N_i$ is the vertex neighborhood: $N_i = \{v_j : e_{ij} \in E \or e_{ji} \in E\}$. For undirected graphs,
  * $e_{ij}$ and $e_{ji}$ are considered identical hence the clustering coefficient is given by:
  * $C_i = \frac{2|\{e_{jk}: v_j,v_k \in N_i, e_{jk} \in E\}|}{k_i(k_i-1)}$. 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClusteringCoefficient.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClusteringCoefficient.java
@@ -1,0 +1,138 @@
+/*
+ * (C) Copyright 2017-2017, by Assaf Mizrachi and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.scoring;
+
+import java.util.*;
+import java.util.stream.*;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.interfaces.*;
+
+/**
+ * Clusteing coefficient.
+ * 
+ * <p>
+ * Computes the clustering coefficient of each vertex of a graph. The clustering coefficient of a
+ * node $v$ in a directed graph is given by the expression: $C_i = \frac{|\{e_{jk}: v_j,v_k \in N_i, e_{jk} \in E\}|}{k_i(k_i-1)}$
+ * where $N_i$ is the vertex neighbourhood: $N_i = \{v_j : e_{ij} \in E \or e_{ji} \in E\}$. For undirected graphs,
+ * $e_{ij}$ and $e_{ji}$ are considered identical hence the clustering coefficient is given by:
+ * $C_i = \frac{2|\{e_{jk}: v_j,v_k \in N_i, e_{jk} \in E\}|}{k_i(k_i-1)}$. 
+
+ * For more details see
+ * <a href="https://en.wikipedia.org/wiki/Clustering_coefficient">wikipedia</a>.
+ * 
+ * 
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ * 
+ * @author Assaf Mizrachi
+ * @since June 2018
+ */
+public class ClusteringCoefficient<V, E>
+    implements VertexScoringAlgorithm<V, Double>
+{
+
+    /**
+     * Underlying graph
+     */
+    private final Graph<V, E> graph;
+    /**
+     * The actual scores
+     */
+    private Map<V, Double> scores;
+
+    /**
+     * Construct a new instance.
+     * 
+     * @param graph the input graph
+     */
+    public ClusteringCoefficient(Graph<V, E> graph)
+    {
+        this.graph = GraphTests.requireDirectedOrUndirected(graph);
+
+        this.scores = null;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<V, Double> getScores()
+    {
+        if (scores == null) {
+            compute();
+        }
+        return Collections.unmodifiableMap(scores);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Double getVertexScore(V v)
+    {
+        if (!graph.containsVertex(v)) {
+            throw new IllegalArgumentException("Cannot return score of unknown vertex");
+        }
+        if (scores == null) {
+            compute();
+        }
+        return scores.get(v);
+    }
+
+    /**
+     * Compute the centrality index
+     */
+    private void compute()
+    {
+        // initialize result container
+        this.scores = new HashMap<>();
+
+        // compute for each source
+        this.graph.vertexSet().forEach(this::compute);
+    }
+
+    private void compute(V v)
+    {
+        // we count each neighbor only once
+        Set<V> neighboursSet = Graphs.successorListOf(graph, v).stream().collect(Collectors.toSet());
+
+        double actualEdgesCount = 0.0;
+        List<V> neighbourhood = new ArrayList<>(neighboursSet);
+        for (V u : neighbourhood) {
+            for (V w : neighbourhood) {       
+                //self edges are not counted.
+                if (v == w) {
+                    continue;
+                }
+                //multiple edges are not counted
+                if (graph.containsEdge(u, w)) {
+                    actualEdgesCount++;
+                }
+                
+            }
+        }
+        
+        long neighbourhoodSize = neighbourhood.size();
+        double potentialEdgesCount = neighbourhoodSize * (neighbourhoodSize - 1);
+        double clusteringCoefficient = potentialEdgesCount == 0 ? 0 : actualEdgesCount / potentialEdgesCount;
+
+        this.scores.put(v, clusteringCoefficient);
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClusteringCoefficient.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClusteringCoefficient.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2017-2017, by Assaf Mizrachi and Contributors.
+ * (C) Copyright 2018-2018, by Assaf Mizrachi and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -41,7 +41,7 @@ import org.jgrapht.alg.interfaces.*;
  * @param <E> the graph edge type
  * 
  * @author Assaf Mizrachi
- * @since June 2018
+ * @since December 2018
  */
 public class ClusteringCoefficient<V, E>
     implements VertexScoringAlgorithm<V, Double>

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClusteringCoefficient.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/ClusteringCoefficient.java
@@ -110,14 +110,14 @@ public class ClusteringCoefficient<V, E>
     private void compute(V v)
     {
         // we count each neighbor only once
-        Set<V> neighboursSet = Graphs.successorListOf(graph, v).stream().collect(Collectors.toSet());
+        Set<V> neighboursSet = Graphs.successorListOf(graph, v).stream().filter(u -> u != v).collect(Collectors.toSet());
 
         double actualEdgesCount = 0.0;
         List<V> neighbourhood = new ArrayList<>(neighboursSet);
         for (V u : neighbourhood) {
             for (V w : neighbourhood) {       
                 //self edges are not counted.
-                if (v == w) {
+                if (u == w) {
                     continue;
                 }
                 //multiple edges are not counted

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/ClusteringCoefficientTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/ClusteringCoefficientTest.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2018-2018, by Assaf Mizrachi and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
 package org.jgrapht.alg.scoring;
 
 import static org.junit.Assert.*;
@@ -11,6 +28,12 @@ import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
 import org.junit.*;
 
+/**
+ * 
+ * Tests for the {@link ClusteringCoefficient} class.
+ * 
+ * @author Assaf Mizrachi
+ */
 public class ClusteringCoefficientTest
 {
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/ClusteringCoefficientTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/ClusteringCoefficientTest.java
@@ -1,0 +1,335 @@
+package org.jgrapht.alg.scoring;
+
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.interfaces.*;
+import org.jgrapht.generate.*;
+import org.jgrapht.graph.*;
+import org.jgrapht.util.*;
+import org.junit.*;
+
+public class ClusteringCoefficientTest
+{
+
+    @Test(expected = NullPointerException.class)
+    public void testNullGraph()
+    {
+        Graph<Integer, DefaultEdge> g = null;
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        alg.getScores();
+    }
+
+    @Test
+    public void testEmptyGraph()
+    {
+        Graph<Integer, DefaultEdge> g = new SimpleGraph<>(DefaultEdge.class);
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        Map<Integer, Double> scores = alg.getScores();
+        assertTrue(scores.isEmpty());
+    }
+    
+    @Test
+    public void testSingletonGraph()
+    {
+        Graph<Integer, DefaultEdge> g = new SimpleGraph<>(DefaultEdge.class);
+        g.addVertex(0);
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        Map<Integer, Double> scores = alg.getScores();
+        assertEquals(0.0, scores.get(0), 0.0);
+    }
+    
+    @Test
+    public void testK2Graph()
+    {
+        Graph<Integer, DefaultEdge> g = new SimpleGraph<>(DefaultEdge.class);
+        g.addVertex(0);
+        g.addVertex(1);
+        g.addEdge(0, 1);
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        Map<Integer, Double> scores = alg.getScores();
+        assertEquals(0.0, scores.get(0), 0.0);
+        assertEquals(0.0, scores.get(1), 0.0);
+    }
+    
+    @Test
+    public void testStar()
+    {
+        int order = 5;
+        
+        Graph<Integer, DefaultEdge> g = new SimpleGraph<>(
+            SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        GraphGenerator<Integer, DefaultEdge, Integer> generator = new StarGraphGenerator<>(order);
+        Map<String, Integer> resultMap = new HashMap<>();
+        generator.generateGraph(g, resultMap);
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        
+        Map<Integer, Double> scores = alg.getScores();
+
+        for (Integer v : scores.keySet()) {
+            assertEquals(0.0, scores.get(v), 0.0);
+        }
+
+    }
+    
+    @Test
+    public void testLinear()
+    {
+        int order = 5;
+        
+        Graph<Integer, DefaultEdge> g = new SimpleGraph<>(
+            SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        GraphGenerator<Integer, DefaultEdge, Integer> generator = new LinearGraphGenerator<>(order);
+        Map<String, Integer> resultMap = new HashMap<>();
+        generator.generateGraph(g, resultMap);
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        
+        Map<Integer, Double> scores = alg.getScores();
+
+        for (Integer v : scores.keySet()) {
+            assertEquals(0.0, scores.get(v), 0.0);
+        }
+    }
+    
+    @Test
+    public void testRing()
+    {
+        int order = 5;
+        
+        Graph<Integer, DefaultEdge> g = new SimpleGraph<>(
+            SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        GraphGenerator<Integer, DefaultEdge, Integer> generator = new RingGraphGenerator<>(order);
+        Map<String, Integer> resultMap = new HashMap<>();
+        generator.generateGraph(g, resultMap);
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        
+        Map<Integer, Double> scores = alg.getScores();
+
+        for (Integer v : scores.keySet()) {
+            assertEquals(0.0, scores.get(v), 0.0);
+        }
+    }
+    
+    @Test
+    public void testClique()
+    {
+        int order = 5;
+        
+        Graph<Integer, DefaultEdge> g = new SimpleGraph<>(
+            SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        GraphGenerator<Integer, DefaultEdge, Integer> generator = new CompleteGraphGenerator<>(order);
+        Map<String, Integer> resultMap = new HashMap<>();
+        generator.generateGraph(g, resultMap);
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        
+        Map<Integer, Double> scores = alg.getScores();
+
+        for (Integer v : scores.keySet()) {
+            assertEquals(1.0, scores.get(v), 0.0);
+        }
+    }
+    
+    @Test
+    public void testUndirected1()
+    {
+        int order = 4;
+        
+        Graph<Integer, DefaultEdge> g = new SimpleGraph<>(
+            SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        GraphGenerator<Integer, DefaultEdge, Integer> generator = new CompleteGraphGenerator<>(order);
+        Map<String, Integer> resultMap = new HashMap<>();
+        generator.generateGraph(g, resultMap);
+        
+        g.removeEdge(2, 3);
+        g.removeEdge(2, 4);
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        
+        Map<Integer, Double> scores = alg.getScores();
+        
+        assertEquals(0.333, scores.get(1), 0.001);
+        assertEquals(0.0, scores.get(2), 0.0);
+        assertEquals(1.0, scores.get(3), 0.0);
+        assertEquals(1.0, scores.get(4), 0.0);
+    }
+    
+    @Test
+    public void testUndirected2()
+    {
+        Graph<Integer, DefaultEdge> g = createUndirected2();
+        
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        
+        Map<Integer, Double> scores = alg.getScores();
+        
+        assertEquals(1.0, scores.get(0), 0.0);
+        assertEquals(0.333, scores.get(1), 0.001);
+        assertEquals(0.333, scores.get(2), 0.001);
+        assertEquals(0.666, scores.get(3), 0.001);
+        assertEquals(0.5, scores.get(4), 0.0);
+        assertEquals(0.4, scores.get(5), 0.0);
+        assertEquals(1.0, scores.get(6), 0.0);
+        assertEquals(1.0, scores.get(7), 0.0);
+    }
+    
+    @Test
+    public void testDirected()
+    {
+        Graph<Integer, DefaultEdge> g = createDirected();
+        
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        
+        Map<Integer, Double> scores = alg.getScores();
+        
+        assertEquals(0.666, scores.get(1), 0.001);
+        assertEquals(0.0, scores.get(2), 0.0);
+        assertEquals(0.5, scores.get(3), 0.0);
+        assertEquals(0.5, scores.get(4), 0.0);
+    }
+    
+    @Test
+    public void testDirected2()
+    {
+        Graph<Integer, DefaultEdge> g = createDirected2();
+        
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        
+        Map<Integer, Double> scores = alg.getScores();
+        assertEquals(0.916, scores.get(1), 0.001);
+        assertEquals(0.571, scores.get(2), 0.001);
+        assertEquals(0.567, scores.get(3), 0.001);
+        assertEquals(0.916, scores.get(4), 0.001);
+        assertEquals(0.518, scores.get(5), 0.001);
+        assertEquals(0.333, scores.get(6), 0.001);
+        assertEquals(1.000, scores.get(7), 0.001);
+        assertEquals(0.800, scores.get(8), 0.001);
+        assertEquals(1.000, scores.get(9), 0.001);
+        assertEquals(0.800, scores.get(10), 0.001);
+    }
+    
+    private Graph<Integer, DefaultEdge> createUndirected2()
+    {
+        Graph<Integer, DefaultEdge> g = new SimpleGraph<>(DefaultEdge.class);
+        g.addVertex(0);
+        g.addVertex(1);
+        g.addVertex(2);
+        g.addVertex(3);
+        g.addVertex(4);
+        g.addVertex(5);
+        g.addVertex(6);
+        g.addVertex(7);
+        g.addEdge(0, 1);
+        g.addEdge(0, 2);
+        g.addEdge(1, 2);
+        g.addEdge(1, 5);
+        g.addEdge(2, 3);
+        g.addEdge(2, 4);
+        g.addEdge(3, 4);
+        g.addEdge(3, 5);
+        g.addEdge(4, 5);
+        g.addEdge(4, 6);
+        g.addEdge(4, 7);
+        g.addEdge(5, 6);
+        g.addEdge(5, 7);
+        g.addEdge(6, 7);
+
+        return g;
+    }
+    
+    private Graph<Integer, DefaultEdge> createDirected()
+    {
+        Graph<Integer, DefaultEdge> g = new SimpleDirectedGraph<>(DefaultEdge.class);
+        g.addVertex(1);
+        g.addVertex(2);
+        g.addVertex(3);
+        g.addVertex(4);
+        g.addEdge(1, 2);
+        g.addEdge(1, 3);
+        g.addEdge(1, 4);
+        g.addEdge(3, 2);
+        g.addEdge(3, 4);
+        g.addEdge(4, 1);
+        g.addEdge(4, 2);
+        g.addEdge(4, 3);
+
+        return g;
+    }
+    
+    private Graph<Integer, DefaultEdge> createDirected2()
+    {
+        Graph<Integer, DefaultEdge> g = new SimpleDirectedGraph<>(DefaultEdge.class);
+        g.addVertex(1);
+        g.addVertex(2);
+        g.addVertex(3);
+        g.addVertex(4);
+        g.addVertex(5);
+        g.addVertex(6);
+        g.addVertex(7);
+        g.addVertex(8);
+        g.addVertex(9);
+        g.addVertex(10);
+        
+        g.addEdge(1, 2);
+        g.addEdge(1, 5);
+        g.addEdge(1, 7);
+        g.addEdge(1, 9);
+        
+        g.addEdge(2, 1);
+        g.addEdge(2, 3);
+        g.addEdge(2, 4);
+        g.addEdge(2, 5);
+        g.addEdge(2, 7);
+        g.addEdge(2, 8);
+        g.addEdge(2, 9);
+        
+        g.addEdge(3, 2);
+        g.addEdge(3, 4);
+        g.addEdge(3, 5);
+        g.addEdge(3, 6);
+        g.addEdge(3, 7);
+        g.addEdge(3, 10);
+        
+        g.addEdge(4, 1);
+        g.addEdge(4, 2);
+        g.addEdge(4, 5);
+        g.addEdge(4, 7);
+        
+        g.addEdge(5, 1);
+        g.addEdge(5, 2);
+        g.addEdge(5, 3);
+        g.addEdge(5, 4);
+        g.addEdge(5, 7);
+        g.addEdge(5, 8);
+        g.addEdge(5, 9);
+        g.addEdge(5, 10);
+        
+        g.addEdge(6, 3);
+        g.addEdge(6, 7);
+        g.addEdge(6, 9);
+        
+        g.addEdge(7, 2);
+        g.addEdge(7, 4);
+        g.addEdge(7, 5);
+        
+        g.addEdge(8, 1);
+        g.addEdge(8, 2);
+        g.addEdge(8, 4);
+        g.addEdge(8, 5);
+        g.addEdge(8, 7);
+        g.addEdge(8, 9);
+        
+        g.addEdge(9, 2);
+        g.addEdge(9, 5);
+        g.addEdge(9, 7);
+        
+        g.addEdge(10, 1);
+        g.addEdge(10, 2);
+        g.addEdge(10, 3);
+        g.addEdge(10, 5);
+        g.addEdge(10, 7);
+
+        return g;
+    }
+    
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/ClusteringCoefficientTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/ClusteringCoefficientTest.java
@@ -134,16 +134,39 @@ public class ClusteringCoefficientTest
     @Test
     public void testUndirected1()
     {
-        int order = 4;
+        Graph<Integer, DefaultEdge> g = createUndirected();
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
         
-        Graph<Integer, DefaultEdge> g = new SimpleGraph<>(
-            SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
-        GraphGenerator<Integer, DefaultEdge, Integer> generator = new CompleteGraphGenerator<>(order);
-        Map<String, Integer> resultMap = new HashMap<>();
-        generator.generateGraph(g, resultMap);
+        Map<Integer, Double> scores = alg.getScores();
         
-        g.removeEdge(2, 3);
-        g.removeEdge(2, 4);
+        assertEquals(0.333, scores.get(1), 0.001);
+        assertEquals(0.0, scores.get(2), 0.0);
+        assertEquals(1.0, scores.get(3), 0.0);
+        assertEquals(1.0, scores.get(4), 0.0);
+    }
+    
+    @Test
+    public void testMultipleEdgesDoNotCount()
+    {
+        Graph<Integer, DefaultEdge> g = createUndirected();
+        g.addEdge(1, 2);
+        g.addEdge(1, 4);
+        VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
+        
+        Map<Integer, Double> scores = alg.getScores();
+        
+        assertEquals(0.333, scores.get(1), 0.001);
+        assertEquals(0.0, scores.get(2), 0.0);
+        assertEquals(1.0, scores.get(3), 0.0);
+        assertEquals(1.0, scores.get(4), 0.0);
+    }
+    
+    @Test
+    public void testSelfLoopDoNotCount()
+    {
+        Graph<Integer, DefaultEdge> g = createUndirected();
+        g.addEdge(1, 1);
+        g.addEdge(2, 2);
         VertexScoringAlgorithm<Integer, Double> alg = new ClusteringCoefficient<>(g);
         
         Map<Integer, Double> scores = alg.getScores();
@@ -206,6 +229,20 @@ public class ClusteringCoefficientTest
         assertEquals(0.800, scores.get(8), 0.001);
         assertEquals(1.000, scores.get(9), 0.001);
         assertEquals(0.800, scores.get(10), 0.001);
+    }
+    
+    private Graph<Integer, DefaultEdge> createUndirected()
+    {
+        Graph<Integer, DefaultEdge> g = new Pseudograph<>(
+            SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        GraphGenerator<Integer, DefaultEdge, Integer> generator = new CompleteGraphGenerator<>(4);
+        Map<String, Integer> resultMap = new HashMap<>();
+        generator.generateGraph(g, resultMap);
+        
+        g.removeEdge(2, 3);
+        g.removeEdge(2, 4);
+        
+        return g;
     }
     
     private Graph<Integer, DefaultEdge> createUndirected2()


### PR DESCRIPTION
Implementation for computing the local for a vertex in a graph. The local clustering coefficient of a vertex in a graph quantifies how close its neighbors are to being a clique and given by the proportion of links between the vertices within its neighborhood divided by the number of links that could possibly exist between them. The implementation directly follows the above description. For further reading see https://en.wikipedia.org/wiki/Clustering_coefficient.
