### PR TITLE
complete graph generators with preexisting vertex set

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/generate/CompleteBipartiteGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/CompleteBipartiteGraphGenerator.java
@@ -36,20 +36,43 @@ public class CompleteBipartiteGraphGenerator<V, E>
     GraphGenerator<V, E, V>
 {
     private final int sizeA, sizeB;
+    private final Set<V> partitionA, partitionB;
 
     /**
      * Creates a new CompleteBipartiteGraphGenerator object.
      *
-     * @param partitionOne number of vertices in the first partition
-     * @param partitionTwo number of vertices in the second partition
+     * @param partitionA number of vertices in the first partition
+     * @param partitionB number of vertices in the second partition
      */
-    public CompleteBipartiteGraphGenerator(int partitionOne, int partitionTwo)
+    public CompleteBipartiteGraphGenerator(int partitionA, int partitionB)
     {
-        if (partitionOne < 0 || partitionTwo < 0) {
+        if (partitionA < 0 || partitionB < 0) {
             throw new IllegalArgumentException("partition sizes must be non-negative");
         }
-        this.sizeA = partitionOne;
-        this.sizeB = partitionTwo;
+        this.sizeA = partitionA;
+        this.sizeB = partitionB;
+        this.partitionA=new LinkedHashSet<>(sizeA);
+        this.partitionB=new LinkedHashSet<>(sizeB);
+    }
+
+    /**
+     * Creates a new CompleteBipartiteGraphGenerator object.
+     * A complete bipartite graph is generated on the vertices provided between the vertices provided in the two partitions.
+     * Note that <i>all</i> vertices in both {@code partitionA} and {@code partitionB} must be present in the graph or an
+     * exception will be thrown during the invocation of {@link #generateGraph(Graph, Map)}
+     *
+     * @param partitionA first partition
+     * @param partitionB second partition
+     */
+    public CompleteBipartiteGraphGenerator(Set<V> partitionA, Set<V> partitionB)
+    {
+        if (partitionA.isEmpty() || partitionB.isEmpty()) {
+            throw new IllegalArgumentException("partitions must be non-empty");
+        }
+        this.sizeA = 0;
+        this.sizeB = 0;
+        this.partitionA=partitionA;
+        this.partitionB=partitionB;
     }
 
     /**
@@ -58,23 +81,17 @@ public class CompleteBipartiteGraphGenerator<V, E>
     @Override
     public void generateGraph(Graph<V, E> target, Map<String, V> resultMap)
     {
-        if ((sizeA < 1) && (sizeB < 1)) {
-            return;
-        }
-
         // Create vertices in each of the partitions
-        Set<V> a = new HashSet<>();
-        Set<V> b = new HashSet<>();
         for (int i = 0; i < sizeA; i++) {
-            a.add(target.addVertex());
+            partitionA.add(target.addVertex());
         }
         for (int i = 0; i < sizeB; i++) {
-            b.add(target.addVertex());
+            partitionB.add(target.addVertex());
         }
 
         // Add an edge for each pair of vertices in different partitions
-        for (V u : a) {
-            for (V v : b) {
+        for (V u : partitionA) {
+            for (V v : partitionB) {
                 target.addEdge(u, v);
             }
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/CompleteGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/CompleteGraphGenerator.java
@@ -42,15 +42,26 @@ public class CompleteGraphGenerator<V, E>
     /**
      * Construct a new CompleteGraphGenerator.
      *
-     * @param size number of vertices to be generated
+     * The generator will first add {@code size} nodes to the target graph when invoking {@link #generateGraph(Graph, Map)}.
+     * Next, a complete graph is generated on <i>all</i> nodes present in the target graph, including any nodes that were already present in the target graph.
+     *
+     * @param size number of vertices that will be added to the graph
      * @throws IllegalArgumentException if the specified size is negative
      */
     public CompleteGraphGenerator(int size)
     {
-        if (size < 0) {
+        if (size < 0)
             throw new IllegalArgumentException("size must be non-negative");
-        }
         this.size = size;
+    }
+
+    /**
+     * Construct a new CompleteGraphGenerator.
+     *
+     * A complete graph will be generated using the vertices already present in the target graph when invoking {@link #generateGraph(Graph, Map)}
+     */
+    public CompleteGraphGenerator(){
+        size=0;
     }
 
     /**
@@ -59,10 +70,6 @@ public class CompleteGraphGenerator<V, E>
     @Override
     public void generateGraph(Graph<V, E> target, Map<String, V> resultMap)
     {
-        if (size < 1) {
-            return;
-        }
-
         /*
          * Ensure directed or undirected
          */
@@ -72,16 +79,15 @@ public class CompleteGraphGenerator<V, E>
         /*
          * Add vertices
          */
-        List<V> nodes = new ArrayList<>(size);
-        for (int i = 0; i < size; i++) {
-            nodes.add(target.addVertex());
-        }
+        for(int i=0; i<size; i++)
+            target.addVertex();
 
         /*
          * Add edges
          */
-        for (int i = 0; i < size; i++) {
-            for (int j = i + 1; j < size; j++) {
+        List<V> nodes = new ArrayList<>(target.vertexSet());
+        for (int i = 0; i < nodes.size(); i++) {
+            for (int j = i + 1; j < nodes.size(); j++) {
                 V v = nodes.get(i);
                 V u = nodes.get(j);
                 target.addEdge(v, u);

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/GraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/GraphGeneratorTest.java
@@ -156,6 +156,21 @@ public class GraphGeneratorTest
         assertEquals(90, completeGraph.edgeSet().size());
     }
 
+    @Test
+    public void testCompleteGraphGeneratorWithPreexistingVertices()
+    {
+        Graph<Object, DefaultEdge> completeGraph = new SimpleGraph<>(
+                SupplierUtil.OBJECT_SUPPLIER, SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        for(int i=0; i<10; i++)
+            completeGraph.addVertex();
+        CompleteGraphGenerator<Object, DefaultEdge> completeGenerator =
+                new CompleteGraphGenerator<>();
+        completeGenerator.generateGraph(completeGraph);
+
+        // complete graph with 10 vertices has 10*(10-1)/2 = 45 edges
+        assertEquals(45, completeGraph.edgeSet().size());
+    }
+
     /**
      * .
      */
@@ -198,6 +213,28 @@ public class GraphGeneratorTest
             SupplierUtil.OBJECT_SUPPLIER, SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
         CompleteBipartiteGraphGenerator<Object, DefaultEdge> completeBipartiteGenerator =
             new CompleteBipartiteGraphGenerator<>(10, 4);
+        completeBipartiteGenerator.generateGraph(completeBipartiteGraph);
+
+        // Complete bipartite graph with 10 and 4 vertices should have 14
+        // total vertices and 4*10=40 total edges
+        assertEquals(14, completeBipartiteGraph.vertexSet().size());
+        assertEquals(40, completeBipartiteGraph.edgeSet().size());
+    }
+
+    @Test
+    public void testCompleteBipartiteGraphGeneratorWithPreexistingVertices()
+    {
+        Graph<Object, DefaultEdge> completeBipartiteGraph = new SimpleGraph<>(
+                SupplierUtil.OBJECT_SUPPLIER, SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        Set<Object> partitionA=new HashSet<>();
+        for(int i=0; i<10; i++)
+            partitionA.add(completeBipartiteGraph.addVertex());
+        Set<Object> partitionB=new HashSet<>();
+        for(int i=0; i<4; i++)
+            partitionB.add(completeBipartiteGraph.addVertex());
+
+        CompleteBipartiteGraphGenerator<Object, DefaultEdge> completeBipartiteGenerator =
+                new CompleteBipartiteGraphGenerator<>(partitionA, partitionB);
         completeBipartiteGenerator.generateGraph(completeBipartiteGraph);
 
         // Complete bipartite graph with 10 and 4 vertices should have 14


### PR DESCRIPTION
The original complete graph generator would first add X vertices to the graph, and then add all edges between the added vertices. This PR makes it possible add 0 vertices to the graph, but add all edges between the vertices that already exist in the graph. The result is obviously a complete graph.

Similarly, for the complete bipartite graph generator, one can now only add the edges between 2 pre-existing partitions, i.e. without adding vertices to the graph.