### PR TITLE
unified flow interfaces

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
@@ -180,9 +180,7 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
      */
     @Override
     public Map<E, Double> getFlowMap() {
-        if(minimumCostFlow == null)
-            return null;
-        return this.minimumCostFlow.getFlowMap();
+        return minimumCostFlow == null ? null : this.minimumCostFlow.getFlowMap();
     }
 
     /**
@@ -197,7 +195,7 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
      * {@inheritDoc}
      */
     @Override
-    public MinimumCostFlow<E> getMinimumCostFlow(final MinimumCostFlowProblem minimumCostFlowProblem) {
+    public MinimumCostFlow<E> getMinimumCostFlow(final MinimumCostFlowProblem<V,E> minimumCostFlowProblem) {
         this.problem = Objects.requireNonNull(minimumCostFlowProblem);
         if (problem.getGraph().getType().isUndirected()) {
             throw new IllegalArgumentException("The algorithm doesn't support undirected flow networks");

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
@@ -118,11 +118,11 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
     /**
      * Number of vertices in the network
      */
-    private final int n;
+    private int n;
     /**
      * Number of edges in the network
      */
-    private final int m;
+    private int m;
     /**
      * Variable that is used to determine whether a vertex has been labeled temporarily or permanently during
      * Dijkstra's algorithm
@@ -136,10 +136,6 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
      * Computed minimum cost flow
      */
     private MinimumCostFlow<E> minimumCostFLow;
-    /**
-     * Solution to the dual linear program formulated on the input flow network
-     */
-    private DualSolution<V> dualSolution;
     /**
      * Array of internal nodes used by the algorithm. Node: these nodes are stored in the same order as vertices of
      * the specified flow network. This allows to determine quickly their counterparts in the network.
@@ -161,28 +157,19 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
 
     /**
      * Constructs a new instance of the algorithm which uses default scaling factor.
-     *
-     * @param problem a minimum cost flow problem
      */
-    public CapacityScalingMinimumCostFlow(MinimumCostFlowProblem<V, E> problem) {
-        this(problem, DEFAULT_SCALING_FACTOR);
+    public CapacityScalingMinimumCostFlow() {
+        this(DEFAULT_SCALING_FACTOR);
     }
 
     /**
      * Constructs a new instance of the algorithm with custom {@code scalingFactor}. If the {@code scalingFactor}
      * is less than 2, the algorithm doesn't use scaling.
      *
-     * @param problem       a minimum cost flow problem
      * @param scalingFactor custom scaling factor
      */
-    public CapacityScalingMinimumCostFlow(MinimumCostFlowProblem<V, E> problem, int scalingFactor) {
-        if (problem.getGraph().getType().isUndirected()) {
-            throw new IllegalArgumentException("The algorithm doesn't support undirected flow networks");
-        }
-        this.problem = Objects.requireNonNull(problem);
+    public CapacityScalingMinimumCostFlow(int scalingFactor) {
         this.scalingFactor = scalingFactor;
-        n = problem.getGraph().vertexSet().size();
-        m = problem.getGraph().edgeSet().size();
         Node.ID = 0; // for debug
     }
 
@@ -191,7 +178,7 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
      */
     @Override
     public Map<E, Double> getFlowMap() {
-        return this.getMinimumCostFlow().getFlowMap();
+        return this.minimumCostFLow.getFlowMap();
     }
 
     /**
@@ -206,10 +193,15 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
      * {@inheritDoc}
      */
     @Override
-    public MinimumCostFlow<E> getMinimumCostFlow() {
-        if (minimumCostFLow == null) {
-            lazyCalculateMinimumCostFlow();
+    public MinimumCostFlow<E> getMinimumCostFlow(final MinimumCostFlowProblem minimumCostFlowProblem) {
+        this.problem = Objects.requireNonNull(minimumCostFlowProblem);
+        if (problem.getGraph().getType().isUndirected()) {
+            throw new IllegalArgumentException("The algorithm doesn't support undirected flow networks");
         }
+        n = problem.getGraph().vertexSet().size();
+        m = problem.getGraph().edgeSet().size();
+        calculateMinimumCostFlow();
+        
         return minimumCostFLow;
     }
 
@@ -219,40 +211,27 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
      * It is represented as a mapping from graph nodes to their potentials (dual variables). Reduced cost
      * of a arc $(a, b)$ is defined as $cost((a, b)) + potential(b) - potential(b)$. According
      * to the reduced cost optimality conditions, a feasible solution to the minimum cost flow problem is
-     * optimal if and if reduced cost of every non-saturated arc is greater than or equal to $0$.
+     * optimal if and only if reduced cost of every non-saturated arc is greater than or equal to $0$.
      *
      * @return solution to the dual linear program formulated on the network.
      */
-    public DualSolution<V> getDualSolution() {
-        dualSolution = lazyComputeDualSolution();
-        return dualSolution;
-    }
+    public Map<V, Double> getDualSolution() {
 
-    /**
-     * Lazily computes solution to the dual linear program formulated on the flow network.
-     *
-     * @return a solution to the dual linear program
-     */
-    private DualSolution<V> lazyComputeDualSolution() {
-        lazyCalculateMinimumCostFlow();
-        if (dualSolution == null) {
-            Map<V, Double> dualVariables = new HashMap<>();
-            for (int i = 0; i < n; i++) {
-                dualVariables.put(graphVertices.get(i), nodes[i].potential);
-            }
-            dualSolution = new DualSolution<>(dualVariables);
+        if(minimumCostFLow == null)
+            throw new RuntimeException("Cannot return a dual solution before getMinimumCostFlow(MinimumCostFlowProblem minimumCostFlowProblem) is invoked!");
+
+        Map<V, Double> dualVariables = new HashMap<>();
+        for (int i = 0; i < n; i++) {
+            dualVariables.put(graphVertices.get(i), nodes[i].potential);
         }
-        return dualSolution;
+        return dualVariables;
     }
 
     /**
-     * Lazily calculated a solution to the specified minimum cost flow problem. If the scaling factor is greater than 1,
+     * Calculated a solution to the specified minimum cost flow problem. If the scaling factor is greater than 1,
      * performs scaling phases, otherwise uses simple capacity scaling algorithm.
      */
-    private void lazyCalculateMinimumCostFlow() {
-        if (minimumCostFLow != null) {
-            return;
-        }
+    private void calculateMinimumCostFlow() {
         init();
         if (scalingFactor > 1) {
             // run with scaling
@@ -303,7 +282,7 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
         int i = 0;
         for (V vertex : graph.vertexSet()) {
             graphVertices.add(vertex);
-            int supply = problem.getNodeDemands().apply(vertex);
+            int supply = problem.getNodeSupply().apply(vertex);
             supplySum += supply;
             nodes[i] = new Node(supply);
             nodeMap.put(vertex, nodes[i]);
@@ -607,7 +586,9 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
      * @return true, if the computed solution is optimal, false otherwise.
      */
     public boolean testOptimality(double eps) {
-        lazyCalculateMinimumCostFlow();
+        if(minimumCostFLow == null)
+            throw new RuntimeException("Cannot return a dual solution before getMinimumCostFlow(MinimumCostFlowProblem minimumCostFlowProblem) is invoked!");
+
         for (Node node : nodes) {
             for (Arc arc = node.firstNonSaturated; arc != null; arc = arc.next) {
                 if (arc.getReducedCost() < -eps) {
@@ -616,41 +597,6 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
             }
         }
         return true;
-    }
-
-    /**
-     * Solution to the dual linear program formulated on the network. Serves as a certificate of optimality.
-     * <p>
-     * It is represented as a mapping from graph nodes to their potentials (dual variables). Reduced cost
-     * of a arc $(a, b)$ is defined as $cost((a, b)) + potential(b) - potential(b)$. According
-     * to the reduced cost optimality conditions, a feasible solution to the minimum cost flow problem is
-     * optimal if and if reduced cost of every non-saturated arc is greater than or equal to $0$.
-     *
-     * @param <V> graph vertex type
-     */
-    public static class DualSolution<V> {
-        /**
-         * Mapping from vertices to their dual variables
-         */
-        Map<V, Double> dualVariables;
-
-        /**
-         * Constructs a new dual solution for minimum cost flow problem
-         *
-         * @param dualVariables mapping from vertices to their dual variables
-         */
-        public DualSolution(Map<V, Double> dualVariables) {
-            this.dualVariables = dualVariables;
-        }
-
-        /**
-         * Returns the mapping from vertices to their dual variables
-         *
-         * @return the mapping from vertices to their dual variables
-         */
-        public Map<V, Double> getDualVariables() {
-            return dualVariables;
-        }
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
@@ -190,6 +190,14 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
      * {@inheritDoc}
      */
     @Override
+    public Map<E, Double> getFlowMap() {
+        return this.getMinimumCostFlow().getFlowMap();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public V getFlowDirection(E edge) {
         return problem.getGraph().getEdgeTarget(edge);
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
@@ -135,7 +135,7 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
     /**
      * Computed minimum cost flow
      */
-    private MinimumCostFlow<E> minimumCostFLow;
+    private MinimumCostFlow<E> minimumCostFlow;
     /**
      * Array of internal nodes used by the algorithm. Node: these nodes are stored in the same order as vertices of
      * the specified flow network. This allows to determine quickly their counterparts in the network.
@@ -174,11 +174,15 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
     }
 
     /**
-     * {@inheritDoc}
+     * Returns mapping from edge to flow value through this particular edge
+     *
+     * @return maximum flow mapping, or null if a MinimumCostFlowProblem has not yet been solved.
      */
     @Override
     public Map<E, Double> getFlowMap() {
-        return this.minimumCostFLow.getFlowMap();
+        if(minimumCostFlow == null)
+            return null;
+        return this.minimumCostFlow.getFlowMap();
     }
 
     /**
@@ -202,7 +206,7 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
         m = problem.getGraph().edgeSet().size();
         calculateMinimumCostFlow();
         
-        return minimumCostFLow;
+        return minimumCostFlow;
     }
 
     /**
@@ -213,12 +217,13 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
      * to the reduced cost optimality conditions, a feasible solution to the minimum cost flow problem is
      * optimal if and only if reduced cost of every non-saturated arc is greater than or equal to $0$.
      *
-     * @return solution to the dual linear program formulated on the network.
+     * @return solution to the dual linear program formulated on the network, or null if a MinimumCostFlowProblem has
+     * not yet been solved.
      */
     public Map<V, Double> getDualSolution() {
 
-        if(minimumCostFLow == null)
-            throw new RuntimeException("Cannot return a dual solution before getMinimumCostFlow(MinimumCostFlowProblem minimumCostFlowProblem) is invoked!");
+        if(minimumCostFlow == null)
+            return null;
 
         Map<V, Double> dualVariables = new HashMap<>();
         for (int i = 0; i < n; i++) {
@@ -251,7 +256,7 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
             Pair<List<Node>, Set<Node>> pair = scale(1);
             pushAllFlow(pair.getFirst(), pair.getSecond(), 1);
         }
-        minimumCostFLow = finish();
+        minimumCostFlow = finish();
     }
 
     /**
@@ -586,7 +591,7 @@ public class CapacityScalingMinimumCostFlow<V, E> implements MinimumCostFlowAlgo
      * @return true, if the computed solution is optimal, false otherwise.
      */
     public boolean testOptimality(double eps) {
-        if(minimumCostFLow == null)
+        if(minimumCostFlow == null)
             throw new RuntimeException("Cannot return a dual solution before getMinimumCostFlow(MinimumCostFlowProblem minimumCostFlowProblem) is invoked!");
 
         for (Node node : nodes) {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/FlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/FlowAlgorithm.java
@@ -20,7 +20,7 @@ package org.jgrapht.alg.interfaces;
 import java.util.*;
 
 /**
- * Iterface for flow algorithms
+ * Interface for flow algorithms
  * @author Joris Kinable
  *
  * @param <V> the graph vertex type
@@ -33,7 +33,7 @@ public interface FlowAlgorithm<V,E> {
      * @return flow
      */
     default Flow getFlow(){
-        return new FlowImpl(this.getFlowMap());
+        return new FlowImpl<>(this.getFlowMap());
     }
 
     /**
@@ -44,7 +44,7 @@ public interface FlowAlgorithm<V,E> {
     Map<E, Double> getFlowMap();
 
     /**
-     * For the specified {@code edge} $(u, v)$ return vertex $v$ if the flow goes from $u$ to $v$, or returns
+     * For the specified {@code edge} $(u, v)$ returns vertex $v$ if the flow goes from $u$ to $v$, or returns
      * vertex $u$ otherwise. For directed flow networks the result is always the head of the specified arc.
      * <p>
      * <em>Note:</em> not all minimum cost flow algorithms may support undirected graphs.
@@ -58,7 +58,6 @@ public interface FlowAlgorithm<V,E> {
      * Represents a minimum cost flow.
      *
      * @param <E> graph edge type
-     * @since July 2018
      */
     interface Flow<E> {
         /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/FlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/FlowAlgorithm.java
@@ -1,0 +1,104 @@
+/*
+ * (C) Copyright 2018-2018, by Joris Kinable and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.interfaces;
+
+import java.util.*;
+
+/**
+ * Iterface for flow algorithms
+ * @author Joris Kinable
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ */
+public interface FlowAlgorithm<V,E> {
+
+    /**
+     * Returns a <em>read-only</em> mapping from edges to the corresponding flow values.
+     *
+     * @return a <em>read-only</em> mapping from edges to the corresponding flow values.
+     */
+    Map<E, Double> getFlowMap();
+
+    /**
+     * For the specified {@code edge} $(u, v)$ return vertex $v$ if the flow goes from $u$ to $v$, or returns
+     * vertex $u$ otherwise. For directed flow networks the result is always the head of the specified arc.
+     * <p>
+     * <em>Note:</em> not all minimum cost flow algorithms may support undirected graphs.
+     *
+     * @param edge an edge from the specified flow network
+     * @return the direction of the flow on the {@code edge}
+     */
+    V getFlowDirection(E edge);
+
+    /**
+     * Represents a minimum cost flow.
+     *
+     * @param <E> graph edge type
+     * @since July 2018
+     */
+    interface Flow<E> {
+        /**
+         * Returns the flow on the {@code edge}
+         *
+         * @param edge an edge from the flow network
+         * @return the flow on the {@code edge}
+         */
+        default double getFlow(E edge){
+            return getFlowMap().get(edge);
+        }
+
+        /**
+         * Returns a mapping from the network flow edges to the corresponding flow values. The mapping
+         * contains all edges of the flow network regardless of whether there is a non-zero flow on an
+         * edge or not.
+         *
+         * @return a read-only map that defines a feasible flow of minimum cost.
+         */
+        Map<E, Double> getFlowMap();
+    }
+
+    /**
+     * Default implementation of the {@link MinimumCostFlowAlgorithm.MinimumCostFlow}
+     *
+     * @param <E> graph edge type
+     */
+    class FlowImpl<E> implements Flow<E> {
+        /**
+         * A mapping defining the flow on the network
+         */
+        private Map<E, Double> flowMap;
+
+        /**
+         * Constructs a new instance of minimum cost flow
+         *
+         * @param flowMap the mapping defining the flow on the network
+         */
+        public FlowImpl(Map<E, Double> flowMap) {
+            this.flowMap = Collections.unmodifiableMap(flowMap);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public Map<E, Double> getFlowMap() {
+            return flowMap;
+        }
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/FlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/FlowAlgorithm.java
@@ -21,6 +21,7 @@ import java.util.*;
 
 /**
  * Interface for flow algorithms
+ *
  * @author Joris Kinable
  *
  * @param <V> the graph vertex type
@@ -30,6 +31,7 @@ public interface FlowAlgorithm<V,E> {
 
     /**
      * Result object of a flow algorithm
+     *
      * @return flow
      */
     default Flow getFlow(){
@@ -47,7 +49,7 @@ public interface FlowAlgorithm<V,E> {
      * For the specified {@code edge} $(u, v)$ returns vertex $v$ if the flow goes from $u$ to $v$, or returns
      * vertex $u$ otherwise. For directed flow networks the result is always the head of the specified arc.
      * <p>
-     * <em>Note:</em> not all minimum cost flow algorithms may support undirected graphs.
+     * <em>Note:</em> not all flow algorithms may support undirected graphs.
      *
      * @param edge an edge from the specified flow network
      * @return the direction of the flow on the {@code edge}
@@ -55,7 +57,7 @@ public interface FlowAlgorithm<V,E> {
     V getFlowDirection(E edge);
 
     /**
-     * Represents a minimum cost flow.
+     * Represents a flow.
      *
      * @param <E> graph edge type
      */
@@ -75,13 +77,13 @@ public interface FlowAlgorithm<V,E> {
          * contains all edges of the flow network regardless of whether there is a non-zero flow on an
          * edge or not.
          *
-         * @return a read-only map that defines a feasible flow of minimum cost.
+         * @return a read-only map that defines a feasible flow.
          */
         Map<E, Double> getFlowMap();
     }
 
     /**
-     * Default implementation of the {@link MinimumCostFlowAlgorithm.MinimumCostFlow}
+     * Default implementation of {@link Flow}
      *
      * @param <E> graph edge type
      */
@@ -92,7 +94,7 @@ public interface FlowAlgorithm<V,E> {
         private Map<E, Double> flowMap;
 
         /**
-         * Constructs a new instance of minimum cost flow
+         * Constructs a new flow
          *
          * @param flowMap the mapping defining the flow on the network
          */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/FlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/FlowAlgorithm.java
@@ -29,6 +29,14 @@ import java.util.*;
 public interface FlowAlgorithm<V,E> {
 
     /**
+     * Result object of a flow algorithm
+     * @return flow
+     */
+    default Flow getFlow(){
+        return new FlowImpl(this.getFlowMap());
+    }
+
+    /**
      * Returns a <em>read-only</em> mapping from edges to the corresponding flow values.
      *
      * @return a <em>read-only</em> mapping from edges to the corresponding flow values.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MaximumFlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MaximumFlowAlgorithm.java
@@ -30,7 +30,7 @@ import java.util.*;
  * @param <E> the graph edge type
  *
  */
-public interface MaximumFlowAlgorithm<V, E>
+public interface MaximumFlowAlgorithm<V, E> extends FlowAlgorithm<V,E>
 {
 
     /**
@@ -54,8 +54,25 @@ public interface MaximumFlowAlgorithm<V, E>
      * @param source source vertex
      * @param sink sink vertex
      * @return the value of the maximum flow
+     * @deprecated replaced by @link{getMaximumFlowValue}
      */
+    @Deprecated
     default double calculateMaximumFlow(V source, V sink)
+    {
+        return getMaximumFlow(source, sink).getValue();
+    }
+
+    /**
+     * Sets current source to <tt>source</tt>, current sink to <tt>sink</tt>, then calculates
+     * maximum flow from <tt>source</tt> to <tt>sink</tt>. Note, that <tt>source</tt> and
+     * <tt>sink</tt> must be vertices of the <tt>
+     * network</tt> passed to the constructor, and they must be different.
+     *
+     * @param source source vertex
+     * @param sink sink vertex
+     * @return the value of the maximum flow
+     */
+    default double getMaximumFlowValue(V source, V sink)
     {
         return getMaximumFlow(source, sink).getValue();
     }
@@ -68,41 +85,10 @@ public interface MaximumFlowAlgorithm<V, E>
      * compatibility. This function should be enforced in the next version.
      *
      * @return maximum flow value
+     * @deprecated method has been removed
      */
+    @Deprecated
     default double getMaximumFlowValue()
-    {
-        throw new UnsupportedOperationException("Function not implemented");
-    }
-
-    /**
-     * Returns maximum flow, that was calculated during last <tt>
-     * calculateMaximumFlow</tt> call, or <tt>null</tt>, if there was no <tt>
-     * calculateMaximumFlow</tt> calls.
-     *
-     * NOTE: this function currently has a default implementation to guarantee backwards
-     * compatibility. This function should be enforced in the next version.
-     *
-     * @return <i>read-only</i> mapping from edges to doubles - flow values
-     */
-    default Map<E, Double> getFlowMap()
-    {
-        throw new UnsupportedOperationException("Function not implemented");
-    }
-
-    /**
-     * Returns the direction of the flow on an edge $(u,v)$. In case $(u,v)$ is a directed edge
-     * (arc), this function will always return the edge target $v$. However, if $(u,v)$ is an edge
-     * in an undirected graph, flow may go through the edge in either side. If the flow goes from
-     * $u$ to $v$, we return $v$, otherwise $u$. If the flow on an edge equals $0$, the returned
-     * value has no meaning.
-     *
-     * NOTE: this function currently has a default implementation to guarantee backwards
-     * compatibility. This function should be enforced in the next version.
-     *
-     * @param e edge
-     * @return the vertex where the flow leaves the edge
-     */
-    default V getFlowDirection(E e)
     {
         throw new UnsupportedOperationException("Function not implemented");
     }
@@ -112,7 +98,7 @@ public interface MaximumFlowAlgorithm<V, E>
      *
      * @param <E> the graph edge type
      */
-    interface MaximumFlow<E>
+    interface MaximumFlow<E> extends Flow<E>
     {
         /**
          * Returns value of the maximum-flow for the given network
@@ -125,8 +111,10 @@ public interface MaximumFlowAlgorithm<V, E>
          * Returns mapping from edge to flow value through this particular edge
          *
          * @return maximum flow
+         * @deprecated Method renamed to getFlowMap
          */
-        Map<E, Double> getFlow();
+        @Deprecated
+        default Map<E, Double> getFlow(){return getFlowMap();}
     }
 
     /**
@@ -134,12 +122,11 @@ public interface MaximumFlowAlgorithm<V, E>
      *
      * @param <E> the graph edge type
      */
-    class MaximumFlowImpl<E>
+    class MaximumFlowImpl<E> extends FlowImpl<E>
         implements
         MaximumFlow<E>
     {
         private Double value;
-        private Map<E, Double> flow;
 
         /**
          * Create a new maximum flow
@@ -149,8 +136,8 @@ public interface MaximumFlowAlgorithm<V, E>
          */
         public MaximumFlowImpl(Double value, Map<E, Double> flow)
         {
+            super(flow);
             this.value = value;
-            this.flow = Collections.unmodifiableMap(flow);
         }
 
         @Override
@@ -160,15 +147,9 @@ public interface MaximumFlowAlgorithm<V, E>
         }
 
         @Override
-        public Map<E, Double> getFlow()
-        {
-            return flow;
-        }
-
-        @Override
         public String toString()
         {
-            return "Flow Value: " + value + "\nFlow map:\n" + flow;
+            return "Flow Value: " + value + "\nFlow map:\n" + getFlowMap();
         }
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MinimumCostFlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MinimumCostFlowAlgorithm.java
@@ -55,7 +55,6 @@ public interface MinimumCostFlowAlgorithm<V, E> extends FlowAlgorithm<V,E>{
      * Represents a minimum cost flow.
      *
      * @param <E> graph edge type
-     * @since July 2018
      */
     interface MinimumCostFlow<E> extends Flow<E>{
         /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MinimumCostFlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MinimumCostFlowAlgorithm.java
@@ -17,9 +17,8 @@
  */
 package org.jgrapht.alg.interfaces;
 
-import org.jgrapht.alg.flow.mincost.*;
+import org.jgrapht.alg.flow.mincost.MinimumCostFlowProblem;
 
-import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -40,7 +39,7 @@ public interface MinimumCostFlowAlgorithm<V, E> extends FlowAlgorithm<V,E>{
      * @param minimumCostFlowProblem minimum cost flow problem
      * @return minimum cost flow
      */
-    MinimumCostFlow<E> getMinimumCostFlow(MinimumCostFlowProblem minimumCostFlowProblem);
+    MinimumCostFlow<E> getMinimumCostFlow(MinimumCostFlowProblem<V,E> minimumCostFlowProblem);
 
     /**
      * Returns the objective value (cost) of a solution to the minimum cost flow problem.
@@ -48,7 +47,7 @@ public interface MinimumCostFlowAlgorithm<V, E> extends FlowAlgorithm<V,E>{
      * @param minimumCostFlowProblem minimum cost flow problem
      * @return the objective value (cost) of a solution to the minimum cost flow problem.
      */
-    default double getFlowCost(MinimumCostFlowProblem minimumCostFlowProblem) {
+    default double getFlowCost(MinimumCostFlowProblem<V,E> minimumCostFlowProblem) {
         return getMinimumCostFlow(minimumCostFlowProblem).getCost();
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MinimumCostFlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MinimumCostFlowAlgorithm.java
@@ -30,7 +30,7 @@ import java.util.Map;
  * @param <E> graph edge type
  * @author Timofey Chudakov
  */
-public interface MinimumCostFlowAlgorithm<V, E> {
+public interface MinimumCostFlowAlgorithm<V, E> extends FlowAlgorithm<V,E>{
 
     /**
      * Calculates feasible flow of minimum cost for the minimum cost flow problem. If minimum cost
@@ -49,25 +49,7 @@ public interface MinimumCostFlowAlgorithm<V, E> {
         return getMinimumCostFlow().getCost();
     }
 
-    /**
-     * Returns a <em>read-only</em> mapping from edges to the corresponding flow values.
-     *
-     * @return a <em>read-only</em> mapping from edges to the corresponding flow values.
-     */
-    default Map<E, Double> getFlowMap() {
-        return getMinimumCostFlow().getFlowMap();
-    }
 
-    /**
-     * For the specified {@code edge} $(u, v)$ return vertex $v$ if the flow goes from $u$ to $v$, or returns
-     * vertex $u$ otherwise. For directed flow networks the result is always the head of the specified arc.
-     * <p>
-     * <em>Note:</em> not all minimum cost flow algorithms may support undirected graphs.
-     *
-     * @param edge an edge from the specified flow network
-     * @return the direction of the flow on the {@code edge}
-     */
-    V getFlowDirection(E edge);
 
     /**
      * Represents a minimum cost flow.
@@ -75,30 +57,13 @@ public interface MinimumCostFlowAlgorithm<V, E> {
      * @param <E> graph edge type
      * @since July 2018
      */
-    interface MinimumCostFlow<E> {
+    interface MinimumCostFlow<E> extends Flow<E>{
         /**
          * Returns the cost of the flow
          *
          * @return the cost of the flow
          */
         double getCost();
-
-        /**
-         * Returns the flow on the {@code edge}
-         *
-         * @param edge an edge from the flow network
-         * @return the flow on the {@code edge}
-         */
-        double getFlow(E edge);
-
-        /**
-         * Returns a mapping from the network flow edges to the corresponding flow values. The mapping
-         * contains all edges of the flow network regardless of whether there is a non-zero flow on an
-         * edge or not.
-         *
-         * @return a read-only map that defines a feasible flow of minimum cost.
-         */
-        Map<E, Double> getFlowMap();
     }
 
     /**
@@ -106,15 +71,11 @@ public interface MinimumCostFlowAlgorithm<V, E> {
      *
      * @param <E> graph edge type
      */
-    class MinimumCostFlowImpl<E> implements MinimumCostFlow<E> {
+    class MinimumCostFlowImpl<E> extends FlowImpl<E> implements MinimumCostFlow<E> {
         /**
          * The cost of the flow defined by the mapping {@code flowMap}
          */
         double cost;
-        /**
-         * A mapping defining the flow on the network
-         */
-        private Map<E, Double> flowMap;
 
         /**
          * Constructs a new instance of minimum cost flow
@@ -123,16 +84,8 @@ public interface MinimumCostFlowAlgorithm<V, E> {
          * @param flowMap the mapping defining the flow on the network
          */
         public MinimumCostFlowImpl(double cost, Map<E, Double> flowMap) {
+            super(flowMap);
             this.cost = cost;
-            this.flowMap = Collections.unmodifiableMap(flowMap);
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public Map<E, Double> getFlowMap() {
-            return flowMap;
         }
 
         /**
@@ -141,14 +94,6 @@ public interface MinimumCostFlowAlgorithm<V, E> {
         @Override
         public double getCost() {
             return cost;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public double getFlow(E edge) {
-            return flowMap.get(edge);
         }
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MinimumCostFlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MinimumCostFlowAlgorithm.java
@@ -17,6 +17,8 @@
  */
 package org.jgrapht.alg.interfaces;
 
+import org.jgrapht.alg.flow.mincost.*;
+
 import java.util.Collections;
 import java.util.Map;
 
@@ -33,20 +35,21 @@ import java.util.Map;
 public interface MinimumCostFlowAlgorithm<V, E> extends FlowAlgorithm<V,E>{
 
     /**
-     * Calculates feasible flow of minimum cost for the minimum cost flow problem. If minimum cost
-     * flow in not unique, the algorithm chooses the result arbitrarily.
+     * Calculates feasible flow of minimum cost for the minimum cost flow problem.
      *
+     * @param minimumCostFlowProblem minimum cost flow problem
      * @return minimum cost flow
      */
-    MinimumCostFlow<E> getMinimumCostFlow();
+    MinimumCostFlow<E> getMinimumCostFlow(MinimumCostFlowProblem minimumCostFlowProblem);
 
     /**
-     * Returns the cost of the computed minimum cost flow.
+     * Returns the objective value (cost) of a solution to the minimum cost flow problem.
      *
-     * @return the cost of a minimum cost flow.
+     * @param minimumCostFlowProblem minimum cost flow problem
+     * @return the objective value (cost) of a solution to the minimum cost flow problem.
      */
-    default double getFlowCost() {
-        return getMinimumCostFlow().getCost();
+    default double getFlowCost(MinimumCostFlowProblem minimumCostFlowProblem) {
+        return getMinimumCostFlow(minimumCostFlowProblem).getCost();
     }
 
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlowTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlowTest.java
@@ -19,7 +19,6 @@ package org.jgrapht.alg.flow.mincost;
 
 import org.jgrapht.Graph;
 import org.jgrapht.Graphs;
-import org.jgrapht.alg.flow.mincost.CapacityScalingMinimumCostFlow.DualSolution;
 import org.jgrapht.alg.interfaces.MinimumCostFlowAlgorithm.MinimumCostFlow;
 import org.jgrapht.graph.DefaultDirectedWeightedGraph;
 import org.jgrapht.graph.DefaultWeightedEdge;
@@ -1059,21 +1058,21 @@ public class CapacityScalingMinimumCostFlowTest {
                 upperMap.put(edge, data[3]);
             }
         }
-        MinimumCostFlowProblem<Integer, DefaultWeightedEdge> problem = new MinimumCostFlowProblem<>(graph, v -> supplyMap.getOrDefault(v, 0), upperMap::get, e -> lowerMap.getOrDefault(e, 0));
-        CapacityScalingMinimumCostFlow<Integer, DefaultWeightedEdge> minimumCostFlow = new CapacityScalingMinimumCostFlow<>(problem, scalingFactor);
-        assertEquals(cost, minimumCostFlow.getFlowCost(), EPS);
-        assertTrue(minimumCostFlow.testOptimality(EPS));
+        MinimumCostFlowProblem<Integer, DefaultWeightedEdge> problem = new MinimumCostFlowProblem.MinimumCostFlowProblemImpl<>(graph, v -> supplyMap.getOrDefault(v, 0), upperMap::get, e -> lowerMap.getOrDefault(e, 0));
+        CapacityScalingMinimumCostFlow<Integer, DefaultWeightedEdge> minimumCostFlowAlgorithm = new CapacityScalingMinimumCostFlow<>(scalingFactor);
+        MinimumCostFlow<DefaultWeightedEdge> minimumCostFlow=minimumCostFlowAlgorithm.getMinimumCostFlow(problem);
+        assertEquals(cost, minimumCostFlow.getCost(), EPS);
+        assertTrue(minimumCostFlowAlgorithm.testOptimality(EPS));
 
-        assertTrue(checkFlowAndDualSolution(minimumCostFlow.getDualSolution(), minimumCostFlow.getMinimumCostFlow(), problem));
+        assertTrue(checkFlowAndDualSolution(minimumCostFlowAlgorithm.getDualSolution(), minimumCostFlow, problem));
     }
 
 
-    private <V, E> boolean checkFlowAndDualSolution(DualSolution<V> dualSolution, MinimumCostFlow<E> flow, MinimumCostFlowProblem<V, E> problem) {
+    private <V, E> boolean checkFlowAndDualSolution(Map<V, Double> dualVariables, MinimumCostFlow<E> flow, MinimumCostFlowProblem<V, E> problem) {
         Graph<V, E> graph = problem.getGraph();
-        Map<V, Double> dualVariables = dualSolution.getDualVariables();
         // check supply constraints
         for (V vertex : graph.vertexSet()) {
-            int supply = problem.getNodeDemands().apply(vertex);
+            int supply = problem.getNodeSupply().apply(vertex);
             int flowIn = 0;
             for (E edge : graph.incomingEdgesOf(vertex)) {
                 flowIn += flow.getFlow(edge);


### PR DESCRIPTION
Added a `FlowAlgorithm` interface to ensure that flow algorithms (min cost flow/max flow) have a unified interface. The purpose of this interface is not to allow the user to swap min cost flow and max flow algorithms (this doesn't seem to be very useful). Instead, the interface ensures that all flow algorithms have similar methods and names.