### PR TITLE
updated versions of jgrapht's dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ A local copy of the Javadoc HTML files is included in the distribution. The late
 - [ANTLR](http://www.antlr.org) is a parser generator.  It is used for reading text files containing graph representations, and is only required by the jgrapht-io module.  ANTLR v4 is licensed under the terms of the [BSD license](http://www.antlr.org/license.html).
 - [Guava](https://github.com/google/guava) is Google's core libraries for Java. You need Guava only if you are already using Guava's graph data-structures and wish to use our adapter classes in order to execute JGraphT's algorithms. Only required by the jgrapht-guava module.
 - [Apache Commons Proper](http://commons.apache.org/components.html) is an Apache project containing reusable Java components. The packages [commons-text](https://commons.apache.org/proper/commons-text/) and [commons-lang3.](http://commons.apache.org/proper/commons-lang/) which provide additional utilities for String manipulation are only required by the jgrapht-io module.
+- [fastutil](http://fastutil.di.unimi.it/) provides a collection of type-specific maps, sets, lists and queues with a small memory footprint and fast access and insertion. Fastutil is only required by the jgrapht-opt module.
 
 ## Online Resources ##
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # JGraphT
 
-Released: May 16, 2018</p>
+Released: October 18, 2018</p>
 
 Written by [Barak Naveh](mailto:barak_naveh@users.sourceforge.net)  and Contributors
 
@@ -134,6 +134,7 @@ A local copy of the Javadoc HTML files is included in the distribution. The late
 - [JGraphX](http://www.jgraph.com/jgraph.html) is a graph visualizations and editing component (the successor to the older JGraph library). You need JGraphX only if you want to use the JGraphXAdapter to visualize the JGraphT graph interactively via JGraphX. JGraphX is licensed under the terms of the BSD license.
 - [ANTLR](http://www.antlr.org) is a parser generator.  It is used for reading text files containing graph representations, and is only required by the jgrapht-io module.  ANTLR v4 is licensed under the terms of the [BSD license](http://www.antlr.org/license.html).
 - [Guava](https://github.com/google/guava) is Google's core libraries for Java. You need Guava only if you are already using Guava's graph data-structures and wish to use our adapter classes in order to execute JGraphT's algorithms. Only required by the jgrapht-guava module.
+- [Apache Commons Proper](http://commons.apache.org/components.html) is an Apache project containing reusable Java components. The packages [commons-text](https://commons.apache.org/proper/commons-text/) and [commons-lang3.](http://commons.apache.org/proper/commons-lang/) which provide additional utilities for String manipulation are only required by the jgrapht-io module.
 
 ## Online Resources ##
 

--- a/etc/ReleaseProcess.md
+++ b/etc/ReleaseProcess.md
@@ -1,7 +1,7 @@
 # JGraphT Release Process
 
 1. Let other developers on [jgrapht-dev](https://groups.google.com/forum/#!forum/jgrapht-dev) know that you're starting on the release and ask them to hold off on merging changes until the release is complete.
-1. Check and, if necessary, update dependencies: `mvn versions:display-dendency-updates`
+1. Check and, if necessary, update dependencies: `mvn versions:display-dendency-updates`. Recompile to check whether any of the version updates introduced errors, e.g. because some methods have been deprecated: `mvn -Dmaven.compiler.showWarnings=true -Dmaven.compiler.showDeprecation=true clean compile`
 1. Review the README.md, HISTORY.md, CONTRIBUTORS.md, and update:
     * Version
     * Dependencies

--- a/etc/ReleaseProcess.md
+++ b/etc/ReleaseProcess.md
@@ -1,6 +1,7 @@
 # JGraphT Release Process
 
 1. Let other developers on [jgrapht-dev](https://groups.google.com/forum/#!forum/jgrapht-dev) know that you're starting on the release and ask them to hold off on merging changes until the release is complete.
+1. Check and, if necessary, update dependencies: `mvn versions:display-dendency-updates`
 1. Review the README.md, HISTORY.md, CONTRIBUTORS.md, and update:
     * Version
     * Dependencies

--- a/jgrapht-core/pom.xml
+++ b/jgrapht-core/pom.xml
@@ -44,13 +44,13 @@
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-core</artifactId>
-			<version>1.19</version>
+			<version>1.21</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.openjdk.jmh</groupId>
 			<artifactId>jmh-generator-annprocess</artifactId>
-			<version>1.19</version>
+			<version>1.21</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/jgrapht-guava/pom.xml
+++ b/jgrapht-guava/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>24.1-jre</version>
+            <version>26.0-jre</version>
             <exclusions>
                     <exclusion>
                         <groupId>com.google.code.findbugs</groupId>

--- a/jgrapht-io/pom.xml
+++ b/jgrapht-io/pom.xml
@@ -157,8 +157,8 @@
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
-			<artifactId>commons-lang3</artifactId>
-			<version>3.8.1</version>
+			<artifactId>commons-text</artifactId>
+			<version>1.5</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/jgrapht-io/pom.xml
+++ b/jgrapht-io/pom.xml
@@ -153,12 +153,12 @@
 		<dependency>
 			<groupId>org.antlr</groupId>
 			<artifactId>antlr4-runtime</artifactId>
-			<version>4.7</version>
+			<version>4.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.5</version>
+			<version>3.8.1</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DOTImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DOTImporter.java
@@ -19,8 +19,8 @@ package org.jgrapht.io;
 
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.*;
-import org.apache.commons.lang3.*;
-import org.apache.commons.lang3.text.translate.*;
+import org.apache.commons.text.*;
+import org.apache.commons.text.translate.*;
 import org.jgrapht.*;
 
 import java.io.*;
@@ -53,9 +53,7 @@ public class DOTImporter<V, E>
     public static final String DEFAULT_GRAPH_ID_KEY = "ID";
 
     // identifier unescape rule
-    private static final CharSequenceTranslator UNESCAPE_ID = new AggregateTranslator(
-        new LookupTranslator(
-            new String[][] { { "\\\\", "\\" }, { "\\\"", "\"" }, { "\\'", "'" }, { "\\", "" } }));
+    private final CharSequenceTranslator UNESCAPE_ID;
 
     /**
      * Constructs a new importer.
@@ -97,6 +95,14 @@ public class DOTImporter<V, E>
         super(vertexProvider, edgeProvider, (vertexUpdater != null) ? vertexUpdater : (c, a) -> {
         }, (graphUpdater != null) ? graphUpdater : (c, a) -> {
         });
+
+        Map<CharSequence,CharSequence> lookupMap=new HashMap<>();
+        lookupMap.put("\\\\", "\\");
+        lookupMap.put("\\\"", "\"");
+        lookupMap.put("\\'", "'");
+        lookupMap.put("\\", "");
+        UNESCAPE_ID = new AggregateTranslator(new LookupTranslator(lookupMap));
+
     }
 
     /**
@@ -809,7 +815,7 @@ public class DOTImporter<V, E>
      * @param input the input
      * @return the unescaped output
      */
-    private static String unescapeId(String input)
+    private String unescapeId(String input)
     {
         final char QUOTE = '"';
         if (input.charAt(0) != QUOTE || input.charAt(input.length() - 1) != QUOTE) {

--- a/jgrapht-io/src/main/java/org/jgrapht/io/GmlExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/GmlExporter.java
@@ -17,7 +17,7 @@
  */
 package org.jgrapht.io;
 
-import org.apache.commons.lang3.*;
+import org.apache.commons.text.*;
 import org.jgrapht.*;
 
 import java.io.*;

--- a/jgrapht-io/src/main/java/org/jgrapht/io/GmlImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/GmlImporter.java
@@ -20,7 +20,7 @@ package org.jgrapht.io;
 import org.antlr.v4.runtime.*;
 import org.antlr.v4.runtime.misc.*;
 import org.antlr.v4.runtime.tree.*;
-import org.apache.commons.lang3.*;
+import org.apache.commons.text.*;
 import org.jgrapht.*;
 import org.jgrapht.io.GmlParser.*;
 

--- a/jgrapht-opt/pom.xml
+++ b/jgrapht-opt/pom.xml
@@ -74,7 +74,7 @@
 		<dependency>
 			<groupId>it.unimi.dsi</groupId>
 			<artifactId>fastutil</artifactId>
-			<version>8.2.1</version>
+			<version>8.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
 			<dependency>
 			    <groupId>org.xmlunit</groupId>
 			    <artifactId>xmlunit-core</artifactId>
-			    <version>2.5.1</version>
+			    <version>2.6.2</version>
 			    <scope>test</scope>
 			</dependency>
 			<dependency>
@@ -135,7 +135,7 @@
   						<dependency>
    							<groupId>org.apache.maven.surefire</groupId>
    							<artifactId>surefire-junit47</artifactId>
-   							<version>2.21.0</version>
+   							<version>2.22.1</version>
   						</dependency>
  					</dependencies>
 					<executions>


### PR DESCRIPTION
updated versions of jgrapht's dependencies
Updating the dependencies caused the following warnings:

> [WARNING] /home/jkinable/workspace/javaIDEA/jgrapht/jgrapht/jgrapht-io/src/main/java/org/jgrapht/io/GmlImporter.java:[422,36] org.apache.commons.lang3.StringEscapeUtils in org.apache.commons.lang3 has been deprecated
> [WARNING] /home/jkinable/workspace/javaIDEA/jgrapht/jgrapht/jgrapht-io/src/main/java/org/jgrapht/io/DOTImporter.java:[56,26] org.apache.commons.lang3.text.translate.CharSequenceTranslator in org.apache.commons.lang3.text.translate has been deprecated
> [WARNING] /home/jkinable/workspace/javaIDEA/jgrapht/jgrapht/jgrapht-io/src/main/java/org/jgrapht/io/DOTImporter.java:[56,67] org.apache.commons.lang3.text.translate.AggregateTranslator in org.apache.commons.lang3.text.translate has been deprecated
> [WARNING] /home/jkinable/workspace/javaIDEA/jgrapht/jgrapht/jgrapht-io/src/main/java/org/jgrapht/io/DOTImporter.java:[57,13] org.apache.commons.lang3.text.translate.LookupTranslator in org.apache.commons.lang3.text.translate has been deprecated
> [WARNING] /home/jkinable/workspace/javaIDEA/jgrapht/jgrapht/jgrapht-io/src/main/java/org/jgrapht/io/DOTImporter.java:[835,28] org.apache.commons.lang3.StringEscapeUtils in org.apache.commons.lang3 has been deprecated
> [WARNING] /home/jkinable/workspace/javaIDEA/jgrapht/jgrapht/jgrapht-io/src/main/java/org/jgrapht/io/GmlExporter.java:[120,27] org.apache.commons.lang3.StringEscapeUtils in org.apache.commons.lang3 has been deprecated

These warnings have been fixed as well. In `DOTImporter`, `private static final CharSequenceTranslator UNESCAPE_ID` had to be changed to `private final CharSequenceTranslator UNESCAPE_ID`. 