### PR TITLE
DOT graph and HTML-Like attributes, alternative

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/AttributeType.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/AttributeType.java
@@ -30,6 +30,7 @@ public enum AttributeType
     FLOAT("float"),
     DOUBLE("double"),
     STRING("string"),
+    HTML("html"),
     UNKNOWN("unknown");
 
     private String name;
@@ -70,6 +71,8 @@ public enum AttributeType
             return DOUBLE;
         case "string":
             return STRING;
+        case "html":
+            return HTML;
         case "unknown":
             return UNKNOWN;
         }

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
@@ -17,6 +17,7 @@
  */
 package org.jgrapht.io;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jgrapht.*;
 
 import java.io.*;
@@ -319,14 +320,20 @@ public class DOTExporter<V, E>
             return;
         }
         out.print(" [ ");
-        if (labelName == null) {
-            Attribute labelAttribute = attributes.get("label");
-            if (labelAttribute != null) {
-                labelName = labelAttribute.getValue();
+        final Attribute labelAttribute;
+        if (labelName == null && attributes.containsKey("label")) {
+            labelAttribute = attributes.get("label");
+        } else if (labelName != null) {
+            if (labelName.startsWith("<") && labelName.endsWith(">")) {
+                labelAttribute = new DefaultAttribute<>(StringUtils.substring(labelName, 1, -1), AttributeType.HTML);
+            } else {
+                labelAttribute = DefaultAttribute.createAttribute(labelName);
             }
+        } else {
+            labelAttribute = null;
         }
-        if (labelName != null) {
-            out.print("label=\"" + escapeDoubleQuotes(labelName) + "\" ");
+        if (labelAttribute != null) {
+             renderAttribute(out, "label", labelAttribute);
         }
         if (attributes != null) {
             for (Map.Entry<String, Attribute> entry : attributes.entrySet()) {
@@ -335,10 +342,22 @@ public class DOTExporter<V, E>
                     // already handled by special case above
                     continue;
                 }
-                out.print(name + "=\"" + escapeDoubleQuotes(entry.getValue().getValue()) + "\" ");
+                renderAttribute(out, name, entry.getValue());
             }
         }
         out.print("]");
+    }
+
+    private void renderAttribute(PrintWriter out, String attrName, Attribute attribute)
+    {
+        out.print(attrName + "=");
+        final String attrValue = attribute.getValue();
+        if (AttributeType.HTML.equals(attribute.getType())) {
+            out.print("<" + attrValue + ">");
+        } else {
+            out.print("\"" + escapeDoubleQuotes(attrValue) + "\"");
+        }
+        out.print(" ");
     }
 
     private static String escapeDoubleQuotes(String labelName)

--- a/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/DOTExporter.java
@@ -321,16 +321,10 @@ public class DOTExporter<V, E>
         }
         out.print(" [ ");
         final Attribute labelAttribute;
-        if (labelName == null && attributes.containsKey("label")) {
-            labelAttribute = attributes.get("label");
-        } else if (labelName != null) {
-            if (labelName.startsWith("<") && labelName.endsWith(">")) {
-                labelAttribute = new DefaultAttribute<>(StringUtils.substring(labelName, 1, -1), AttributeType.HTML);
-            } else {
-                labelAttribute = DefaultAttribute.createAttribute(labelName);
-            }
+        if (labelName != null) {
+            labelAttribute = DefaultAttribute.createAttribute(labelName);
         } else {
-            labelAttribute = null;
+            labelAttribute = attributes.get("label");
         }
         if (labelAttribute != null) {
              renderAttribute(out, "label", labelAttribute);

--- a/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
@@ -182,6 +182,41 @@ public class DOTExporterTest
     }
 
     @Test
+    public void testNodeHtmlLabel()
+    {
+        DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(
+            new StringComponentNameProvider<>(), vertex -> "<<b>html label</b>>", null);
+
+        StringWriter outputWriter = new StringWriter();
+
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("myVertex");
+        exporter.exportGraph(graph, outputWriter);
+
+        assertThat(outputWriter.toString(), containsString("label=<<b>html label</b>>"));
+    }
+
+    @Test
+    public void testNodeHtmlLabelFromAttribute()
+    {
+        DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(
+            new StringComponentNameProvider<>(), vertex -> null, null,
+                vertex -> {
+                    final HashMap<String, Attribute> attrs = new HashMap<>();
+                    attrs.put("label", new DefaultAttribute<>("<b>html label</b>", AttributeType.HTML));
+                    return attrs;
+                }, null);
+
+        StringWriter outputWriter = new StringWriter();
+
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("myVertex");
+        exporter.exportGraph(graph, outputWriter);
+
+        assertThat(outputWriter.toString(), containsString("label=<<b>html label</b>>"));
+    }
+
+    @Test
     public void testDifferentGraphID()
         throws UnsupportedEncodingException,
         ExportException

--- a/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/DOTExporterTest.java
@@ -193,7 +193,7 @@ public class DOTExporterTest
         graph.addVertex("myVertex");
         exporter.exportGraph(graph, outputWriter);
 
-        assertThat(outputWriter.toString(), containsString("label=<<b>html label</b>>"));
+        assertThat(outputWriter.toString(), containsString("label=\"<<b>html label</b>>\""));
     }
 
     @Test


### PR DESCRIPTION
Fixes support of HTML-like attribute in DOT graph export.

This is an alternative to #705 as it introduce a new `AttributeType.HTML`. More details in #698

<!-- describe the changes you have made here: what, why, …
     Link issues by using the following pattern: [#333](https://github.com/jgrapht/jgrapht/issues/333).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
