### PR TITLE
Add links in Guava adapater package-info.

### DIFF
--- a/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/package-info.java
+++ b/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/package-info.java
@@ -1,4 +1,7 @@
 /**
- * Guava adapters.
+ * <a href="https://jgrapht.org/guide/UserOverview#guava-graph-adapter">Guava
+ * adapters</a> allow you to <a
+ * href="https://jgrapht.org/guide/GuavaAdapter">run
+ * JGraphT algorithms directly against Guava's common.graph data structures</a>.
  */
 package org.jgrapht.graph.guava;


### PR DESCRIPTION
Our suggestion for linking to JGraphT's adapter from the Guava wiki was recently accepted:

https://github.com/google/guava/issues/3365

Their link goes straight to our package-info, so I'm updating our package-info with the links to our wiki as well.