### PR TITLE
Fix GraphWalk equality method

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
@@ -224,6 +224,10 @@ public class GraphWalk<V, E>
         @SuppressWarnings("unchecked") GraphWalk<V, E> other = (GraphWalk<V, E>) o;
         if (this.isEmpty() && other.isEmpty())
             return true;
+
+        if (this.isEmpty())
+            return false;
+
         if (!this.startVertex.equals(other.getStartVertex())
             || !this.endVertex.equals(other.getEndVertex()))
             return false;

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
@@ -303,4 +303,18 @@ public class GraphWalkTest
         Assert.assertEquals(gw1, gw3);
     }
 
+    @Test
+    public void testFirstEmptyWalkEquality()
+    {
+        Graph<Integer, DefaultEdge> graph1 = new SimpleGraph<>(DefaultEdge.class);
+        GraphWalk<Integer, DefaultEdge> gw1 =
+            new GraphWalk<>(graph1, null, null, null, Collections.emptyList(), 0);
+
+        Graph<Integer, DefaultEdge> graph2 = new SimpleGraph<>(DefaultEdge.class);
+        graph.addVertex(0);
+        GraphWalk<Integer, DefaultEdge> gw2 =
+            new GraphWalk<>(graph2, 0, 0, Collections.singletonList(0), Collections.emptyList(), 0);
+        Assert.assertFalse(gw1->equals(gw2));
+    }
+
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
@@ -311,10 +311,10 @@ public class GraphWalkTest
             new GraphWalk<>(graph1, null, null, null, Collections.emptyList(), 0);
 
         Graph<Integer, DefaultEdge> graph2 = new SimpleGraph<>(DefaultEdge.class);
-        graph.addVertex(0);
+        graph2.addVertex(0);
         GraphWalk<Integer, DefaultEdge> gw2 =
             new GraphWalk<>(graph2, 0, 0, Collections.singletonList(0), Collections.emptyList(), 0);
-        Assert.assertFalse(gw1->equals(gw2));
+        Assert.assertNotEquals(gw1, gw2);
     }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/GraphWalkTest.java
@@ -307,13 +307,11 @@ public class GraphWalkTest
     public void testFirstEmptyWalkEquality()
     {
         Graph<Integer, DefaultEdge> graph1 = new SimpleGraph<>(DefaultEdge.class);
-        GraphWalk<Integer, DefaultEdge> gw1 =
-            new GraphWalk<>(graph1, null, null, null, Collections.emptyList(), 0);
+        GraphWalk<Integer,DefaultEdge> gw1 = GraphWalk.emptyWalk(graph1);
 
         Graph<Integer, DefaultEdge> graph2 = new SimpleGraph<>(DefaultEdge.class);
         graph2.addVertex(0);
-        GraphWalk<Integer, DefaultEdge> gw2 =
-            new GraphWalk<>(graph2, 0, 0, Collections.singletonList(0), Collections.emptyList(), 0);
+        GraphWalk<Integer,DefaultEdge> gw2 = GraphWalk.singletonWalk(graph2, 0);
         Assert.assertNotEquals(gw1, gw2);
     }
 


### PR DESCRIPTION
This PR fixes possible bug in `GraphWalk` equality method. [This](https://github.com/jgrapht/jgrapht/blob/master/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java#L227) line of code will raise `java.lang.NullPointerException`, if the current graph is empty (so, `this.startVertex` is null), while the `other` graph is not. I checked it in [this](https://travis-ci.org/bingo-soft/jgrapht/jobs/613935305#L3150) build with no fix and one extra unit test, which tests exactly this case. If we add a fix to `equals` method, then everything is ok. The fix is simple:
`if (this.isEmpty())
            return false;`

----

- [+] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [+] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [+] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [+] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [+] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [+] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [+] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
