### PR TITLE
Specifics hash lookups optimization

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -451,7 +451,7 @@ public abstract class AbstractBaseGraph<V, E>
         E e = getEdge(sourceVertex, targetVertex);
 
         if (e != null) {
-            specifics.removeEdgeFromTouchingVertices(e);
+            specifics.removeEdgeFromTouchingVertices(sourceVertex, targetVertex, e);
             intrusiveEdgesSpecifics.remove(e);
         }
 
@@ -465,7 +465,9 @@ public abstract class AbstractBaseGraph<V, E>
     public boolean removeEdge(E e)
     {
         if (containsEdge(e)) {
-            specifics.removeEdgeFromTouchingVertices(e);
+            V sourceVertex = getEdgeSource(e);
+            V targetVertex = getEdgeTarget(e);
+            specifics.removeEdgeFromTouchingVertices(sourceVertex, targetVertex, e);
             intrusiveEdgesSpecifics.remove(e);
             return true;
         } else {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -226,7 +226,7 @@ public abstract class AbstractBaseGraph<V, E>
 
         if (!type.isAllowingMultipleEdges()) {
             E e = specifics
-                .computeEdgeToTouchingVerticesIfAbsent(sourceVertex, targetVertex, edgeSupplier);
+                .createEdgeToTouchingVerticesIfAbsent(sourceVertex, targetVertex, edgeSupplier);
             if (e != null && intrusiveEdgesSpecifics.add(e, sourceVertex, targetVertex)) {
                 return e;
             }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -116,12 +116,14 @@ public abstract class AbstractBaseGraph<V, E>
 
         this.graphSpecificsStrategy =
             Objects.requireNonNull(graphSpecificsStrategy, GRAPH_SPECIFICS_STRATEGY_REQUIRED);
-        this.specifics = Objects.requireNonNull(
-            graphSpecificsStrategy.getSpecificsFactory().apply(this, type),
-            GRAPH_SPECIFICS_MUST_NOT_BE_NULL);
-        this.intrusiveEdgesSpecifics = Objects.requireNonNull(
-            graphSpecificsStrategy.getIntrusiveEdgesSpecificsFactory().apply(type),
-            GRAPH_SPECIFICS_MUST_NOT_BE_NULL);
+        this.specifics = Objects
+            .requireNonNull(
+                graphSpecificsStrategy.getSpecificsFactory().apply(this, type),
+                GRAPH_SPECIFICS_MUST_NOT_BE_NULL);
+        this.intrusiveEdgesSpecifics = Objects
+            .requireNonNull(
+                graphSpecificsStrategy.getIntrusiveEdgesSpecificsFactory().apply(type),
+                GRAPH_SPECIFICS_MUST_NOT_BE_NULL);
     }
 
     /**
@@ -214,10 +216,6 @@ public abstract class AbstractBaseGraph<V, E>
         assertVertexExist(sourceVertex);
         assertVertexExist(targetVertex);
 
-        if (!type.isAllowingMultipleEdges() && containsEdge(sourceVertex, targetVertex)) {
-            return null;
-        }
-
         if (!type.isAllowingSelfLoops() && sourceVertex.equals(targetVertex)) {
             throw new IllegalArgumentException(LOOPS_NOT_ALLOWED);
         }
@@ -226,10 +224,18 @@ public abstract class AbstractBaseGraph<V, E>
             throw new UnsupportedOperationException(THE_GRAPH_CONTAINS_NO_EDGE_SUPPLIER);
         }
 
-        E e = edgeSupplier.get();
-        if (intrusiveEdgesSpecifics.add(e, sourceVertex, targetVertex)) {
-            specifics.addEdgeToTouchingVertices(e);
-            return e;
+        if (!type.isAllowingMultipleEdges()) {
+            E e = specifics
+                .computeEdgeToTouchingVerticesIfAbsent(sourceVertex, targetVertex, edgeSupplier);
+            if (e != null && intrusiveEdgesSpecifics.add(e, sourceVertex, targetVertex)) {
+                return e;
+            }
+        } else {
+            E e = edgeSupplier.get();
+            if (intrusiveEdgesSpecifics.add(e, sourceVertex, targetVertex)) {
+                specifics.addEdgeToTouchingVertices(sourceVertex, targetVertex, e);
+                return e;
+            }
         }
         return null;
     }
@@ -247,20 +253,17 @@ public abstract class AbstractBaseGraph<V, E>
         assertVertexExist(sourceVertex);
         assertVertexExist(targetVertex);
 
-        if (!type.isAllowingMultipleEdges() && containsEdge(sourceVertex, targetVertex)) {
-            return false;
-        }
-
         if (!type.isAllowingSelfLoops() && sourceVertex.equals(targetVertex)) {
             throw new IllegalArgumentException(LOOPS_NOT_ALLOWED);
         }
 
-        if (intrusiveEdgesSpecifics.add(e, sourceVertex, targetVertex)) {
-            specifics.addEdgeToTouchingVertices(e);
-            return true;
+        if (!type.isAllowingMultipleEdges()) {
+            return specifics.addEdgeToTouchingVerticesIfAbsent(sourceVertex, targetVertex, e)
+                && intrusiveEdgesSpecifics.add(e, sourceVertex, targetVertex);
+        } else {
+            return specifics.addEdgeToTouchingVertices(sourceVertex, targetVertex, e)
+                && intrusiveEdgesSpecifics.add(e, sourceVertex, targetVertex);
         }
-
-        return false;
     }
 
     @Override

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -264,7 +264,7 @@ public class DirectedSpecifics<V, E>
 
     /**
      * {@inheritDoc}
-     * @deprecated Use method {@link #removeEdgeToTouchingVertices(Object, Object, Object)} instead.
+     * @deprecated Use method {@link #removeEdgeFromTouchingVertices(Object, Object, Object)} instead.
      */
     @Override
     @Deprecated

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -134,6 +134,16 @@ public class DirectedSpecifics<V, E>
         return null;
     }
 
+    @Override
+    @Deprecated
+    public void addEdgeToTouchingVertices(E e)
+    {
+        V source = graph.getEdgeSource(e);
+        V target = graph.getEdgeTarget(e);
+        getEdgeContainer(source).addOutgoingEdge(e);
+        getEdgeContainer(target).addIncomingEdge(e);
+    }
+    
     /**
      * {@inheritDoc}
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -174,7 +174,7 @@ public class DirectedSpecifics<V, E>
     }
 
     @Override
-    public E computeEdgeToTouchingVerticesIfAbsent(
+    public E createEdgeToTouchingVerticesIfAbsent(
         V sourceVertex, V targetVertex, Supplier<E> edgeSupplier)
     {
         // lookup for edge with same source and target
@@ -264,8 +264,10 @@ public class DirectedSpecifics<V, E>
 
     /**
      * {@inheritDoc}
+     * @deprecated Use method {@link #removeEdgeToTouchingVertices(Object, Object, Object)} instead.
      */
     @Override
+    @Deprecated
     public void removeEdgeFromTouchingVertices(E e)
     {
         V source = graph.getEdgeSource(e);
@@ -273,6 +275,16 @@ public class DirectedSpecifics<V, E>
 
         getEdgeContainer(source).removeOutgoingEdge(e);
         getEdgeContainer(target).removeIncomingEdge(e);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeEdgeFromTouchingVertices(V sourceVertex, V targetVertex, E e)
+    {
+        getEdgeContainer(sourceVertex).removeOutgoingEdge(e);
+        getEdgeContainer(targetVertex).removeIncomingEdge(e);
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import org.jgrapht.Graph;
 import org.jgrapht.graph.EdgeSetFactory;
@@ -137,13 +138,49 @@ public class DirectedSpecifics<V, E>
      * {@inheritDoc}
      */
     @Override
-    public void addEdgeToTouchingVertices(E e)
+    public boolean addEdgeToTouchingVertices(V sourceVertex, V targetVertex, E e)
     {
-        V source = graph.getEdgeSource(e);
-        V target = graph.getEdgeTarget(e);
+        getEdgeContainer(sourceVertex).addOutgoingEdge(e);
+        getEdgeContainer(targetVertex).addIncomingEdge(e);
+        return true;
+    }
 
-        getEdgeContainer(source).addOutgoingEdge(e);
-        getEdgeContainer(target).addIncomingEdge(e);
+    @Override
+    public boolean addEdgeToTouchingVerticesIfAbsent(V sourceVertex, V targetVertex, E e)
+    {
+        // lookup for edge with same source and target
+        DirectedEdgeContainer<V, E> ec = getEdgeContainer(sourceVertex);
+        for (E outEdge : ec.outgoing) {
+            if (graph.getEdgeTarget(outEdge).equals(targetVertex)) {
+                return false;
+            }
+        }
+
+        // add
+        ec.addOutgoingEdge(e);
+        getEdgeContainer(targetVertex).addIncomingEdge(e);
+
+        return true;
+    }
+
+    @Override
+    public E computeEdgeToTouchingVerticesIfAbsent(
+        V sourceVertex, V targetVertex, Supplier<E> edgeSupplier)
+    {
+        // lookup for edge with same source and target
+        DirectedEdgeContainer<V, E> ec = getEdgeContainer(sourceVertex);
+        for (E e : ec.outgoing) {
+            if (graph.getEdgeTarget(e).equals(targetVertex)) {
+                return null;
+            }
+        }
+
+        // create and add
+        E e = edgeSupplier.get();
+        ec.addOutgoingEdge(e);
+        getEdgeContainer(targetVertex).addIncomingEdge(e);
+
+        return e;
     }
 
     /**
@@ -246,4 +283,5 @@ public class DirectedSpecifics<V, E>
 
         return ec;
     }
+
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -213,9 +213,8 @@ public class DirectedSpecifics<V, E>
 
         if (graph.getType().isAllowingSelfLoops()) {
             for (E e : getEdgeContainer(vertex).outgoing) {
-                V source = graph.getEdgeSource(e);
                 V target = graph.getEdgeTarget(e);
-                if (!source.equals(target)) {
+                if (!vertex.equals(target)) {
                     inAndOut.add(e);
                 }
             }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
@@ -109,22 +109,27 @@ public class FastLookupDirectedSpecifics<V, E>
     @Override
     public boolean addEdgeToTouchingVerticesIfAbsent(V sourceVertex, V targetVertex, E e)
     {
-        if (!super.addEdgeToTouchingVerticesIfAbsent(sourceVertex, targetVertex, e)) {
+        // first lookup using our own index
+        E edge = getEdge(sourceVertex, targetVertex);
+        if (edge != null) { 
             return false;
         }
-        addToIndex(sourceVertex, targetVertex, e);
-        return true;
+
+        return addEdgeToTouchingVertices(sourceVertex, targetVertex, e);
     }
 
     @Override
     public E computeEdgeToTouchingVerticesIfAbsent(
         V sourceVertex, V targetVertex, Supplier<E> edgeSupplier)
     {
-        E e = super.computeEdgeToTouchingVerticesIfAbsent(sourceVertex, targetVertex, edgeSupplier);
-        if (e == null) {
+        // first lookup using our own index
+        E edge = getEdge(sourceVertex, targetVertex);
+        if (edge != null) { 
             return null;
         }
-        addToIndex(sourceVertex, targetVertex, e);
+        
+        E e = edgeSupplier.get();
+        addEdgeToTouchingVertices(sourceVertex, targetVertex, e);
         return e;
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
@@ -119,7 +119,7 @@ public class FastLookupDirectedSpecifics<V, E>
     }
 
     @Override
-    public E computeEdgeToTouchingVerticesIfAbsent(
+    public E createEdgeToTouchingVerticesIfAbsent(
         V sourceVertex, V targetVertex, Supplier<E> edgeSupplier)
     {
         // first lookup using our own index
@@ -134,6 +134,7 @@ public class FastLookupDirectedSpecifics<V, E>
     }
 
     @Override
+    @Deprecated
     public void removeEdgeFromTouchingVertices(E e)
     {
         super.removeEdgeFromTouchingVertices(e);
@@ -141,6 +142,14 @@ public class FastLookupDirectedSpecifics<V, E>
         V source = graph.getEdgeSource(e);
         V target = graph.getEdgeTarget(e);
         removeFromIndex(source, target, e);
+    }
+    
+    @Override
+    public void removeEdgeFromTouchingVertices(V sourceVertex, V targetVertex, E e)
+    {
+        super.removeEdgeFromTouchingVertices(sourceVertex, targetVertex, e);
+        
+        removeFromIndex(sourceVertex, targetVertex, e);
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
@@ -17,12 +17,15 @@
  */
 package org.jgrapht.graph.specifics;
 
-import org.jgrapht.*;
-import org.jgrapht.alg.util.*;
-import org.jgrapht.graph.*;
-
-import java.util.*;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.function.Supplier;
+
+import org.jgrapht.Graph;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.graph.EdgeSetFactory;
 
 /**
  * Fast implementation of DirectedSpecifics. This class uses additional data structures to improve
@@ -135,7 +138,14 @@ public class FastLookupDirectedSpecifics<V, E>
         removeFromIndex(source, target, e);
     }
 
-    private void addToIndex(V sourceVertex, V targetVertex, E e)
+    /**
+     * Add an edge to the index.
+     * 
+     * @param sourceVertex the source vertex
+     * @param targetVertex the target vertex
+     * @param e the edge
+     */
+    protected void addToIndex(V sourceVertex, V targetVertex, E e)
     {
         Pair<V, V> vertexPair = new Pair<>(sourceVertex, targetVertex);
         Set<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);
@@ -148,13 +158,15 @@ public class FastLookupDirectedSpecifics<V, E>
         }
     }
 
-    /*
-     * Remove the edge from the touchingVerticesToEdgeMap. If there are no more remaining edges for
-     * a pair of touching vertices, remove the pair from the map.
+    /**
+     * Remove an edge from the index.
+     * 
+     * @param sourceVertex the source vertex
+     * @param targetVertex the target vertex
+     * @param e the edge
      */
-    private void removeFromIndex(V sourceVertex, V targetVertex, E e)
+    protected void removeFromIndex(V sourceVertex, V targetVertex, E e)
     {
-
         Pair<V, V> vertexPair = new Pair<>(sourceVertex, targetVertex);
         Set<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);
         if (edgeSet != null) {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
@@ -17,11 +17,16 @@
  */
 package org.jgrapht.graph.specifics;
 
-import org.jgrapht.*;
-import org.jgrapht.alg.util.*;
-import org.jgrapht.graph.*;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
 
-import java.util.*;
+import org.jgrapht.Graph;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.alg.util.UnorderedPair;
+import org.jgrapht.graph.EdgeSetFactory;
 
 /**
  * Fast implementation of UndirectedSpecifics. This class uses additional data structures to improve
@@ -64,9 +69,6 @@ public class FastLookupUndirectedSpecifics<V, E>
         this.touchingVerticesToEdgeMap = Objects.requireNonNull(touchingVerticesToEdgeMap);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public Set<E> getAllEdges(V sourceVertex, V targetVertex)
     {
@@ -85,9 +87,6 @@ public class FastLookupUndirectedSpecifics<V, E>
         }
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public E getEdge(V sourceVertex, V targetVertex)
     {
@@ -99,52 +98,71 @@ public class FastLookupUndirectedSpecifics<V, E>
             return edges.iterator().next();
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public void addEdgeToTouchingVertices(E e)
+    public boolean addEdgeToTouchingVertices(V sourceVertex, V targetVertex, E e)
     {
+        if (!super.addEdgeToTouchingVertices(sourceVertex, targetVertex, e)) {
+            return false;
+        }
+        addToIndex(sourceVertex, targetVertex, e);
+        return true;
+    }
+
+    @Override
+    public boolean addEdgeToTouchingVerticesIfAbsent(V sourceVertex, V targetVertex, E e)
+    {
+        if (!super.addEdgeToTouchingVerticesIfAbsent(sourceVertex, targetVertex, e)) {
+            return false;
+        }
+        addToIndex(sourceVertex, targetVertex, e);
+        return true;
+    }
+
+    @Override
+    public E computeEdgeToTouchingVerticesIfAbsent(
+        V sourceVertex, V targetVertex, Supplier<E> edgeSupplier)
+    {
+        E e = super.computeEdgeToTouchingVerticesIfAbsent(sourceVertex, targetVertex, edgeSupplier);
+        if (e == null) {
+            return null;
+        }
+        addToIndex(sourceVertex, targetVertex, e);
+        return e;
+    }
+
+    @Override
+    public void removeEdgeFromTouchingVertices(E e)
+    {
+        super.removeEdgeFromTouchingVertices(e);
+
         V source = graph.getEdgeSource(e);
         V target = graph.getEdgeTarget(e);
+        removeFromIndex(source, target, e);
+    }
 
-        getEdgeContainer(source).addEdge(e);
-
-        // Add edge to touchingVerticesToEdgeMap for the UnorderedPair {u,v}
-        Pair<V, V> vertexPair = new UnorderedPair<>(source, target);
+    /*
+     * Add edge to touchingVerticesToEdgeMap for the UnorderedPair {u,v}
+     */
+    private void addToIndex(V sourceVertex, V targetVertex, E e)
+    {
+        Pair<V, V> vertexPair = new UnorderedPair<>(sourceVertex, targetVertex);
         Set<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);
         if (edgeSet != null)
             edgeSet.add(e);
         else {
-            edgeSet = edgeSetFactory.createEdgeSet(source);
+            edgeSet = edgeSetFactory.createEdgeSet(sourceVertex);
             edgeSet.add(e);
             touchingVerticesToEdgeMap.put(vertexPair, edgeSet);
         }
-
-        if (!source.equals(target)) { // If not a self loop
-            getEdgeContainer(target).addEdge(e);
-        }
     }
 
-    /**
-     * {@inheritDoc}
+    /*
+     * Remove the edge from the touchingVerticesToEdgeMap. If there are no more remaining edges for
+     * a pair of touching vertices, remove the pair from the map.
      */
-    @Override
-    public void removeEdgeFromTouchingVertices(E e)
+    private void removeFromIndex(V sourceVertex, V targetVertex, E e)
     {
-        V source = graph.getEdgeSource(e);
-        V target = graph.getEdgeTarget(e);
-
-        getEdgeContainer(source).removeEdge(e);
-
-        if (!source.equals(target))
-            getEdgeContainer(target).removeEdge(e);
-
-        /*
-         * Remove the edge from the touchingVerticesToEdgeMap. If there are no more remaining edges
-         * for a pair of touching vertices, remove the pair from the map.
-         */
-        Pair<V, V> vertexPair = new UnorderedPair<>(source, target);
+        Pair<V, V> vertexPair = new UnorderedPair<>(sourceVertex, targetVertex);
         Set<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);
         if (edgeSet != null) {
             edgeSet.remove(e);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
@@ -121,7 +121,7 @@ public class FastLookupUndirectedSpecifics<V, E>
     }
 
     @Override
-    public E computeEdgeToTouchingVerticesIfAbsent(
+    public E createEdgeToTouchingVerticesIfAbsent(
         V sourceVertex, V targetVertex, Supplier<E> edgeSupplier)
     {
         // first lookup using our own index
@@ -136,6 +136,7 @@ public class FastLookupUndirectedSpecifics<V, E>
     }
 
     @Override
+    @Deprecated
     public void removeEdgeFromTouchingVertices(E e)
     {
         super.removeEdgeFromTouchingVertices(e);
@@ -143,6 +144,14 @@ public class FastLookupUndirectedSpecifics<V, E>
         V source = graph.getEdgeSource(e);
         V target = graph.getEdgeTarget(e);
         removeFromIndex(source, target, e);
+    }
+    
+    @Override
+    public void removeEdgeFromTouchingVertices(V sourceVertex, V targetVertex, E e)
+    {
+        super.removeEdgeFromTouchingVertices(sourceVertex, targetVertex, e);
+
+        removeFromIndex(sourceVertex, targetVertex, e);
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
@@ -111,22 +111,27 @@ public class FastLookupUndirectedSpecifics<V, E>
     @Override
     public boolean addEdgeToTouchingVerticesIfAbsent(V sourceVertex, V targetVertex, E e)
     {
-        if (!super.addEdgeToTouchingVerticesIfAbsent(sourceVertex, targetVertex, e)) {
+        // first lookup using our own index
+        E edge = getEdge(sourceVertex, targetVertex);
+        if (edge != null) { 
             return false;
         }
-        addToIndex(sourceVertex, targetVertex, e);
-        return true;
+        
+        return addEdgeToTouchingVertices(sourceVertex, targetVertex, e);
     }
 
     @Override
     public E computeEdgeToTouchingVerticesIfAbsent(
         V sourceVertex, V targetVertex, Supplier<E> edgeSupplier)
     {
-        E e = super.computeEdgeToTouchingVerticesIfAbsent(sourceVertex, targetVertex, edgeSupplier);
-        if (e == null) {
+        // first lookup using our own index
+        E edge = getEdge(sourceVertex, targetVertex);
+        if (edge != null) { 
             return null;
         }
-        addToIndex(sourceVertex, targetVertex, e);
+        
+        E e = edgeSupplier.get();
+        addEdgeToTouchingVertices(sourceVertex, targetVertex, e);
         return e;
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
@@ -140,10 +140,14 @@ public class FastLookupUndirectedSpecifics<V, E>
         removeFromIndex(source, target, e);
     }
 
-    /*
-     * Add edge to touchingVerticesToEdgeMap for the UnorderedPair {u,v}
+    /**
+     * Add an edge to the index.
+     * 
+     * @param sourceVertex the source vertex
+     * @param targetVertex the target vertex
+     * @param e the edge
      */
-    private void addToIndex(V sourceVertex, V targetVertex, E e)
+    protected void addToIndex(V sourceVertex, V targetVertex, E e)
     {
         Pair<V, V> vertexPair = new UnorderedPair<>(sourceVertex, targetVertex);
         Set<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);
@@ -156,11 +160,14 @@ public class FastLookupUndirectedSpecifics<V, E>
         }
     }
 
-    /*
-     * Remove the edge from the touchingVerticesToEdgeMap. If there are no more remaining edges for
-     * a pair of touching vertices, remove the pair from the map.
+    /**
+     * Remove an edge from the index.
+     * 
+     * @param sourceVertex the source vertex
+     * @param targetVertex the target vertex
+     * @param e the edge
      */
-    private void removeFromIndex(V sourceVertex, V targetVertex, E e)
+    protected void removeFromIndex(V sourceVertex, V targetVertex, E e)
     {
         Pair<V, V> vertexPair = new UnorderedPair<>(sourceVertex, targetVertex);
         Set<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
@@ -18,6 +18,7 @@
 package org.jgrapht.graph.specifics;
 
 import java.util.*;
+import java.util.function.Supplier;
 
 /**
  * An interface encapsulating the basic graph operations. Different implementations have different
@@ -76,10 +77,34 @@ public interface Specifics<V, E>
 
     /**
      * Adds the specified edge to the edge containers of its source and target vertices.
-     *
+     * 
+     * @param sourceVertex the source vertex
+     * @param targetVertex the target vertex
      * @param e the edge
+     * @return true if the edge was added, false otherwise
      */
-    void addEdgeToTouchingVertices(E e);
+    boolean addEdgeToTouchingVertices(V sourceVertex, V targetVertex, E e);
+
+    /**
+     * Adds a new edge to the edge containers of its source and target vertices.
+     * 
+     * @param sourceVertex the source vertex
+     * @param targetVertex the target vertex
+     * @param e the edge
+     * @return true if the edge was added, false otherwise
+     */
+    boolean addEdgeToTouchingVerticesIfAbsent(V sourceVertex, V targetVertex, E e);
+    
+    /**
+     * Adds a new edge to the edge containers of its source and target vertices.
+     * 
+     * @param sourceVertex the source vertex
+     * @param targetVertex the target vertex
+     * @param edgeSupplier the function which will create the edge
+     * @return the newly created edge or null if an edge with the same source and target vertices
+     *         was already present
+     */
+    E computeEdgeToTouchingVerticesIfAbsent(V sourceVertex, V targetVertex, Supplier<E> edgeSupplier);
 
     /**
      * Returns the degree of the specified vertex. A degree of a vertex in an undirected graph is

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
@@ -78,6 +78,15 @@ public interface Specifics<V, E>
     /**
      * Adds the specified edge to the edge containers of its source and target vertices.
      * 
+     * @param e the edge
+     * @deprecated Use method {@link #addEdgeToTouchingVertices(Object, Object, Object)} instead.
+     */
+    @Deprecated
+    void addEdgeToTouchingVertices(E e);
+    
+    /**
+     * Adds the specified edge to the edge containers of its source and target vertices.
+     * 
      * @param sourceVertex the source vertex
      * @param targetVertex the target vertex
      * @param e the edge

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
@@ -175,7 +175,7 @@ public interface Specifics<V, E>
      * Removes the specified edge from the edge containers of its source and target vertices.
      *
      * @param e the edge
-     * @deprecated Use method {@link #removeEdgeToTouchingVertices(Object, Object, Object)} instead.
+     * @deprecated Use method {@link #removeEdgeFromTouchingVertices(Object, Object, Object)} instead.
      */
     @Deprecated
     void removeEdgeFromTouchingVertices(E e);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
@@ -95,7 +95,8 @@ public interface Specifics<V, E>
     boolean addEdgeToTouchingVertices(V sourceVertex, V targetVertex, E e);
 
     /**
-     * Adds a new edge to the edge containers of its source and target vertices.
+     * Adds the specified edge to the edge containers of its source and target vertices only
+     * if the edge is not already in the graph.
      * 
      * @param sourceVertex the source vertex
      * @param targetVertex the target vertex
@@ -105,7 +106,9 @@ public interface Specifics<V, E>
     boolean addEdgeToTouchingVerticesIfAbsent(V sourceVertex, V targetVertex, E e);
     
     /**
-     * Adds a new edge to the edge containers of its source and target vertices.
+     * Computes an edge given an edge supplier and adds it to the edge containers of its source 
+     * and target vertices only if the graph does not contain other edges with the same source and 
+     * target vertices. 
      * 
      * @param sourceVertex the source vertex
      * @param targetVertex the target vertex

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
@@ -83,7 +83,7 @@ public interface Specifics<V, E>
      */
     @Deprecated
     void addEdgeToTouchingVertices(E e);
-    
+
     /**
      * Adds the specified edge to the edge containers of its source and target vertices.
      * 
@@ -95,8 +95,8 @@ public interface Specifics<V, E>
     boolean addEdgeToTouchingVertices(V sourceVertex, V targetVertex, E e);
 
     /**
-     * Adds the specified edge to the edge containers of its source and target vertices only
-     * if the edge is not already in the graph.
+     * Adds the specified edge to the edge containers of its source and target vertices only if the
+     * edge is not already in the graph.
      * 
      * @param sourceVertex the source vertex
      * @param targetVertex the target vertex
@@ -104,11 +104,11 @@ public interface Specifics<V, E>
      * @return true if the edge was added, false otherwise
      */
     boolean addEdgeToTouchingVerticesIfAbsent(V sourceVertex, V targetVertex, E e);
-    
+
     /**
-     * Computes an edge given an edge supplier and adds it to the edge containers of its source 
-     * and target vertices only if the graph does not contain other edges with the same source and 
-     * target vertices. 
+     * Creates an edge given an edge supplier and adds it to the edge containers of its source and
+     * target vertices only if the graph does not contain other edges with the same source and
+     * target vertices.
      * 
      * @param sourceVertex the source vertex
      * @param targetVertex the target vertex
@@ -116,7 +116,8 @@ public interface Specifics<V, E>
      * @return the newly created edge or null if an edge with the same source and target vertices
      *         was already present
      */
-    E computeEdgeToTouchingVerticesIfAbsent(V sourceVertex, V targetVertex, Supplier<E> edgeSupplier);
+    E createEdgeToTouchingVerticesIfAbsent(
+        V sourceVertex, V targetVertex, Supplier<E> edgeSupplier);
 
     /**
      * Returns the degree of the specified vertex. A degree of a vertex in an undirected graph is
@@ -174,6 +175,18 @@ public interface Specifics<V, E>
      * Removes the specified edge from the edge containers of its source and target vertices.
      *
      * @param e the edge
+     * @deprecated Use method {@link #removeEdgeToTouchingVertices(Object, Object, Object)} instead.
      */
+    @Deprecated
     void removeEdgeFromTouchingVertices(E e);
+
+    /**
+     * Removes the specified edge from the edge containers of its source and target vertices.
+     *
+     * @param sourceVertex the source vertex
+     * @param targetVertex the target vertex
+     * @param e the edge
+     */
+    void removeEdgeFromTouchingVertices(V sourceVertex, V targetVertex, E e);
+    
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
@@ -143,6 +143,19 @@ public class UndirectedSpecifics<V, E>
     }
 
     @Override
+    @Deprecated
+    public void addEdgeToTouchingVertices(E e)
+    {
+        V source = graph.getEdgeSource(e);
+        V target = graph.getEdgeTarget(e);
+        getEdgeContainer(source).addEdge(e);
+
+        if (!source.equals(target)) {
+            getEdgeContainer(target).addEdge(e);
+        }
+    }
+    
+    @Override
     public boolean addEdgeToTouchingVertices(V sourceVertex, V targetVertex, E e)
     {
         getEdgeContainer(sourceVertex).addEdge(e);

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
@@ -277,7 +277,7 @@ public class UndirectedSpecifics<V, E>
 
     /**
      * {@inheritDoc}
-     * @deprecated Use method {@link #removeEdgeToTouchingVertices(Object, Object, Object)} instead.
+     * @deprecated Use method {@link #removeEdgeFromTouchingVertices(Object, Object, Object)} instead.
      */
     @Override
     @Deprecated

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
@@ -184,7 +184,7 @@ public class UndirectedSpecifics<V, E>
     }
 
     @Override
-    public E computeEdgeToTouchingVerticesIfAbsent(
+    public E createEdgeToTouchingVerticesIfAbsent(
         V sourceVertex, V targetVertex, Supplier<E> edgeSupplier)
     {
         // lookup for edge with same source and target
@@ -277,8 +277,10 @@ public class UndirectedSpecifics<V, E>
 
     /**
      * {@inheritDoc}
+     * @deprecated Use method {@link #removeEdgeToTouchingVertices(Object, Object, Object)} instead.
      */
     @Override
+    @Deprecated
     public void removeEdgeFromTouchingVertices(E e)
     {
         V source = graph.getEdgeSource(e);
@@ -288,6 +290,19 @@ public class UndirectedSpecifics<V, E>
 
         if (!source.equals(target)) {
             getEdgeContainer(target).removeEdge(e);
+        }
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void removeEdgeFromTouchingVertices(V sourceVertex, V targetVertex, E e)
+    {
+        getEdgeContainer(sourceVertex).removeEdge(e);
+
+        if (!sourceVertex.equals(targetVertex)) {
+            getEdgeContainer(targetVertex).removeEdge(e);
         }
     }
 


### PR DESCRIPTION
First steps for improving performance as discussed in #721. 

The point of this PR is to allow using methods such as `computeIfAbsent` which are present in Java 8 hash tables. These methods use only one lookup instead of two in case the item is not present.

In order to do so I had to add a few additional methods in the `Specifics` class such as:

- `boolean addEdgeToTouchingVertices(V sourceVertex, V targetVertex, E e)`
- `boolean addEdgeToTouchingVerticesIfAbsent(V sourceVertex, V targetVertex, E e)`
- `E computeEdgeToTouchingVerticesIfAbsent(V sourceVertex, V targetVertex, Supplier<E> edgeSupplier)`

I also changed the first method from `addEdgeToTouchingVertices(E)` to the one above. The reason for this is that the `Specifics` class should not care at all about source and target (the `InstrusiveEdgesSpecifics` class is responsible for that part). 

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
