### PR TITLE
Lemon Graph Format Exporter

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/LemonExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/LemonExporter.java
@@ -27,6 +27,10 @@ import org.jgrapht.Graph;
 
 /**
  * Exports a graph into Lemon graph format (LGF).
+ * 
+ * <p>
+ * This is the custom graph format used in the <a href="https://lemon.cs.elte.hu">Lemon</a> graph
+ * library.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -132,9 +136,8 @@ public class LemonExporter<V, E>
 
     private void exportHeader(PrintWriter out)
     {
-        out.println("@attributes");
-        out.println("Creator" + DELIM + quoted(CREATOR));
-        out.println("Version" + DELIM + quoted(VERSION));
+        out.println("#Creator:" + DELIM + CREATOR);
+        out.println("#Version:" + DELIM + VERSION);
         out.println();
     }
 

--- a/jgrapht-io/src/main/java/org/jgrapht/io/LemonExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/LemonExporter.java
@@ -1,0 +1,182 @@
+/*
+ * (C) Copyright 2018-2018, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.io;
+
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.commons.lang3.StringEscapeUtils;
+import org.jgrapht.Graph;
+
+/**
+ * Exports a graph into Lemon graph format (LGF).
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ *
+ * @author Dimitrios Michail
+ */
+public class LemonExporter<V, E>
+    extends
+    AbstractBaseExporter<V, E>
+    implements
+    GraphExporter<V, E>
+{
+    private static final String CREATOR = "JGraphT Lemon (LGF) Exporter";
+    private static final String VERSION = "1";
+
+    private static final String DELIM = " ";
+    private static final String TAB1 = "\t";
+
+    private final Set<Parameter> parameters;
+
+    /**
+     * Parameters that affect the behavior of the {@link LemonExporter} exporter.
+     */
+    public enum Parameter
+    {
+        /**
+         * If set the exporter outputs edge weights
+         */
+        EXPORT_EDGE_WEIGHTS,
+        /**
+         * If set the exporter escapes all strings as Java strings, otherwise no escaping is
+         * performed.
+         */
+        ESCAPE_STRINGS_AS_JAVA,
+    }
+
+    /**
+     * Constructs a new exporter.
+     */
+    public LemonExporter()
+    {
+        this(new IntegerComponentNameProvider<>());
+    }
+
+    /**
+     * Constructs a new exporter with a given vertex ID provider.
+     *
+     * @param vertexIDProvider for generating vertex IDs. Must not be null.
+     */
+    public LemonExporter(ComponentNameProvider<V> vertexIDProvider)
+    {
+        super(vertexIDProvider);
+        this.parameters = new HashSet<>();
+    }
+
+    @Override
+    public void exportGraph(Graph<V, E> g, Writer writer)
+    {
+        PrintWriter out = new PrintWriter(writer);
+
+        exportHeader(out);
+        exportVertices(out, g);
+        exportEdges(out, g);
+
+        out.flush();
+    }
+
+    /**
+     * Return if a particular parameter of the exporter is enabled
+     * 
+     * @param p the parameter
+     * @return {@code true} if the parameter is set, {@code false} otherwise
+     */
+    public boolean isParameter(Parameter p)
+    {
+        return parameters.contains(p);
+    }
+
+    /**
+     * Set the value of a parameter of the exporter
+     * 
+     * @param p the parameter
+     * @param value the value to set
+     */
+    public void setParameter(Parameter p, boolean value)
+    {
+        if (value) {
+            parameters.add(p);
+        } else {
+            parameters.remove(p);
+        }
+    }
+
+    private String quoted(final String s)
+    {
+        boolean escapeStringAsJava = parameters.contains(Parameter.ESCAPE_STRINGS_AS_JAVA);
+        if (escapeStringAsJava) {
+            return "\"" + StringEscapeUtils.escapeJava(s) + "\"";
+        } else {
+            return "\"" + s + "\"";
+        }
+    }
+
+    private void exportHeader(PrintWriter out)
+    {
+        out.println("@attributes");
+        out.println("Creator" + DELIM + quoted(CREATOR));
+        out.println("Version" + DELIM + quoted(VERSION));
+        out.println();
+    }
+
+    private void exportVertices(PrintWriter out, Graph<V, E> g)
+    {
+        out.println("@nodes");
+        out.println("label");
+        for (V v : g.vertexSet()) {
+            String id = vertexIDProvider.getName(v);
+            String quotedId = quoted(id);
+            out.println(quotedId);
+        }
+        out.println();
+    }
+
+    private void exportEdges(PrintWriter out, Graph<V, E> g)
+    {
+        boolean exportEdgeWeights = parameters.contains(Parameter.EXPORT_EDGE_WEIGHTS);
+
+        out.println("@arcs");
+        out.print(TAB1);
+        out.print(TAB1);
+        if (exportEdgeWeights) {
+            out.println("weight");
+        } else {
+            out.println("-");
+        }
+
+        for (E edge : g.edgeSet()) {
+            String s = vertexIDProvider.getName(g.getEdgeSource(edge));
+            String t = vertexIDProvider.getName(g.getEdgeTarget(edge));
+
+            out.print(quoted(s));
+            out.print(TAB1);
+            out.print(quoted(t));
+            if (exportEdgeWeights) {
+                out.print(TAB1);
+                out.print(Double.toString(g.getEdgeWeight(edge)));
+            }
+            out.println();
+        }
+        out.println();
+    }
+
+}

--- a/jgrapht-io/src/main/java/org/jgrapht/io/LemonExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/LemonExporter.java
@@ -124,13 +124,13 @@ public class LemonExporter<V, E>
         }
     }
 
-    private String quoted(final String s)
+    private String prepareId(final String s)
     {
         boolean escapeStringAsJava = parameters.contains(Parameter.ESCAPE_STRINGS_AS_JAVA);
         if (escapeStringAsJava) {
             return "\"" + StringEscapeUtils.escapeJava(s) + "\"";
         } else {
-            return "\"" + s + "\"";
+            return s;
         }
     }
 
@@ -147,7 +147,7 @@ public class LemonExporter<V, E>
         out.println("label");
         for (V v : g.vertexSet()) {
             String id = vertexIDProvider.getName(v);
-            String quotedId = quoted(id);
+            String quotedId = prepareId(id);
             out.println(quotedId);
         }
         out.println();
@@ -170,9 +170,9 @@ public class LemonExporter<V, E>
             String s = vertexIDProvider.getName(g.getEdgeSource(edge));
             String t = vertexIDProvider.getName(g.getEdgeTarget(edge));
 
-            out.print(quoted(s));
+            out.print(prepareId(s));
             out.print(TAB1);
-            out.print(quoted(t));
+            out.print(prepareId(t));
             if (exportEdgeWeights) {
                 out.print(TAB1);
                 out.print(Double.toString(g.getEdgeWeight(edge)));

--- a/jgrapht-io/src/test/java/org/jgrapht/io/LemonExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/LemonExporterTest.java
@@ -51,14 +51,14 @@ public class LemonExporterTest
             + NL
             + "@nodes" + NL
             + "label" + NL
-            + "\"1\"" + NL
-            + "\"2\"" + NL
-            + "\"3\"" + NL            
+            + "1" + NL
+            + "2" + NL
+            + "3" + NL            
             + NL
             + "@arcs" + NL
             + "\t\t-" + NL
-            + "\"1\"\t\"2\"" + NL
-            + "\"3\"\t\"1\"" + NL            
+            + "1\t2" + NL
+            + "3\t1" + NL            
             + NL;
     
     private static final String UNDIRECTED_DEFAULT_WEIGHTS =
@@ -67,14 +67,14 @@ public class LemonExporterTest
             + NL
             + "@nodes" + NL
             + "label" + NL
-            + "\"1\"" + NL
-            + "\"2\"" + NL
-            + "\"3\"" + NL            
+            + "1" + NL
+            + "2" + NL
+            + "3" + NL            
             + NL
             + "@arcs" + NL
             + "\t\tweight" + NL
-            + "\"1\"\t\"2\"\t1.0" + NL
-            + "\"3\"\t\"1\"\t1.0" + NL            
+            + "1\t2\t1.0" + NL
+            + "3\t1\t1.0" + NL            
             + NL;
     
     private static final String UNDIRECTED_WEIGHTED =
@@ -83,16 +83,32 @@ public class LemonExporterTest
             + NL
             + "@nodes" + NL
             + "label" + NL
-            + "\"1\"" + NL
-            + "\"2\"" + NL
-            + "\"3\"" + NL            
+            + "1" + NL
+            + "2" + NL
+            + "3" + NL            
             + NL
             + "@arcs" + NL
             + "\t\tweight" + NL
-            + "\"1\"\t\"2\"\t2.0" + NL
-            + "\"3\"\t\"1\"\t5.0" + NL            
+            + "1\t2\t2.0" + NL
+            + "3\t1\t5.0" + NL            
             + NL;
 
+    private static final String UNDIRECTED_WITH_ESCAPE =
+        "#Creator: JGraphT Lemon (LGF) Exporter" + NL
+        + "#Version: 1" + NL
+        + NL
+        + "@nodes" + NL
+        + "label" + NL
+        + "\"1\"" + NL
+        + "\"2\"" + NL
+        + "\"3\"" + NL            
+        + NL
+        + "@arcs" + NL
+        + "\t\t-" + NL
+        + "\"1\"\t\"2\"" + NL
+        + "\"3\"\t\"1\"" + NL            
+        + NL;
+    
     @Test
     public void testUndirected()
         throws UnsupportedEncodingException,
@@ -154,6 +170,26 @@ public class LemonExporterTest
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED_WEIGHTED, res);
     }
+    
+    @Test
+    public void testUndirectedWithEscape()
+        throws UnsupportedEncodingException,
+        ExportException
+    {
+        Graph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+
+        LemonExporter<String, DefaultEdge> exporter = new LemonExporter<String, DefaultEdge>();
+        exporter.setParameter(LemonExporter.Parameter.ESCAPE_STRINGS_AS_JAVA, true);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.exportGraph(g, os);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(UNDIRECTED_WITH_ESCAPE, res);
+    }
 
     @Test
     public void testParameters()
@@ -165,6 +201,12 @@ public class LemonExporterTest
         assertTrue(exporter.isParameter(LemonExporter.Parameter.EXPORT_EDGE_WEIGHTS));
         exporter.setParameter(LemonExporter.Parameter.EXPORT_EDGE_WEIGHTS, false);
         assertFalse(exporter.isParameter(LemonExporter.Parameter.EXPORT_EDGE_WEIGHTS));
+        
+        assertFalse(exporter.isParameter(LemonExporter.Parameter.ESCAPE_STRINGS_AS_JAVA));
+        exporter.setParameter(LemonExporter.Parameter.ESCAPE_STRINGS_AS_JAVA, true);
+        assertTrue(exporter.isParameter(LemonExporter.Parameter.ESCAPE_STRINGS_AS_JAVA));
+        exporter.setParameter(LemonExporter.Parameter.ESCAPE_STRINGS_AS_JAVA, false);
+        assertFalse(exporter.isParameter(LemonExporter.Parameter.ESCAPE_STRINGS_AS_JAVA));
     }
 
 }

--- a/jgrapht-io/src/test/java/org/jgrapht/io/LemonExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/LemonExporterTest.java
@@ -1,0 +1,173 @@
+/*
+ * (C) Copyright 2018-2018, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.io;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.UnsupportedEncodingException;
+
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.SimpleWeightedGraph;
+import org.junit.Test;
+
+/**
+ * Tests for {@link LemonExporter}
+ * 
+ * @author Dimitrios Michail
+ */
+public class LemonExporterTest
+{
+    private static final String V1 = "v1";
+    private static final String V2 = "v2";
+    private static final String V3 = "v3";
+
+    private static final String NL = System.getProperty("line.separator");
+
+    // @formatter:off
+    private static final String UNDIRECTED =
+    		"@attributes" + NL
+            + "Creator \"JGraphT Lemon (LGF) Exporter\"" + NL
+            + "Version \"1\"" + NL
+            + NL
+            + "@nodes" + NL
+            + "label" + NL
+            + "\"1\"" + NL
+            + "\"2\"" + NL
+            + "\"3\"" + NL            
+            + NL
+            + "@arcs" + NL
+            + "\t\t-" + NL
+            + "\"1\"\t\"2\"" + NL
+            + "\"3\"\t\"1\"" + NL            
+            + NL;
+    
+    private static final String UNDIRECTED_DEFAULT_WEIGHTS =
+    		"@attributes" + NL
+            + "Creator \"JGraphT Lemon (LGF) Exporter\"" + NL
+            + "Version \"1\"" + NL
+            + NL
+            + "@nodes" + NL
+            + "label" + NL
+            + "\"1\"" + NL
+            + "\"2\"" + NL
+            + "\"3\"" + NL            
+            + NL
+            + "@arcs" + NL
+            + "\t\tweight" + NL
+            + "\"1\"\t\"2\"\t1.0" + NL
+            + "\"3\"\t\"1\"\t1.0" + NL            
+            + NL;
+    
+    private static final String UNDIRECTED_WEIGHTED =
+    		"@attributes" + NL
+            + "Creator \"JGraphT Lemon (LGF) Exporter\"" + NL
+            + "Version \"1\"" + NL
+            + NL
+            + "@nodes" + NL
+            + "label" + NL
+            + "\"1\"" + NL
+            + "\"2\"" + NL
+            + "\"3\"" + NL            
+            + NL
+            + "@arcs" + NL
+            + "\t\tweight" + NL
+            + "\"1\"\t\"2\"\t2.0" + NL
+            + "\"3\"\t\"1\"\t5.0" + NL            
+            + NL;
+
+    @Test
+    public void testUndirected()
+        throws UnsupportedEncodingException,
+        ExportException
+    {
+        Graph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+
+        LemonExporter<String, DefaultEdge> exporter = new LemonExporter<String, DefaultEdge>();
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.exportGraph(g, os);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(UNDIRECTED, res);
+    }
+
+    @Test
+    public void testUnweightedUndirected()
+        throws UnsupportedEncodingException,
+        ExportException
+    {
+        Graph<String, DefaultEdge> g = new SimpleGraph<>(DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+        g.addVertex(V3);
+        g.addEdge(V3, V1);
+
+        LemonExporter<String, DefaultEdge> exporter = new LemonExporter<>();
+        exporter.setParameter(LemonExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.exportGraph(g, os);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(UNDIRECTED_DEFAULT_WEIGHTS, res);
+    }
+
+    @Test
+    public void testWeightedUndirected()
+        throws UnsupportedEncodingException,
+        ExportException
+    {
+        SimpleGraph<String, DefaultWeightedEdge> g =
+            new SimpleWeightedGraph<String, DefaultWeightedEdge>(DefaultWeightedEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addVertex(V3);
+        DefaultWeightedEdge e1 = g.addEdge(V1, V2);
+        g.setEdgeWeight(e1, 2.0);
+        DefaultWeightedEdge e2 = g.addEdge(V3, V1);
+        g.setEdgeWeight(e2, 5.0);
+
+        LemonExporter<String, DefaultWeightedEdge> exporter = new LemonExporter<>();
+        exporter.setParameter(LemonExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.exportGraph(g, os);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(UNDIRECTED_WEIGHTED, res);
+    }
+
+    @Test
+    public void testParameters()
+    {
+        LemonExporter<String, DefaultWeightedEdge> exporter =
+            new LemonExporter<String, DefaultWeightedEdge>();
+        assertFalse(exporter.isParameter(LemonExporter.Parameter.EXPORT_EDGE_WEIGHTS));
+        exporter.setParameter(LemonExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
+        assertTrue(exporter.isParameter(LemonExporter.Parameter.EXPORT_EDGE_WEIGHTS));
+        exporter.setParameter(LemonExporter.Parameter.EXPORT_EDGE_WEIGHTS, false);
+        assertFalse(exporter.isParameter(LemonExporter.Parameter.EXPORT_EDGE_WEIGHTS));
+    }
+
+}

--- a/jgrapht-io/src/test/java/org/jgrapht/io/LemonExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/LemonExporterTest.java
@@ -46,9 +46,8 @@ public class LemonExporterTest
 
     // @formatter:off
     private static final String UNDIRECTED =
-    		"@attributes" + NL
-            + "Creator \"JGraphT Lemon (LGF) Exporter\"" + NL
-            + "Version \"1\"" + NL
+            "#Creator: JGraphT Lemon (LGF) Exporter" + NL
+            + "#Version: 1" + NL
             + NL
             + "@nodes" + NL
             + "label" + NL
@@ -63,9 +62,8 @@ public class LemonExporterTest
             + NL;
     
     private static final String UNDIRECTED_DEFAULT_WEIGHTS =
-    		"@attributes" + NL
-            + "Creator \"JGraphT Lemon (LGF) Exporter\"" + NL
-            + "Version \"1\"" + NL
+            "#Creator: JGraphT Lemon (LGF) Exporter" + NL
+            + "#Version: 1" + NL
             + NL
             + "@nodes" + NL
             + "label" + NL
@@ -80,9 +78,8 @@ public class LemonExporterTest
             + NL;
     
     private static final String UNDIRECTED_WEIGHTED =
-    		"@attributes" + NL
-            + "Creator \"JGraphT Lemon (LGF) Exporter\"" + NL
-            + "Version \"1\"" + NL
+            "#Creator: JGraphT Lemon (LGF) Exporter" + NL
+            + "#Version: 1" + NL
             + NL
             + "@nodes" + NL
             + "label" + NL


### PR DESCRIPTION
A simple Lemon graph format (LGF) exporter. This is the internal format used by the LEMON library. This way someone can export a graph from JGraphT and run an algorithm with Lemon.
----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
