### PR TITLE
BellmanFordShortestPath - allow and handle negative weight cycles

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseShortestPathAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseShortestPathAlgorithm.java
@@ -38,17 +38,17 @@ abstract class BaseShortestPathAlgorithm<V, E>
     /**
      * Error message for reporting the existence of a negative-weight cycle.
      */
-    static final String GRAPH_CONTAINS_A_NEGATIVE_WEIGHT_CYCLE =
+    protected static final String GRAPH_CONTAINS_A_NEGATIVE_WEIGHT_CYCLE =
         "Graph contains a negative-weight cycle";
     /**
      * Error message for reporting that a source vertex is missing.
      */
-    static final String GRAPH_MUST_CONTAIN_THE_SOURCE_VERTEX =
+    protected static final String GRAPH_MUST_CONTAIN_THE_SOURCE_VERTEX =
         "Graph must contain the source vertex!";
     /**
      * Error message for reporting that a sink vertex is missing.
      */
-    static final String GRAPH_MUST_CONTAIN_THE_SINK_VERTEX = "Graph must contain the sink vertex!";
+    protected static final String GRAPH_MUST_CONTAIN_THE_SINK_VERTEX = "Graph must contain the sink vertex!";
 
     /**
      * The underlying graph.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TreeSingleSourcePathsImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TreeSingleSourcePathsImpl.java
@@ -151,6 +151,9 @@ public class TreeSingleSourcePathsImpl<V, E>
                         break;
                     }
                 }
+                if (e == p.getSecond()) {
+                    break;
+                }
             }
             edgeList.addFirst(e);
             vertexList.addFirst(cur);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPathTest.java
@@ -208,8 +208,8 @@ public class BellmanFordShortestPathTest
         // then
         assertEquals("0", tree.getStartVertex());
         assertEquals("3", tree.getEndVertex());
-        assertEquals(Arrays.asList(e01, e12, e23, e35, e54, e43), tree.getEdgeList());
-        assertEquals(Arrays.asList("0", "1", "2", "3", "5", "4", "3"), tree.getVertexList());
+        assertEquals(Arrays.asList(e01, e12, e25, e54, e43), tree.getEdgeList());
+        assertEquals(Arrays.asList("0", "1", "2", "5", "4", "3"), tree.getVertexList());
     }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPathTest.java
@@ -123,7 +123,7 @@ public class BellmanFordShortestPathTest
     }
 
     @Test
-    public void testNegativeCycleDetection()
+    public void testNegativeCycleDetection_throwsException()
     {
         DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =
             new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
@@ -153,7 +153,7 @@ public class BellmanFordShortestPathTest
     }
 
     @Test
-    public void testNegativeEdgeUndirectedGraph()
+    public void testNegativeEdgeUndirectedGraph_throwsException()
     {
         WeightedPseudograph<String, DefaultWeightedEdge> g =
             new WeightedPseudograph<>(DefaultWeightedEdge.class);
@@ -169,6 +169,47 @@ public class BellmanFordShortestPathTest
         } catch (RuntimeException e) {
             assertEquals("Graph contains a negative-weight cycle", e.getMessage());
         }
+    }
+
+    @Test
+    public void testNegativeCycleDirectedGraph_cycleReturned()
+    {
+        // given
+        DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =
+            new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+        g.addVertex("0");
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addVertex("4");
+        g.addVertex("5");
+        DefaultWeightedEdge e02 = g.addEdge("0", "2");
+        g.setEdgeWeight(e02, 100);
+        DefaultWeightedEdge e01 = g.addEdge("0", "1");
+        g.setEdgeWeight(e01, 5);
+        DefaultWeightedEdge e12 = g.addEdge("1", "2");
+        g.setEdgeWeight(e12, 5);
+        DefaultWeightedEdge e23 = g.addEdge("2", "3");
+        g.setEdgeWeight(e23, 4);
+        DefaultWeightedEdge e43 = g.addEdge("4", "3");
+        g.setEdgeWeight(e43, -10);
+        DefaultWeightedEdge e54 = g.addEdge("5", "4");
+        g.setEdgeWeight(e54, 3);
+        DefaultWeightedEdge e25 = g.addEdge("2", "5");
+        g.setEdgeWeight(e25, 5);
+        DefaultWeightedEdge e35 = g.addEdge("3", "5");
+        g.setEdgeWeight(e35, 5);
+
+        // when
+        BellmanFordShortestPath<String, DefaultWeightedEdge> alg =
+            new BellmanFordShortestPath<>(g).allowNegativeWeightCycle();
+        GraphPath<String, DefaultWeightedEdge> tree = alg.getPaths("0").getPath("3");
+
+        // then
+        assertEquals("0", tree.getStartVertex());
+        assertEquals("3", tree.getEndVertex());
+        assertEquals(Arrays.asList(e01, e12, e23, e35, e54, e43), tree.getEdgeList());
+        assertEquals(Arrays.asList("0", "1", "2", "3", "5", "4", "3"), tree.getVertexList());
     }
 
 }


### PR DESCRIPTION
Current implementation of Bellman Ford algo for finding shortest path does not handle graphs with negative weight cycles - this pull request fixes it.

BaseShortestPathAlgorithm edit:
I've tried to subclass BellmanFordShortestPath class locally (in seperate project) at first and I had to copy/paste "new" labels for exceptions - this will help future devs to subclass and write their implementations.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
