### PR TITLE
DefaultUndirectedWeightedGraph was duplicated

### DIFF
--- a/guide/UserOverview.md
+++ b/guide/UserOverview.md
@@ -134,7 +134,6 @@ subclasses of any of these).
 |SimpleWeightedGraph           |undirected|no          | no             |yes       |
 |WeightedMultigraph            |undirected|no          | yes            |yes       |
 |WeightedPseudograph           |undirected|yes         | yes            |yes       |
-|DefaultUndirectedWeightedGraph|undirected|yes         | no             |yes       |
 |SimpleDirectedGraph           |directed  |no          | no             |no        |
 |DirectedMultigraph            |directed  |no          | yes            |no        |
 |DirectedPseudograph           |directed  |yes         | yes            |no        |


### PR DESCRIPTION
The class DefaultUndirectedWeightedGraph was reported twice in the Graph Structures table

I just removed the duplicated line.

----

- [X ] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [X ] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [ ] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [X ] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [X ] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
