### PR TITLE
Add checkstyle enforcement for source file headers

### DIFF
--- a/etc/checkstyle_suppressions.xml
+++ b/etc/checkstyle_suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <!-- Ignore header checks for package-info.java files -->
+    <suppress files="package-info\.java" checks="Header"/>
+</suppressions>

--- a/etc/header-boilerplate.txt
+++ b/etc/header-boilerplate.txt
@@ -1,3 +1,5 @@
+/*
+ * (C) Copyright BEGINYEAR-ENDYEAR, by AUTHORNAME and Contributors
  *
  * JGraphT : a free Java graph-theory library
  *

--- a/etc/jgrapht_checks.xml
+++ b/etc/jgrapht_checks.xml
@@ -4,6 +4,18 @@
 "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
+	<module name="SuppressionFilter">
+		<property name="file" value="etc/checkstyle_suppressions.xml"/>
+	</module>
+        
+	<!-- Checks for file header -->
+	<!-- See http://checkstyle.sf.net/config_header.html -->
+	<module name="Header">
+		<property name="headerFile" value="etc/header-boilerplate.txt"/>
+		<property name="ignoreLines" value="2"/>
+		<property name="fileExtensions" value="java"/>
+	</module>
+
 	<!-- Checks for whitespace -->
 	<!-- See http://checkstyle.sf.net/config_whitespace.html -->
 	<module name="FileTabCharacter" />

--- a/etc/updateHeader.sh
+++ b/etc/updateHeader.sh
@@ -14,7 +14,7 @@ function updateOneFile() {
         sed -i '/^\/\/ End/d' "$file"
         sed -i'' '/(C) Copyright/,/\*\// {
                     /(C) Copyright/n
-                    /\*\//r etc/header-boilerplate.txt
+                    /\*\//r etc/header-boilerplate-tail.txt
                     d
                 }' "$file"
     fi
@@ -26,10 +26,12 @@ function updateOneModule() {
 }
 
 pushd $SRC_DIR
+tail -n +3 etc/header-boilerplate.txt > etc/header-boilerplate-tail.txt
 updateOneModule jgrapht-core
 updateOneModule jgrapht-demo
 updateOneModule jgrapht-ext
 updateOneModule jgrapht-guava
 updateOneModule jgrapht-io
 updateOneModule jgrapht-opt
+rm -f etc/header-boilerplate-tail.txt
 popd

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphSpecificsStrategy.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2018-2018, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
 package org.jgrapht.graph;
 
 import java.io.Serializable;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/FastLookupGraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/FastLookupGraphSpecificsStrategy.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2018-2018, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
 package org.jgrapht.graph;
 
 import java.io.Serializable;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphSpecificsStrategy.java
@@ -1,3 +1,20 @@
+/*
+ * (C) Copyright 2018-2018, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
 package org.jgrapht.graph;
 
 import java.io.Serializable;


### PR DESCRIPTION
The check is disabled for package-info.java since we don't bother with headers there.

I fixed three remaining violations from recent @d-michail changes.

I also tweaked the updateHeader.sh script so that the boilerplate text file can be reused.
