### PR TITLE
Updating SerailizationTestUtils to make it generic.

### DIFF
--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SerializationTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SerializationTest.java
@@ -145,8 +145,7 @@ public class SerializationTest
         graph1.addEdge(v2, v3);
         graph1.addEdge(v1, v3);
 
-        SimpleGraph<String, DefaultEdge> graph2 =
-            (SimpleGraph<String, DefaultEdge>) serializeAndDeserialize(graph1);
+        SimpleGraph<String, DefaultEdge> graph2 = serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(2, 2, 2));
     }
@@ -170,8 +169,7 @@ public class SerializationTest
         graph1.addEdge(v2, v3);
         graph1.addEdge(v1, v3);
 
-        Multigraph<String, DefaultEdge> graph2 =
-            (Multigraph<String, DefaultEdge>) serializeAndDeserialize(graph1);
+        Multigraph<String, DefaultEdge> graph2 = serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(3, 3, 2));
     }
@@ -196,8 +194,7 @@ public class SerializationTest
         graph1.addEdge(v2, v3);
         graph1.addEdge(v1, v3);
 
-        Pseudograph<String, DefaultEdge> graph2 =
-            (Pseudograph<String, DefaultEdge>) serializeAndDeserialize(graph1);
+        Pseudograph<String, DefaultEdge> graph2 = serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(4, 3, 2));
     }
@@ -223,8 +220,7 @@ public class SerializationTest
         graph1.addEdge(v2, v3);
         graph1.addEdge(v3, v1);
 
-        DefaultUndirectedGraph<String, DefaultEdge> graph2 =
-            (DefaultUndirectedGraph<String, DefaultEdge>) serializeAndDeserialize(graph1);
+        DefaultUndirectedGraph<String, DefaultEdge> graph2 = serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(3, 2, 2));
     }
@@ -253,8 +249,7 @@ public class SerializationTest
         graph1.setEdgeWeight(e23, 2.0);
         graph1.setEdgeWeight(e31, 3.0);
 
-        SimpleWeightedGraph<String, DefaultWeightedEdge> graph2 =
-            (SimpleWeightedGraph<String, DefaultWeightedEdge>) serializeAndDeserialize(graph1);
+        SimpleWeightedGraph<String, DefaultWeightedEdge> graph2 = serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(2, 2, 2));
 
@@ -290,8 +285,7 @@ public class SerializationTest
         graph1.setEdgeWeight(e23, 2.0);
         graph1.setEdgeWeight(e31, 3.0);
 
-        WeightedMultigraph<String, DefaultWeightedEdge> graph2 =
-            (WeightedMultigraph<String, DefaultWeightedEdge>) serializeAndDeserialize(graph1);
+        WeightedMultigraph<String, DefaultWeightedEdge> graph2 = serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(3, 3, 2));
 
@@ -332,8 +326,7 @@ public class SerializationTest
         graph1.setEdgeWeight(e23, 2.0);
         graph1.setEdgeWeight(e31, 3.0);
 
-        WeightedPseudograph<String, DefaultWeightedEdge> graph2 =
-            (WeightedPseudograph<String, DefaultWeightedEdge>) serializeAndDeserialize(graph1);
+        WeightedPseudograph<String, DefaultWeightedEdge> graph2 = serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(4, 3, 2));
 
@@ -373,8 +366,7 @@ public class SerializationTest
         graph1.setEdgeWeight(e31, 3.0);
 
         DefaultUndirectedWeightedGraph<String, DefaultWeightedEdge> graph2 =
-            (DefaultUndirectedWeightedGraph<String, DefaultWeightedEdge>) serializeAndDeserialize(
-                graph1);
+            serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(3, 2, 2));
 
@@ -403,8 +395,7 @@ public class SerializationTest
         graph1.addEdge(v2, v3);
         graph1.addEdge(v1, v3);
 
-        SimpleDirectedGraph<String, DefaultEdge> graph2 =
-            (SimpleDirectedGraph<String, DefaultEdge>) serializeAndDeserialize(graph1);
+        SimpleDirectedGraph<String, DefaultEdge> graph2 = serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(2, 2, 2));
     }
@@ -429,8 +420,7 @@ public class SerializationTest
         graph1.addEdge(v2, v3);
         graph1.addEdge(v2, v3);
 
-        DirectedMultigraph<String, DefaultEdge> graph2 =
-            (DirectedMultigraph<String, DefaultEdge>) serializeAndDeserialize(graph1);
+        DirectedMultigraph<String, DefaultEdge> graph2 = serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(1, 3, 2));
     }
@@ -459,8 +449,7 @@ public class SerializationTest
         graph1.addEdge(v1, v1); // self-loop
         graph1.addEdge(v1, v3);
 
-        DirectedPseudograph<String, DefaultEdge> graph2 =
-            (DirectedPseudograph<String, DefaultEdge>) serializeAndDeserialize(graph1);
+        DirectedPseudograph<String, DefaultEdge> graph2 = serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(4, 3, 2));
     }
@@ -486,8 +475,7 @@ public class SerializationTest
         graph1.addEdge(v2, v3);
         graph1.addEdge(v3, v1);
 
-        DefaultDirectedGraph<String, DefaultEdge> graph2 =
-            (DefaultDirectedGraph<String, DefaultEdge>) serializeAndDeserialize(graph1);
+        DefaultDirectedGraph<String, DefaultEdge> graph2 = serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(3, 2, 2));
     }
@@ -517,8 +505,7 @@ public class SerializationTest
         graph1.setEdgeWeight(e31, 3.0);
 
         SimpleDirectedWeightedGraph<String, DefaultWeightedEdge> graph2 =
-            (SimpleDirectedWeightedGraph<String, DefaultWeightedEdge>) serializeAndDeserialize(
-                graph1);
+            serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(2, 2, 2));
 
@@ -556,8 +543,7 @@ public class SerializationTest
         graph1.setEdgeWeight(e31, 3.0);
 
         DirectedWeightedMultigraph<String, DefaultWeightedEdge> graph2 =
-            (DirectedWeightedMultigraph<String, DefaultWeightedEdge>) serializeAndDeserialize(
-                graph1);
+            serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(3, 3, 2));
 
@@ -603,8 +589,7 @@ public class SerializationTest
         graph1.setEdgeWeight(e31, 3.0);
 
         DirectedWeightedPseudograph<String, DefaultWeightedEdge> graph2 =
-            (DirectedWeightedPseudograph<String, DefaultWeightedEdge>) serializeAndDeserialize(
-                graph1);
+            serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(4, 3, 2));
 
@@ -645,8 +630,7 @@ public class SerializationTest
         graph1.setEdgeWeight(e31, 3.0);
 
         DefaultDirectedWeightedGraph<String, DefaultWeightedEdge> graph2 =
-            (DefaultDirectedWeightedGraph<String, DefaultWeightedEdge>) serializeAndDeserialize(
-                graph1);
+            serializeAndDeserialize(graph1);
 
         verifyBasic(graph1, graph2, Arrays.asList(3, 2, 2));
 

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SerializationTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SerializationTest.java
@@ -134,7 +134,6 @@ public class SerializationTest
      * no multiple-edges
      * unweighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSimpleGraph()
         throws Exception
@@ -157,7 +156,6 @@ public class SerializationTest
      * multiple-edges
      * unweighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testMultiGraph()
         throws Exception
@@ -181,7 +179,6 @@ public class SerializationTest
      * multiple-edges
      * unweighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testPseudograph()
         throws Exception
@@ -207,7 +204,6 @@ public class SerializationTest
      * no multiple edges
      * unweighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testDefaultUndirectedGraph()
         throws Exception
@@ -233,7 +229,6 @@ public class SerializationTest
      * no-multiple edges
      * weighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSimpleWeightedGraph()
         throws Exception
@@ -266,7 +261,6 @@ public class SerializationTest
      * multiple edges
      * weighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testWeightedMultigraph()
         throws Exception
@@ -305,7 +299,6 @@ public class SerializationTest
      * multiple edges
      * weighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testWeightedPseudograph()
         throws Exception
@@ -347,7 +340,6 @@ public class SerializationTest
      * no multiple edges
      * weighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testDefaultUndirectedWeightedGraph()
         throws Exception
@@ -383,7 +375,6 @@ public class SerializationTest
      * no multiple-edges
      * unweighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSimpleDirectedGraph()
         throws Exception
@@ -408,7 +399,6 @@ public class SerializationTest
      * multiple edges
      * unweighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testDirectedMultigraph()
         throws Exception
@@ -433,7 +423,6 @@ public class SerializationTest
      * multiple-edges
      * unweighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testDirectedPseudograph()
         throws Exception
@@ -462,7 +451,6 @@ public class SerializationTest
      * no multiple-edges
      * unweighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testDefaultDirectedGraph()
         throws Exception
@@ -488,7 +476,6 @@ public class SerializationTest
      * no multiple edges
      * weighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSimpleDirectedWeightedGraph()
         throws Exception
@@ -522,7 +509,6 @@ public class SerializationTest
      * multiple edges
      * weighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testDirectedWeightedMultiGraph()
         throws Exception
@@ -563,7 +549,6 @@ public class SerializationTest
      * multiple edges
      * weighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testDirectedWeightedPseudograph()
         throws Exception
@@ -610,7 +595,6 @@ public class SerializationTest
      * no multiple edges
      * weighted
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testDefaultDirectedWeightedGraph()
         throws Exception

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SerializationTestUtils.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SerializationTestUtils.java
@@ -31,6 +31,7 @@ public class SerializationTestUtils
     {
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> T serializeAndDeserialize(T obj)
         throws Exception
     {

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SerializationTestUtils.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SerializationTestUtils.java
@@ -31,7 +31,7 @@ public class SerializationTestUtils
     {
     }
 
-    public static Object serializeAndDeserialize(Object obj)
+    public static <T> T serializeAndDeserialize(T obj)
         throws Exception
     {
         ByteArrayOutputStream bout = new ByteArrayOutputStream();
@@ -43,7 +43,7 @@ public class SerializationTestUtils
         ByteArrayInputStream bin = new ByteArrayInputStream(bout.toByteArray());
         ObjectInputStream in = new ObjectInputStream(bin);
 
-        obj = in.readObject();
+        obj = (T) in.readObject();
         return obj;
     }
 }

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableGraphAdapterTest.java
@@ -153,7 +153,6 @@ public class ImmutableGraphAdapterTest
     /**
      * Test the most general version of the directed graph.
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSerialization()
         throws Exception
@@ -174,8 +173,7 @@ public class ImmutableGraphAdapterTest
         Graph<String, EndpointPair<String>> initialGraph =
             new ImmutableGraphAdapter<>(ImmutableGraph.copyOf(graph));
 
-        Graph<String, EndpointPair<String>> g =
-            (Graph<String, EndpointPair<String>>) SerializationTestUtils
+        Graph<String, EndpointPair<String>> g = SerializationTestUtils
                 .serializeAndDeserialize(initialGraph);
 
         assertFalse(g.getType().isAllowingMultipleEdges());

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableGraphAdapterTest.java
@@ -173,8 +173,8 @@ public class ImmutableGraphAdapterTest
         Graph<String, EndpointPair<String>> initialGraph =
             new ImmutableGraphAdapter<>(ImmutableGraph.copyOf(graph));
 
-        Graph<String, EndpointPair<String>> g = SerializationTestUtils
-                .serializeAndDeserialize(initialGraph);
+        Graph<String, EndpointPair<String>> g =
+            SerializationTestUtils.serializeAndDeserialize(initialGraph);
 
         assertFalse(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableNetworkAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableNetworkAdapterTest.java
@@ -159,7 +159,6 @@ public class ImmutableNetworkAdapterTest
     /**
      * Tests serialization
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSerialization()
         throws Exception

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableNetworkAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableNetworkAdapterTest.java
@@ -200,8 +200,7 @@ public class ImmutableNetworkAdapterTest
         assertTrue(g.getType().isAllowingCycles());
         assertFalse(g.getType().isModifiable());
 
-        Graph<String, DefaultEdge> g2 =
-            (Graph<String, DefaultEdge>) SerializationTestUtils.serializeAndDeserialize(g);
+        Graph<String, DefaultEdge> g2 = SerializationTestUtils.serializeAndDeserialize(g);
 
         assertTrue(g2.getType().isAllowingMultipleEdges());
         assertTrue(g2.getType().isAllowingSelfLoops());

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableValueGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableValueGraphAdapterTest.java
@@ -292,8 +292,7 @@ public class ImmutableValueGraphAdapterTest
             new ImmutableValueGraphAdapter<>(ImmutableValueGraph.copyOf(graph),
                 (ToDoubleFunction<MyValue> & Serializable) v -> v.getValue());
 
-        Graph<String, EndpointPair<String>> g =
-            (Graph<String, EndpointPair<String>>) SerializationTestUtils
+        Graph<String, EndpointPair<String>> g = SerializationTestUtils
                 .serializeAndDeserialize(initialGraph);
 
         assertFalse(g.getType().isAllowingMultipleEdges());

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableValueGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableValueGraphAdapterTest.java
@@ -58,7 +58,7 @@ public class ImmutableValueGraphAdapterTest
 
         Graph<String, EndpointPair<String>> g =
             new ImmutableValueGraphAdapter<>(ImmutableValueGraph.copyOf(graph),
-                (ToDoubleFunction<MyValue> & Serializable) v -> v.getValue());
+                (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
 
         assertFalse(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());
@@ -170,7 +170,7 @@ public class ImmutableValueGraphAdapterTest
 
         Graph<String, EndpointPair<String>> g =
             new ImmutableValueGraphAdapter<>(ImmutableValueGraph.copyOf(graph),
-                (ToDoubleFunction<MyValue> & Serializable) v -> v.getValue());
+                (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
 
         assertFalse(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());
@@ -269,7 +269,6 @@ public class ImmutableValueGraphAdapterTest
     /**
      * Test the most general version of the directed graph.
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSerialization()
         throws Exception
@@ -290,7 +289,7 @@ public class ImmutableValueGraphAdapterTest
 
         Graph<String, EndpointPair<String>> initialGraph =
             new ImmutableValueGraphAdapter<>(ImmutableValueGraph.copyOf(graph),
-                (ToDoubleFunction<MyValue> & Serializable) v -> v.getValue());
+                (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
 
         Graph<String, EndpointPair<String>> g =
             SerializationTestUtils.serializeAndDeserialize(initialGraph);

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableValueGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableValueGraphAdapterTest.java
@@ -292,8 +292,8 @@ public class ImmutableValueGraphAdapterTest
             new ImmutableValueGraphAdapter<>(ImmutableValueGraph.copyOf(graph),
                 (ToDoubleFunction<MyValue> & Serializable) v -> v.getValue());
 
-        Graph<String, EndpointPair<String>> g = SerializationTestUtils
-                .serializeAndDeserialize(initialGraph);
+        Graph<String, EndpointPair<String>> g =
+            SerializationTestUtils.serializeAndDeserialize(initialGraph);
 
         assertFalse(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableGraphAdapterTest.java
@@ -264,7 +264,6 @@ public class MutableGraphAdapterTest
     /**
      * Tests serialization
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSerialization1()
         throws Exception

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableGraphAdapterTest.java
@@ -19,9 +19,9 @@ package org.jgrapht.graph.guava;
 
 import com.google.common.graph.*;
 import org.jgrapht.Graph;
-import org.jgrapht.graph.*;
 import org.jgrapht.alg.interfaces.*;
 import org.jgrapht.alg.vertexcover.*;
+import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
 import org.junit.*;
 
@@ -269,11 +269,9 @@ public class MutableGraphAdapterTest
     public void testSerialization1()
         throws Exception
     {
-        Graph<String,
-            DefaultEdge> g = new MutableNetworkAdapter<>(
-                NetworkBuilder
-                    .undirected().allowsParallelEdges(false).allowsSelfLoops(true).build(),
-                SupplierUtil.createRandomUUIDStringSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER);
+        Graph<String, DefaultEdge> g = new MutableNetworkAdapter<>(
+            NetworkBuilder.undirected().allowsParallelEdges(false).allowsSelfLoops(true).build(),
+            SupplierUtil.createRandomUUIDStringSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER);
 
         assertFalse(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableGraphAdapterTest.java
@@ -210,7 +210,6 @@ public class MutableGraphAdapterTest
     /**
      * Tests serialization
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSerialization()
         throws Exception
@@ -237,8 +236,7 @@ public class MutableGraphAdapterTest
         g.addEdge("v5", "v5");
         g.addEdge("v5", "v2");
 
-        Graph<String, DefaultEdge> g2 =
-            (Graph<String, DefaultEdge>) SerializationTestUtils.serializeAndDeserialize(g);
+        Graph<String, EndpointPair<String>> g2 = SerializationTestUtils.serializeAndDeserialize(g);
 
         assertFalse(g2.getType().isAllowingMultipleEdges());
         assertTrue(g2.getType().isAllowingSelfLoops());
@@ -291,8 +289,7 @@ public class MutableGraphAdapterTest
         g.addEdge("v2", "v3");
         g.addEdge("v3", "v3");
 
-        Graph<String, DefaultEdge> g2 =
-            (Graph<String, DefaultEdge>) SerializationTestUtils.serializeAndDeserialize(g);
+        Graph<String, DefaultEdge> g2 = SerializationTestUtils.serializeAndDeserialize(g);
 
         assertFalse(g2.getType().isAllowingMultipleEdges());
         assertTrue(g2.getType().isAllowingSelfLoops());

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableNetworkAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableNetworkAdapterTest.java
@@ -192,7 +192,6 @@ public class MutableNetworkAdapterTest
     /**
      * Tests serialization
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSerialization()
         throws Exception
@@ -250,7 +249,6 @@ public class MutableNetworkAdapterTest
     /**
      * Tests serialization
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSerialization1()
         throws Exception

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableNetworkAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableNetworkAdapterTest.java
@@ -225,8 +225,7 @@ public class MutableNetworkAdapterTest
         g.addEdge("v5", "v2");
         g.addEdge("v5", "v5");
 
-        Graph<String, DefaultEdge> g2 =
-            (Graph<String, DefaultEdge>) SerializationTestUtils.serializeAndDeserialize(g);
+        Graph<String, DefaultEdge> g2 = SerializationTestUtils.serializeAndDeserialize(g);
 
         assertTrue(g2.getType().isAllowingMultipleEdges());
         assertTrue(g2.getType().isAllowingSelfLoops());
@@ -279,8 +278,7 @@ public class MutableNetworkAdapterTest
         g.addEdge("v2", "v3");
         g.addEdge("v3", "v3");
 
-        Graph<String, DefaultEdge> g2 =
-            (Graph<String, DefaultEdge>) SerializationTestUtils.serializeAndDeserialize(g);
+        Graph<String, DefaultEdge> g2 = SerializationTestUtils.serializeAndDeserialize(g);
 
         assertFalse(g2.getType().isAllowingMultipleEdges());
         assertTrue(g2.getType().isAllowingSelfLoops());

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableNetworkAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableNetworkAdapterTest.java
@@ -57,10 +57,9 @@ public class MutableNetworkAdapterTest
     @Test
     public void testDirectedGraph()
     {
-        Graph<String,
-            DefaultEdge> g = new MutableNetworkAdapter<>(
-                NetworkBuilder.directed().allowsParallelEdges(true).allowsSelfLoops(true).build(),
-                SupplierUtil.createStringSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER);
+        Graph<String, DefaultEdge> g = new MutableNetworkAdapter<>(
+            NetworkBuilder.directed().allowsParallelEdges(true).allowsSelfLoops(true).build(),
+            SupplierUtil.createStringSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER);
 
         assertTrue(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());
@@ -126,10 +125,9 @@ public class MutableNetworkAdapterTest
     @Test
     public void testUndirectedGraph()
     {
-        Graph<String,
-            DefaultEdge> g = new MutableNetworkAdapter<>(
-                NetworkBuilder.undirected().allowsParallelEdges(true).allowsSelfLoops(true).build(),
-                null, SupplierUtil.DEFAULT_EDGE_SUPPLIER);
+        Graph<String, DefaultEdge> g = new MutableNetworkAdapter<>(
+            NetworkBuilder.undirected().allowsParallelEdges(true).allowsSelfLoops(true).build(),
+            null, SupplierUtil.DEFAULT_EDGE_SUPPLIER);
 
         assertTrue(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());
@@ -199,10 +197,9 @@ public class MutableNetworkAdapterTest
     public void testSerialization()
         throws Exception
     {
-        Graph<String,
-            DefaultEdge> g = new MutableNetworkAdapter<>(
-                NetworkBuilder.directed().allowsParallelEdges(true).allowsSelfLoops(true).build(),
-                null, SupplierUtil.DEFAULT_EDGE_SUPPLIER);
+        Graph<String, DefaultEdge> g = new MutableNetworkAdapter<>(
+            NetworkBuilder.directed().allowsParallelEdges(true).allowsSelfLoops(true).build(), null,
+            SupplierUtil.DEFAULT_EDGE_SUPPLIER);
 
         assertTrue(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());
@@ -258,11 +255,9 @@ public class MutableNetworkAdapterTest
     public void testSerialization1()
         throws Exception
     {
-        Graph<String,
-            DefaultEdge> g = new MutableNetworkAdapter<>(
-                NetworkBuilder
-                    .undirected().allowsParallelEdges(false).allowsSelfLoops(true).build(),
-                null, SupplierUtil.DEFAULT_EDGE_SUPPLIER);
+        Graph<String, DefaultEdge> g = new MutableNetworkAdapter<>(
+            NetworkBuilder.undirected().allowsParallelEdges(false).allowsSelfLoops(true).build(),
+            null, SupplierUtil.DEFAULT_EDGE_SUPPLIER);
 
         assertFalse(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableValueGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableValueGraphAdapterTest.java
@@ -310,7 +310,6 @@ public class MutableValueGraphAdapterTest
     /**
      * Tests serialization
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSerialization()
         throws Exception
@@ -338,8 +337,7 @@ public class MutableValueGraphAdapterTest
         g.addEdge("v5", "v5");
         g.addEdge("v5", "v2");
 
-        Graph<String, DefaultEdge> g2 =
-            (Graph<String, DefaultEdge>) SerializationTestUtils.serializeAndDeserialize(g);
+        Graph<String, EndpointPair<String>> g2 = SerializationTestUtils.serializeAndDeserialize(g);
 
         assertFalse(g2.getType().isAllowingMultipleEdges());
         assertTrue(g2.getType().isAllowingSelfLoops());
@@ -367,7 +365,6 @@ public class MutableValueGraphAdapterTest
     /**
      * Tests serialization
      */
-    @SuppressWarnings("unchecked")
     @Test
     public void testSerialization1()
         throws Exception
@@ -390,8 +387,7 @@ public class MutableValueGraphAdapterTest
         g.addEdge("v2", "v3");
         g.addEdge("v3", "v3");
 
-        Graph<String, DefaultEdge> g2 =
-            (Graph<String, DefaultEdge>) SerializationTestUtils.serializeAndDeserialize(g);
+        Graph<String, EndpointPair<String>> g2 = SerializationTestUtils.serializeAndDeserialize(g);
 
         assertFalse(g2.getType().isAllowingMultipleEdges());
         assertTrue(g2.getType().isAllowingSelfLoops());

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableValueGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableValueGraphAdapterTest.java
@@ -58,7 +58,7 @@ public class MutableValueGraphAdapterTest
 
         Graph<String, EndpointPair<String>> g =
             new MutableValueGraphAdapter<>(graph, new MyValue(1.0d),
-                (ToDoubleFunction<MyValue> & Serializable) v -> v.getValue());
+                (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
 
         assertFalse(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());
@@ -183,7 +183,7 @@ public class MutableValueGraphAdapterTest
     {
         Graph<String, EndpointPair<String>> g = new MutableValueGraphAdapter<>(
             ValueGraphBuilder.directed().allowsSelfLoops(true).build(), new MyValue(1.0),
-            (ToDoubleFunction<MyValue> & Serializable) v -> v.getValue());
+            (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
 
         assertFalse(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());
@@ -249,7 +249,7 @@ public class MutableValueGraphAdapterTest
     {
         Graph<String, EndpointPair<String>> g = new MutableValueGraphAdapter<>(
             ValueGraphBuilder.undirected().allowsSelfLoops(true).build(), new MyValue(1.0),
-            (ToDoubleFunction<MyValue> & Serializable) v -> v.getValue());
+            (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
 
         assertFalse(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());
@@ -316,7 +316,7 @@ public class MutableValueGraphAdapterTest
     {
         Graph<String, EndpointPair<String>> g = new MutableValueGraphAdapter<>(
             ValueGraphBuilder.directed().allowsSelfLoops(true).build(), new MyValue(1.0),
-            (ToDoubleFunction<MyValue> & Serializable) v -> v.getValue());
+            (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
 
         assertFalse(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());
@@ -371,7 +371,7 @@ public class MutableValueGraphAdapterTest
     {
         Graph<String, EndpointPair<String>> g = new MutableValueGraphAdapter<>(
             ValueGraphBuilder.undirected().allowsSelfLoops(true).build(), new MyValue(1.0),
-            (ToDoubleFunction<MyValue> & Serializable) v -> v.getValue());
+            (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
 
         assertFalse(g.getType().isAllowingMultipleEdges());
         assertTrue(g.getType().isAllowingSelfLoops());


### PR DESCRIPTION
Issue#[631](https://github.com/jgrapht/jgrapht/issues/631)

This PR cleans the code related to serailization tests. 
* Specifically making `SerailizationTestUtils#serializeAndDeserialize` generic instead of dealing with raw `Object`. 
* Removing unnecessary `@SuppressWarnings("unchecked")` 
* minor cleaning in the tests.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing) - Unit tests are not required for this PR
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
