### PR TITLE
Updated Yen`s algorithm to operate on pseudo graphs correctly.

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePaths.java
@@ -128,7 +128,7 @@ public class KShortestSimplePaths<V, E>
         Objects.requireNonNull(startVertex, "Start vertex cannot be null");
         Objects.requireNonNull(endVertex, "End vertex cannot be null");
         if (endVertex.equals(startVertex)) {
-            throw new IllegalArgumentException("The end vertex is the same as the start vertex!");
+            return Collections.emptyList();
         }
         if (!graph.containsVertex(startVertex)) {
             throw new IllegalArgumentException("Graph must contain the start vertex!");

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenShortestPathIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/YenShortestPathIterator.java
@@ -223,6 +223,7 @@ public class YenShortestPathIterator<V, E>
         // initializations
         V pathDeviation = deviations.get(path);
         List<V> pathVertices = path.getVertexList();
+        List<E> pathEdges = path.getEdgeList();
         int pathVerticesSize = pathVertices.size();
         int pathDeviationIndex = pathVertices.indexOf(pathDeviation);
 
@@ -275,7 +276,7 @@ public class YenShortestPathIterator<V, E>
             }
             // recover edge
             V recoverVertexSuccessor = pathVertices.get(i + 1);
-            E edge = graph.getEdge(recoverVertex, recoverVertexSuccessor);
+            E edge = pathEdges.get(i);
             customTree.recoverEdge(edge);
 
             double recoverVertexUpdatedDistance = maskSubgraph.getEdgeWeight(edge)
@@ -304,6 +305,8 @@ public class YenShortestPathIterator<V, E>
         GraphPath<V, E> path, V pathDeviation, int pathDeviationIndex)
     {
         List<V> pathVertices = path.getVertexList();
+        List<E> pathEdges = path.getEdgeList();
+
         Set<V> maskedVertices = new HashSet<>();
         Set<E> maskedEdges = new HashSet<>();
 
@@ -311,9 +314,8 @@ public class YenShortestPathIterator<V, E>
 
         // mask vertices and edges of the current path
         for (int i = 0; i < pathVerticesSize - 1; i++) {
-            V v = pathVertices.get(i);
-            maskedVertices.add(v);
-            maskedEdges.add(graph.getEdge(v, pathVertices.get(i + 1)));
+            maskedVertices.add(pathVertices.get(i));
+            maskedEdges.add(pathEdges.get(i));
         }
 
         // mask corresponding edges of coinciding paths
@@ -330,8 +332,7 @@ public class YenShortestPathIterator<V, E>
                 continue;
             }
 
-            V successor = resultPathVertices.get(deviationIndex + 1);
-            maskedEdges.add(graph.getEdge(pathDeviation, successor));
+            maskedEdges.add(resultPath.getEdgeList().get(deviationIndex));
         }
         return Pair.of(maskedVertices, maskedEdges);
     }
@@ -350,16 +351,17 @@ public class YenShortestPathIterator<V, E>
         GraphPath<V, E> path, int recoverVertexIndex, GraphPath<V, E> spurPath)
     {
         List<V> pathVertices = path.getVertexList();
+        List<E> pathEdges = path.getEdgeList();
 
         List<V> candidatePathVertices = new LinkedList<>();
         List<E> candidatePathEdges = new LinkedList<>();
 
         double rootPathWeight = 0.0;
-        for (int j = 0; j < recoverVertexIndex; j++) {
-            E edge = graph.getEdge(pathVertices.get(j), pathVertices.get(j + 1));
+        for (int i = 0; i < recoverVertexIndex; i++) {
+            E edge = pathEdges.get(i);
             rootPathWeight += graph.getEdgeWeight(edge);
             candidatePathEdges.add(edge);
-            candidatePathVertices.add(pathVertices.get(j));
+            candidatePathVertices.add(pathVertices.get(i));
         }
 
         ListIterator<V> spurPathVerticesIterator =
@@ -465,7 +467,9 @@ public class YenShortestPathIterator<V, E>
 
             for (E e : super.g.outgoingEdgesOf(v)) {
                 V successor = Graphs.getOppositeVertex(super.g, e, v);
-
+                if(successor.equals(v)){
+                    continue;
+                }
                 double updatedDistance = Double.POSITIVE_INFINITY;
                 if (super.map.containsKey(successor)) {
                     updatedDistance = super.map.get(successor).getFirst();
@@ -495,7 +499,9 @@ public class YenShortestPathIterator<V, E>
 
                 for (E e : super.g.incomingEdgesOf(vertex)) {
                     V predecessor = Graphs.getOppositeVertex(super.g, e, vertex);
-
+                    if(predecessor.equals(vertex)){
+                        continue;
+                    }
                     double predecessorDistance = Double.POSITIVE_INFINITY;
                     if (super.map.containsKey(predecessor)) {
                         predecessorDistance = super.map.get(predecessor).getFirst();

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseKShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseKShortestPathTest.java
@@ -49,9 +49,15 @@ class BaseKShortestPathTest
     protected final int[][] notShortestPathEdgesGraph = { { 1, 2, 1 }, { 1, 3, 3 }, { 1, 4, 4 },
         { 1, 5, 5 }, { 1, 6, 6 }, { 1, 7, 7 }, { 1, 8, 8 }, { 1, 9, 9 } };
 
-    protected final int[][] multigraph =
+    protected final int[][] pseudograph1 =
         { { 1, 2, 3 }, { 1, 4, 2 }, { 1, 5, 4 }, { 2, 3, 4 }, { 2, 2, 0 }, { 3, 5, 3 }, { 4, 1, 0 },
             { 4, 3, 2 }, { 4, 4, 0 }, { 4, 6, 0 }, { 5, 3, 2 }, { 5, 6, 2 } };
+
+    protected final int[][] pseudograph2 =
+            { { 1, 1, 0 }, { 1, 1, 1 }, { 1, 2, 2 }, { 1, 2, 3 }, { 1, 2, 4 },
+                    { 2, 2, 5 }, { 2, 3, 6 }, { 2, 3, 7 },
+                    { 3, 3, 8 }, { 3, 4, 9 }, { 3, 4, 10 },
+                    { 4, 4, 11 } };
 
     protected void readGraph(Graph<Integer, DefaultWeightedEdge> graph, int[][] representation)
     {


### PR DESCRIPTION
This PR fixes the issue addressed #803. Previously the Yen\`s algorithm used `getEdge` method to mask edge and create candidates paths. It leaded to wrong results on multigraphs and pseudographs as there might be several edges between two vertices. Also `YenShortestPathIteratorTest`  now uses the `KShortestSimplePaths` implementation to verify the correctness of the paths weights returned by  `YenShortestPathIterator`. Therefore as stated in #804  `KShortestSimplePaths` is changed to return an empty list of paths when `source` and `target` vertices are equal.


----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
