### PR TITLE
Renamed KShortestSimplePaths to BellmanFordKShortestSimplePaths

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BellmanFordKShortestSimplePaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BellmanFordKShortestSimplePaths.java
@@ -38,7 +38,7 @@ import java.util.stream.*;
  * @param <E> the graph edge type
  *
  */
-public class KShortestSimplePaths<V, E>
+public class BellmanFordKShortestSimplePaths<V, E>
     implements
     KShortestPathAlgorithm<V, E>
 {
@@ -56,7 +56,7 @@ public class KShortestSimplePaths<V, E>
      *
      * @param graph graph on which shortest paths are searched
      */
-    public KShortestSimplePaths(Graph<V, E> graph)
+    public BellmanFordKShortestSimplePaths(Graph<V, E> graph)
     {
         this(graph, graph.vertexSet().size() - 1, null);
     }
@@ -70,7 +70,7 @@ public class KShortestSimplePaths<V, E>
      * @param graph graph on which shortest paths are searched.
      * @param pathValidator the path validator to use
      */
-    public KShortestSimplePaths(Graph<V, E> graph, PathValidator<V, E> pathValidator)
+    public BellmanFordKShortestSimplePaths(Graph<V, E> graph, PathValidator<V, E> pathValidator)
     {
         this(graph, graph.vertexSet().size() - 1, pathValidator);
     }
@@ -83,7 +83,7 @@ public class KShortestSimplePaths<V, E>
      *
      * @throws IllegalArgumentException if nMaxHops is negative or 0.
      */
-    public KShortestSimplePaths(Graph<V, E> graph, int nMaxHops)
+    public BellmanFordKShortestSimplePaths(Graph<V, E> graph, int nMaxHops)
     {
         this(graph, nMaxHops, null);
     }
@@ -100,7 +100,7 @@ public class KShortestSimplePaths<V, E>
      *
      * @throws IllegalArgumentException if nMaxHops is negative or 0.
      */
-    public KShortestSimplePaths(Graph<V, E> graph, int nMaxHops, PathValidator<V, E> pathValidator)
+    public BellmanFordKShortestSimplePaths(Graph<V, E> graph, int nMaxHops, PathValidator<V, E> pathValidator)
     {
         this.graph = Objects.requireNonNull(graph, "graph is null");
         this.nMaxHops = nMaxHops;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePaths.java
@@ -49,15 +49,6 @@ public class KShortestSimplePaths<V, E>
     KShortestPathAlgorithm<V, E>
 {
     private final BellmanFordKShortestSimplePaths<V, E> bellmanFordKShortestSimplePaths;
-    
-    /**
-     * Graph on which shortest paths are searched.
-     */
-    private Graph<V, E> graph;
-
-    private int nMaxHops;
-
-    private PathValidator<V, E> pathValidator;
 
     /**
      * Constructs an object to compute ranking shortest paths in a graph.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePaths.java
@@ -1,0 +1,134 @@
+/*
+ * (C) Copyright 2007-2018, by France Telecom and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.interfaces.*;
+import org.jgrapht.graph.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+/**
+ * Deprecated. Should instead use BellmanFordKShortestSimplePaths.
+ * 
+ * The algorithm determines the k shortest simple paths in increasing order of weight. Weights can
+ * be negative (but no negative cycle is allowed), and paths can be constrained by a maximum number
+ * of edges. Graphs with multiple (parallel) edges are allowed.
+ *
+ * <p>
+ * The algorithm is a variant of the Bellman-Ford algorithm but instead of only storing the best
+ * path it stores the "k" best paths at each pass, yielding a complexity of $O(k \cdot n \cdot
+ * (m^2))$ where $m$ is the number of edges and $n$ is the number of vertices.
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ *           
+ * @deprecated Moved/renamed the class to new name BellmanFordKShortestSimplePaths
+ * @see BellmanFordKShortestSimplePaths
+ *
+ */
+@Deprecated
+public class KShortestSimplePaths<V, E>
+    implements
+    KShortestPathAlgorithm<V, E>
+{
+    private final BellmanFordKShortestSimplePaths<V, E> bellmanFordKShortestSimplePaths;
+    
+    /**
+     * Graph on which shortest paths are searched.
+     */
+    private Graph<V, E> graph;
+
+    private int nMaxHops;
+
+    private PathValidator<V, E> pathValidator;
+
+    /**
+     * Constructs an object to compute ranking shortest paths in a graph.
+     *
+     * @param graph graph on which shortest paths are searched
+     */
+    public KShortestSimplePaths(Graph<V, E> graph)
+    {
+        bellmanFordKShortestSimplePaths = new BellmanFordKShortestSimplePaths<>(graph);
+    }
+
+    /**
+     * Constructs an object to compute ranking shortest paths in a graph. A non-null path validator
+     * may be used to accept/deny paths according to some external logic. These validations will be
+     * used in addition to the basic path validations which are that the path is from start to
+     * target with no loops.
+     *
+     * @param graph graph on which shortest paths are searched.
+     * @param pathValidator the path validator to use
+     */
+    public KShortestSimplePaths(Graph<V, E> graph, PathValidator<V, E> pathValidator)
+    {
+        bellmanFordKShortestSimplePaths = new BellmanFordKShortestSimplePaths<>(graph, pathValidator);
+    }
+
+    /**
+     * Constructs an object to calculate ranking shortest paths in a graph.
+     *
+     * @param graph graph on which shortest paths are searched
+     * @param nMaxHops maximum number of edges of the calculated paths
+     *
+     * @throws IllegalArgumentException if nMaxHops is negative or 0.
+     */
+    public KShortestSimplePaths(Graph<V, E> graph, int nMaxHops)
+    {
+        bellmanFordKShortestSimplePaths = new BellmanFordKShortestSimplePaths<>(graph, nMaxHops);
+    }
+
+    /**
+     * Constructs an object to calculate ranking shortest paths in a graph. A non-null path
+     * validator may be used to accept/deny paths according to some external logic. These
+     * validations will be used in addition to the basic path validations which are that the path is
+     * from start to target with no loops.
+     *
+     * @param graph graph on which shortest paths are searched
+     * @param nMaxHops maximum number of edges of the calculated paths
+     * @param pathValidator the path validator to use
+     *
+     * @throws IllegalArgumentException if nMaxHops is negative or 0.
+     */
+    public KShortestSimplePaths(Graph<V, E> graph, int nMaxHops, PathValidator<V, E> pathValidator)
+    {
+        bellmanFordKShortestSimplePaths = new BellmanFordKShortestSimplePaths<>(graph, nMaxHops, pathValidator);
+    }
+
+    /**
+     * Returns a list of the $k$ shortest simple paths in increasing order of weight.
+     *
+     * @param startVertex source vertex of the calculated paths.
+     * @param endVertex target vertex of the calculated paths.
+     *
+     * @return an iterator of paths between the start vertex and the end vertex
+     * @throws IllegalArgumentException if the graph does not contain the startVertex or the
+     *         endVertex
+     * @throws IllegalArgumentException if the startVertex and the endVertex are the same vertices
+     * @throws IllegalArgumentException if k is negative or zero
+     */
+    @Override
+    public List<GraphPath<V, E>> getPaths(V startVertex, V endVertex, int k)
+    {
+        return bellmanFordKShortestSimplePaths.getPaths(startVertex, endVertex, k);
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePathsIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/KShortestSimplePathsIterator.java
@@ -22,7 +22,7 @@ import org.jgrapht.*;
 import java.util.*;
 
 /**
- * Helper class for {@link KShortestSimplePaths}.
+ * Helper class for {@link BellmanFordKShortestSimplePaths}.
  *
  */
 class KShortestSimplePathsIterator<V, E>

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/PathValidator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/PathValidator.java
@@ -21,7 +21,7 @@ import org.jgrapht.*;
 
 /**
  * May be used to provide external path validations in addition to the basic validations done by
- * {@link KShortestSimplePaths} - that the path is from source to target and that it does not
+ * {@link BellmanFordKShortestSimplePaths} - that the path is from source to target and that it does not
  * contain loops.
  * 
  * @param <V> the graph vertex type

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPDiscardsValidPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPDiscardsValidPathsTest.java
@@ -34,7 +34,7 @@ public class KSPDiscardsValidPathsTest
     public void testNot3connectedGraph()
     {
         WeightedMultigraph<String, DefaultWeightedEdge> graph;
-        KShortestSimplePaths<String, DefaultWeightedEdge> paths;
+        BellmanFordKShortestSimplePaths<String, DefaultWeightedEdge> paths;
 
         graph = new WeightedMultigraph<>(DefaultWeightedEdge.class);
         graph.addVertex("S");
@@ -72,7 +72,7 @@ public class KSPDiscardsValidPathsTest
         this.addGraphEdge(graph, "K", "L", 1.0);
         this.addGraphEdge(graph, "L", "S", 1.0);
 
-        paths = new KShortestSimplePaths<>(graph);
+        paths = new BellmanFordKShortestSimplePaths<>(graph);
 
         assertTrue(paths.getPaths("S", "T", 3).size() == 3);
     }
@@ -86,7 +86,7 @@ public class KSPDiscardsValidPathsTest
     public void testBrunoMaoili()
     {
         WeightedMultigraph<String, DefaultWeightedEdge> graph;
-        KShortestSimplePaths<String, DefaultWeightedEdge> paths;
+        BellmanFordKShortestSimplePaths<String, DefaultWeightedEdge> paths;
 
         graph = new WeightedMultigraph<>(DefaultWeightedEdge.class);
         graph.addVertex("A");
@@ -103,13 +103,13 @@ public class KSPDiscardsValidPathsTest
         this.addGraphEdge(graph, "B", "E", 1.0);
         this.addGraphEdge(graph, "C", "D", 1.0);
 
-        paths = new KShortestSimplePaths<>(graph);
+        paths = new BellmanFordKShortestSimplePaths<>(graph);
         assertTrue(paths.getPaths("A", "E", 2).size() == 2);
 
-        paths = new KShortestSimplePaths<>(graph);
+        paths = new BellmanFordKShortestSimplePaths<>(graph);
         assertTrue(paths.getPaths("A", "E", 3).size() == 3);
 
-        paths = new KShortestSimplePaths<>(graph);
+        paths = new BellmanFordKShortestSimplePaths<>(graph);
         assertTrue(paths.getPaths("A", "E", 4).size() == 4);
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPExampleTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPExampleTest.java
@@ -32,7 +32,8 @@ public class KSPExampleTest
         SimpleWeightedGraph<String, DefaultWeightedEdge> graph = new KSPExampleGraph();
 
         String sourceVertex = "S";
-        KShortestSimplePaths<String, DefaultWeightedEdge> ksp = new KShortestSimplePaths<>(graph);
+        BellmanFordKShortestSimplePaths<String, DefaultWeightedEdge>
+            ksp = new BellmanFordKShortestSimplePaths<>(graph);
 
         String targetVertex = "T";
         assertEquals(3, ksp.getPaths(sourceVertex, targetVertex, 4).size());
@@ -45,7 +46,8 @@ public class KSPExampleTest
 
         String sourceVertex = "S";
         int nbPaths = 3;
-        KShortestSimplePaths<String, DefaultWeightedEdge> ksp = new KShortestSimplePaths<>(graph);
+        BellmanFordKShortestSimplePaths<String, DefaultWeightedEdge>
+            ksp = new BellmanFordKShortestSimplePaths<>(graph);
 
         String targetVertex = "T";
         assertEquals(nbPaths, ksp.getPaths(sourceVertex, targetVertex, nbPaths).size());
@@ -58,7 +60,8 @@ public class KSPExampleTest
 
         String sourceVertex = "S";
         int nbPaths = 2;
-        KShortestSimplePaths<String, DefaultWeightedEdge> ksp = new KShortestSimplePaths<>(graph);
+        BellmanFordKShortestSimplePaths<String, DefaultWeightedEdge>
+            ksp = new BellmanFordKShortestSimplePaths<>(graph);
 
         String targetVertex = "T";
         assertEquals(nbPaths, ksp.getPaths(sourceVertex, targetVertex, nbPaths).size());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPPathValidatorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KSPPathValidatorTest.java
@@ -47,8 +47,8 @@ public class KSPPathValidatorTest
         int size = 5;
         SimpleGraph<String, DefaultEdge> clique = buildCliqueGraph(size);
         for (int i = 0; i < size; i++) {
-            KShortestSimplePaths<String, DefaultEdge> ksp =
-                new KShortestSimplePaths<>(clique, Integer.MAX_VALUE, (partialPath, edge) -> false);
+            BellmanFordKShortestSimplePaths<String, DefaultEdge> ksp =
+                new BellmanFordKShortestSimplePaths<>(clique, Integer.MAX_VALUE, (partialPath, edge) -> false);
 
             for (int j = 0; j < size; j++) {
                 if (j == i) {
@@ -71,8 +71,8 @@ public class KSPPathValidatorTest
         int size = 5;
         SimpleGraph<String, DefaultEdge> clique = buildCliqueGraph(size);
         for (int i = 0; i < size; i++) {
-            KShortestSimplePaths<String, DefaultEdge> ksp =
-                new KShortestSimplePaths<>(clique, Integer.MAX_VALUE, (partialPath, edge) -> true);
+            BellmanFordKShortestSimplePaths<String, DefaultEdge> ksp =
+                new BellmanFordKShortestSimplePaths<>(clique, Integer.MAX_VALUE, (partialPath, edge) -> true);
 
             for (int j = 0; j < size; j++) {
                 if (j == i) {
@@ -95,8 +95,8 @@ public class KSPPathValidatorTest
         int size = 10;
         SimpleGraph<Integer, DefaultEdge> ring = buildRingGraph(size);
         for (int i = 0; i < size; i++) {
-            KShortestSimplePaths<Integer, DefaultEdge> ksp =
-                new KShortestSimplePaths<>(ring, Integer.MAX_VALUE, (partialPath, edge) -> {
+            BellmanFordKShortestSimplePaths<Integer, DefaultEdge> ksp =
+                new BellmanFordKShortestSimplePaths<>(ring, Integer.MAX_VALUE, (partialPath, edge) -> {
                     if (partialPath == null) {
                         return true;
                     }
@@ -127,8 +127,8 @@ public class KSPPathValidatorTest
         // generate graph of two cliques connected by single edge
         SimpleGraph<Integer, DefaultEdge> graph = buildGraphForTestDisconnected(cliqueSize);
         for (int i = 0; i < graph.vertexSet().size(); i++) {
-            KShortestSimplePaths<Integer, DefaultEdge> ksp =
-                new KShortestSimplePaths<>(graph, Integer.MAX_VALUE, (partialPath, edge) -> {
+            BellmanFordKShortestSimplePaths<Integer, DefaultEdge> ksp =
+                new BellmanFordKShortestSimplePaths<>(graph, Integer.MAX_VALUE, (partialPath, edge) -> {
                     // accept all requests but the one to pass through the edge connecting
                     // the two cliques.
                     DefaultEdge connectingEdge = graph.getEdge(cliqueSize - 1, cliqueSize);
@@ -163,8 +163,8 @@ public class KSPPathValidatorTest
     public void testGraphPath()
     {
         SimpleDirectedGraph<Integer, DefaultEdge> line = buildLineGraph(10);
-        KShortestSimplePaths<Integer, DefaultEdge> ksp =
-            new KShortestSimplePaths<>(line, new PathValidator<Integer, DefaultEdge>()
+        BellmanFordKShortestSimplePaths<Integer, DefaultEdge> ksp =
+            new BellmanFordKShortestSimplePaths<>(line, new PathValidator<Integer, DefaultEdge>()
             {
 
                 int index = 0;

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KShortestPathCostTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KShortestPathCostTest.java
@@ -40,8 +40,8 @@ public class KShortestPathCostTest
 
         KShortestPathCompleteGraph4 graph = new KShortestPathCompleteGraph4();
 
-        KShortestSimplePaths<String, DefaultWeightedEdge> pathFinder =
-            new KShortestSimplePaths<>(graph);
+        BellmanFordKShortestSimplePaths<String, DefaultWeightedEdge> pathFinder =
+            new BellmanFordKShortestSimplePaths<>(graph);
         List<GraphPath<String, DefaultWeightedEdge>> pathElements =
             pathFinder.getPaths("vS", "v3", nbPaths);
 
@@ -66,8 +66,8 @@ public class KShortestPathCostTest
 
         int maxSize = 10;
 
-        KShortestSimplePaths<String, DefaultWeightedEdge> pathFinder =
-            new KShortestSimplePaths<>(picture1Graph);
+        BellmanFordKShortestSimplePaths<String, DefaultWeightedEdge> pathFinder =
+            new BellmanFordKShortestSimplePaths<>(picture1Graph);
 
         // assertEquals(2, pathFinder.getPaths("v5").size());
 
@@ -158,7 +158,8 @@ public class KShortestPathCostTest
         for (String sourceVertex : graph.vertexSet()) {
             for (String targetVertex : graph.vertexSet()) {
                 if (targetVertex != sourceVertex) {
-                    KShortestSimplePaths<String, E> pathFinder = new KShortestSimplePaths<>(graph);
+                    BellmanFordKShortestSimplePaths<String, E>
+                        pathFinder = new BellmanFordKShortestSimplePaths<>(graph);
 
                     List<GraphPath<String, E>> pathElements =
                         pathFinder.getPaths(sourceVertex, targetVertex, maxSize);
@@ -188,7 +189,8 @@ public class KShortestPathCostTest
         for (String sourceVertex : graph.vertexSet()) {
             for (String targetVertex : graph.vertexSet()) {
                 if (targetVertex != sourceVertex) {
-                    KShortestSimplePaths<String, E> pathFinder = new KShortestSimplePaths<>(graph);
+                    BellmanFordKShortestSimplePaths<String, E>
+                        pathFinder = new BellmanFordKShortestSimplePaths<>(graph);
                     List<GraphPath<String, E>> prevPathElementsResults =
                         pathFinder.getPaths(sourceVertex, targetVertex, 1);
 
@@ -199,7 +201,7 @@ public class KShortestPathCostTest
                     }
 
                     for (int maxSize = 2; maxSize < maxSizeLimit; maxSize++) {
-                        pathFinder = new KShortestSimplePaths<>(graph);
+                        pathFinder = new BellmanFordKShortestSimplePaths<>(graph);
                         List<GraphPath<String, E>> pathElementsResults =
                             pathFinder.getPaths(sourceVertex, targetVertex, maxSize);
 
@@ -265,8 +267,8 @@ public class KShortestPathCostTest
 
         DefaultWeightedEdge src = graph.getEdge("M013", "M014");
 
-        KShortestSimplePaths<String, DefaultWeightedEdge> kPaths =
-            new KShortestSimplePaths<>(graph);
+        BellmanFordKShortestSimplePaths<String, DefaultWeightedEdge> kPaths =
+            new BellmanFordKShortestSimplePaths<>(graph);
         List<GraphPath<String, DefaultWeightedEdge>> paths;
 
         try {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KShortestPathKValuesTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/KShortestPathKValuesTest.java
@@ -51,8 +51,8 @@ public class KShortestPathKValuesTest
         KShortestPathCompleteGraph6 graph = new KShortestPathCompleteGraph6();
 
         for (int maxSize = 1; maxSize <= calculateNbElementaryPathsForCompleteGraph(6); maxSize++) {
-            KShortestSimplePaths<String, DefaultWeightedEdge> finder =
-                new KShortestSimplePaths<>(graph);
+            BellmanFordKShortestSimplePaths<String, DefaultWeightedEdge> finder =
+                new BellmanFordKShortestSimplePaths<>(graph);
 
             assertEquals(finder.getPaths("vS", "v1", maxSize).size(), maxSize);
             assertEquals(finder.getPaths("vS", "v2", maxSize).size(), maxSize);
@@ -98,8 +98,8 @@ public class KShortestPathKValuesTest
         int maxSize = Integer.MAX_VALUE;
 
         for (String sourceVertex : graph.vertexSet()) {
-            KShortestSimplePaths<String, DefaultWeightedEdge> finder =
-                new KShortestSimplePaths<>(graph);
+            BellmanFordKShortestSimplePaths<String, DefaultWeightedEdge> finder =
+                new BellmanFordKShortestSimplePaths<>(graph);
             for (String targetVertex : graph.vertexSet()) {
                 if (targetVertex != sourceVertex) {
                     assertEquals(

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/YenShortestPathIteratorTest.java
@@ -348,7 +348,7 @@ public class YenShortestPathIteratorTest
         graph.addEdge("21","1f");
 
         KShortestPathAlgorithm<String,DefaultEdge> yen = new YenKShortestPath<>(graph);
-        KShortestPathAlgorithm<String,DefaultEdge> simple = new KShortestSimplePaths<>(graph);
+        KShortestPathAlgorithm<String,DefaultEdge> simple = new BellmanFordKShortestSimplePaths<>(graph);
 
         // should contain exactly 3 elements each
         List<GraphPath<String,DefaultEdge>> yenPaths = yen.getPaths("1e","18",7);
@@ -403,7 +403,7 @@ public class YenShortestPathIteratorTest
      * If the overall number of paths between {@code source} and {@code target} is denoted by $n$
      * and the value of {@code #NUMBER_OF_PATH_TO_ITERATE} is denoted by $m$ then the method
      * iterates over $p = min\{n, m\}$ such paths and verifies that they are built correctly.
-     * The method uses the {@link KShortestSimplePaths} implementation to verify the order
+     * The method uses the {@link BellmanFordKShortestSimplePaths} implementation to verify the order
      * of paths returned by {@link YenShortestPathIterator}. Additionally it is checked that
      * all paths returned by the iterator are unique.
      *
@@ -417,7 +417,7 @@ public class YenShortestPathIteratorTest
 
         Set<GraphPath<Integer, DefaultWeightedEdge>> paths = new HashSet<>();
         List<GraphPath<Integer, DefaultWeightedEdge>> expectedPaths
-                = new KShortestSimplePaths<>(graph).getPaths(source, target, NUMBER_OF_PATH_TO_ITERATE);
+                = new BellmanFordKShortestSimplePaths<>(graph).getPaths(source, target, NUMBER_OF_PATH_TO_ITERATE);
         Iterator<GraphPath<Integer, DefaultWeightedEdge>> expectedPathsIterator  = expectedPaths.iterator();
         YenShortestPathIterator<Integer, DefaultWeightedEdge> yenPathIterator =
                 new YenShortestPathIterator<>(graph, source, target);


### PR DESCRIPTION
Classes implementing the interface KShortestPathAlgorithm have names like this:
YenKShortestPath, EppsteinKShortestPath, SuurballeKDisjointShortestPaths, BhandariKDisjointShortestPaths, ...

I think the class KShortestSimplePaths should also have a similar more descriptive name.
In the pull request I have named it to BellmanFordKShortestSimplePaths.