### PR TITLE
Allow outgoing edges selection to be overridable in CrossComponentIterator

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
@@ -308,9 +308,21 @@ public abstract class CrossComponentIterator<V, E, D>
         }
     }
 
+    /**
+     * Selects the outgoing edges for a given vertex based on the source vertex and other traversal
+     * state. The default implementation returns all outgoing edges.
+     *
+     * @param vertex vertex in question
+     * @return set of outgoing edges connected to the vertex
+     */
+    protected Set<E> selectOutgoingEdges(V vertex)
+    {
+        return graph.outgoingEdgesOf(vertex);
+    }
+
     private void addUnseenChildrenOf(V vertex)
     {
-        for (E edge : graph.outgoingEdgesOf(vertex)) {
+        for (E edge : selectOutgoingEdges(vertex)) {
             if (nListeners != 0) {
                 fireEdgeTraversed(createEdgeTraversalEvent(edge));
             }

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/EdgeSelectionTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/EdgeSelectionTest.java
@@ -1,0 +1,147 @@
+/*
+ * (C) Copyright 2019-2019, by Sean Hudson and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.traverse;
+
+import org.jgrapht.*;
+import org.jgrapht.graph.*;
+import org.junit.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for overriding the {@link CrossComponentIterator#selectOutgoingEdges selectOutgoingEdges}
+ * method. Overriding this method allows for selecting outgoing edges based on the source vertex
+ * and other traversal state.
+ *
+ * @author Sean Hudson
+ */
+public class EdgeSelectionTest
+{
+    /**
+     * Tests selecting the outgoing edges based on criteria that incorporates the source, edge and
+     * traversal iterator state.
+     */
+    @Test
+    public void testEdgeSelectionOverride()
+    {
+        Graph<StatefulVertex, StatefulEdge> graph = createGraph();
+        DepthFirstIterator<StatefulVertex, StatefulEdge> iterator =
+            new DepthFirstIterator<StatefulVertex, StatefulEdge>(graph)
+            {
+                String evenEdgeColor = "BLUE";
+                String oddEdgeColor = "RED";
+
+                @Override
+                protected Set<StatefulEdge> selectOutgoingEdges(StatefulVertex vertex)
+                {
+                    return graph.outgoingEdgesOf(vertex).stream().filter(e -> filterEdge(vertex, e))
+                        .collect(Collectors.toSet());
+                }
+
+                /**
+                 * Checks if the edge color corresponds to the vertex parity.
+                 */
+                private boolean filterEdge(StatefulVertex vertex, StatefulEdge edge)
+                {
+                    return vertex.getState() % 2 == 0 ? edge.getColor().equals(evenEdgeColor) :
+                        edge.getColor().equals(oddEdgeColor);
+                }
+            };
+        LexBreadthFirstIteratorTest.MyTraversalListener<StatefulVertex, StatefulEdge> listener =
+            new LexBreadthFirstIteratorTest.MyTraversalListener<>(graph);
+
+        iterator.addTraversalListener(listener);
+        StringBuilder traversedOrder = new StringBuilder();
+        while (iterator.hasNext()) {
+            traversedOrder.append(iterator.next().getState());
+        }
+        assertEquals(graph.vertexSet(), listener.verticesTraversed);
+        assertEquals(graph.vertexSet(), listener.verticesFinished);
+        assertEquals("1342567", traversedOrder.toString());
+    }
+
+    private Graph<StatefulVertex, StatefulEdge> createGraph()
+    {
+        Graph<StatefulVertex, StatefulEdge> graph = new DefaultDirectedGraph<>(StatefulEdge.class);
+
+        StatefulVertex v1 = new StatefulVertex(1);
+        StatefulVertex v2 = new StatefulVertex(2);
+        StatefulVertex v3 = new StatefulVertex(3);
+        StatefulVertex v4 = new StatefulVertex(4);
+        StatefulVertex v5 = new StatefulVertex(5);
+        StatefulVertex v6 = new StatefulVertex(6);
+        StatefulVertex v7 = new StatefulVertex(7);
+
+        graph.addVertex(v1);
+        graph.addVertex(v2);
+        graph.addVertex(v3);
+        graph.addVertex(v4);
+        graph.addVertex(v5);
+        graph.addVertex(v6);
+        graph.addVertex(v7);
+        graph.addVertex(v7);
+
+        graph.addEdge(v1, v2, new StatefulEdge("BLUE"));
+        graph.addEdge(v1, v3, new StatefulEdge("RED"));
+        graph.addEdge(v1, v3, new StatefulEdge("BLUE"));
+        graph.addEdge(v2, v4, new StatefulEdge("BLUE"));
+        graph.addEdge(v2, v5, new StatefulEdge("BLUE"));
+        graph.addEdge(v2, v5, new StatefulEdge("RED"));
+        graph.addEdge(v3, v4, new StatefulEdge("RED"));
+        graph.addEdge(v3, v7, new StatefulEdge("BLUE"));
+        graph.addEdge(v4, v6, new StatefulEdge("RED"));
+        graph.addEdge(v6, v2, new StatefulEdge("BLUE"));
+        graph.addEdge(v7, v5, new StatefulEdge("RED"));
+
+        return graph;
+    }
+
+    private static class StatefulEdge
+        extends DefaultWeightedEdge
+    {
+        private final String color;
+
+        StatefulEdge(String color)
+        {
+            this.color = color;
+        }
+
+        String getColor()
+        {
+            return color;
+        }
+    }
+
+    private static class StatefulVertex
+    {
+        private final int state;
+
+        StatefulVertex(int state)
+        {
+            this.state = state;
+        }
+
+        int getState()
+        {
+            return state;
+        }
+    }
+}


### PR DESCRIPTION
Motivation: CrossComponentIterator does not provide an easy way of extending the edge selection process when determining the next vertices to add (e.g. if I want to ignore some edges based on a vertex attribute). By making these methods protected we allow for more powerful extensibility without any changes to the current behavior. Also, most other methods in this class are protected, allowing for extensible templating.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
