### PR TITLE
Enable arbitrary (e.g. 0) base ID

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/io/IntegerComponentNameProvider.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/IntegerComponentNameProvider.java
@@ -27,20 +27,44 @@ import java.util.*;
  * @param <T> the component type
  *
  * @author Trevor Harmon
+ * @author Amr ALHOSSARY (?)
  */
 public class IntegerComponentNameProvider<T>
     implements
     ComponentNameProvider<T>
 {
-    private int nextID = 1;
+    private static final int DEFAULT_BASE = 1;
+    
+    /**
+     * The first ID to use.
+     */
+    private int base;
+    private int nextID;
     private final Map<T, Integer> idMap = new HashMap<>();
+
+    /**
+     * Create a provider with the default base id (1).
+     */
+    public IntegerComponentNameProvider()
+    {
+        this(DEFAULT_BASE);
+    }
+
+    /**create a provider with a given arbitrary base
+     * @param base the first Id to use.
+     */
+    public IntegerComponentNameProvider(int base)
+    {
+        this.base = base;
+        clear();
+    }
 
     /**
      * Clears all cached identifiers, and resets the unique identifier counter.
      */
     public void clear()
     {
-        nextID = 1;
+        nextID = base;
         idMap.clear();
     }
 

--- a/jgrapht-io/src/main/java/org/jgrapht/io/IntegerComponentNameProvider.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/io/IntegerComponentNameProvider.java
@@ -27,14 +27,14 @@ import java.util.*;
  * @param <T> the component type
  *
  * @author Trevor Harmon
- * @author Amr ALHOSSARY (?)
+ * @author Amr ALHOSSARY
  */
 public class IntegerComponentNameProvider<T>
     implements
     ComponentNameProvider<T>
 {
     private static final int DEFAULT_BASE = 1;
-    
+
     /**
      * The first ID to use.
      */
@@ -50,7 +50,9 @@ public class IntegerComponentNameProvider<T>
         this(DEFAULT_BASE);
     }
 
-    /**create a provider with a given arbitrary base
+    /**
+     * Create a provider with a given arbitrary base
+     * 
      * @param base the first Id to use.
      */
     public IntegerComponentNameProvider(int base)

--- a/jgrapht-io/src/test/java/org/jgrapht/io/IntegerComponentNameProviderTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/IntegerComponentNameProviderTest.java
@@ -1,9 +1,31 @@
+/*
+ * (C) Copyright 2016-2017, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
 package org.jgrapht.io;
 
 import static org.junit.Assert.*;
 
 import org.junit.Test;
 
+/**
+ * Test for IntegerComponentNameProvider
+ * 
+ * @author Amr ALHOSSARY
+ */
 public class IntegerComponentNameProviderTest
 {
 

--- a/jgrapht-io/src/test/java/org/jgrapht/io/IntegerComponentNameProviderTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/io/IntegerComponentNameProviderTest.java
@@ -1,0 +1,41 @@
+package org.jgrapht.io;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+public class IntegerComponentNameProviderTest
+{
+
+    @Test
+    public void testConstructors()
+    {
+        IntegerComponentNameProvider<Object> provider = new IntegerComponentNameProvider<>();
+        String id1 = provider.getName(new Object());
+        assertEquals("1", id1);
+        String id2 = provider.getName(new Object());
+        assertEquals("2", id2);
+
+        provider = new IntegerComponentNameProvider<>(0);
+        id1 = provider.getName(new Object());
+        assertEquals("0", id1);
+        id2 = provider.getName(new Object());
+        assertEquals("1", id2);
+    
+    }
+
+    @Test
+    public void testClear()
+    {
+        IntegerComponentNameProvider<Object> provider = new IntegerComponentNameProvider<>();
+        String id1 = provider.getName(new Object());
+        assertEquals("1", id1);
+        String id2 = provider.getName(new Object());
+        assertEquals("2", id2);
+        provider.clear();
+        id1 = provider.getName(new Object());
+        assertEquals("1", id1);
+        id2 = provider.getName(new Object());
+        assertEquals("2", id2);
+    }
+}


### PR DESCRIPTION
Added a new constructor with "base" parameter.
----
In order to enable writing graphs out with IDs starting from an arbitrary number, I added this field, and parameters.

The Changes are referenced in issue: [#836](https://github.com/jgrapht/jgrapht/issues/836).

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
