### PR TITLE
Implemented Yen`s algorithm

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenKShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenKShortestPath.java
@@ -1,0 +1,103 @@
+/*
+ * (C) Copyright 2019-2019, by Semen Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.interfaces.KShortestPathAlgorithm;
+import org.jheaps.AddressableHeap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Implementation of Yen`s algorithm for finding $k$ shortest loopless paths.
+ *
+ * <p>
+ * The time complexity of the algorithm is $O(kn(m + n log n))$, where $n$ is the
+ * amount of vertices in the graph, $m$ is the amount of edges in the graph and
+ * $k$ is the amount of paths needed.
+ *
+ * <p>
+ * The algorithm is originally described in:
+ * Q. V. Martins, Ernesto and M. B. Pascoal, Marta. (2003).
+ * A new implementation of Yen’s ranking loopless paths algorithm.
+ * Quarterly Journal of the Belgian, French and Italian Operations Research Societies.
+ * 1. 121-133. 10.1007/s10288-002-0010-2.
+ *
+ * <p>
+ * The implementation iterates over the existing loopless path between the
+ * {@code source} and the {@code sink} and forms the resulting list. During
+ * the execution the algorithm keeps track of how many candidates with minimum
+ * weight exist. If the amount is greater or equal to the amount of path needed
+ * to complet the execution, the algorithm retrieves the rest of the path from
+ * the candidates heap and adds them to the resulting list.
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ * @author Semen Chudakov
+ * @see YenShortestPathIterator
+ */
+public class YenKShortestPath<V, E> implements KShortestPathAlgorithm<V, E> {
+    /**
+     * Underlying graph.
+     */
+    private final Graph<V, E> graph;
+
+    /**
+     * Constructs an instance of the algorithm  for the given {@code graph}.
+     *
+     * @param graph graph
+     */
+    public YenKShortestPath(Graph<V, E> graph) {
+        this.graph = Objects.requireNonNull(graph, "Graph cannot be null!");
+    }
+
+    /**
+     * Computes {@code k} shortest loopless paths between {@code source}
+     * and {@code sink}. If the amount of paths is denoted by $n$,
+     * the method returns $m = min\{k, n\}$ such paths. The paths are
+     * produced in sorted order by weights.
+     *
+     * @param source the source vertex
+     * @param sink   the target vertex
+     * @param k      the number of shortest paths to return
+     * @return a list of k shortest paths
+     */
+    @Override
+    public List<GraphPath<V, E>> getPaths(V source, V sink, int k) {
+        if (k < 0) {
+            throw new IllegalArgumentException("k should be positive");
+        }
+        List<GraphPath<V, E>> result = new ArrayList<>();
+        YenShortestPathIterator<V, E> iterator = new YenShortestPathIterator<>(graph, source, sink);
+        for (int i = 0; i < k && iterator.hasNext(); i++) {
+            int amountOfPathLeft = k - i;
+            if (iterator.getAmountOfCandidatesWithMinimumWeight() == amountOfPathLeft) {
+                AddressableHeap<Double, GraphPath<V, E>> candidates = iterator.getCandidatePaths();
+                for (int j = 0; j < amountOfPathLeft; j++) {
+                    result.add(candidates.deleteMin().getValue());
+                }
+                break;
+            }
+            result.add(iterator.next());
+        }
+        return result;
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenKShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenKShortestPath.java
@@ -71,9 +71,9 @@ public class YenKShortestPath<V, E> implements KShortestPathAlgorithm<V, E> {
 
     /**
      * Computes {@code k} shortest loopless paths between {@code source}
-     * and {@code sink}. If the amount of paths is denoted by $n$,
-     * the method returns $m = min\{k, n\}$ such paths. The paths are
-     * produced in sorted order by weights.
+     * and {@code sink}. If the overall number of such paths is denoted by $n$,
+     * the method returns $m = min\{k, n\}$ such paths. The paths are produced
+     * in sorted order by weights.
      *
      * @param source the source vertex
      * @param sink   the target vertex
@@ -89,7 +89,7 @@ public class YenKShortestPath<V, E> implements KShortestPathAlgorithm<V, E> {
         YenShortestPathIterator<V, E> iterator = new YenShortestPathIterator<>(graph, source, sink);
         for (int i = 0; i < k && iterator.hasNext(); i++) {
             int amountOfPathLeft = k - i;
-            if (iterator.getAmountOfCandidatesWithMinimumWeight() == amountOfPathLeft) {
+            if (iterator.getNumberOfCandidatesWithMinimumWeight() == amountOfPathLeft) {
                 AddressableHeap<Double, GraphPath<V, E>> candidates = iterator.getCandidatePaths();
                 for (int j = 0; j < amountOfPathLeft; j++) {
                     result.add(candidates.deleteMin().getValue());

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenKShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenKShortestPath.java
@@ -46,7 +46,7 @@ import java.util.Objects;
  * {@code source} and the {@code sink} and forms the resulting list. During
  * the execution the algorithm keeps track of how many candidates with minimum
  * weight exist. If the amount is greater or equal to the amount of path needed
- * to complet the execution, the algorithm retrieves the rest of the path from
+ * to complete the execution, the algorithm retrieves the rest of the path from
  * the candidates heap and adds them to the resulting list.
  *
  * @param <V> the graph vertex type
@@ -61,7 +61,7 @@ public class YenKShortestPath<V, E> implements KShortestPathAlgorithm<V, E> {
     private final Graph<V, E> graph;
 
     /**
-     * Constructs an instance of the algorithm  for the given {@code graph}.
+     * Constructs an instance of the algorithm for the given {@code graph}.
      *
      * @param graph graph
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenShortestPathIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenShortestPathIterator.java
@@ -51,8 +51,8 @@ import java.util.function.Supplier;
  *
  * <p>
  * The main idea of this algorithm is to divide each path between the {@link #source} and the
- * {@link #sink} into the root part, which coincides within some of the paths computed so far, and
- * the spur part, which deviates from all other path computed so far. Therefore for each path the
+ * {@link #sink} into the root part - the part that coincides within some of the paths computed so far, and
+ * the spur part, the part that deviates from all other paths computed so far. Therefore for each path the
  * algorithm maintains a vertex, at which the path deviates from its "parent" path (the candidate path
  * using which it was computed).
  *
@@ -60,7 +60,7 @@ import java.util.function.Supplier;
  * First the algorithm finds the shortest path between the {@link #source} and the {@link #sink},
  * which is put into the candidates heap. The {@link #source} is assigned to be its deviation vertex.
  * Then on each iteration the algorithm takes a candidate from the heap with minimum weight, puts it into the
- * result list and builds all possible deviations from it wrt other paths, that are in the result list.
+ * result list and builds all possible deviations from it wrt. other paths, that are in the result list.
  * By generating spur paths starting only from the vertices that are after the deviation vertex of current
  * path (including the deviation vertex) it is possible to avoid building duplicated candidates.
  *
@@ -93,7 +93,7 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
     private AddressableHeap<Double, GraphPath<V, E>> candidatePaths;
 
     /**
-     * Keeps track of at which vertex each path
+     * Keeps track of the vertex at which each path
      * deviates from its "parent" path.
      */
     private Map<GraphPath<V, E>, V> deviations;
@@ -106,12 +106,26 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
      */
     private Map<Double, Integer> weightsFrequencies;
 
+    /**
+     * Stores the amount of paths in {@link #candidatePaths}
+     * with minimum weight.
+     */
     private int amountOfCandidatesWithMinimumWeight;
 
+    /**
+     * Getter for {@link #amountOfCandidatesWithMinimumWeight}.
+     *
+     * @return current amount of candidate paths with minimum weight
+     */
     int getAmountOfCandidatesWithMinimumWeight() {
         return amountOfCandidatesWithMinimumWeight;
     }
 
+    /**
+     * Getter for {@link #candidatePaths}.
+     *
+     * @return heap with candidate paths
+     */
     AddressableHeap<Double, GraphPath<V, E>> getCandidatePaths() {
         return candidatePaths;
     }
@@ -162,11 +176,17 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean hasNext() {
         return !candidatePaths.isEmpty();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public GraphPath<V, E> next() {
         if (candidatePaths.isEmpty()) {
@@ -392,6 +412,17 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
          */
         Set<E> maskedEdges;
 
+        /**
+         * Constructs an instance of the shortest paths tree for the given
+         * {@code maskSubgraph}, {@code maskedVertices}, {@code maskedEdges}, {@code reversedTree}, {@code treeSource}.
+         *
+         * @param maskSubgraph   graph which has removed vertices and edges
+         * @param maskedVertices vertices removed form the graph
+         * @param maskedEdges    edges removed from the graph
+         * @param reversedTree   shortest path tree in the edge reverted
+         *                       {@code maskSubgraph} starting at {@code treeSource}.
+         * @param treeSource     source vertex of the  {@code reversedTree}
+         */
         YenShortestPathsTree(Graph<V, E> maskSubgraph, Set<V> maskedVertices, Set<E> maskedEdges,
                              Map<V, Pair<Double, E>> reversedTree, V treeSource) {
             super(maskSubgraph, treeSource, reversedTree);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenShortestPathIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenShortestPathIterator.java
@@ -1,0 +1,475 @@
+/*
+ * (C) Copyright 2019-2019, by Semen Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.graph.EdgeReversedGraph;
+import org.jgrapht.graph.GraphWalk;
+import org.jgrapht.graph.MaskSubgraph;
+import org.jheaps.AddressableHeap;
+import org.jheaps.tree.PairingHeap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Supplier;
+
+
+/**
+ * Iterator over the shortest loopless path between two vertices in a graph sorted by weight.
+ *
+ * <p>
+ * For this iterator to work correctly the graph must not be modified during iteration.
+ * Currently there are no means to ensure that, nor to fail-fast. The results of such
+ * modifications are undefined.
+ *
+ * <p>
+ * The main idea of this algorithm is to divide each path between the {@link #source} and the
+ * {@link #sink} into the root part, which coincides within some of the paths computed so far, and
+ * the spur part, which deviates from all other path computed so far. Therefore for each path the
+ * algorithm maintains a vertex, at which the path deviates from its "parent" path (the candidate path
+ * using which it was computed).
+ *
+ * <p>
+ * First the algorithm finds the shortest path between the {@link #source} and the {@link #sink},
+ * which is put into the candidates heap. The {@link #source} is assigned to be its deviation vertex.
+ * Then on each iteration the algorithm takes a candidate from the heap with minimum weight, puts it into the
+ * result list and builds all possible deviations from it wrt other paths, that are in the result list.
+ * By generating spur paths starting only from the vertices that are after the deviation vertex of current
+ * path (including the deviation vertex) it is possible to avoid building duplicated candidates.
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ * @author Semen Chudakov
+ */
+public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> {
+    /**
+     * Underlying graph.
+     */
+    private final Graph<V, E> graph;
+    /**
+     * Source vertex.
+     */
+    private final V source;
+    /**
+     * Sink vertex.
+     */
+    private final V sink;
+
+    /**
+     * List of the paths returned so far via the {@link #next()} method.
+     */
+    private List<GraphPath<V, E>> resultList;
+
+    /**
+     * Heap of the candidate path generated so far and sorted my their weights.
+     */
+    private AddressableHeap<Double, GraphPath<V, E>> candidatePaths;
+
+    /**
+     * Keeps track of at which vertex each path
+     * deviates from its "parent" path.
+     */
+    private Map<GraphPath<V, E>, V> deviations;
+
+    /**
+     * Keeps track of the amount of path in the candidates
+     * heap which have a particular weight. The algorithm
+     * uses this map to maintain the amount of paths with
+     * minimum weight in the heap.
+     */
+    private Map<Double, Integer> weightsFrequencies;
+
+    private int amountOfCandidatesWithMinimumWeight;
+
+    int getAmountOfCandidatesWithMinimumWeight() {
+        return amountOfCandidatesWithMinimumWeight;
+    }
+
+    AddressableHeap<Double, GraphPath<V, E>> getCandidatePaths() {
+        return candidatePaths;
+    }
+
+    /**
+     * Constructs an instance of the algorithm for given {@code graph},
+     * {@code source} and {@code sink}.
+     *
+     * @param graph  graph
+     * @param source source vertex
+     * @param sink   sink vertex
+     */
+    public YenShortestPathIterator(Graph<V, E> graph, V source, V sink) {
+        this(graph, source, sink, PairingHeap::new);
+    }
+
+    /**
+     * Constructs an instance of the algorithm for given {@code graph},
+     * {@code source}, {@code sink} and {@code heapSupplier}.
+     *
+     * @param graph        graph
+     * @param source       source vertex
+     * @param sink         sink vertex
+     * @param heapSupplier supplier of the preferable heap implementation
+     */
+    public YenShortestPathIterator(Graph<V, E> graph, V source, V sink,
+                                   Supplier<AddressableHeap<Double, GraphPath<V, E>>> heapSupplier) {
+        this.graph = Objects.requireNonNull(graph, "Graph cannot be null!");
+        if (!graph.containsVertex(source)) {
+            throw new IllegalArgumentException("Graph should contain source vertex!");
+        }
+        this.source = source;
+        if (!graph.containsVertex(source)) {
+            throw new IllegalArgumentException("Graph should contain sink vertex!");
+        }
+        this.sink = sink;
+        Objects.requireNonNull(heapSupplier, "Heap supplier cannot be null");
+        this.resultList = new ArrayList<>();
+        this.candidatePaths = heapSupplier.get();
+        this.deviations = new HashMap<>();
+        this.weightsFrequencies = new HashMap<>();
+
+        GraphPath<V, E> shortestPath = DijkstraShortestPath.findPathBetween(graph, source, sink);
+        if (shortestPath != null) {
+            candidatePaths.insert(shortestPath.getWeight(), shortestPath);
+            deviations.put(shortestPath, source);
+            weightsFrequencies.put(shortestPath.getWeight(), 1);
+        }
+    }
+
+    @Override
+    public boolean hasNext() {
+        return !candidatePaths.isEmpty();
+    }
+
+    @Override
+    public GraphPath<V, E> next() {
+        if (candidatePaths.isEmpty()) {
+            throw new NoSuchElementException();
+        }
+
+        GraphPath<V, E> path = candidatePaths.deleteMin().getValue();
+        resultList.add(path);
+        double pathWeight = path.getWeight();
+        int minWeightFrequency = weightsFrequencies.get(pathWeight);
+        if (minWeightFrequency == 1) {
+            weightsFrequencies.remove(pathWeight);
+            if (candidatePaths.isEmpty()) {
+                amountOfCandidatesWithMinimumWeight = 0;
+            } else {
+                amountOfCandidatesWithMinimumWeight = weightsFrequencies.get(candidatePaths.findMin().getKey());
+            }
+        } else {
+            weightsFrequencies.put(pathWeight, minWeightFrequency - 1);
+        }
+
+        addDeviations(path);
+
+        return path;
+    }
+
+    /**
+     * Builds unique loopless deviations from the given path
+     * in the {@link #graph}. First receives the deviation
+     * vertex of the current path as well as sets of vertices
+     * and edges to be masked during the computations. Then
+     * creates an instance of the {@link MaskSubgraph}
+     * and builds a reversed shortest paths tree starting at
+     * {@link #sink} in it. Finally builds new paths by deviating
+     * from the vertices of the provided {@code path}.
+     * <p>
+     * For more information on this step refer to the article
+     * with the original description of the algorithm.
+     *
+     * @param path path to build deviations of
+     */
+    private void addDeviations(GraphPath<V, E> path) {
+        // initializations
+        V pathDeviation = deviations.get(path);
+        List<V> pathVertices = path.getVertexList();
+        int pathVerticesSize = pathVertices.size();
+        int pathDeviationIndex = pathVertices.indexOf(pathDeviation);
+
+        // receive masked vertices and edges
+        Pair<Set<V>, Set<E>> p = getMaskedVerticesAndEdges(path, pathDeviation, pathDeviationIndex);
+        Set<V> maskedVertices = p.getFirst();
+        Set<E> maskedEdges = p.getSecond();
+
+
+        // build reversed shortest paths tree
+        Graph<V, E> maskSubgraph = new MaskSubgraph<>(graph, maskedVertices::contains, maskedEdges::contains);
+        Graph<V, E> revertedMaskedGraph = new EdgeReversedGraph<>(maskSubgraph);
+        DijkstraShortestPath<V, E> shortestPath = new DijkstraShortestPath<>(revertedMaskedGraph);
+        TreeSingleSourcePathsImpl<V, E> singleSourcePaths = (TreeSingleSourcePathsImpl<V, E>) shortestPath.getPaths(sink);
+        Map<V, Pair<Double, E>> distanceAndPredecessorMap = new HashMap<>(singleSourcePaths.getDistanceAndPredecessorMap());
+        YenShortestPathsTree customTree = new YenShortestPathsTree(maskSubgraph, maskedVertices,
+                maskedEdges, distanceAndPredecessorMap, sink);
+
+
+        // build spur paths by iteratively recovering vertices of the current path
+        boolean proceed = true;
+        for (int i = pathVerticesSize - 2; i >= 0 && proceed; i--) {
+            V recoverVertex = pathVertices.get(i);
+            if (recoverVertex.equals(pathDeviation)) {
+                proceed = false;
+            }
+
+            // recover vertex
+            customTree.recoverVertex(recoverVertex);
+            customTree.correctCostForward(recoverVertex);
+            GraphPath<V, E> spurPath = customTree.getPath(recoverVertex);
+
+            // construct a new path if possible
+            if (spurPath != null) {
+                customTree.correctCostBackward(recoverVertex);
+
+                GraphPath<V, E> candidate = getCandidatePath(path, i, spurPath);
+                double candidateWeight = candidate.getWeight();
+
+                candidatePaths.insert(candidateWeight, candidate);
+                deviations.put(candidate, recoverVertex);
+
+                if (weightsFrequencies.containsKey(candidateWeight)) {
+                    weightsFrequencies.computeIfPresent(candidateWeight, (weight, frequency) -> frequency + 1);
+                } else {
+                    weightsFrequencies.put(candidateWeight, 1);
+                }
+            }
+            // recover edge
+            V recoverVertexSuccessor = pathVertices.get(i + 1);
+            E edge = graph.getEdge(recoverVertex, recoverVertexSuccessor);
+            customTree.recoverEdge(edge);
+
+            double recoverVertexUpdatedCost = maskSubgraph.getEdgeWeight(edge) +
+                    customTree.map.get(recoverVertexSuccessor).getFirst();
+
+            if (customTree.map.get(recoverVertex).getFirst() > recoverVertexUpdatedCost) {
+                customTree.map.put(recoverVertex, Pair.of(recoverVertexUpdatedCost, edge));
+                customTree.correctCostBackward(recoverVertex);
+            }
+        }
+    }
+
+    /**
+     * For the given {@code path} builds sets of vertices and edges to be masked.
+     * First masks all edges and vertices of the provided {@code path} except for the {@link #sink}.
+     * Then for each path in the {@link #resultList} that coincides in the {@code path}
+     * until the {@code pathDeviation} masks the edge between the {@code pathDeviation} and its
+     * successor in this path.
+     *
+     * @param path               path to mask vertices and edges of
+     * @param pathDeviation      deviation vertex of the path
+     * @param pathDeviationIndex index of the deviation vertex in the
+     *                           vertices list of the path
+     * @return pair of sets of masked vertices and edges
+     */
+    private Pair<Set<V>, Set<E>> getMaskedVerticesAndEdges(GraphPath<V, E> path,
+                                                           V pathDeviation, int pathDeviationIndex) {
+        List<V> pathVertices = path.getVertexList();
+        Set<V> maskedVertices = new HashSet<>();
+        Set<E> maskedEdges = new HashSet<>();
+
+        int pathVerticesSize = pathVertices.size();
+
+        // mask vertices and edges of the current path
+        for (int i = 0; i < pathVerticesSize - 1; i++) {
+            V v = pathVertices.get(i);
+            maskedVertices.add(v);
+            maskedEdges.add(graph.getEdge(v, pathVertices.get(i + 1)));
+        }
+
+        // mask corresponding edges of coinciding paths
+        int resultListSize = resultList.size();
+        for (int i = 0; i < resultListSize - 1; i++) { // the vertex of the current paths has already been masked
+            GraphPath<V, E> resultPath = resultList.get(i);
+            List<V> resultPathVertices = resultPath.getVertexList();
+            int deviationIndex = resultPathVertices.indexOf(pathDeviation);
+
+            if (deviationIndex < 0 || deviationIndex != pathDeviationIndex ||
+                    !equalLists(pathVertices, resultPathVertices, deviationIndex)) {
+                continue;
+            }
+
+            V successor = resultPathVertices.get(deviationIndex + 1);
+            maskedEdges.add(graph.getEdge(pathDeviation, successor));
+        }
+        return Pair.of(maskedVertices, maskedEdges);
+    }
+
+    /**
+     * Builds a candidate path based on the information provided in the
+     * methods parameters. First adds the root part of the candidate by
+     * traversing the vertices and edges of the {@code path} until the
+     * {@code recoverVertexIndex}. Then adds vertices and edges of the
+     * {@code spurPath}.
+     *
+     * @param path               path the candidate path deviates from
+     * @param recoverVertexIndex vertex that is being recovered
+     * @param spurPath           spur path of the candidate
+     * @return candidate path
+     */
+    private GraphPath<V, E> getCandidatePath(GraphPath<V, E> path, int recoverVertexIndex, GraphPath<V, E> spurPath) {
+        List<V> pathVertices = path.getVertexList();
+
+        LinkedList<V> candidatePathVertices = new LinkedList<>();
+        LinkedList<E> candidatePathEdges = new LinkedList<>();
+
+        double rootPathWeight = 0.0;
+        for (int j = 0; j < recoverVertexIndex; j++) {
+            E edge = graph.getEdge(pathVertices.get(j), pathVertices.get(j + 1));
+            rootPathWeight += graph.getEdgeWeight(edge);
+            candidatePathEdges.add(edge);
+            candidatePathVertices.add(pathVertices.get(j));
+        }
+
+        ListIterator<V> spurPathVerticesIterator = spurPath.getVertexList().listIterator(spurPath.getVertexList().size());
+        while (spurPathVerticesIterator.hasPrevious()) {
+            candidatePathVertices.add(spurPathVerticesIterator.previous());
+        }
+        ListIterator<E> spurPathEdgesIterator = spurPath.getEdgeList().listIterator(spurPath.getEdgeList().size());
+        while (spurPathEdgesIterator.hasPrevious()) {
+            candidatePathEdges.add(spurPathEdgesIterator.previous());
+        }
+
+        double candidateWeight = rootPathWeight + spurPath.getWeight();
+        return new GraphWalk<>(graph, source, sink,
+                candidatePathVertices, candidatePathEdges, candidateWeight);
+    }
+
+    /**
+     * Checks if the lists have the same content until the {@code index} (inclusive).
+     *
+     * @param first  first list
+     * @param second second list
+     * @param index  position in the lists
+     * @return true iff the contents of the list are equal until the index
+     */
+    private boolean equalLists(List<V> first, List<V> second, int index) {
+        for (int i = 0; i <= index; i++) {
+            if (!first.get(i).equals(second.get(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Helper class which represents the shortest paths tree based on which
+     * the spur paths for the candidates are computed.
+     */
+    class YenShortestPathsTree extends TreeSingleSourcePathsImpl<V, E> {
+        /**
+         * Vertices which are masked in the {@link #g}.
+         */
+        Set<V> maskedVertices;
+        /**
+         * Edges which are masked in the {@link #g}.
+         */
+        Set<E> maskedEdges;
+
+        YenShortestPathsTree(Graph<V, E> maskSubgraph, Set<V> maskedVertices, Set<E> maskedEdges,
+                             Map<V, Pair<Double, E>> reversedTree, V treeSource) {
+            super(maskSubgraph, treeSource, reversedTree);
+            this.maskedVertices = maskedVertices;
+            this.maskedEdges = maskedEdges;
+        }
+
+        /**
+         * Restores vertex {@code v} in the {@link #g}.
+         *
+         * @param v vertex to be recovered
+         */
+        void recoverVertex(V v) {
+            maskedVertices.remove(v);
+        }
+
+        /**
+         * Restores edge {@code e} in the {@link #g}.
+         *
+         * @param e edge to be recovered
+         */
+        void recoverEdge(E e) {
+            maskedEdges.remove(e);
+        }
+
+        /**
+         * Updates the cost of provided vertex {@code v} in the shortest paths tree
+         * based on the current costs of its successors in the {@link #g}.
+         *
+         * @param v vertex which should be updated
+         */
+        void correctCostForward(V v) {
+            super.map.putIfAbsent(v, new Pair<>(Double.POSITIVE_INFINITY, null));
+
+            for (E e : super.g.outgoingEdgesOf(v)) {
+                V successor = Graphs.getOppositeVertex(super.g, e, v);
+
+                double updatedDistance = Double.POSITIVE_INFINITY;
+                if (super.map.containsKey(successor)) {
+                    updatedDistance = super.map.get(successor).getFirst();
+                }
+                updatedDistance += super.g.getEdgeWeight(e);
+
+                double currentDistance = super.map.get(v).getFirst();
+                if (currentDistance > updatedDistance) {
+                    super.map.put(v, Pair.of(updatedDistance, e));
+                }
+            }
+        }
+
+        /**
+         * Updates the cost of relevant precedents of the input vertex.
+         *
+         * @param v vertex cost should be updated
+         */
+        void correctCostBackward(V v) {
+            List<V> vertices = new LinkedList<>();
+            vertices.add(v);
+
+            while (!vertices.isEmpty()) {
+                V vertex = vertices.remove(0);
+                double vertexCost = super.map.get(vertex).getFirst();
+
+                for (E e : super.g.incomingEdgesOf(vertex)) {
+                    V predecessor = Graphs.getOppositeVertex(super.g, e, vertex);
+
+                    double predecessorCost = Double.POSITIVE_INFINITY;
+                    if (super.map.containsKey(predecessor)) {
+                        predecessorCost = super.map.get(predecessor).getFirst();
+                    }
+
+                    double updatedCost = vertexCost + super.g.getEdgeWeight(e);
+                    if (predecessorCost > updatedCost) {
+                        super.map.put(predecessor, Pair.of(updatedCost, e));
+                        vertices.add(predecessor);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenShortestPathIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenShortestPathIterator.java
@@ -475,7 +475,7 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
         }
 
         /**
-         * Updates the distance of relevant precedents of the input vertex.
+         * Updates the distance of relevant predecessors of the input vertex.
          *
          * @param v vertex which distance should be updated
          */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenShortestPathIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenShortestPathIterator.java
@@ -50,15 +50,15 @@ import java.util.function.Supplier;
  * modifications are undefined.
  *
  * <p>
- * The main idea of this algorithm is to divide each path between the {@link #source} and the
- * {@link #sink} into the root part - the part that coincides within some of the paths computed so far, and
+ * The main idea of this algorithm is to divide each path between the {@code source} and the
+ * {@code sink} into the root part - the part that coincides within some of the paths computed so far, and
  * the spur part, the part that deviates from all other paths computed so far. Therefore, for each path the
  * algorithm maintains a vertex, at which the path deviates from its "parent" path (the candidate path
  * using which it was computed).
  *
  * <p>
- * First the algorithm finds the shortest path between the {@link #source} and the {@link #sink},
- * which is put into the candidates heap. The {@link #source} is assigned to be its deviation vertex.
+ * First the algorithm finds the shortest path between the {@code source} and the {@code sink},
+ * which is put into the candidates heap. The {@code source} is assigned to be its deviation vertex.
  * Then on each iteration the algorithm takes a candidate from the heap with minimum weight, puts it into the
  * result list and builds all possible deviations from it wrt. other paths, that are in the result list.
  * By generating spur paths starting only from the vertices that are after the deviation vertex of current
@@ -107,7 +107,7 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
     private Map<Double, Integer> weightsFrequencies;
 
     /**
-     * Stores the number of paths in {@link #candidatePaths}
+     * Stores the number of paths in {@code candidatePaths}
      * with minimum weight.
      */
     private int numberOfCandidatesWithMinimumWeight;
@@ -122,7 +122,7 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
     }
 
     /**
-     * Getter for {@link #candidatePaths}.
+     * Returns heap with candidate paths.
      *
      * @return heap with candidate paths
      */
@@ -215,12 +215,12 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
 
     /**
      * Builds unique loopless deviations from the given path
-     * in the {@link #graph}. First receives the deviation
+     * in the {@code graph}. First receives the deviation
      * vertex of the current path as well as sets of vertices
      * and edges to be masked during the computations. Then
      * creates an instance of the {@link MaskSubgraph}
      * and builds a reversed shortest paths tree starting at
-     * {@link #sink} in it. Finally builds new paths by deviating
+     * {@code sink} in it. Finally builds new paths by deviating
      * from the vertices of the provided {@code path}.
      * <p>
      * For more information on this step refer to the article
@@ -285,11 +285,11 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
             E edge = graph.getEdge(recoverVertex, recoverVertexSuccessor);
             customTree.recoverEdge(edge);
 
-            double recoverVertexUpdatedCost = maskSubgraph.getEdgeWeight(edge) +
+            double recoverVertexUpdatedDistance = maskSubgraph.getEdgeWeight(edge) +
                     customTree.map.get(recoverVertexSuccessor).getFirst();
 
-            if (customTree.map.get(recoverVertex).getFirst() > recoverVertexUpdatedCost) {
-                customTree.map.put(recoverVertex, Pair.of(recoverVertexUpdatedCost, edge));
+            if (customTree.map.get(recoverVertex).getFirst() > recoverVertexUpdatedDistance) {
+                customTree.map.put(recoverVertex, Pair.of(recoverVertexUpdatedDistance, edge));
                 customTree.correctDistanceBackward(recoverVertex);
             }
         }
@@ -297,8 +297,8 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
 
     /**
      * For the given {@code path} builds sets of vertices and edges to be masked.
-     * First masks all edges and vertices of the provided {@code path} except for the {@link #sink}.
-     * Then for each path in the {@link #resultList} that coincides in the {@code path}
+     * First masks all edges and vertices of the provided {@code path} except for the {@code sink}.
+     * Then for each path in the {@code resultList} that coincides in the {@code path}
      * until the {@code pathDeviation} masks the edge between the {@code pathDeviation} and its
      * successor in this path.
      *
@@ -405,11 +405,11 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
      */
     class YenShortestPathsTree extends TreeSingleSourcePathsImpl<V, E> {
         /**
-         * Vertices which are masked in the {@link #g}.
+         * Vertices which are masked in the {@code g}.
          */
         Set<V> maskedVertices;
         /**
-         * Edges which are masked in the {@link #g}.
+         * Edges which are masked in the {@code g}.
          */
         Set<E> maskedEdges;
 
@@ -432,7 +432,7 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
         }
 
         /**
-         * Restores vertex {@code v} in the {@link #g}.
+         * Restores vertex {@code v} in the {@code g}.
          *
          * @param v vertex to be recovered
          */
@@ -441,7 +441,7 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
         }
 
         /**
-         * Restores edge {@code e} in the {@link #g}.
+         * Restores edge {@code e} in the {@code g}.
          *
          * @param e edge to be recovered
          */
@@ -450,8 +450,8 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
         }
 
         /**
-         * Updates the cost of provided vertex {@code v} in the shortest paths tree
-         * based on the current costs of its successors in the {@link #g}.
+         * Updates the distance of provided vertex {@code v} in the shortest paths tree
+         * based on the current distances of its successors in the {@code g}.
          *
          * @param v vertex which should be updated
          */
@@ -475,9 +475,9 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
         }
 
         /**
-         * Updates the cost of relevant precedents of the input vertex.
+         * Updates the distance of relevant precedents of the input vertex.
          *
-         * @param v vertex cost should be updated
+         * @param v vertex which distance should be updated
          */
         void correctDistanceBackward(V v) {
             List<V> vertices = new LinkedList<>();
@@ -485,19 +485,19 @@ public class YenShortestPathIterator<V, E> implements Iterator<GraphPath<V, E>> 
 
             while (!vertices.isEmpty()) {
                 V vertex = vertices.remove(0);
-                double vertexCost = super.map.get(vertex).getFirst();
+                double vertexDistance = super.map.get(vertex).getFirst();
 
                 for (E e : super.g.incomingEdgesOf(vertex)) {
                     V predecessor = Graphs.getOppositeVertex(super.g, e, vertex);
 
-                    double predecessorCost = Double.POSITIVE_INFINITY;
+                    double predecessorDistance = Double.POSITIVE_INFINITY;
                     if (super.map.containsKey(predecessor)) {
-                        predecessorCost = super.map.get(predecessor).getFirst();
+                        predecessorDistance = super.map.get(predecessor).getFirst();
                     }
 
-                    double updatedCost = vertexCost + super.g.getEdgeWeight(e);
-                    if (predecessorCost > updatedCost) {
-                        super.map.put(predecessor, Pair.of(updatedCost, e));
+                    double updatedDistance = vertexDistance + super.g.getEdgeWeight(e);
+                    if (predecessorDistance > updatedDistance) {
+                        super.map.put(predecessor, Pair.of(updatedDistance, e));
                         vertices.add(predecessor);
                     }
                 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseKShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseKShortestPathTest.java
@@ -1,0 +1,79 @@
+/*
+ * (C) Copyright 2019-2019, by Semen Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
+import org.jgrapht.graph.DefaultWeightedEdge;
+
+public class BaseKShortestPathTest {
+    final int[][] simpleGraph1 = {
+            {1, 2, 2}, {2, 3, 20}, {3, 4, 14},
+            {1, 5, 13}, {2, 6, 27}, {3, 7, 14}, {4, 8, 15},
+            {5, 6, 9}, {6, 7, 10}, {7, 8, 25},
+            {5, 9, 15}, {6, 10, 20}, {7, 11, 12}, {8, 12, 7},
+            {9, 10, 18}, {10, 11, 8}, {11, 12, 11}
+    };
+    final int[][] simpleGraph2 = {{1, 2, 5}, {1, 3, 6}, {2, 3, 7}, {2, 4, 8}, {3, 4, 9}};
+    final int[][] simpleGraph3 = {
+            {0, 1, 6}, {2, 0, 9}, {4, 0, 4}, {0, 5, 6}, {0, 6, 5},
+            {2, 1, 1}, {1, 4, 9}, {4, 1, 2}, {1, 5, 7}, {1, 6, 5},
+            {2, 4, 1}, {2, 5, 0}, {3, 4, 4}, {4, 3, 4}, {4, 5, 6},
+            {5, 4, 8}, {4, 6, 3}, {6, 5, 0}
+    };
+    final int[][] simpleGraph4 = {
+            {1, 2, 5}, {2, 3, 8}, {2, 4, 7},
+            {1, 4, 6}, {4, 3, 9}
+    };
+
+    final int[][] cyclicGraph1 = {{1, 2, 1}, {2, 1, 1}};
+
+    final int[][] cyclicGraph2 = {
+            {1, 2, 1}, {2, 3, 1}, {3, 4, 1}, {4, 1, 1},
+            {1, 5, 2}, {5, 6, 2}, {6, 7, 2}, {7, 1, 2},
+            {3, 6, 2}, {6, 3, 2}
+    };
+
+    final int[][] cyclicGraph3 = {
+            {1, 2, 1}, {2, 3, 1}, {3, 4, 1},
+            {4, 3, 1}, {4, 5, 1}, {5, 4, 1}
+    };
+
+    final int[][] restHeapGraph = {
+            {1, 2, 2}, {1, 3, 3}, {1, 4, 4}, {1, 5, 5}, {1, 6, 6}, {1, 7, 7}, {1, 8, 8}, {1, 9, 9},
+            {2, 10, 1}, {3, 10, 1}, {4, 10, 1}, {5, 10, 1}, {6, 10, 1}, {7, 10, 1}, {8, 10, 1}, {9, 10, 1}
+    };
+    final int[][] notShortestPathEdgesGraph = {
+            {1, 2, 1},
+            {1, 3, 3}, {1, 4, 4}, {1, 5, 5}, {1, 6, 6}, {1, 7, 7}, {1, 8, 8}, {1, 9, 9}
+    };
+
+    final int[][] multigraph = {
+            {1, 2, 3}, {1, 4, 2}, {1, 5, 4},
+            {2, 3, 4},{2, 2, 0},
+            {3, 5, 3},
+            {4, 1, 0}, {4, 3, 2}, {4, 4, 0},{4, 6, 0},
+            {5, 3, 2}, {5, 6, 2}
+    };
+
+    void readGraph(Graph<Integer, DefaultWeightedEdge> graph, int[][] representation) {
+        for (int[] ints : representation) {
+            Graphs.addEdgeWithVertices(graph, ints[0], ints[1], ints[2]);
+        }
+    }
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseKShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseKShortestPathTest.java
@@ -21,57 +21,58 @@ import org.jgrapht.Graph;
 import org.jgrapht.Graphs;
 import org.jgrapht.graph.DefaultWeightedEdge;
 
-public class BaseKShortestPathTest {
-    final int[][] simpleGraph1 = {
+/**
+ * Base test for K shortest paths algorithms.
+ * Currently extended by {@link YenShortestPathIterator}
+ * and {@link YenKShortestPath}.
+ */
+class BaseKShortestPathTest {
+    protected final int[][] simpleGraph1 = {
             {1, 2, 2}, {2, 3, 20}, {3, 4, 14},
             {1, 5, 13}, {2, 6, 27}, {3, 7, 14}, {4, 8, 15},
             {5, 6, 9}, {6, 7, 10}, {7, 8, 25},
             {5, 9, 15}, {6, 10, 20}, {7, 11, 12}, {8, 12, 7},
             {9, 10, 18}, {10, 11, 8}, {11, 12, 11}
     };
-    final int[][] simpleGraph2 = {{1, 2, 5}, {1, 3, 6}, {2, 3, 7}, {2, 4, 8}, {3, 4, 9}};
-    final int[][] simpleGraph3 = {
+    protected final int[][] simpleGraph2 = {{1, 2, 5}, {1, 3, 6}, {2, 3, 7}, {2, 4, 8}, {3, 4, 9}};
+    protected final int[][] simpleGraph3 = {
             {0, 1, 6}, {2, 0, 9}, {4, 0, 4}, {0, 5, 6}, {0, 6, 5},
             {2, 1, 1}, {1, 4, 9}, {4, 1, 2}, {1, 5, 7}, {1, 6, 5},
             {2, 4, 1}, {2, 5, 0}, {3, 4, 4}, {4, 3, 4}, {4, 5, 6},
             {5, 4, 8}, {4, 6, 3}, {6, 5, 0}
     };
-    final int[][] simpleGraph4 = {
+    protected final int[][] simpleGraph4 = {
             {1, 2, 5}, {2, 3, 8}, {2, 4, 7},
             {1, 4, 6}, {4, 3, 9}
     };
 
-    final int[][] cyclicGraph1 = {{1, 2, 1}, {2, 1, 1}};
+    protected final int[][] cyclicGraph1 = {{1, 2, 1}, {2, 1, 1}};
 
-    final int[][] cyclicGraph2 = {
+    protected final int[][] cyclicGraph2 = {
             {1, 2, 1}, {2, 3, 1}, {3, 4, 1}, {4, 1, 1},
             {1, 5, 2}, {5, 6, 2}, {6, 7, 2}, {7, 1, 2},
             {3, 6, 2}, {6, 3, 2}
     };
 
-    final int[][] cyclicGraph3 = {
+    protected final int[][] cyclicGraph3 = {
             {1, 2, 1}, {2, 3, 1}, {3, 4, 1},
             {4, 3, 1}, {4, 5, 1}, {5, 4, 1}
     };
 
-    final int[][] restHeapGraph = {
-            {1, 2, 2}, {1, 3, 3}, {1, 4, 4}, {1, 5, 5}, {1, 6, 6}, {1, 7, 7}, {1, 8, 8}, {1, 9, 9},
-            {2, 10, 1}, {3, 10, 1}, {4, 10, 1}, {5, 10, 1}, {6, 10, 1}, {7, 10, 1}, {8, 10, 1}, {9, 10, 1}
-    };
-    final int[][] notShortestPathEdgesGraph = {
+    protected final int[][] notShortestPathEdgesGraph = {
             {1, 2, 1},
             {1, 3, 3}, {1, 4, 4}, {1, 5, 5}, {1, 6, 6}, {1, 7, 7}, {1, 8, 8}, {1, 9, 9}
     };
 
-    final int[][] multigraph = {
+    protected final int[][] multigraph = {
             {1, 2, 3}, {1, 4, 2}, {1, 5, 4},
-            {2, 3, 4},{2, 2, 0},
+            {2, 3, 4}, {2, 2, 0},
             {3, 5, 3},
-            {4, 1, 0}, {4, 3, 2}, {4, 4, 0},{4, 6, 0},
+            {4, 1, 0}, {4, 3, 2}, {4, 4, 0}, {4, 6, 0},
             {5, 3, 2}, {5, 6, 2}
     };
 
-    void readGraph(Graph<Integer, DefaultWeightedEdge> graph, int[][] representation) {
+    protected void readGraph(Graph<Integer, DefaultWeightedEdge> graph, int[][] representation) {
         for (int[] ints : representation) {
             Graphs.addEdgeWithVertices(graph, ints[0], ints[1], ints[2]);
         }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenKShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenKShortestPathTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Test for the {@link YenKShortestPath}.
+ * Tests for the {@link YenKShortestPath}.
  */
 public class YenKShortestPathTest extends BaseKShortestPathTest {
     @Test(expected = IllegalArgumentException.class)
@@ -84,7 +84,7 @@ public class YenKShortestPathTest extends BaseKShortestPathTest {
     /**
      * If the specified k is greater than the total amount of paths between
      * source and target, a list of all existing paths should be returned
-     * and not exception should be thrown.
+     * and no exception should be thrown.
      */
     @Test
     public void testLessThanKPaths() {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenKShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenKShortestPathTest.java
@@ -1,0 +1,106 @@
+/*
+ * (C) Copyright 2019-2019, by Semen Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.Graphs;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleDirectedWeightedGraph;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Test case for the {@link YenKShortestPath}.
+ */
+public class YenKShortestPathTest extends BaseKShortestPathTest {
+    @Test(expected = IllegalArgumentException.class)
+    public void testNegativeK() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        Graphs.addEdgeWithVertices(graph, 1, 2);
+        new YenKShortestPath<>(graph).getPaths(1, 2, -1);
+    }
+
+    /**
+     * If k equals $0$ and there is no paths in the graph
+     * between source and target, no exception should be thrown
+     * and an empty list should be returned.
+     */
+    @Test
+    public void testKEqualsZero() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        graph.addVertex(2);
+        List<GraphPath<Integer, DefaultWeightedEdge>> paths
+                = new YenKShortestPath<>(graph).getPaths(1, 2, 0);
+        assertEquals(0, paths.size());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoSourceGraph() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(2);
+        new YenKShortestPath<>(graph).getPaths(1, 2, 1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoSinkGraph() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        new YenKShortestPath<>(graph).getPaths(1, 2, 1);
+    }
+
+    @Test
+    public void testCyclicGraph() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        readGraph(graph, cyclicGraph3);
+        List<GraphPath<Integer, DefaultWeightedEdge>> paths =
+                new YenKShortestPath<>(graph).getPaths(1, 3, 1);
+        List<Double> weights = Collections.singletonList(2.0);
+
+        assertSameWeights(paths, weights);
+    }
+
+    /**
+     * If the specified k is greater than the total amount of paths between
+     * source and target, a list of all existing paths should be returned
+     * and not exception should be thrown.
+     */
+    @Test
+    public void testLessThanKPaths() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        readGraph(graph, simpleGraph1);
+        List<GraphPath<Integer, DefaultWeightedEdge>> paths =
+                new YenKShortestPath<>(graph).getPaths(1, 12, 12);
+        List<Double> weights = Arrays.asList(55.0, 58.0, 59.0, 61.0, 62.0, 64.0, 65.0, 68.0, 68.0, 71.0);
+
+        assertSameWeights(paths, weights);
+    }
+
+    private void assertSameWeights(List<GraphPath<Integer, DefaultWeightedEdge>> paths, List<Double> weights) {
+        assertEquals(weights.size(), paths.size());
+        for (int i = 0; i < paths.size(); i++) {
+            assertEquals(weights.get(i), paths.get(i).getWeight(), 1e-9);
+        }
+    }
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenKShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenKShortestPathTest.java
@@ -31,7 +31,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 /**
- * Test case for the {@link YenKShortestPath}.
+ * Test for the {@link YenKShortestPath}.
  */
 public class YenKShortestPathTest extends BaseKShortestPathTest {
     @Test(expected = IllegalArgumentException.class)
@@ -42,7 +42,7 @@ public class YenKShortestPathTest extends BaseKShortestPathTest {
     }
 
     /**
-     * If k equals $0$ and there is no paths in the graph
+     * If k equals to $0$ and there is no paths in the graph
      * between source and target, no exception should be thrown
      * and an empty list should be returned.
      */

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
@@ -40,7 +40,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 /**
- * Test case for the {@link YenShortestPathIterator}.
+ * Test for the {@link YenShortestPathIterator}.
  */
 public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
@@ -24,6 +24,7 @@ import org.jgrapht.generate.GnpRandomGraphGenerator;
 import org.jgrapht.generate.GraphGenerator;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.jgrapht.graph.GraphWalk;
 import org.jgrapht.graph.SimpleDirectedWeightedGraph;
 import org.jgrapht.util.SupplierUtil;
 import org.junit.Test;
@@ -40,9 +41,22 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 /**
- * Test for the {@link YenShortestPathIterator}.
+ * Tests for the {@link YenShortestPathIterator}.
  */
 public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
+
+    /**
+     * Seed value which is used to generate random graphs
+     * by {@link #getRandomGraph(Graph, int, double)} method.
+     */
+    private static final long SEED = 13l;
+    /**
+     * Number of path to iterate over for each random graph
+     * in the {@link #assertCorrectness(Graph, Integer, Integer)}
+     * method.
+     */
+    private static final int NUMBER_OF_PATH_TO_ITERATE = 10;
+
 
     @Test(expected = IllegalArgumentException.class)
     public void testNoSourceGraph() {
@@ -88,7 +102,7 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
         YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
                 new YenShortestPathIterator<>(graph, source, target);
         assertTrue(it.hasNext());
-        performAssertion(graph, it, source, target, 0.0, false);
+        performAssertion(it, 0.0, false);
     }
 
     @Test
@@ -115,16 +129,16 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(graph, it, source, target, 55.0, true);
-        performAssertion(graph, it, source, target, 58.0, true);
-        performAssertion(graph, it, source, target, 59.0, true);
-        performAssertion(graph, it, source, target, 61.0, true);
-        performAssertion(graph, it, source, target, 62.0, true);
-        performAssertion(graph, it, source, target, 64.0, true);
-        performAssertion(graph, it, source, target, 65.0, true);
-        performAssertion(graph, it, source, target, 68.0, true);
-        performAssertion(graph, it, source, target, 68.0, true);
-        performAssertion(graph, it, source, target, 71.0, false);
+        performAssertion(it, 55.0, true);
+        performAssertion(it, 58.0, true);
+        performAssertion(it, 59.0, true);
+        performAssertion(it, 61.0, true);
+        performAssertion(it, 62.0, true);
+        performAssertion(it, 64.0, true);
+        performAssertion(it, 65.0, true);
+        performAssertion(it, 68.0, true);
+        performAssertion(it, 68.0, true);
+        performAssertion(it, 71.0, false);
     }
 
     @Test
@@ -137,9 +151,9 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(graph, it, source, target, 13.0, true);
-        performAssertion(graph, it, source, target, 15.0, true);
-        performAssertion(graph, it, source, target, 21.0, false);
+        performAssertion(it, 13.0, true);
+        performAssertion(it, 15.0, true);
+        performAssertion(it, 21.0, false);
     }
 
     @Test
@@ -152,9 +166,9 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(graph, it, source, target, 9.0, true);
-        performAssertion(graph, it, source, target, 13.0, true);
-        performAssertion(graph, it, source, target, 15.0, false);
+        performAssertion(it, 9.0, true);
+        performAssertion(it, 13.0, true);
+        performAssertion(it, 15.0, false);
     }
 
     @Test
@@ -167,9 +181,9 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(graph, it, source, target, 13.0, true);
-        performAssertion(graph, it, source, target, 15.0, true);
-        performAssertion(graph, it, source, target, 21.0, false);
+        performAssertion(it, 13.0, true);
+        performAssertion(it, 15.0, true);
+        performAssertion(it, 21.0, false);
     }
 
     @Test
@@ -182,7 +196,7 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(graph, it, source, target, 1.0, false);
+        performAssertion(it, 1.0, false);
     }
 
     @Test
@@ -195,8 +209,8 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(graph, it, source, target, 4.0, true);
-        performAssertion(graph, it, source, target, 4.0, false);
+        performAssertion(it, 4.0, true);
+        performAssertion(it, 4.0, false);
     }
 
     @Test
@@ -209,7 +223,7 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(graph, it, source, target, 2.0, false);
+        performAssertion(it, 2.0, false);
     }
 
 
@@ -223,9 +237,9 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(graph, it, source, target, 4.0, true);
-        performAssertion(graph, it, source, target, 7.0, true);
-        performAssertion(graph, it, source, target, 10.0, false);
+        performAssertion(it, 4.0, true);
+        performAssertion(it, 7.0, true);
+        performAssertion(it, 10.0, false);
     }
 
     @Test
@@ -238,7 +252,7 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 = new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(graph, it, source, target, 1.0, false);
+        performAssertion(it, 1.0, false);
     }
 
     @Test
@@ -256,72 +270,71 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
         }
     }
 
-
+    /**
+     * If the overall number of paths between {@code source}
+     * and {@code target} is denoted by $n$ and the value of
+     * {@link #NUMBER_OF_PATH_TO_ITERATE} is denoted by $m$
+     * then the method iterates over $p = min\{n, m\}$ such paths
+     * and verifies that they are built correctly. Additionally
+     * method checks that are returned in the increasing order by
+     * weight.
+     *
+     * @param graph  graph the iterator is being tested on
+     * @param source source vertex
+     * @param target target vertex
+     */
     private void assertCorrectness(Graph<Integer, DefaultWeightedEdge> graph,
                                    Integer source, Integer target) {
-        int amountOfPathsToIterate = 10;
         YenShortestPathIterator<Integer, DefaultWeightedEdge> it
                 = new YenShortestPathIterator<>(graph, source, target);
         GraphPath<Integer, DefaultWeightedEdge> path;
         double previousPathWeight = 0.0;
         Set<GraphPath<Integer, DefaultWeightedEdge>> paths = new HashSet<>();
         int i = 0;
-        for (; i < amountOfPathsToIterate && it.hasNext(); i++) {
+        for (; i < NUMBER_OF_PATH_TO_ITERATE && it.hasNext(); i++) {
             path = it.next();
             paths.add(path);
-            assertCorrectPath(graph, path, source, target);
+            ((GraphWalk<Integer, DefaultWeightedEdge>) path).verify();
             assertTrue(previousPathWeight <= path.getWeight());
             previousPathWeight = path.getWeight();
         }
         assertEquals(i, paths.size());
     }
 
-    private void performAssertion(Graph<Integer, DefaultWeightedEdge> graph,
-                                  YenShortestPathIterator<Integer, DefaultWeightedEdge> it,
-                                  Integer source, Integer target, double expectedWeight, boolean hasNext) {
+    /**
+     * Performs assertions to check correctness of the next
+     * path which the {@code it} is expected to return.
+     *
+     * @param it             shortest paths iterator
+     * @param expectedWeight expected weight of the next path
+     * @param hasNext        expected return value of the
+     *                       {@link YenShortestPathIterator#hasNext()} method
+     */
+    private void performAssertion(YenShortestPathIterator<Integer, DefaultWeightedEdge> it,
+                                  double expectedWeight, boolean hasNext) {
         GraphPath<Integer, DefaultWeightedEdge> path = it.next();
         assertEquals(expectedWeight, path.getWeight(), 1e-9);
-        assertCorrectPath(graph, path, source, target);
+        ((GraphWalk<Integer, DefaultWeightedEdge>) path).verify();
         assertLooplessPath(path);
         assertEquals(it.hasNext(), hasNext);
     }
 
-    private void assertCorrectPath(Graph<Integer, DefaultWeightedEdge> graph,
-                                   GraphPath<Integer, DefaultWeightedEdge> path,
-                                   Integer source, Integer target) {
-        List<DefaultWeightedEdge> edgeList = path.getEdgeList();
-
-        double expectedWeight = path.getWeight();
-        double actualWeight = edgeList.stream().mapToDouble(graph::getEdgeWeight).sum();
-        assertEquals(expectedWeight, actualWeight, 1e-9);
-
-        if (edgeList.size() == 0) {
-            assertEquals(source, target);
-        } else {
-            assertEquals(graph.getEdgeSource(edgeList.get(0)), source);
-            assertEquals(graph.getEdgeTarget(edgeList.get(edgeList.size() - 1)), target);
-
-            if (edgeList.size() >= 2) {
-                Iterator<DefaultWeightedEdge> it = edgeList.iterator();
-                DefaultWeightedEdge curr = it.next();
-                DefaultWeightedEdge next;
-                while (it.hasNext()) {
-                    next = it.next();
-                    assertEquals(graph.getEdgeTarget(curr), graph.getEdgeSource(next));
-                    curr = next;
-                }
-            }
-        }
-    }
-
+    /**
+     * Asserts that {@code path} is loopless. More formally
+     * checks that the {@code path} has no duplicate vertices.
+     */
     private void assertLooplessPath(GraphPath<Integer, DefaultWeightedEdge> path) {
         Set<Integer> uniqueVertices = new HashSet<>(path.getVertexList());
         assertEquals(path.getVertexList().size(), uniqueVertices.size());
     }
 
+    /**
+     * Generates random graph from the $G(n, p)$ model
+     * using {@link #SEED} as a parameter for the generator instance.
+     */
     private void getRandomGraph(Graph<Integer, DefaultWeightedEdge> graph, int n, double p) {
         GraphGenerator<Integer, DefaultWeightedEdge, Integer> generator
-                = new GnpRandomGraphGenerator<>(n, p);
+                = new GnpRandomGraphGenerator<>(n, p, SEED);
         generator.generateGraph(graph);
 
         graph.edgeSet().forEach(e -> graph.setEdgeWeight(e, Math.random()));

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
@@ -31,8 +31,6 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
@@ -52,7 +50,7 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
     private static final long SEED = 13l;
     /**
      * Number of path to iterate over for each random graph
-     * in the {@code assertCorrectness(Graph, Integer, Integer)}
+     * in the {@code testOnRandomGraph(Graph, Integer, Integer)}
      * method.
      */
     private static final int NUMBER_OF_PATH_TO_ITERATE = 10;
@@ -102,7 +100,7 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
         YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
                 new YenShortestPathIterator<>(graph, source, target);
         assertTrue(it.hasNext());
-        performAssertion(it, 0.0, false);
+        verifyNextPath(it, 0.0, false);
     }
 
     @Test
@@ -129,16 +127,16 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(it, 55.0, true);
-        performAssertion(it, 58.0, true);
-        performAssertion(it, 59.0, true);
-        performAssertion(it, 61.0, true);
-        performAssertion(it, 62.0, true);
-        performAssertion(it, 64.0, true);
-        performAssertion(it, 65.0, true);
-        performAssertion(it, 68.0, true);
-        performAssertion(it, 68.0, true);
-        performAssertion(it, 71.0, false);
+        verifyNextPath(it, 55.0, true);
+        verifyNextPath(it, 58.0, true);
+        verifyNextPath(it, 59.0, true);
+        verifyNextPath(it, 61.0, true);
+        verifyNextPath(it, 62.0, true);
+        verifyNextPath(it, 64.0, true);
+        verifyNextPath(it, 65.0, true);
+        verifyNextPath(it, 68.0, true);
+        verifyNextPath(it, 68.0, true);
+        verifyNextPath(it, 71.0, false);
     }
 
     @Test
@@ -151,9 +149,9 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(it, 13.0, true);
-        performAssertion(it, 15.0, true);
-        performAssertion(it, 21.0, false);
+        verifyNextPath(it, 13.0, true);
+        verifyNextPath(it, 15.0, true);
+        verifyNextPath(it, 21.0, false);
     }
 
     @Test
@@ -166,9 +164,9 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(it, 9.0, true);
-        performAssertion(it, 13.0, true);
-        performAssertion(it, 15.0, false);
+        verifyNextPath(it, 9.0, true);
+        verifyNextPath(it, 13.0, true);
+        verifyNextPath(it, 15.0, false);
     }
 
     @Test
@@ -181,9 +179,9 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(it, 13.0, true);
-        performAssertion(it, 15.0, true);
-        performAssertion(it, 21.0, false);
+        verifyNextPath(it, 13.0, true);
+        verifyNextPath(it, 15.0, true);
+        verifyNextPath(it, 21.0, false);
     }
 
     @Test
@@ -196,7 +194,7 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(it, 1.0, false);
+        verifyNextPath(it, 1.0, false);
     }
 
     @Test
@@ -209,8 +207,8 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(it, 4.0, true);
-        performAssertion(it, 4.0, false);
+        verifyNextPath(it, 4.0, true);
+        verifyNextPath(it, 4.0, false);
     }
 
     @Test
@@ -223,7 +221,7 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(it, 2.0, false);
+        verifyNextPath(it, 2.0, false);
     }
 
 
@@ -237,9 +235,9 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(it, 4.0, true);
-        performAssertion(it, 7.0, true);
-        performAssertion(it, 10.0, false);
+        verifyNextPath(it, 4.0, true);
+        verifyNextPath(it, 7.0, true);
+        verifyNextPath(it, 10.0, false);
     }
 
     @Test
@@ -252,11 +250,11 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
                 = new YenShortestPathIterator<>(graph, source, target);
 
         assertTrue(it.hasNext());
-        performAssertion(it, 1.0, false);
+        verifyNextPath(it, 1.0, false);
     }
 
     @Test
-    public void testRandomGraphs() {
+    public void testOnRandomGraphs() {
         int n = 100;
         double p = 0.5;
         for (int i = 0; i < 1000; i++) {
@@ -266,7 +264,7 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
             getRandomGraph(graph, n, p);
             Integer source = (int) (Math.random() * n);
             Integer target = (int) (Math.random() * n);
-            assertCorrectness(graph, source, target);
+            testOnRandomGraph(graph, source, target);
         }
     }
 
@@ -283,7 +281,7 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
      * @param source source vertex
      * @param target target vertex
      */
-    private void assertCorrectness(Graph<Integer, DefaultWeightedEdge> graph,
+    private void testOnRandomGraph(Graph<Integer, DefaultWeightedEdge> graph,
                                    Integer source, Integer target) {
         YenShortestPathIterator<Integer, DefaultWeightedEdge> it
                 = new YenShortestPathIterator<>(graph, source, target);
@@ -310,8 +308,8 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
      * @param hasNext        expected return value of the
      *                       {@link YenShortestPathIterator#hasNext()} method
      */
-    private void performAssertion(YenShortestPathIterator<Integer, DefaultWeightedEdge> it,
-                                  double expectedWeight, boolean hasNext) {
+    private void verifyNextPath(YenShortestPathIterator<Integer, DefaultWeightedEdge> it,
+                                double expectedWeight, boolean hasNext) {
         GraphPath<Integer, DefaultWeightedEdge> path = it.next();
         assertEquals(expectedWeight, path.getWeight(), 1e-9);
         ((GraphWalk<Integer, DefaultWeightedEdge>) path).verify();

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
@@ -1,0 +1,329 @@
+/*
+ * (C) Copyright 2019-2019, by Semen Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.Graphs;
+import org.jgrapht.generate.GnpRandomGraphGenerator;
+import org.jgrapht.generate.GraphGenerator;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.jgrapht.graph.SimpleDirectedWeightedGraph;
+import org.jgrapht.util.SupplierUtil;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Test case for the {@link YenShortestPathIterator}.
+ */
+public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoSourceGraph() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(2);
+        new YenShortestPathIterator<>(graph, 1, 2);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNoSinkGraph() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        new YenShortestPathIterator<>(graph, 1, 2);
+    }
+
+    @Test
+    public void testNoPathInGraph() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        graph.addVertex(2);
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, 1, 2);
+        assertFalse(it.hasNext());
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testNoPathLeft() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        graph.addVertex(2);
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, 1, 2);
+        assertFalse(it.hasNext());
+        it.next();
+    }
+
+    @Test
+    public void testSourceEqualsTarget() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        Integer source = 1;
+        Integer target = 1;
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, source, target);
+        assertTrue(it.hasNext());
+        performAssertion(graph, it, source, target, 0.0, false);
+    }
+
+    @Test
+    public void testOnlyShortestPathGraph() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        DefaultWeightedEdge a = Graphs.addEdgeWithVertices(graph, 1, 2, 1.0);
+        DefaultWeightedEdge b = Graphs.addEdgeWithVertices(graph, 2, 3, 1.0);
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, 1, 3);
+        assertTrue(it.hasNext());
+        GraphPath<Integer, DefaultWeightedEdge> path = it.next();
+        assertEquals(2.0, path.getWeight(), 1e-9);
+        assertEquals(Arrays.asList(a, b), path.getEdgeList());
+        assertFalse(it.hasNext());
+    }
+
+    @Test
+    public void testSimpleGraph1() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        readGraph(graph, simpleGraph1);
+        Integer source = 1;
+        Integer target = 12;
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, source, target);
+
+        assertTrue(it.hasNext());
+        performAssertion(graph, it, source, target, 55.0, true);
+        performAssertion(graph, it, source, target, 58.0, true);
+        performAssertion(graph, it, source, target, 59.0, true);
+        performAssertion(graph, it, source, target, 61.0, true);
+        performAssertion(graph, it, source, target, 62.0, true);
+        performAssertion(graph, it, source, target, 64.0, true);
+        performAssertion(graph, it, source, target, 65.0, true);
+        performAssertion(graph, it, source, target, 68.0, true);
+        performAssertion(graph, it, source, target, 68.0, true);
+        performAssertion(graph, it, source, target, 71.0, false);
+    }
+
+    @Test
+    public void testSimpleGraph2() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        readGraph(graph, simpleGraph2);
+        Integer source = 1;
+        Integer target = 4;
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, source, target);
+
+        assertTrue(it.hasNext());
+        performAssertion(graph, it, source, target, 13.0, true);
+        performAssertion(graph, it, source, target, 15.0, true);
+        performAssertion(graph, it, source, target, 21.0, false);
+    }
+
+    @Test
+    public void testSimpleGraph3() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        readGraph(graph, simpleGraph3);
+        Integer source = 1;
+        Integer target = 4;
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, source, target);
+
+        assertTrue(it.hasNext());
+        performAssertion(graph, it, source, target, 9.0, true);
+        performAssertion(graph, it, source, target, 13.0, true);
+        performAssertion(graph, it, source, target, 15.0, false);
+    }
+
+    @Test
+    public void testSimpleGraph4() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        readGraph(graph, simpleGraph4);
+        Integer source = 1;
+        Integer target = 3;
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, source, target);
+
+        assertTrue(it.hasNext());
+        performAssertion(graph, it, source, target, 13.0, true);
+        performAssertion(graph, it, source, target, 15.0, true);
+        performAssertion(graph, it, source, target, 21.0, false);
+    }
+
+    @Test
+    public void testCyclicGraph1() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        Integer source = 1;
+        Integer target = 2;
+        readGraph(graph, cyclicGraph1);
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, source, target);
+
+        assertTrue(it.hasNext());
+        performAssertion(graph, it, source, target, 1.0, false);
+    }
+
+    @Test
+    public void testCyclicGraph2() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        readGraph(graph, cyclicGraph2);
+        Integer source = 1;
+        Integer target = 6;
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, source, target);
+
+        assertTrue(it.hasNext());
+        performAssertion(graph, it, source, target, 4.0, true);
+        performAssertion(graph, it, source, target, 4.0, false);
+    }
+
+    @Test
+    public void testCyclicGraph3() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        readGraph(graph, cyclicGraph3);
+        Integer source = 1;
+        Integer target = 3;
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, source, target);
+
+        assertTrue(it.hasNext());
+        performAssertion(graph, it, source, target, 2.0, false);
+    }
+
+
+    @Test
+    public void testPseudoGraph() {
+        Graph<Integer, DefaultWeightedEdge> graph = new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+        readGraph(graph, multigraph);
+        Integer source = 1;
+        Integer target = 5;
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it =
+                new YenShortestPathIterator<>(graph, source, target);
+
+        assertTrue(it.hasNext());
+        performAssertion(graph, it, source, target, 4.0, true);
+        performAssertion(graph, it, source, target, 7.0, true);
+        performAssertion(graph, it, source, target, 10.0, false);
+    }
+
+    @Test
+    public void testNotShortestPathEdgesGraph() {
+        Graph<Integer, DefaultWeightedEdge> graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        readGraph(graph, notShortestPathEdgesGraph);
+        Integer source = 1;
+        Integer target = 2;
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it
+                = new YenShortestPathIterator<>(graph, source, target);
+
+        assertTrue(it.hasNext());
+        performAssertion(graph, it, source, target, 1.0, false);
+    }
+
+    @Test
+    public void testRandomGraphs() {
+        int n = 100;
+        double p = 0.5;
+        for (int i = 0; i < 1000; i++) {
+            SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph
+                    = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+            graph.setVertexSupplier(SupplierUtil.createIntegerSupplier());
+            getRandomGraph(graph, n, p);
+            Integer source = (int) (Math.random() * n);
+            Integer target = (int) (Math.random() * n);
+            assertCorrectness(graph, source, target);
+        }
+    }
+
+
+    private void assertCorrectness(Graph<Integer, DefaultWeightedEdge> graph,
+                                   Integer source, Integer target) {
+        int amountOfPathsToIterate = 10;
+        YenShortestPathIterator<Integer, DefaultWeightedEdge> it
+                = new YenShortestPathIterator<>(graph, source, target);
+        GraphPath<Integer, DefaultWeightedEdge> path;
+        double previousPathWeight = 0.0;
+        Set<GraphPath<Integer, DefaultWeightedEdge>> paths = new HashSet<>();
+        int i = 0;
+        for (; i < amountOfPathsToIterate && it.hasNext(); i++) {
+            path = it.next();
+            paths.add(path);
+            assertCorrectPath(graph, path, source, target);
+            assertTrue(previousPathWeight <= path.getWeight());
+            previousPathWeight = path.getWeight();
+        }
+        assertEquals(i, paths.size());
+    }
+
+    private void performAssertion(Graph<Integer, DefaultWeightedEdge> graph,
+                                  YenShortestPathIterator<Integer, DefaultWeightedEdge> it,
+                                  Integer source, Integer target, double expectedWeight, boolean hasNext) {
+        GraphPath<Integer, DefaultWeightedEdge> path = it.next();
+        assertEquals(expectedWeight, path.getWeight(), 1e-9);
+        assertCorrectPath(graph, path, source, target);
+        assertLooplessPath(path);
+        assertEquals(it.hasNext(), hasNext);
+    }
+
+    private void assertCorrectPath(Graph<Integer, DefaultWeightedEdge> graph,
+                                   GraphPath<Integer, DefaultWeightedEdge> path,
+                                   Integer source, Integer target) {
+        List<DefaultWeightedEdge> edgeList = path.getEdgeList();
+
+        double expectedWeight = path.getWeight();
+        double actualWeight = edgeList.stream().mapToDouble(graph::getEdgeWeight).sum();
+        assertEquals(expectedWeight, actualWeight, 1e-9);
+
+        if (edgeList.size() == 0) {
+            assertEquals(source, target);
+        } else {
+            assertEquals(graph.getEdgeSource(edgeList.get(0)), source);
+            assertEquals(graph.getEdgeTarget(edgeList.get(edgeList.size() - 1)), target);
+
+            if (edgeList.size() >= 2) {
+                Iterator<DefaultWeightedEdge> it = edgeList.iterator();
+                DefaultWeightedEdge curr = it.next();
+                DefaultWeightedEdge next;
+                while (it.hasNext()) {
+                    next = it.next();
+                    assertEquals(graph.getEdgeTarget(curr), graph.getEdgeSource(next));
+                    curr = next;
+                }
+            }
+        }
+    }
+
+    private void assertLooplessPath(GraphPath<Integer, DefaultWeightedEdge> path) {
+        Set<Integer> uniqueVertices = new HashSet<>(path.getVertexList());
+        assertEquals(path.getVertexList().size(), uniqueVertices.size());
+    }
+
+    private void getRandomGraph(Graph<Integer, DefaultWeightedEdge> graph, int n, double p) {
+        GraphGenerator<Integer, DefaultWeightedEdge, Integer> generator
+                = new GnpRandomGraphGenerator<>(n, p);
+        generator.generateGraph(graph);
+
+        graph.edgeSet().forEach(e -> graph.setEdgeWeight(e, Math.random()));
+    }
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
@@ -47,12 +47,12 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
 
     /**
      * Seed value which is used to generate random graphs
-     * by {@link #getRandomGraph(Graph, int, double)} method.
+     * by {@code getRandomGraph(Graph, int, double)} method.
      */
     private static final long SEED = 13l;
     /**
      * Number of path to iterate over for each random graph
-     * in the {@link #assertCorrectness(Graph, Integer, Integer)}
+     * in the {@code assertCorrectness(Graph, Integer, Integer)}
      * method.
      */
     private static final int NUMBER_OF_PATH_TO_ITERATE = 10;
@@ -273,7 +273,7 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
     /**
      * If the overall number of paths between {@code source}
      * and {@code target} is denoted by $n$ and the value of
-     * {@link #NUMBER_OF_PATH_TO_ITERATE} is denoted by $m$
+     * {@code #NUMBER_OF_PATH_TO_ITERATE} is denoted by $m$
      * then the method iterates over $p = min\{n, m\}$ such paths
      * and verifies that they are built correctly. Additionally
      * method checks that are returned in the increasing order by
@@ -329,8 +329,11 @@ public class YenShortestPathIteratorTest extends BaseKShortestPathTest {
     }
 
     /**
-     * Generates random graph from the $G(n, p)$ model
-     * using {@link #SEED} as a parameter for the generator instance.
+     * Generates random graph from the $G(n, p)$ model.
+     *
+     * @param graph graph instance for the generator
+     * @param n     the number of nodes
+     * @param p     the edge probability
      */
     private void getRandomGraph(Graph<Integer, DefaultWeightedEdge> graph, int n, double p) {
         GraphGenerator<Integer, DefaultWeightedEdge, Integer> generator


### PR DESCRIPTION
Implemented Yen`s algorithm for finding k shortest loopless path in a graph.
The original algorithm is described [here](https://pdfs.semanticscholar.org/aa6a/64afc25f48ad44e510d0055405836c8cc325.pdf).
The technique how to speed up the algorithm can be found in
Q. V. Martins, Ernesto and M. B. Pascoal, Marta. (2003). A new implementation of Yen’s ranking loopless paths algorithm. Quarterly Journal of the Belgian, French and Italian Operations Research Societies. 1. 121-133. 10.1007/s10288-002-0010-2.


- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
