### PR TITLE
Added negative weight cycle computation in Bellman-Ford

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
@@ -21,7 +21,6 @@ import org.jgrapht.*;
 import org.jgrapht.graph.*;
 
 import java.util.*;
-import java.util.stream.*;
 
 /**
  * A Dijkstra-like algorithm to find all paths between two sets of nodes in a directed graph, with

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseShortestPathAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseShortestPathAlgorithm.java
@@ -38,17 +38,17 @@ abstract class BaseShortestPathAlgorithm<V, E>
     /**
      * Error message for reporting the existence of a negative-weight cycle.
      */
-    static final String GRAPH_CONTAINS_A_NEGATIVE_WEIGHT_CYCLE =
+    protected static final String GRAPH_CONTAINS_A_NEGATIVE_WEIGHT_CYCLE =
         "Graph contains a negative-weight cycle";
     /**
      * Error message for reporting that a source vertex is missing.
      */
-    static final String GRAPH_MUST_CONTAIN_THE_SOURCE_VERTEX =
+    protected static final String GRAPH_MUST_CONTAIN_THE_SOURCE_VERTEX =
         "Graph must contain the source vertex!";
     /**
      * Error message for reporting that a sink vertex is missing.
      */
-    static final String GRAPH_MUST_CONTAIN_THE_SINK_VERTEX = "Graph must contain the sink vertex!";
+    protected static final String GRAPH_MUST_CONTAIN_THE_SINK_VERTEX = "Graph must contain the sink vertex!";
 
     /**
      * The underlying graph.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPath.java
@@ -33,10 +33,10 @@ import java.util.*;
  * 
  * <p>
  * Negative weight cycles are not allowed and will be reported by the algorithm. This implies that
- * negative edge weights are not allowed in undirected graphs. In such cases, method
- * {@link #getNegativeWeightCycle()} can be used to obtain the negative weight cycle which was
- * detected. Note that the algorithm will not report or find negative weight cycles which are not
- * reachable from the source vertex.
+ * negative edge weights are not allowed in undirected graphs. In such cases the code will throw an
+ * exception of type {@link NegativeCycleDetectedException} which will contain the detected negative
+ * weight cycle. Note that the algorithm will not report or find negative weight cycles which are
+ * not reachable from the source vertex.
  *
  * <p>
  * The running time is $O(|E||V|)$.
@@ -80,8 +80,7 @@ public class BellmanFordShortestPath<V, E>
      * @param graph the input graph
      * @param epsilon tolerance when comparing floating point values
      * @param maxHops execute the algorithm for at most this many iterations. If this is smaller
-     *        than the number of vertices, then the negative cycle detection feature is
-     *        disabled.
+     *        than the number of vertices, then the negative cycle detection feature is disabled.
      * @throws IllegalArgumentException if the number of maxHops is not positive
      */
     public BellmanFordShortestPath(Graph<V, E> graph, double epsilon, int maxHops)
@@ -172,8 +171,8 @@ public class BellmanFordShortestPath<V, E>
         }
 
         /*
-         * Check for negative cycles. The user can disable this by providing
-         * a maxHops parameter smaller than the number of vertices.
+         * Check for negative cycles. The user can disable this by providing a maxHops parameter
+         * smaller than the number of vertices.
          */
         if (maxHops >= n) {
             for (V v : updated[curUpdated]) {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPath.java
@@ -19,6 +19,7 @@ package org.jgrapht.alg.shortestpath;
 
 import org.jgrapht.*;
 import org.jgrapht.alg.util.*;
+import org.jgrapht.graph.GraphWalk;
 
 import java.lang.reflect.*;
 import java.util.*;
@@ -28,9 +29,12 @@ import java.util.*;
  *
  * <p>
  * Computes shortest paths from a single source vertex to all other vertices in a weighted graph.
- * The Bellman-Ford algorithm supports negative edge weights. Negative weight cycles are not allowed
- * and will be reported by the algorithm. This implies that negative edge weights are not allowed in
- * undirected graphs.
+ * The Bellman-Ford algorithm supports negative edge weights. 
+ * 
+ * <p>Negative weight cycles are not allowed and will be reported by the algorithm. This implies that
+ * negative edge weights are not allowed in undirected graphs. In such cases, method {@link #getNegativeWeightCycle()} can 
+ * be used to obtain the negative weight cycle which was detected. Note that the algorithm will not report or find negative
+ * weight cycles which are not reachable from the source vertex.
  *
  * <p>
  * The running time is $O(|E||V|)$.
@@ -45,6 +49,8 @@ public class BellmanFordShortestPath<V, E>
     BaseShortestPathAlgorithm<V, E>
 {
     private final Comparator<Double> comparator;
+    private GraphPath<V,E> negativeWeightCycle;
+    private final int maxHops;
 
     /**
      * Construct a new instance.
@@ -64,8 +70,26 @@ public class BellmanFordShortestPath<V, E>
      */
     public BellmanFordShortestPath(Graph<V, E> graph, double epsilon)
     {
+        this(graph, ToleranceDoubleComparator.DEFAULT_EPSILON, Integer.MAX_VALUE);
+    }
+    
+    /**
+     * Construct a new instance.
+     *
+     * @param graph the input graph
+     * @param epsilon tolerance when comparing floating point values
+     * @param maxHops execute the algorithm for at most this many iterations. If this is smaller than 
+     *        the number of vertices minus 1, then the negative cycle detection feature is disabled.
+     * @throws IllegalArgumentException if the number of maxHops is not positive 
+     */
+    public BellmanFordShortestPath(Graph<V, E> graph, double epsilon, int maxHops)
+    {
         super(graph);
         this.comparator = new ToleranceDoubleComparator(epsilon);
+        if (maxHops < 1) { 
+            throw new IllegalArgumentException("Number of hops must be positive");
+        }
+        this.maxHops = maxHops;
     }
 
     /**
@@ -101,10 +125,11 @@ public class BellmanFordShortestPath<V, E>
             distance.put(v, Double.POSITIVE_INFINITY);
         }
         distance.put(source, 0d);
+        negativeWeightCycle = null;
 
         /*
          * Maintain two sets of vertices whose edges need relaxation. The first set is the current
-         * set of vertices while the second if the set for the subsequent iteration.
+         * set of vertices while the second is the set for the subsequent iteration.
          */
         Set<V>[] updated = (Set<V>[]) Array.newInstance(Set.class, 2);
         updated[0] = new LinkedHashSet<>();
@@ -115,7 +140,7 @@ public class BellmanFordShortestPath<V, E>
         /*
          * Relax edges.
          */
-        for (int i = 0; i < n - 1; i++) {
+        for (int i = 0; i < Math.min(n-1, maxHops); i++) {
             Set<V> curVertexSet = updated[curUpdated];
             Set<V> nextVertexSet = updated[(curUpdated + 1) % 2];
 
@@ -144,12 +169,17 @@ public class BellmanFordShortestPath<V, E>
         /*
          * Check for negative cycles
          */
-        for (V v : updated[curUpdated]) {
-            for (E e : graph.outgoingEdgesOf(v)) {
-                V u = Graphs.getOppositeVertex(graph, e, v);
-                double newDist = distance.get(v) + graph.getEdgeWeight(e);
-                if (comparator.compare(newDist, distance.get(u)) < 0) {
-                    throw new RuntimeException(GRAPH_CONTAINS_A_NEGATIVE_WEIGHT_CYCLE);
+        if (maxHops >= n-1) { 
+            for (V v : updated[curUpdated]) {
+                for (E e : graph.outgoingEdgesOf(v)) {
+                    V u = Graphs.getOppositeVertex(graph, e, v);
+                    double newDist = distance.get(v) + graph.getEdgeWeight(e);
+                    if (comparator.compare(newDist, distance.get(u)) < 0) {
+                        // record update and compute cycle
+                        pred.put(u, e);
+                        negativeWeightCycle = computeNegativeCycle(e, pred);
+                        throw new RuntimeException(GRAPH_CONTAINS_A_NEGATIVE_WEIGHT_CYCLE);
+                    }
                 }
             }
         }
@@ -162,6 +192,16 @@ public class BellmanFordShortestPath<V, E>
             distanceAndPredecessorMap.put(v, Pair.of(distance.get(v), pred.get(v)));
         }
         return new TreeSingleSourcePathsImpl<>(graph, source, distanceAndPredecessorMap);
+    }
+    
+    /**
+     * Get a negative weight cycle, if it exists, otherwise {@link Optional#empty()}. This method
+     * returns the cycle found in the last execution of the algorithm (if any).
+     * 
+     * @return a negative weight cycle, if it exists, otherwise {@link Optional#empty()}.
+     */
+    public Optional<GraphPath<V,E>> getNegativeWeightCycle() { 
+        return Optional.ofNullable(negativeWeightCycle);
     }
 
     /**
@@ -179,5 +219,42 @@ public class BellmanFordShortestPath<V, E>
     public static <V, E> GraphPath<V, E> findPathBetween(Graph<V, E> graph, V source, V sink)
     {
         return new BellmanFordShortestPath<>(graph).getPath(source, sink);
+    }
+
+    /**
+     * Computes a negative weight cycle assuming that the algorithm has already determined that it
+     * exists.
+     * 
+     * @param edge an edge which we know that belongs to the negative weight cycle
+     * @param pred the predecessor array
+     * 
+     * @return the negative weight cycle
+     */
+    private GraphPath<V, E> computeNegativeCycle(E edge, Map<V, E> pred) {
+        // find a vertex of the cycle
+        Set<V> visited = new HashSet<>();
+        V start = graph.getEdgeTarget(edge);
+        visited.add(start);
+        V cur = Graphs.getOppositeVertex(graph, edge, start);
+        
+        while(!visited.contains(cur)) {
+            visited.add(cur);
+            E e = pred.get(cur);
+            cur = Graphs.getOppositeVertex(graph, e, cur);
+        }
+
+        // now build the actual cycle
+        List<E> cycle = new ArrayList<>();
+        double weight = 0d;
+        start = cur;
+        do { 
+            E e = pred.get(cur);
+            cycle.add(e);
+            weight += graph.getEdgeWeight(e);
+            cur = Graphs.getOppositeVertex(graph, e, cur);
+        } while (cur != start);
+        Collections.reverse(cycle);
+        
+        return new GraphWalk<>(graph, start, start, cycle, weight);
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/JohnsonShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/JohnsonShortestPaths.java
@@ -50,6 +50,10 @@ import org.jgrapht.util.TypeUtil;
  * <p>
  * Since Johnson's algorithm creates additional vertices, this implementation requires the user to
  * provide a graph which is initialized with a vertex supplier.
+ * 
+ * <p>
+ * In case the algorithm detects a negative weight cycle it will throw an exception of type
+ * {@link NegativeCycleDetectedException} which will contain the detected negative weight cycle.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/JohnsonShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/JohnsonShortestPaths.java
@@ -17,6 +17,7 @@
  */
 package org.jgrapht.alg.shortestpath;
 
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -57,10 +58,11 @@ import org.jgrapht.util.TypeUtil;
  * @since February 2017
  */
 public class JohnsonShortestPaths<V, E>
-    extends BaseShortestPathAlgorithm<V, E>
+    extends
+    BaseShortestPathAlgorithm<V, E>
 {
     private double[][] distance;
-    private E [][] pred;
+    private E[][] pred;
     private Map<V, Integer> vertexIndices;
 
     private final Comparator<Double> comparator;
@@ -92,6 +94,7 @@ public class JohnsonShortestPaths<V, E>
      *
      * @throws IllegalArgumentException in case the provided vertex factory creates vertices which
      *         are already in the original graph
+     * @throws NegativeCycleDetectedException in case a negative weight cycle is detected
      */
     @Override
     public GraphPath<V, E> getPath(V source, V sink)
@@ -102,24 +105,24 @@ public class JohnsonShortestPaths<V, E>
         if (!graph.containsVertex(sink)) {
             throw new IllegalArgumentException(GRAPH_MUST_CONTAIN_THE_SINK_VERTEX);
         }
-        
+
         run();
-        
+
         if (source.equals(sink)) {
             return GraphWalk.singletonWalk(graph, source, 0d);
         }
-        
+
         int vSource = vertexIndices.get(source);
         int vSink = vertexIndices.get(sink);
-        
+
         V cur = sink;
         E e = pred[vSource][vSink];
-        if (e == null) { 
+        if (e == null) {
             return null;
         }
-        
+
         LinkedList<E> edgeList = new LinkedList<>();
-        while(e != null) { 
+        while (e != null) {
             edgeList.addFirst(e);
             cur = Graphs.getOppositeVertex(graph, e, cur);
             e = pred[vSource][vertexIndices.get(cur)];
@@ -152,6 +155,7 @@ public class JohnsonShortestPaths<V, E>
      *
      * @throws IllegalArgumentException in case the provided vertex factory creates vertices which
      *         are already in the original graph
+     * @throws NegativeCycleDetectedException in case a negative weight cycle is detected
      */
     @Override
     public SingleSourcePaths<V, E> getPaths(V source)
@@ -170,17 +174,24 @@ public class JohnsonShortestPaths<V, E>
         }
         GraphTests.requireDirectedOrUndirected(graph);
 
-        boolean graphHasNegativeEdgeWeights = false;
+        E detectedNegativeEdge = null;
         for (E e : graph.edgeSet()) {
             if (comparator.compare(graph.getEdgeWeight(e), 0.0) < 0) {
-                graphHasNegativeEdgeWeights = true;
+                detectedNegativeEdge = e;
                 break;
             }
         }
 
-        if (graphHasNegativeEdgeWeights) {
+        if (detectedNegativeEdge != null) {
             if (graph.getType().isUndirected()) {
-                throw new RuntimeException(GRAPH_CONTAINS_A_NEGATIVE_WEIGHT_CYCLE);
+                V source = graph.getEdgeSource(detectedNegativeEdge);
+                double weight = graph.getEdgeWeight(detectedNegativeEdge);
+                GraphWalk<V,
+                    E> cycle = new GraphWalk<>(
+                        graph, source, source,
+                        Arrays.asList(detectedNegativeEdge, detectedNegativeEdge), 2d * weight);
+                throw new NegativeCycleDetectedException(
+                    GRAPH_CONTAINS_A_NEGATIVE_WEIGHT_CYCLE, cycle);
             }
             runWithNegativeEdgeWeights(graph);
         } else {
@@ -358,7 +369,8 @@ public class JohnsonShortestPaths<V, E>
     }
 
     class JohnsonSingleSourcePaths
-        implements SingleSourcePaths<V, E>
+        implements
+        SingleSourcePaths<V, E>
     {
         private V source;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/NegativeCycleDetectedException.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/NegativeCycleDetectedException.java
@@ -1,0 +1,89 @@
+/*
+ * (C) Copyright 2018-2018, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * This program and the accompanying materials are dual-licensed under
+ * either
+ *
+ * (a) the terms of the GNU Lesser General Public License version 2.1
+ * as published by the Free Software Foundation, or (at your option) any
+ * later version.
+ *
+ * or (per the licensee's choosing)
+ *
+ * (b) the terms of the Eclipse Public License v1.0 as published by
+ * the Eclipse Foundation.
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.GraphPath;
+
+/**
+ * An exception used to notify about the detection of a negative cycle. The exception 
+ * may carry the negative cycle to the user.
+ * 
+ * @author Dimitrios Michail
+ */
+public class NegativeCycleDetectedException
+    extends
+    RuntimeException
+{
+    private static final long serialVersionUID = -8064609917721881630L;
+
+    private GraphPath<?, ?> cycle;
+    
+    /**
+     * Constructs a new exception with {@code null} as its detail message. The cause is not
+     * initialized, and may subsequently be initialized by a call to {@link #initCause}.
+     */
+    public NegativeCycleDetectedException()
+    {
+        super();
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for later retrieval by the
+     *        {@link #getMessage()} method.
+     */
+    public NegativeCycleDetectedException(String message)
+    {
+        super(message);
+    }
+    
+    /**
+     * Constructs a new exception with the specified detail message. The cause is not initialized,
+     * and may subsequently be initialized by a call to {@link #initCause}.
+     *
+     * @param message the detail message. The detail message is saved for later retrieval by the
+     *        {@link #getMessage()} method.
+     * @param cycle the negative weight cycle
+     */
+    public NegativeCycleDetectedException(String message, GraphPath<?,?> cycle)
+    {
+        super(message);
+        this.cycle = cycle;
+    }
+
+    /**
+     * Get the actual negative cycle, or null if not provided.
+     * @return the negative cycle or null.
+     */
+    public GraphPath<?, ?> getCycle()
+    {
+        return cycle;
+    }
+
+    /**
+     * Set the negative cycle.
+     * @param cycle the negative cycle.
+     */
+    public void setCycle(GraphPath<?, ?> cycle)
+    {
+        this.cycle = cycle;
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TreeSingleSourcePathsImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TreeSingleSourcePathsImpl.java
@@ -101,6 +101,16 @@ public class TreeSingleSourcePathsImpl<V, E>
     }
 
     /**
+     * Get the internal map used for representing the paths.
+     * 
+     * @return the internal distance and predecessor map used for representing the paths.
+     */
+    public Map<V, Pair<Double, E>> getDistanceAndPredecessorMap()
+    {
+        return Collections.unmodifiableMap(map);
+    }
+
+    /**
      * {@inheritDoc}
      */
     @Override

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPathTest.java
@@ -151,6 +151,43 @@ public class BellmanFordShortestPathTest
             assertEquals("Graph contains a negative-weight cycle", e.getMessage());
         }
     }
+    
+    @Test
+    public void testNegativeCycleDetectionActualCycle()
+    {
+        DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =
+            new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+        g.addVertex("w");
+        g.addVertex("y");
+        g.addVertex("x");
+        g.addVertex("z");
+        g.addVertex("s");
+        g.setEdgeWeight(g.addEdge("w", "z"), 2);
+        g.setEdgeWeight(g.addEdge("y", "w"), 4);
+        g.setEdgeWeight(g.addEdge("x", "w"), 6);
+        g.setEdgeWeight(g.addEdge("x", "y"), 3);
+        g.setEdgeWeight(g.addEdge("z", "x"), -7);
+        g.setEdgeWeight(g.addEdge("y", "z"), 3);
+        g.setEdgeWeight(g.addEdge("z", "y"), -3);
+        g.setEdgeWeight(g.addEdge("s", "w"), 0.0);
+        g.setEdgeWeight(g.addEdge("s", "y"), 0.0);
+        g.setEdgeWeight(g.addEdge("s", "x"), 0.0);
+        g.setEdgeWeight(g.addEdge("s", "z"), 0.0);
+
+        BellmanFordShortestPath<String, DefaultWeightedEdge> alg = new BellmanFordShortestPath<>(g);
+        try {
+            alg.getPaths("s");
+            fail("Negative-weight cycle not detected");
+        } catch (RuntimeException e) {
+            assertEquals("Graph contains a negative-weight cycle", e.getMessage());
+            
+            GraphPath<String, DefaultWeightedEdge> cycle = alg.getNegativeWeightCycle().get();
+            assertEquals("x", cycle.getStartVertex());
+            assertEquals("x", cycle.getEndVertex());
+            assertEquals(-1.0d, cycle.getWeight(), 1e-9);
+            assertEquals(3, cycle.getLength());
+        }
+    }
 
     @Test
     public void testNegativeEdgeUndirectedGraph()
@@ -168,6 +205,136 @@ public class BellmanFordShortestPathTest
             fail("Negative-weight cycle not detected");
         } catch (RuntimeException e) {
             assertEquals("Graph contains a negative-weight cycle", e.getMessage());
+        }
+    }
+    
+    @Test
+    public void testNegativeEdgeUndirectedGraphActualCycle()
+    {
+        WeightedPseudograph<String, DefaultWeightedEdge> g =
+            new WeightedPseudograph<>(DefaultWeightedEdge.class);
+        g.addVertex("w");
+        g.addVertex("y");
+        g.addVertex("x");
+        g.setEdgeWeight(g.addEdge("w", "y"), 1);
+        g.setEdgeWeight(g.addEdge("y", "x"), 1);
+        g.setEdgeWeight(g.addEdge("y", "x"), -1);
+        
+        BellmanFordShortestPath<String, DefaultWeightedEdge> alg = new BellmanFordShortestPath<>(g);
+        try {
+            alg.getPaths("w");
+            fail("Negative-weight cycle not detected");
+        } catch (RuntimeException e) {
+            assertEquals("Graph contains a negative-weight cycle", e.getMessage());
+            
+            GraphPath<String, DefaultWeightedEdge> cycle = alg.getNegativeWeightCycle().get();
+            assertEquals("x", cycle.getStartVertex());
+            assertEquals("x", cycle.getEndVertex());
+            assertEquals(-2.0d, cycle.getWeight(), 1e-9);
+            assertEquals(2, cycle.getLength());
+        }
+    }
+    
+    @Test
+    public void testDoNotDetectNonReachableNegativeCycle()
+    {
+        DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =
+            new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addVertex("4");
+        g.addVertex("5");
+        g.addVertex("6");
+        g.addVertex("7");
+        g.setEdgeWeight(g.addEdge("1", "2"), 1);
+        g.setEdgeWeight(g.addEdge("2", "3"), 1);
+        g.setEdgeWeight(g.addEdge("3", "4"), 1);
+        
+        g.setEdgeWeight(g.addEdge("5", "4"), 1);
+        g.setEdgeWeight(g.addEdge("5", "6"), -1);
+        g.setEdgeWeight(g.addEdge("6", "7"), -1);
+        g.setEdgeWeight(g.addEdge("7", "5"), -1);
+
+        BellmanFordShortestPath<String, DefaultWeightedEdge> alg = new BellmanFordShortestPath<>(g);
+        alg.getPaths("1");
+    }
+    
+    @Test
+    public void testNegativeCycle()
+    {
+        DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =
+            new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addVertex("4");
+        g.addVertex("5");
+        g.addVertex("6");
+        g.addVertex("7");
+        g.addVertex("8");
+        g.addVertex("9");
+        g.addVertex("x");
+        
+        g.setEdgeWeight(g.addEdge("1", "2"), 1);
+        g.setEdgeWeight(g.addEdge("2", "3"), 1);
+        g.setEdgeWeight(g.addEdge("3", "4"), 1);
+        g.setEdgeWeight(g.addEdge("4", "5"), 1);
+        g.setEdgeWeight(g.addEdge("5", "6"), 1);
+        g.setEdgeWeight(g.addEdge("6", "7"), 1);
+        g.setEdgeWeight(g.addEdge("7", "8"), 1);
+        g.setEdgeWeight(g.addEdge("8", "9"), 1);
+        
+        g.setEdgeWeight(g.addEdge("7", "x"), -3);
+        g.setEdgeWeight(g.addEdge("x", "4"), -3);
+
+        BellmanFordShortestPath<String, DefaultWeightedEdge> alg = new BellmanFordShortestPath<>(g);
+        try {
+            alg.getPaths("1");
+            fail("Negative-weight cycle not detected");
+        } catch (RuntimeException e) {
+            assertEquals("Graph contains a negative-weight cycle", e.getMessage());
+            
+            GraphPath<String, DefaultWeightedEdge> cycle = alg.getNegativeWeightCycle().get();
+            assertEquals("6", cycle.getStartVertex());
+            assertEquals("6", cycle.getEndVertex());
+            assertEquals(-3.0d, cycle.getWeight(), 1e-9);
+            assertEquals(5, cycle.getLength());
+        }
+    }
+    
+    @Test
+    public void testNegativeCycleWithMaxHops()
+    {
+        DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =
+            new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addVertex("4");
+        
+        g.setEdgeWeight(g.addEdge("1", "2"), 1);
+        g.setEdgeWeight(g.addEdge("2", "3"), 1);
+        g.setEdgeWeight(g.addEdge("3", "4"), 1);
+        g.setEdgeWeight(g.addEdge("4", "1"), -5);
+
+        int maxHops = 2;
+        BellmanFordShortestPath<String, DefaultWeightedEdge> alg = new BellmanFordShortestPath<>(g, 1e-16, maxHops);
+        GraphPath<String, DefaultWeightedEdge> path1 = alg.getPaths("1").getPath("3");
+        assertEquals(2.0d, path1.getWeight(), 1e-9);
+        
+        BellmanFordShortestPath<String, DefaultWeightedEdge> alg1 = new BellmanFordShortestPath<>(g, 1e-16, maxHops+1);
+        try {
+            alg1.getPaths("1");
+            fail("Negative-weight cycle not detected");
+        } catch (RuntimeException e) {
+            assertEquals("Graph contains a negative-weight cycle", e.getMessage());
+            
+            GraphPath<String, DefaultWeightedEdge> cycle = alg1.getNegativeWeightCycle().get();
+            assertEquals("1", cycle.getStartVertex());
+            assertEquals("1", cycle.getEndVertex());
+            assertEquals(-2.0d, cycle.getWeight(), 1e-9);
+            assertEquals(4, cycle.getLength());
         }
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BellmanFordShortestPathTest.java
@@ -178,10 +178,11 @@ public class BellmanFordShortestPathTest
         try {
             alg.getPaths("s");
             fail("Negative-weight cycle not detected");
-        } catch (RuntimeException e) {
+        } catch (NegativeCycleDetectedException e) {
             assertEquals("Graph contains a negative-weight cycle", e.getMessage());
             
-            GraphPath<String, DefaultWeightedEdge> cycle = alg.getNegativeWeightCycle().get();
+            @SuppressWarnings("unchecked") 
+            GraphPath<String, DefaultWeightedEdge> cycle = (GraphPath<String, DefaultWeightedEdge>) e.getCycle();
             assertEquals("x", cycle.getStartVertex());
             assertEquals("x", cycle.getEndVertex());
             assertEquals(-1.0d, cycle.getWeight(), 1e-9);
@@ -224,10 +225,11 @@ public class BellmanFordShortestPathTest
         try {
             alg.getPaths("w");
             fail("Negative-weight cycle not detected");
-        } catch (RuntimeException e) {
+        } catch (NegativeCycleDetectedException e) {
             assertEquals("Graph contains a negative-weight cycle", e.getMessage());
             
-            GraphPath<String, DefaultWeightedEdge> cycle = alg.getNegativeWeightCycle().get();
+            @SuppressWarnings("unchecked") 
+            GraphPath<String, DefaultWeightedEdge> cycle = (GraphPath<String, DefaultWeightedEdge>) e.getCycle();
             assertEquals("x", cycle.getStartVertex());
             assertEquals("x", cycle.getEndVertex());
             assertEquals(-2.0d, cycle.getWeight(), 1e-9);
@@ -292,10 +294,12 @@ public class BellmanFordShortestPathTest
         try {
             alg.getPaths("1");
             fail("Negative-weight cycle not detected");
-        } catch (RuntimeException e) {
+        } catch (NegativeCycleDetectedException e) {
             assertEquals("Graph contains a negative-weight cycle", e.getMessage());
             
-            GraphPath<String, DefaultWeightedEdge> cycle = alg.getNegativeWeightCycle().get();
+            @SuppressWarnings("unchecked")
+            GraphPath<String, DefaultWeightedEdge> cycle = (GraphPath<String, DefaultWeightedEdge>) e.getCycle();
+            
             assertEquals("6", cycle.getStartVertex());
             assertEquals("6", cycle.getEndVertex());
             assertEquals(-3.0d, cycle.getWeight(), 1e-9);
@@ -318,7 +322,7 @@ public class BellmanFordShortestPathTest
         g.setEdgeWeight(g.addEdge("3", "4"), 1);
         g.setEdgeWeight(g.addEdge("4", "1"), -5);
 
-        int maxHops = 2;
+        int maxHops = 3;
         BellmanFordShortestPath<String, DefaultWeightedEdge> alg = new BellmanFordShortestPath<>(g, 1e-16, maxHops);
         GraphPath<String, DefaultWeightedEdge> path1 = alg.getPaths("1").getPath("3");
         assertEquals(2.0d, path1.getWeight(), 1e-9);
@@ -327,10 +331,12 @@ public class BellmanFordShortestPathTest
         try {
             alg1.getPaths("1");
             fail("Negative-weight cycle not detected");
-        } catch (RuntimeException e) {
+        } catch (NegativeCycleDetectedException e) {
             assertEquals("Graph contains a negative-weight cycle", e.getMessage());
             
-            GraphPath<String, DefaultWeightedEdge> cycle = alg1.getNegativeWeightCycle().get();
+            @SuppressWarnings("unchecked")
+            GraphPath<String, DefaultWeightedEdge> cycle = (GraphPath<String, DefaultWeightedEdge>) e.getCycle();
+            
             assertEquals("1", cycle.getStartVertex());
             assertEquals("1", cycle.getEndVertex());
             assertEquals(-2.0d, cycle.getWeight(), 1e-9);


### PR DESCRIPTION
Enhanced the Bellman-Ford algorithm 
  - to be able to return the negative weight cycle found
  - to be able to execute only a maximum number of iterations

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
