### PR TITLE
Some small optimizations for Edmonds maximum cardinality matchings

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/matching/GreedyMaximumCardinalityMatching.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/matching/GreedyMaximumCardinalityMatching.java
@@ -23,7 +23,7 @@ import org.jgrapht.alg.interfaces.*;
 import java.util.*;
 
 /**
- * A simple class which computes a random, maximum cardinality matching. The algorithm can run in
+ * A simple class which computes a random, maximal cardinality matching. The algorithm can run in
  * two modes: sorted or unsorted. When unsorted, the matching is obtained by iterating through the
  * edges and adding an edge if it doesn't conflict with the edges already in the matching. When
  * sorted, the edges are first sorted by the sum of degrees of their endpoints. After that, the
@@ -44,7 +44,6 @@ public class GreedyMaximumCardinalityMatching<V, E>
     implements
     MatchingAlgorithm<V, E>
 {
-
     private final Graph<V, E> graph;
     private final boolean sort;
 
@@ -88,7 +87,6 @@ public class GreedyMaximumCardinalityMatching<V, E>
                 }
             }
         } else {
-
             for (V v : graph.vertexSet()) {
                 if (matched.contains(v))
                     continue;
@@ -112,7 +110,6 @@ public class GreedyMaximumCardinalityMatching<V, E>
         implements
         Comparator<E>
     {
-
         @Override
         public int compare(E e1, E e2)
         {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/matching/GreedyMaximumCardinalityMatching.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/matching/GreedyMaximumCardinalityMatching.java
@@ -23,7 +23,7 @@ import org.jgrapht.alg.interfaces.*;
 import java.util.*;
 
 /**
- * A simple class which computes a random, maximal cardinality matching. The algorithm can run in
+ * The greedy algorithm for computing a maximum cardinality matching. The algorithm can run in
  * two modes: sorted or unsorted. When unsorted, the matching is obtained by iterating through the
  * edges and adding an edge if it doesn't conflict with the edges already in the matching. When
  * sorted, the edges are first sorted by the sum of degrees of their endpoints. After that, the
@@ -31,9 +31,9 @@ import java.util.*;
  * produce better results, albeit at the cost of some additional computational overhead.
  * <p>
  * Independent of the mode, the resulting matching is maximal, and is therefore guaranteed to
- * contain at least half of the edges that a maximum matching has ($\frac{1}{2}$ approximation).
- * Runtime complexity: $O(m)$ when the edges are not sorted, $O(m+ m \log n)$ otherwise, where $n$
- * is the number of vertices, and m the number of edges.
+ * contain at least half of the edges that a maximum cardinality matching has ($\frac{1}{2}$ approximation).
+ * Runtime complexity: $O(m)$ when the edges are not sorted, $O(m + m \log n)$ otherwise, where $n$
+ * is the number of vertices, and $m$ the number of edges.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type


### PR DESCRIPTION
A few minor optimizations for our maximum cardinality matching. They improve the performance slightly, but not what I was expecting. 

We still need to do some profiling to figure out why it is slow on sparse graphs.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
