### PR TITLE
Added support for edge weights in CSV Exporter/Importer

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/CSVExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/CSVExporter.java
@@ -204,7 +204,7 @@ public class CSVExporter<V, E>
 
     private void exportAsEdgeList(Graph<V, E> g, PrintWriter out)
     {
-        boolean exportEdgeWeights = parameters.contains(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS);
+        boolean exportEdgeWeights = parameters.contains(CSVFormat.Parameter.EDGE_WEIGHTS);
 
         for (E e : g.edgeSet()) {
             exportEscapedField(out, vertexIDProvider.getName(g.getEdgeSource(e)));
@@ -220,7 +220,7 @@ public class CSVExporter<V, E>
 
     private void exportAsAdjacencyList(Graph<V, E> g, PrintWriter out)
     {
-        boolean exportEdgeWeights = parameters.contains(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS);
+        boolean exportEdgeWeights = parameters.contains(CSVFormat.Parameter.EDGE_WEIGHTS);
         
         for (V v : g.vertexSet()) {
             exportEscapedField(out, vertexIDProvider.getName(v));
@@ -241,6 +241,7 @@ public class CSVExporter<V, E>
     {
         boolean exportNodeId = parameters.contains(CSVFormat.Parameter.MATRIX_FORMAT_NODEID);
         boolean exportEdgeWeights =
+            parameters.contains(CSVFormat.Parameter.EDGE_WEIGHTS) || 
             parameters.contains(CSVFormat.Parameter.MATRIX_FORMAT_EDGE_WEIGHTS);
         boolean zeroWhenNoEdge =
             parameters.contains(CSVFormat.Parameter.MATRIX_FORMAT_ZERO_WHEN_NO_EDGE);

--- a/jgrapht-io/src/main/java/org/jgrapht/io/CSVExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/CSVExporter.java
@@ -220,12 +220,18 @@ public class CSVExporter<V, E>
 
     private void exportAsAdjacencyList(Graph<V, E> g, PrintWriter out)
     {
+        boolean exportEdgeWeights = parameters.contains(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS);
+        
         for (V v : g.vertexSet()) {
             exportEscapedField(out, vertexIDProvider.getName(v));
             for (E e : g.outgoingEdgesOf(v)) {
                 V w = Graphs.getOppositeVertex(g, e, v);
                 out.print(delimiter);
                 exportEscapedField(out, vertexIDProvider.getName(w));
+                if (exportEdgeWeights) { 
+                    out.print(delimiter);
+                    exportEscapedField(out, String.valueOf(g.getEdgeWeight(e)));
+                }
             }
             out.println();
         }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/CSVExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/CSVExporter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2017, by Dimitrios Michail and Contributors.
+ * (C) Copyright 2016-2018, by Dimitrios Michail and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -204,10 +204,16 @@ public class CSVExporter<V, E>
 
     private void exportAsEdgeList(Graph<V, E> g, PrintWriter out)
     {
+        boolean exportEdgeWeights = parameters.contains(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS);
+
         for (E e : g.edgeSet()) {
             exportEscapedField(out, vertexIDProvider.getName(g.getEdgeSource(e)));
             out.print(delimiter);
             exportEscapedField(out, vertexIDProvider.getName(g.getEdgeTarget(e)));
+            if (exportEdgeWeights) { 
+                out.print(delimiter);
+                exportEscapedField(out, String.valueOf(g.getEdgeWeight(e)));
+            }
             out.println();
         }
     }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/CSVFormat.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/CSVFormat.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2017, by Dimitrios Michail and Contributors.
+ * (C) Copyright 2016-2018, by Dimitrios Michail and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -59,6 +59,18 @@ package org.jgrapht.io;
  * 
  * which represents a graph with edges: a-&gt;b, b-&gt;a, d-&gt;a, c-&gt;a, c-&gt;b, b-&gt;d,
  * b-&gt;a. Multiple occurrences of the same edge result into a multi-graph.
+ * 
+ * <p>Weighted variants are also valid if {@link CSVFormat.Parameter#EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS} is
+ * set. In this case the target vertex must be followed by the edge weight. The following example illustrates
+ * the weighted variant:
+ * 
+ * <pre>
+ * a,b,2.0
+ * b,a,3.0
+ * d,a,2.0
+ * c,a,1.5,b,2.5
+ * b,d,3.3,a,5.5
+ * </pre>
  * 
  * </li>
  * <li>
@@ -177,6 +189,11 @@ public enum CSVFormat
          * {@link CSVFormat#MATRIX MATRIX} format.
          */
         MATRIX_FORMAT_ZERO_WHEN_NO_EDGE,
+        /**
+         * Whether to import/export edge weights. Only valid for the {@link CSVFormat#EDGE_LIST EDGE_LIST}
+         * and {@link CSVFormat#ADJACENCY_LIST ADJACENCY_LIST} formats.
+         */
+        EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS,
     }
 
 }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/CSVFormat.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/CSVFormat.java
@@ -60,7 +60,7 @@ package org.jgrapht.io;
  * which represents a graph with edges: a-&gt;b, b-&gt;a, d-&gt;a, c-&gt;a, c-&gt;b, b-&gt;d,
  * b-&gt;a. Multiple occurrences of the same edge result into a multi-graph.
  * 
- * <p>Weighted variants are also valid if {@link CSVFormat.Parameter#EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS} is
+ * <p>Weighted variants are also valid if {@link CSVFormat.Parameter#EDGE_WEIGHTS} is
  * set. In this case the target vertex must be followed by the edge weight. The following example illustrates
  * the weighted variant:
  * 
@@ -104,7 +104,7 @@ package org.jgrapht.io;
  * </pre>
  * 
  * <p>
- * Weighted variants are also valid if {@link CSVFormat.Parameter#MATRIX_FORMAT_EDGE_WEIGHTS} is
+ * Weighted variants are also valid if {@link CSVFormat.Parameter#EDGE_WEIGHTS} is
  * set. The above example would then be:
  * 
  * <pre>
@@ -175,6 +175,10 @@ public enum CSVFormat
     public enum Parameter
     {
         /**
+         * Whether to import/export edge weights.
+         */
+        EDGE_WEIGHTS,
+        /**
          * Whether to import/export node ids. Only valid for the {@link CSVFormat#MATRIX MATRIX}
          * format.
          */
@@ -182,18 +186,15 @@ public enum CSVFormat
         /**
          * Whether to import/export edge weights. Only valid for the {@link CSVFormat#MATRIX MATRIX}
          * format.
+         * @deprecated Use {@link #EDGE_WEIGHTS} instead.
          */
+        @Deprecated
         MATRIX_FORMAT_EDGE_WEIGHTS,
         /**
          * Whether the input/output contains zero for missing edges. Only valid for the
          * {@link CSVFormat#MATRIX MATRIX} format.
          */
         MATRIX_FORMAT_ZERO_WHEN_NO_EDGE,
-        /**
-         * Whether to import/export edge weights. Only valid for the {@link CSVFormat#EDGE_LIST EDGE_LIST}
-         * and {@link CSVFormat#ADJACENCY_LIST ADJACENCY_LIST} formats.
-         */
-        EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS,
     }
 
 }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/CSVImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/CSVImporter.java
@@ -272,7 +272,7 @@ public class CSVImporter<V, E>
         public AdjacencyListCSVListener(Graph<V, E> graph)
         {
             super(graph);
-            this.assumeEdgeWeights = parameters.contains(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS);
+            this.assumeEdgeWeights = parameters.contains(CSVFormat.Parameter.EDGE_WEIGHTS);
         }
 
         @Override
@@ -351,7 +351,8 @@ public class CSVImporter<V, E>
             super(graph);
             this.assumeNodeIds = parameters.contains(CSVFormat.Parameter.MATRIX_FORMAT_NODEID);
             this.assumeEdgeWeights =
-                parameters.contains(CSVFormat.Parameter.MATRIX_FORMAT_EDGE_WEIGHTS);
+                parameters.contains(CSVFormat.Parameter.EDGE_WEIGHTS) || 
+                parameters.contains(CSVFormat.Parameter.MATRIX_FORMAT_EDGE_WEIGHTS);;
             this.assumeZeroWhenNoEdge =
                 parameters.contains(CSVFormat.Parameter.MATRIX_FORMAT_ZERO_WHEN_NO_EDGE);
             this.verticesCount = 0;

--- a/jgrapht-io/src/main/java/org/jgrapht/io/CSVImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/CSVImporter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2017, by Dimitrios Michail and Contributors.
+ * (C) Copyright 2016-2018, by Dimitrios Michail and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -267,9 +267,12 @@ public class CSVImporter<V, E>
         extends
         RowCSVListener
     {
+        private boolean assumeEdgeWeights;
+        
         public AdjacencyListCSVListener(Graph<V, E> graph)
         {
             super(graph);
+            this.assumeEdgeWeights = parameters.contains(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS);
         }
 
         @Override
@@ -287,9 +290,13 @@ public class CSVImporter<V, E>
                 graph.addVertex(source);
             }
             row.remove(0);
-
-            // remaining are targets
-            for (String key : row) {
+            
+            // remaining are targets (if weighted pairs of target-weight)
+            int step = assumeEdgeWeights? 2 : 1;
+            
+            for(int i = 0; i < row.size(); i += step) { 
+                String key = row.get(i);
+                
                 if (key.isEmpty()) {
                     throw new ParseCancellationException("Target vertex cannot be empty");
                 }
@@ -300,11 +307,23 @@ public class CSVImporter<V, E>
                     vertices.put(key, target);
                     graph.addVertex(target);
                 }
+                
+                double weight = Graph.DEFAULT_EDGE_WEIGHT;
+                if (assumeEdgeWeights) { 
+                    try {
+                        weight = Double.parseDouble(row.get(i+1));
+                    } catch (NumberFormatException nfe) {
+                        throw new ParseCancellationException("Failed to parse edge weight");
+                    }
+                }
 
                 try {
                     String label = "e_" + source + "_" + target;
                     E e = edgeProvider.buildEdge(source, target, label, new HashMap<>());
                     graph.addEdge(source, target, e);
+                    if (assumeEdgeWeights) { 
+                        graph.setEdgeWeight(e, weight);
+                    }
                 } catch (IllegalArgumentException e) {
                     throw new ParseCancellationException(
                         "Provided graph does not support input: " + e.getMessage(), e);

--- a/jgrapht-io/src/test/java/org/jgrapht/io/CSVExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/CSVExporterTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2017, by Dimitrios Michail and Contributors.
+ * (C) Copyright 2016-2018, by Dimitrios Michail and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -26,7 +26,7 @@ import java.io.*;
 import static org.junit.Assert.*;
 
 /**
- * .
+ * Tests for {@link CSVExporter}.
  * 
  * @author Dimitrios Michail
  */
@@ -71,11 +71,18 @@ public class CSVExporterTest
         + "5;4;1;2;3;4;5;5" + NL;
     
     private static final String DIRECTED_ADJACENCY_LIST =
-        "1;2;3" + NL
+          "1;2;3" + NL
         + "2" + NL
         + "3;1;4" + NL
         + "4;5" + NL
         + "5;1;2;3;4;5;5" + NL;
+    
+    private static final String DIRECTED_WEIGHTED_ADJACENCY_LIST =
+          "1;2;3.3;3;3.3" + NL
+        + "2" + NL
+        + "3;1;3.3;4;3.3" + NL
+        + "4;5;3.3" + NL
+        + "5;1;3.3;2;3.3;3;3.3;4;3.3;5;3.3;5;3.3" + NL;
     
     private static final String DIRECTED_MATRIX_NODEID =
           ";1;2;3;4;5" + NL
@@ -229,6 +236,36 @@ public class CSVExporterTest
         StringWriter w = new StringWriter();
         exporter.exportGraph(g, w);
         assertEquals(DIRECTED_ADJACENCY_LIST, w.toString());
+    }
+    
+    @Test
+    public void testDirectedWeightedAdjacencyList()
+    {
+        Graph<Integer, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+        g = new AsWeightedGraph<>(g, e -> 3.3, false, false);
+        g.addVertex(1);
+        g.addVertex(2);
+        g.addVertex(3);
+        g.addVertex(4);
+        g.addVertex(5);
+        g.addEdge(1, 2);
+        g.addEdge(1, 3);
+        g.addEdge(3, 1);
+        g.addEdge(3, 4);
+        g.addEdge(4, 5);
+        g.addEdge(5, 1);
+        g.addEdge(5, 2);
+        g.addEdge(5, 3);
+        g.addEdge(5, 4);
+        g.addEdge(5, 5);
+        g.addEdge(5, 5);
+
+        CSVExporter<Integer, DefaultEdge> exporter =
+            new CSVExporter<>(nameProvider, CSVFormat.ADJACENCY_LIST, ';');
+        StringWriter w = new StringWriter();
+        exporter.setParameter(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS, true);
+        exporter.exportGraph(g, w);
+        assertEquals(DIRECTED_WEIGHTED_ADJACENCY_LIST, w.toString());
     }
 
     @Test

--- a/jgrapht-io/src/test/java/org/jgrapht/io/CSVExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/CSVExporterTest.java
@@ -36,26 +36,8 @@ public class CSVExporterTest
     // ---------------------------------------------
 
     private static final String NL = System.getProperty("line.separator");
-
-    private static ComponentNameProvider<Integer> nameProvider =
-        new ComponentNameProvider<Integer>()
-        {
-            @Override
-            public String getName(Integer vertex)
-            {
-                return String.valueOf(vertex);
-            }
-        };
-
-    private static ComponentNameProvider<String> stringNameProvider =
-        new ComponentNameProvider<String>()
-        {
-            @Override
-            public String getName(String vertex)
-            {
-                return vertex;
-            }
-        };
+    private static final ComponentNameProvider<Integer> nameProvider = v->String.valueOf(v);
+    private static final ComponentNameProvider<String> stringNameProvider = v->v;
 
     // @formatter:off
     private static final String UNDIRECTED_EDGE_LIST =
@@ -72,6 +54,14 @@ public class CSVExporterTest
         + "3;4" + NL
         + "4;5" + NL
         + "5;1" + NL;
+
+    private static final String DIRECTED_WEIGHTED_EDGE_LIST =
+          "1;2;2.0" + NL
+        + "1;3;2.0" + NL
+        + "3;1;2.0" + NL
+        + "3;4;2.0" + NL
+        + "4;5;2.0" + NL
+        + "5;1;2.0" + NL;    
     
     private static final String UNDIRECTED_ADJACENCY_LIST =
           "1;2;3;3;5" + NL
@@ -137,7 +127,7 @@ public class CSVExporterTest
       + "\"fred\n\"\"21\"\"\";\"who;;\"" +NL
       + "\"who;;\";'john doe'" + NL;
     
-    //     // @formatter:on
+    // @formatter:on
 
     // ~ Methods
     // ----------------------------------------------------------------
@@ -186,6 +176,31 @@ public class CSVExporterTest
         StringWriter w = new StringWriter();
         exporter.exportGraph(g, w);
         assertEquals(DIRECTED_EDGE_LIST, w.toString());
+    }
+
+    @Test
+    public void testDirectedWeightedEdgeList()
+    {
+        Graph<Integer, DefaultEdge> g = new SimpleDirectedGraph<>(DefaultEdge.class);
+        g = new AsWeightedGraph<>(g, e -> 2.0 , false, false);
+        g.addVertex(1);
+        g.addVertex(2);
+        g.addVertex(3);
+        g.addVertex(4);
+        g.addVertex(5);
+        g.addEdge(1, 2);
+        g.addEdge(1, 3);
+        g.addEdge(3, 1);
+        g.addEdge(3, 4);
+        g.addEdge(4, 5);
+        g.addEdge(5, 1);
+
+        CSVExporter<Integer, DefaultEdge> exporter =
+            new CSVExporter<>(nameProvider, CSVFormat.EDGE_LIST, ';');
+        exporter.setParameter(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS, true);
+        StringWriter w = new StringWriter();
+        exporter.exportGraph(g, w);
+        assertEquals(DIRECTED_WEIGHTED_EDGE_LIST, w.toString());
     }
 
     @Test

--- a/jgrapht-io/src/test/java/org/jgrapht/io/CSVExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/CSVExporterTest.java
@@ -204,7 +204,7 @@ public class CSVExporterTest
 
         CSVExporter<Integer, DefaultEdge> exporter =
             new CSVExporter<>(nameProvider, CSVFormat.EDGE_LIST, ';');
-        exporter.setParameter(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS, true);
+        exporter.setParameter(CSVFormat.Parameter.EDGE_WEIGHTS, true);
         StringWriter w = new StringWriter();
         exporter.exportGraph(g, w);
         assertEquals(DIRECTED_WEIGHTED_EDGE_LIST, w.toString());
@@ -263,7 +263,7 @@ public class CSVExporterTest
         CSVExporter<Integer, DefaultEdge> exporter =
             new CSVExporter<>(nameProvider, CSVFormat.ADJACENCY_LIST, ';');
         StringWriter w = new StringWriter();
-        exporter.setParameter(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS, true);
+        exporter.setParameter(CSVFormat.Parameter.EDGE_WEIGHTS, true);
         exporter.exportGraph(g, w);
         assertEquals(DIRECTED_WEIGHTED_ADJACENCY_LIST, w.toString());
     }
@@ -435,7 +435,7 @@ public class CSVExporterTest
         CSVExporter<Integer, DefaultWeightedEdge> exporter =
             new CSVExporter<>(nameProvider, CSVFormat.MATRIX, ';');
         exporter.setParameter(CSVFormat.Parameter.MATRIX_FORMAT_ZERO_WHEN_NO_EDGE, true);
-        exporter.setParameter(CSVFormat.Parameter.MATRIX_FORMAT_EDGE_WEIGHTS, true);
+        exporter.setParameter(CSVFormat.Parameter.EDGE_WEIGHTS, true);
         StringWriter w = new StringWriter();
         exporter.exportGraph(g, w);
         assertEquals(DIRECTED_MATRIX_NO_NODEID_ZERO_NO_EDGE_WEIGHTED, w.toString());
@@ -467,7 +467,7 @@ public class CSVExporterTest
 
         CSVExporter<Integer, DefaultWeightedEdge> exporter =
             new CSVExporter<>(nameProvider, CSVFormat.MATRIX, ';');
-        exporter.setParameter(CSVFormat.Parameter.MATRIX_FORMAT_EDGE_WEIGHTS, true);
+        exporter.setParameter(CSVFormat.Parameter.EDGE_WEIGHTS, true);
         StringWriter w = new StringWriter();
         exporter.exportGraph(g, w);
         assertEquals(DIRECTED_MATRIX_NO_NODEID_WEIGHTED, w.toString());

--- a/jgrapht-io/src/test/java/org/jgrapht/io/CSVImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/CSVImporterTest.java
@@ -63,7 +63,7 @@ public class CSVImporterTest
         CSVImporter<String, E> importer = createImporter(g, format, delimiter);
         
         if ((format == CSVFormat.EDGE_LIST || format == CSVFormat.ADJACENCY_LIST) && weighted) { 
-            importer.setParameter(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS, true);
+            importer.setParameter(CSVFormat.Parameter.EDGE_WEIGHTS, true);
         }
         
         importer.importGraph(g, new StringReader(input));
@@ -275,7 +275,7 @@ public class CSVImporterTest
 
         CSVImporter<String, DefaultWeightedEdge> importer =
             createImporter(g, CSVFormat.MATRIX, ';');
-        importer.setParameter(CSVFormat.Parameter.MATRIX_FORMAT_EDGE_WEIGHTS, true);
+        importer.setParameter(CSVFormat.Parameter.EDGE_WEIGHTS, true);
         importer.setParameter(CSVFormat.Parameter.MATRIX_FORMAT_ZERO_WHEN_NO_EDGE, true);
         importer.importGraph(g, new StringReader(input));
 
@@ -326,7 +326,7 @@ public class CSVImporterTest
 
         CSVImporter<String, DefaultWeightedEdge> importer =
             createImporter(g, CSVFormat.MATRIX, ',');
-        importer.setParameter(CSVFormat.Parameter.MATRIX_FORMAT_EDGE_WEIGHTS, true);
+        importer.setParameter(CSVFormat.Parameter.EDGE_WEIGHTS, true);
         importer.importGraph(g, new StringReader(input));
 
         assertEquals(5, g.vertexSet().size());
@@ -540,7 +540,7 @@ public class CSVImporterTest
             createImporter(g, CSVFormat.MATRIX, ';');
         importer.setParameter(CSVFormat.Parameter.MATRIX_FORMAT_NODEID, true);
         importer.setParameter(CSVFormat.Parameter.MATRIX_FORMAT_ZERO_WHEN_NO_EDGE, true);
-        importer.setParameter(CSVFormat.Parameter.MATRIX_FORMAT_EDGE_WEIGHTS, true);
+        importer.setParameter(CSVFormat.Parameter.EDGE_WEIGHTS, true);
         importer.importGraph(g, new StringReader(input));
 
         assertEquals(5, g.vertexSet().size());

--- a/jgrapht-io/src/test/java/org/jgrapht/io/CSVImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/CSVImporterTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2017, by Dimitrios Michail and Contributors.
+ * (C) Copyright 2016-2018, by Dimitrios Michail and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -61,6 +61,11 @@ public class CSVImporterTest
         }
 
         CSVImporter<String, E> importer = createImporter(g, format, delimiter);
+        
+        if ((format == CSVFormat.EDGE_LIST || format == CSVFormat.ADJACENCY_LIST) && weighted) { 
+            importer.setParameter(CSVFormat.Parameter.EDGE_OR_ADJACENCY_LIST_EDGE_WEIGHTS, true);
+        }
+        
         importer.importGraph(g, new StringReader(input));
 
         return g;
@@ -90,6 +95,36 @@ public class CSVImporterTest
         assertTrue(g.containsEdge("2", "3"));
         assertTrue(g.containsEdge("3", "4"));
         assertTrue(g.containsEdge("4", "1"));
+    }
+    
+    @Test
+    public void testEdgeListDirectedWeighted()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "1,2,1.0\n"
+                     + "2,3,2.0\n"
+                     + "3,4,3.0\n"
+                     + "4,1,4.0\n";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g =
+            readGraph(input, CSVFormat.EDGE_LIST, ',', DefaultEdge.class, true, true);
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(4, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsVertex("4"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertEquals(1.0, g.getEdgeWeight(g.getEdge("1", "2")), 1e-9);
+        assertTrue(g.containsEdge("2", "3"));
+        assertEquals(2.0, g.getEdgeWeight(g.getEdge("2", "3")), 1e-9);
+        assertTrue(g.containsEdge("3", "4"));
+        assertEquals(3.0, g.getEdgeWeight(g.getEdge("3", "4")), 1e-9);
+        assertTrue(g.containsEdge("4", "1"));
+        assertEquals(4.0, g.getEdgeWeight(g.getEdge("4", "1")), 1e-9);
     }
 
     @Test
@@ -150,6 +185,50 @@ public class CSVImporterTest
         assertTrue(g.containsEdge("4", "1"));
         assertTrue(g.containsEdge("4", "5"));
         assertTrue(g.containsEdge("4", "6"));
+    }
+    
+    @Test
+    public void testAdjacencyListDirectedWeightedWithSemicolon()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "1;2;2.1;3;3.1;4;4.1\n"
+                     + "2;3;3.1\n"
+                     + "3;4;4.1;5;5.1;6;6.1\n"
+                     + "4;1;1.1;5;5.1;6;6.1\n";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g =
+            readGraph(input, CSVFormat.ADJACENCY_LIST, ';', DefaultEdge.class, true, true);
+
+        assertEquals(6, g.vertexSet().size());
+        assertEquals(10, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsVertex("4"));
+        assertTrue(g.containsVertex("5"));
+        assertTrue(g.containsVertex("6"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertEquals(2.1, g.getEdgeWeight(g.getEdge("1", "2")), 1e-9);
+        assertTrue(g.containsEdge("1", "3"));
+        assertEquals(3.1, g.getEdgeWeight(g.getEdge("1", "3")), 1e-9);
+        assertTrue(g.containsEdge("1", "4"));
+        assertEquals(4.1, g.getEdgeWeight(g.getEdge("1", "4")), 1e-9);
+        assertTrue(g.containsEdge("2", "3"));
+        assertEquals(3.1, g.getEdgeWeight(g.getEdge("2", "3")), 1e-9);
+        assertTrue(g.containsEdge("3", "4"));
+        assertEquals(4.1, g.getEdgeWeight(g.getEdge("3", "4")), 1e-9);
+        assertTrue(g.containsEdge("3", "5"));
+        assertEquals(5.1, g.getEdgeWeight(g.getEdge("3", "5")), 1e-9);
+        assertTrue(g.containsEdge("3", "6"));
+        assertEquals(6.1, g.getEdgeWeight(g.getEdge("3", "6")), 1e-9);
+        assertTrue(g.containsEdge("4", "1"));
+        assertEquals(1.1, g.getEdgeWeight(g.getEdge("4", "1")), 1e-9);
+        assertTrue(g.containsEdge("4", "5"));
+        assertEquals(5.1, g.getEdgeWeight(g.getEdge("4", "5")), 1e-9);
+        assertTrue(g.containsEdge("4", "6"));
+        assertEquals(6.1, g.getEdgeWeight(g.getEdge("4", "6")), 1e-9);
     }
 
     @Test


### PR DESCRIPTION
Added support for exporting and importing edge weights in our CSV exporter/importer.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
