### PR TITLE
K disjoint paths null pointer bug fix

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseKDisjointShortestPathsAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseKDisjointShortestPathsAlgorithm.java
@@ -48,6 +48,7 @@ import java.util.stream.*;
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
  * @author Assaf Mizrachi
+ * @author Benjamin Krogh
  */
 abstract class BaseKDisjointShortestPathsAlgorithm<V, E>
         implements

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseKDisjointShortestPathsAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseKDisjointShortestPathsAlgorithm.java
@@ -152,7 +152,7 @@ abstract class BaseKDisjointShortestPathsAlgorithm<V, E>
      */
     private List<GraphPath<V, E>> resolvePaths(V startVertex, V endVertex) {
         // first we need to remove overlapping edges.
-        findOverlappingEdges();
+        findValidEdges();
 
         // now we might be left with path fragments (not necessarily leading from start to end).
         // We need to merge them to valid paths.
@@ -200,7 +200,7 @@ abstract class BaseKDisjointShortestPathsAlgorithm<V, E>
      * pair, disregarding direction. At the end of this method, each path contains unique edges but
      * not necessarily connecting the start to end vertex.
      */
-    private void findOverlappingEdges() {
+    private void findValidEdges() {
         Map<UnorderedPair<V, V>, E> validEdges = new HashMap<>();
         for (List<E> path : pathList) {
             for (E e : path) {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseKDisjointShortestPathsAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseKDisjointShortestPathsAlgorithm.java
@@ -196,10 +196,9 @@ abstract class BaseKDisjointShortestPathsAlgorithm<V, E>
     }
 
     /**
-     * Iterate over all paths to remove overlapping edges (i.e. those edges contained in more than
-     * one path). Two edges are considered as overlapping in case both edges connect the same vertex
-     * pair, disregarding direction. At the end of this method, each path contains unique edges but
-     * not necessarily connecting the start to end vertex.
+     * Iterate over all paths and remove all edges used an even number of times.
+     * The remaining edges forms the valid edge set, which is used in the buildPaths method to construct
+     * the k-shortest paths
      */
     private void findValidEdges() {
         Map<UnorderedPair<V, V>, E> validEdges = new HashMap<>();

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KDisjointShortestPathsTestCase.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KDisjointShortestPathsTestCase.java
@@ -21,10 +21,12 @@ import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
 import org.jgrapht.generate.*;
 import org.jgrapht.graph.*;
+import org.jgrapht.graph.builder.GraphBuilder;
 import org.jgrapht.util.*;
 import org.junit.*;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
 
@@ -922,6 +924,76 @@ public abstract class KDisjointShortestPathsTestCase
         for (int i = 2; i < 20; i++) {
             List<GraphPath<Integer, DefaultWeightedEdge>> pathList = alg.getPaths(i, 1, 2);
             assertEquals(1, pathList.size());
+        }
+    }
+
+    /**
+     * A complex test case with the goal of finding the three shortest paths from vertex 1 to vertex 2 through the following weighted directed graph. Vertices are numbers in boxes, i.e., 1, 3, 4, 5, 6, 7, 8, 2.
+     * Weights are numbers close to an edge. Each edge has its origin to the left, and destination to the right
+     * The source is node 1. Sink is node 2.
+     * The weight of each edge is the unboxed number close the edge.
+     *
+     *                         +-+        2        +-+
+     *                        /|3|-----------------|6|-
+     *                     /-- +-+ \--          /- +-+ \-
+     *                  /--           \-     /--5        \--
+     *              /---                \-/--             1 \-
+     *           /--  1                 /- \--                \-
+     *        /--                    /--    1 \-                \--
+     * +-+ /--                 +-+ /-           \  +-+             \- +-+
+     * |1|---------------------|4|-----------------|7|----------------|2|
+     * +-+ \---        1       +-+       6     /-  +-+      1     /-- +-+
+     *         \---                         /--                /--
+     *             \--                   --/                 /-
+     *              1 \---            /-- 3               /-- 1
+     *                    \--- +-+ /--             +-+ /--
+     *                        \|5|-----------------|8|-
+     *                         +-+         6       +-+
+     *
+     * The expected result is the three paths through vertices:
+     * p1 = 1, 3, 7, 2
+     * p2 = 1, 4, 6, 2
+     * p3 = 1, 5, 8, 2
+     *
+     */
+    @Test
+    public void testThreeDisjointPathsWithMultiHitsOnEdge() {
+        GraphBuilder<Integer, DefaultWeightedEdge, ? extends SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge>> builder = SimpleDirectedWeightedGraph.createBuilder(DefaultWeightedEdge.class);
+        builder.addEdge(1, 3, 1);
+        builder.addEdge(1, 4, 1);
+        builder.addEdge(1, 5, 1);
+
+        builder.addEdge(3, 6, 2);
+        builder.addEdge(3, 7, 1);
+        builder.addEdge(4, 7, 6);
+        builder.addEdge(4, 6, 5);
+        builder.addEdge(5, 7, 3);
+        builder.addEdge(5, 8, 6);
+
+        builder.addEdge(6, 2, 1);
+        builder.addEdge(7, 2, 1);
+        builder.addEdge(7, 3, 1);
+        builder.addEdge(8, 2, 1);
+
+        SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph = builder.build();
+        KShortestPathAlgorithm<Integer, DefaultWeightedEdge> ksp = getKShortestPathAlgorithm(graph);
+        List<GraphPath<Integer, DefaultWeightedEdge>> paths = ksp.getPaths(1, 2, 3);
+
+        int[] p1 = {1, 3, 7, 2};
+        int[] p2 = {1, 4, 6, 2};
+        int[] p3 = {1, 5, 8, 2};
+
+        List<int[]> expectedPaths = Arrays.asList(p1, p2, p3);
+
+        List<int[]> resultPaths = paths.stream()
+                .map(GraphPath::getVertexList)
+                .map(vlist -> vlist.stream().mapToInt(i -> i).toArray())
+                .collect(Collectors.toList());
+
+        Assert.assertEquals(expectedPaths.size(), resultPaths.size());
+        for (int[] expectedPath : expectedPaths) {
+            boolean isIncluded = resultPaths.stream().anyMatch(result -> Arrays.equals(result, expectedPath));
+            Assert.assertTrue(isIncluded);
         }
     }
 


### PR DESCRIPTION
Identified a bug causing null pointer exceptions in k disjoint shortest path algorithms. Added a minimal test case that triggers the bug in both Suur. Implemented bug fixes in code.
[#790](https://github.com/jgrapht/jgrapht/issues/790)

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
