### PR TITLE
Add a maximum path limit for each cycle to the HawickJames algorithm

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
@@ -188,8 +188,9 @@ public class HawickJamesSimpleCycles<V, E>
         for (int wPos = 0; wPos < B[u].size(); wPos++) {
             Integer w = B[u].get(wPos);
 
-            wPos -= frequency(B[u], w);
+            wPos -= B[u].size();
             B[u].removeAll(singletonList(w));
+            wPos -= B[u].size();
 
             if (blocked[w]) {
                 unblock(w);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
@@ -304,7 +304,7 @@ public class HawickJamesSimpleCycles<V, E>
      * This is the default behaviour of the algorithm.
      * It will keep looking as long as there are paths available.
      */
-    public void unlimitedPaths()
+    public void clearPathLimit()
     {
         this.hasLimit = false;
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
@@ -17,9 +17,20 @@
  */
 package org.jgrapht.alg.cycle;
 
-import org.jgrapht.*;
+import org.jgrapht.Graph;
+import org.jgrapht.GraphTests;
+import org.jgrapht.Graphs;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import static java.util.Collections.frequency;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Find all simple cycles of a directed graph using the algorithm described by Hawick and James.
@@ -34,27 +45,12 @@ import java.util.*;
  *
  * @author Luiz Kill
  */
-public class HawickJamesSimpleCycles<V, E>
-    implements
-    DirectedSimpleCycles<V, E>
-{
-    private enum Operation
-    {
-        ENUMERATE,
-        PRINT_ONLY,
-        COUNT_ONLY
-    }
+public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E> {
 
-    // The graph
     private Graph<V, E> graph;
 
-    // Number of vertices
     private int nVertices = 0;
-
-    // Number of simple cycles
     private long nCycles = 0;
-
-    // Simple cycles found
     private List<List<V>> cycles = null;
 
     // The main state of the algorithm
@@ -64,16 +60,18 @@ public class HawickJamesSimpleCycles<V, E>
     private boolean[] blocked = null;
     private ArrayDeque<Integer> stack = null;
 
-    // Giving an index to every V
+    // Indexing the vertices
     private V[] iToV = null;
     private Map<V, Integer> vToI = null;
+
+    private int pathLimit = 0;
+    private boolean hasLimit = false;
+    private Runnable operation;
 
     /**
      * Create a simple cycle finder with an unspecified graph.
      */
-    public HawickJamesSimpleCycles()
-    {
-    }
+    public HawickJamesSimpleCycles() { }
 
     /**
      * Create a simple cycle finder for the specified graph.
@@ -83,30 +81,22 @@ public class HawickJamesSimpleCycles<V, E>
      * @throws IllegalArgumentException if the graph argument is <code>
      * null</code>.
      */
-    public HawickJamesSimpleCycles(Graph<V, E> graph)
-        throws IllegalArgumentException
-    {
+    public HawickJamesSimpleCycles(Graph<V, E> graph) throws IllegalArgumentException {
         this.graph = GraphTests.requireDirected(graph, "Graph must be directed");
     }
 
     @SuppressWarnings("unchecked")
-    private void initState(Operation o)
-    {
-        nCycles = 0;
+    private void initState() {
         nVertices = graph.vertexSet().size();
-        if (o == Operation.ENUMERATE) {
-            cycles = new ArrayList<>();
-        }
         blocked = new boolean[nVertices];
         stack = new ArrayDeque<>(nVertices);
 
         B = new ArrayList[nVertices];
         for (int i = 0; i < nVertices; i++) {
-            // B[i] = new ArrayList<Integer>(nVertices);
             B[i] = new ArrayList<>();
         }
 
-        iToV = (V[]) graph.vertexSet().toArray();
+        iToV = (V[])graph.vertexSet().toArray();
         vToI = new HashMap<>();
         for (int i = 0; i < iToV.length; i++) {
             vToI.put(iToV[i], i);
@@ -118,8 +108,7 @@ public class HawickJamesSimpleCycles<V, E>
     }
 
     @SuppressWarnings("unchecked")
-    private List<Integer>[] buildAdjacencyList()
-    {
+    private List<Integer>[] buildAdjacencyList() {
         @SuppressWarnings("rawtypes") List[] Ak = new ArrayList[nVertices];
         for (int j = 0; j < nVertices; j++) {
             V v = iToV[j];
@@ -134,21 +123,18 @@ public class HawickJamesSimpleCycles<V, E>
         return Ak;
     }
 
-    private void clearState()
-    {
+    private void clearState() {
         Ak = null;
         nVertices = 0;
         blocked = null;
         stack = null;
         iToV = null;
         vToI = null;
-
-        Ak = null;
         B = null;
+        operation = () -> { };
     }
 
-    private boolean circuit(Integer v, Operation o)
-    {
+    private boolean circuit(Integer v, int steps) {
         boolean f = false;
 
         stack.push(v);
@@ -160,28 +146,11 @@ public class HawickJamesSimpleCycles<V, E>
             }
 
             if (Objects.equals(w, start)) {
-                if (o == Operation.ENUMERATE) {
-                    List<V> cycle = new ArrayList<>(stack.size());
-
-                    for (Integer aStack : stack) {
-                        cycle.add(iToV[aStack]);
-                    }
-
-                    cycles.add(cycle);
-                }
-
-                if (o == Operation.PRINT_ONLY) {
-                    for (Integer i : stack) {
-                        System.out.print(iToV[i].toString() + " ");
-                    }
-                    System.out.println("");
-                }
-
-                nCycles++;
+                operation.run();
 
                 f = true;
             } else if (!blocked[w]) {
-                if (circuit(w, o)) {
+                if (limitReached(steps) || circuit(w, steps + 1)) {
                     f = true;
                 }
             }
@@ -206,14 +175,14 @@ public class HawickJamesSimpleCycles<V, E>
         return f;
     }
 
-    private void unblock(Integer u)
-    {
+    private void unblock(Integer u) {
         blocked[u] = false;
 
         for (int wPos = 0; wPos < B[u].size(); wPos++) {
             Integer w = B[u].get(wPos);
 
-            wPos -= removeFromList(B[u], w);
+            wPos -= frequency(B[u], w);
+            B[u].removeAll(singletonList(w));
 
             if (blocked[w]) {
                 unblock(w);
@@ -222,44 +191,20 @@ public class HawickJamesSimpleCycles<V, E>
     }
 
     /**
-     * Remove all occurrences of a value from the list.
-     *
-     * @param u the Integer to be removed.
-     * @param list the list from which all the occurrences of u must be removed.
-     */
-    private int removeFromList(List<Integer> list, Integer u)
-    {
-        int nOccurrences = 0;
-
-        Iterator<Integer> iterator = list.iterator();
-        while (iterator.hasNext()) {
-            Integer w = iterator.next();
-            if (Objects.equals(w, u)) {
-                nOccurrences++;
-                iterator.remove();
-            }
-        }
-
-        return nOccurrences;
-    }
-
-    /**
      * Get the graph
-     * 
+     *
      * @return graph
      */
-    public Graph<V, E> getGraph()
-    {
+    public Graph<V, E> getGraph() {
         return graph;
     }
 
     /**
      * Set the graph
-     * 
+     *
      * @param graph graph
      */
-    public void setGraph(Graph<V, E> graph)
-    {
+    public void setGraph(Graph<V, E> graph) {
         this.graph = GraphTests.requireDirected(graph, "Graph must be directed");
     }
 
@@ -267,25 +212,15 @@ public class HawickJamesSimpleCycles<V, E>
      * {@inheritDoc}
      */
     @Override
-    public List<List<V>> findSimpleCycles()
-        throws IllegalArgumentException
-    {
+    public List<List<V>> findSimpleCycles() throws IllegalArgumentException {
         if (graph == null) {
             throw new IllegalArgumentException("Null graph.");
         }
 
-        initState(Operation.ENUMERATE);
-
-        for (int i = 0; i < nVertices; i++) {
-            for (int j = 0; j < nVertices; j++) {
-                blocked[j] = false;
-                B[j].clear();
-            }
-
-            start = vToI.get(iToV[i]);
-            circuit(start, Operation.ENUMERATE);
-        }
-
+        initState();
+        cycles = new ArrayList<>();
+        operation = () -> cycles.add(stack.stream().map(v -> iToV[v]).collect(toList()));
+        analyzeCircuits();
         List<List<V>> result = cycles;
         clearState();
         return result;
@@ -295,40 +230,40 @@ public class HawickJamesSimpleCycles<V, E>
      * Print to the standard output all simple cycles without building a list to keep them, thus
      * avoiding high memory consumption when investigating large and much connected graphs.
      */
-    public void printSimpleCycles()
-    {
+    public void printSimpleCycles() {
         if (graph == null) {
             throw new IllegalArgumentException("Null graph.");
         }
 
-        initState(Operation.PRINT_ONLY);
+        initState();
+        operation = () -> {
+            stack.stream().map(i -> iToV[i].toString() + " ").forEach(System.out::print);
+            System.out.println();
+        };
 
-        for (int i = 0; i < nVertices; i++) {
-            for (int j = 0; j < nVertices; j++) {
-                blocked[j] = false;
-                B[j].clear();
-            }
-
-            start = vToI.get(iToV[i]);
-            circuit(start, Operation.PRINT_ONLY);
-        }
-
+        analyzeCircuits();
         clearState();
     }
 
     /**
      * Count the number of simple cycles. It can count up to Long.MAX cycles in a graph.
-     * 
+     *
      * @return the number of simple cycles
      */
-    public long countSimpleCycles()
-    {
+    public long countSimpleCycles() {
         if (graph == null) {
             throw new IllegalArgumentException("Null graph.");
         }
 
-        initState(Operation.COUNT_ONLY);
+        initState();
+        nCycles = 0;
+        operation = () -> nCycles++;
+        analyzeCircuits();
+        clearState();
+        return nCycles;
+    }
 
+    private void analyzeCircuits() {
         for (int i = 0; i < nVertices; i++) {
             for (int j = 0; j < nVertices; j++) {
                 blocked[j] = false;
@@ -336,11 +271,29 @@ public class HawickJamesSimpleCycles<V, E>
             }
 
             start = vToI.get(iToV[i]);
-            circuit(start, Operation.COUNT_ONLY);
+            circuit(start, 0);
         }
+    }
 
-        clearState();
+    /**
+     * Limits the maximum number of edges in a cycle.
+     *
+     * @param pathLimit maximum paths.
+     */
+    public void setPathLimit(int pathLimit) {
+        this.pathLimit = pathLimit - 1;
+        this.hasLimit = true;
+    }
 
-        return nCycles;
+    /**
+     * This is the default behaviour of the algorithm.
+     * It will keep looking as long as there are paths available.
+     */
+    public void unlimitedPaths() {
+        this.hasLimit = false;
+    }
+
+    private boolean limitReached(int steps) {
+        return hasLimit && steps >= pathLimit;
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
@@ -21,7 +21,6 @@ import org.jgrapht.*;
 
 import java.util.*;
 
-import static java.util.Collections.frequency;
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 
@@ -188,9 +187,10 @@ public class HawickJamesSimpleCycles<V, E>
         for (int wPos = 0; wPos < B[u].size(); wPos++) {
             Integer w = B[u].get(wPos);
 
-            wPos -= B[u].size();
+            int sizeBeforeRemove = B[u].size();
             B[u].removeAll(singletonList(w));
-            wPos -= B[u].size();
+            wPos -= (sizeBeforeRemove - B[u].size());
+
 
             if (blocked[w]) {
                 unblock(w);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
@@ -17,16 +17,9 @@
  */
 package org.jgrapht.alg.cycle;
 
-import org.jgrapht.Graph;
-import org.jgrapht.GraphTests;
-import org.jgrapht.Graphs;
+import org.jgrapht.*;
 
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 import static java.util.Collections.frequency;
 import static java.util.Collections.singletonList;
@@ -45,7 +38,10 @@ import static java.util.stream.Collectors.toList;
  *
  * @author Luiz Kill
  */
-public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E> {
+public class HawickJamesSimpleCycles<V, E>
+    implements
+    DirectedSimpleCycles<V, E>
+{
 
     private Graph<V, E> graph;
 
@@ -71,7 +67,9 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
     /**
      * Create a simple cycle finder with an unspecified graph.
      */
-    public HawickJamesSimpleCycles() { }
+    public HawickJamesSimpleCycles()
+    {
+    }
 
     /**
      * Create a simple cycle finder for the specified graph.
@@ -81,12 +79,16 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
      * @throws IllegalArgumentException if the graph argument is <code>
      * null</code>.
      */
-    public HawickJamesSimpleCycles(Graph<V, E> graph) throws IllegalArgumentException {
+    public HawickJamesSimpleCycles(Graph<V, E> graph)
+        throws IllegalArgumentException
+    {
         this.graph = GraphTests.requireDirected(graph, "Graph must be directed");
     }
 
     @SuppressWarnings("unchecked")
-    private void initState() {
+    private void initState()
+    {
+        nCycles = 0;
         nVertices = graph.vertexSet().size();
         blocked = new boolean[nVertices];
         stack = new ArrayDeque<>(nVertices);
@@ -96,7 +98,7 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
             B[i] = new ArrayList<>();
         }
 
-        iToV = (V[])graph.vertexSet().toArray();
+        iToV = (V[]) graph.vertexSet().toArray();
         vToI = new HashMap<>();
         for (int i = 0; i < iToV.length; i++) {
             vToI.put(iToV[i], i);
@@ -108,7 +110,8 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
     }
 
     @SuppressWarnings("unchecked")
-    private List<Integer>[] buildAdjacencyList() {
+    private List<Integer>[] buildAdjacencyList()
+    {
         @SuppressWarnings("rawtypes") List[] Ak = new ArrayList[nVertices];
         for (int j = 0; j < nVertices; j++) {
             V v = iToV[j];
@@ -123,7 +126,8 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
         return Ak;
     }
 
-    private void clearState() {
+    private void clearState()
+    {
         Ak = null;
         nVertices = 0;
         blocked = null;
@@ -131,10 +135,12 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
         iToV = null;
         vToI = null;
         B = null;
-        operation = () -> { };
+        operation = () -> {
+        };
     }
 
-    private boolean circuit(Integer v, int steps) {
+    private boolean circuit(Integer v, int steps)
+    {
         boolean f = false;
 
         stack.push(v);
@@ -175,7 +181,8 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
         return f;
     }
 
-    private void unblock(Integer u) {
+    private void unblock(Integer u)
+    {
         blocked[u] = false;
 
         for (int wPos = 0; wPos < B[u].size(); wPos++) {
@@ -192,19 +199,21 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
 
     /**
      * Get the graph
-     *
+     * 
      * @return graph
      */
-    public Graph<V, E> getGraph() {
+    public Graph<V, E> getGraph()
+    {
         return graph;
     }
 
     /**
      * Set the graph
-     *
+     * 
      * @param graph graph
      */
-    public void setGraph(Graph<V, E> graph) {
+    public void setGraph(Graph<V, E> graph)
+    {
         this.graph = GraphTests.requireDirected(graph, "Graph must be directed");
     }
 
@@ -212,7 +221,9 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
      * {@inheritDoc}
      */
     @Override
-    public List<List<V>> findSimpleCycles() throws IllegalArgumentException {
+    public List<List<V>> findSimpleCycles()
+        throws IllegalArgumentException
+    {
         if (graph == null) {
             throw new IllegalArgumentException("Null graph.");
         }
@@ -230,7 +241,8 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
      * Print to the standard output all simple cycles without building a list to keep them, thus
      * avoiding high memory consumption when investigating large and much connected graphs.
      */
-    public void printSimpleCycles() {
+    public void printSimpleCycles()
+    {
         if (graph == null) {
             throw new IllegalArgumentException("Null graph.");
         }
@@ -247,10 +259,11 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
 
     /**
      * Count the number of simple cycles. It can count up to Long.MAX cycles in a graph.
-     *
+     * 
      * @return the number of simple cycles
      */
-    public long countSimpleCycles() {
+    public long countSimpleCycles()
+    {
         if (graph == null) {
             throw new IllegalArgumentException("Null graph.");
         }
@@ -263,7 +276,8 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
         return nCycles;
     }
 
-    private void analyzeCircuits() {
+    private void analyzeCircuits()
+    {
         for (int i = 0; i < nVertices; i++) {
             for (int j = 0; j < nVertices; j++) {
                 blocked[j] = false;
@@ -280,7 +294,8 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
      *
      * @param pathLimit maximum paths.
      */
-    public void setPathLimit(int pathLimit) {
+    public void setPathLimit(int pathLimit)
+    {
         this.pathLimit = pathLimit - 1;
         this.hasLimit = true;
     }
@@ -289,11 +304,13 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
      * This is the default behaviour of the algorithm.
      * It will keep looking as long as there are paths available.
      */
-    public void unlimitedPaths() {
+    public void unlimitedPaths()
+    {
         this.hasLimit = false;
     }
 
-    private boolean limitReached(int steps) {
+    private boolean limitReached(int steps)
+    {
         return hasLimit && steps >= pathLimit;
     }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/HawickJamesSimpleCyclesTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/HawickJamesSimpleCyclesTest.java
@@ -1,0 +1,240 @@
+/*
+ * (C) Copyright 2013-2017, by Nikolay Ognyanov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.cycle;
+
+import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
+import org.jgrapht.graph.DefaultDirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.junit.Test;
+
+import java.util.List;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Unit tests for class {@link HawickJamesSimpleCycles}.
+ *
+ * @author Edwin Ouwehand
+ */
+public class HawickJamesSimpleCyclesTest {
+
+    @Test
+    public void noCyclesCount() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addVertex("C");
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "C");
+
+        assertEquals(0, new HawickJamesSimpleCycles<>(graph).countSimpleCycles());
+    }
+
+    @Test
+    public void reflexiveCycleCount() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addEdge("A", "A");
+        assertEquals(1, new HawickJamesSimpleCycles<>(graph).countSimpleCycles());
+    }
+
+    @Test
+    public void singleDirectCycleCount() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "A");
+
+        assertEquals(1, new HawickJamesSimpleCycles<>(graph).countSimpleCycles());
+    }
+
+    @Test
+    public void indirectCycleCount() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addVertex("C");
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "C");
+        graph.addEdge("C", "A");
+
+        assertEquals(1, new HawickJamesSimpleCycles<>(graph).countSimpleCycles());
+    }
+
+    @Test
+    public void noCyclesFind() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addVertex("C");
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "C");
+
+        assertTrue(new HawickJamesSimpleCycles<>(graph).findSimpleCycles().isEmpty());
+    }
+
+    @Test
+    public void reflexiveCycleFind() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addEdge("A", "A");
+
+        List<List<String>> cycles = new HawickJamesSimpleCycles<>(graph).findSimpleCycles();
+        assertEquals(1, cycles.size());
+        assertEquals(singletonList("A"), cycles.get(0));
+    }
+
+    @Test
+    public void singleDirectFind() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "A");
+
+        List<List<String>> cycles = new HawickJamesSimpleCycles<>(graph).findSimpleCycles();
+
+        assertEquals(1, cycles.size());
+        assertTrue(cycles.get(0).containsAll(asList("A", "B")));
+    }
+
+    @Test
+    public void indirectCycleFind() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addVertex("C");
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "C");
+        graph.addEdge("C", "A");
+
+        List<List<String>> cycles = new HawickJamesSimpleCycles<>(graph).findSimpleCycles();
+
+        assertEquals(1, cycles.size());
+        assertTrue(cycles.get(0).containsAll(asList("A", "B", "C")));
+    }
+
+    @Test
+    public void twoCycles() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addVertex("C");
+
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "A");
+        graph.addEdge("B", "C");
+        graph.addEdge("C", "A");
+
+        List<List<String>> cycles = new HawickJamesSimpleCycles<>(graph).findSimpleCycles();
+
+        assertEquals(2, cycles.size());
+        assertTrue(cycles.get(0).containsAll(asList("A", "B")));
+        assertTrue(cycles.get(1).containsAll(asList("A", "B", "C")));
+    }
+
+    @Test
+    public void twoSharingEdge() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addVertex("C");
+        graph.addVertex("D");
+
+        graph.addEdge("B", "C"); //Shared
+        graph.addEdge("A", "B");
+        graph.addEdge("C", "A");
+        graph.addEdge("D", "B");
+        graph.addEdge("C", "D");
+
+        List<List<String>> cycles = new HawickJamesSimpleCycles<>(graph).findSimpleCycles();
+
+        assertEquals(2, cycles.size());
+        assertTrue(cycles.get(0).containsAll(asList("A", "B", "C")));
+        assertTrue(cycles.get(1).containsAll(asList("D", "B", "C")));
+    }
+
+    @Test
+    public void simplestCycles() {
+        // We do NOT want to find A -> B, B -> B, B -> A as an additional cycle here,
+        // nor B -> A, A -> A, A -> B for that matter. Only the most simple ones.
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "A");
+        graph.addEdge("A", "A");
+        graph.addEdge("B", "B");
+
+        List<List<String>> cycles = new HawickJamesSimpleCycles<>(graph).findSimpleCycles();
+
+        assertEquals(3, cycles.size());
+        assertEquals(asList("B", "A"), cycles.get(0));
+        assertEquals(singletonList("A"), cycles.get(1));
+        assertEquals(singletonList("B"), cycles.get(2));
+    }
+
+    @Test
+    public void complexGraph() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        Graphs.addAllVertices(graph, asList("A", "B", "C", "D", "E", "F"));
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "C");
+        graph.addEdge("B", "E");
+        graph.addEdge("C", "D");
+        graph.addEdge("D", "E");
+        graph.addEdge("E", "F");
+        graph.addEdge("F", "A");
+
+        List<List<String>> cycles = new HawickJamesSimpleCycles<>(graph).findSimpleCycles();
+
+        assertEquals(2, cycles.size());
+
+        List<String> cycle0 = cycles.get(0);
+        assertTrue(cycle0.containsAll(asList("A", "B", "C", "D", "E", "F")));
+
+        List<String> cycle1 = cycles.get(1);
+        assertTrue(cycle1.containsAll(asList("A", "B", "E", "F")));
+    }
+
+    @Test
+    public void consecutiveRuns() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addVertex("C");
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "C");
+        graph.addEdge("C", "A");
+
+        HawickJamesSimpleCycles<String, DefaultEdge> hjsc = new HawickJamesSimpleCycles<>(graph);
+
+        List<List<String>> run1 = hjsc.findSimpleCycles();
+        assertEquals(1, run1.size());
+        assertTrue(run1.get(0).containsAll(asList("A", "B", "C")));
+
+        List<List<String>> run2 = hjsc.findSimpleCycles();
+        assertEquals(1, run2.size());
+        assertTrue(run2.get(0).containsAll(asList("A", "B", "C")));
+    }
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/HawickJamesSimpleCyclesTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/HawickJamesSimpleCyclesTest.java
@@ -237,4 +237,60 @@ public class HawickJamesSimpleCyclesTest {
         assertEquals(1, run2.size());
         assertTrue(run2.get(0).containsAll(asList("A", "B", "C")));
     }
+
+    @Test
+    public void limitPaths1() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "A");
+
+        HawickJamesSimpleCycles<String, DefaultEdge> hjsc = new HawickJamesSimpleCycles<>(graph);
+        hjsc.setPathLimit(1);
+
+        assertTrue(hjsc.findSimpleCycles().isEmpty());
+    }
+
+    @Test
+    public void limitPaths2() {
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addVertex("C");
+
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "C");
+        graph.addEdge("C", "A");
+
+        HawickJamesSimpleCycles<String, DefaultEdge> hjsc = new HawickJamesSimpleCycles<>(graph);
+        hjsc.setPathLimit(2);
+
+        assertTrue(hjsc.findSimpleCycles().isEmpty());
+    }
+
+    @Test
+    public void limitPathsTwoCycles() {
+        // Two smaller cycles are still found
+        Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("A");
+        graph.addVertex("B");
+        graph.addVertex("C");
+        graph.addVertex("D");
+
+        graph.addEdge("A", "B");
+        graph.addEdge("B", "A");
+
+        graph.addEdge("C", "D");
+        graph.addEdge("D", "C");
+
+        HawickJamesSimpleCycles<String, DefaultEdge> hjsc = new HawickJamesSimpleCycles<>(graph);
+        hjsc.setPathLimit(2);
+
+        List<List<String>> cycles = hjsc.findSimpleCycles();
+        assertEquals(2, cycles.size());
+        assertTrue(cycles.get(0).containsAll(asList("A", "B")));
+        assertTrue(cycles.get(1).containsAll(asList("C", "D")));
+    }
 }


### PR DESCRIPTION
Motivation: In its current form the algorithm does not perform well when many cycles exist. For example, 40 vertices, 400 edges and a high number of cycles runs out of memory with 16G. In this case it makes sense to limit search depth, because the majority of the longer paths are probably already part of a smaller cycle and therefore don't have to be explored.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
