### PR TITLE
DOT graph and HTML-Like attributes

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
@@ -326,7 +326,7 @@ public class DOTExporter<V, E>
             }
         }
         if (labelName != null) {
-            out.print("label=\"" + escapeDoubleQuotes(labelName) + "\" ");
+            renderAttribute(out, "label", labelName);
         }
         if (attributes != null) {
             for (Map.Entry<String, Attribute> entry : attributes.entrySet()) {
@@ -335,10 +335,21 @@ public class DOTExporter<V, E>
                     // already handled by special case above
                     continue;
                 }
-                out.print(name + "=\"" + escapeDoubleQuotes(entry.getValue().getValue()) + "\" ");
+                renderAttribute(out, name, entry.getValue().getValue());
             }
         }
         out.print("]");
+    }
+
+    private void renderAttribute(PrintWriter out, String attrName, String attrValue)
+    {
+        out.print(attrName + "=");
+        if (attrValue.startsWith("<") && attrValue.endsWith(">")) {
+            out.print(attrValue);
+        } else {
+            out.print("\"" + escapeDoubleQuotes(attrValue) + "\"");
+        }
+        out.print(" ");
     }
 
     private static String escapeDoubleQuotes(String labelName)

--- a/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
@@ -182,6 +182,21 @@ public class DOTExporterTest
     }
 
     @Test
+    public void testHtmlNodeLabel()
+    {
+        DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(
+            new StringComponentNameProvider<>(), vertex -> "<<b>html label</b>>", null);
+
+        StringWriter outputWriter = new StringWriter();
+
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("myVertex");
+        exporter.exportGraph(graph, outputWriter);
+
+        assertThat(outputWriter.toString(), containsString("label=<<b>html label</b>>"));
+    }
+
+    @Test
     public void testDifferentGraphID()
         throws UnsupportedEncodingException,
         ExportException


### PR DESCRIPTION
Fixes support of HTML-like attribute in DOT graph export

see #698

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
