### PR TITLE
Make DoublyLinkedList a fully capable java.util.List and Deque

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/planar/BoyerMyrvoldPlanarityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/planar/BoyerMyrvoldPlanarityInspector.java
@@ -2018,12 +2018,7 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
 
         void removeShortCircuitEdges()
         {
-            for (Iterator<Edge> iterator = embedded.iterator(); iterator.hasNext();) {
-                Edge edge = iterator.next();
-                if (edge.shortCircuit) {
-                    iterator.remove();
-                }
-            }
+            embedded.removeIf(e -> e.shortCircuit);
         }
 
         /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/planar/BoyerMyrvoldPlanarityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/planar/BoyerMyrvoldPlanarityInspector.java
@@ -868,7 +868,7 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
                  * the stack and therefore will be processed in the again reverse order
                  */
                 Iterator<Edge> iterator =
-                    info.current.embedded.wrappingIterator(info.prevEdge, true);
+                    info.current.embedded.reverseCircularIterator(info.prevEdge);
                 while (iterator.hasNext()) {
                     Edge currentEdge = iterator.next();
                     Node opposite = currentEdge.getOpposite(info.current);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/planar/BoyerMyrvoldPlanarityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/planar/BoyerMyrvoldPlanarityInspector.java
@@ -252,7 +252,7 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
                 for (Node node : list) {
                     nodes.set(i++, node);
                     if (node.parentEdge != null) {
-                        node.listNode = node.parentEdge.source.separatedDfsChildList.addLast(node);
+                        node.listNode = node.parentEdge.source.separatedDfsChildList.addElementLast(node);
                     }
                 }
             }
@@ -316,8 +316,8 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
         Node root = info.parent;
         Node virtualRootChild = virtualRoot.parentEdge.target;
 
-        root.pertinentRoots.remove(virtualRoot.listNode);
-        root.separatedDfsChildList.remove(virtualRootChild.listNode);
+        root.pertinentRoots.removeNode(virtualRoot.listNode);
+        root.separatedDfsChildList.removeNode(virtualRootChild.listNode);
 
         root.mergeChildEdges(virtualRoot.embedded, info.vIn, info.vOut, info.parentNext, virtualRoot.parentEdge);
 
@@ -424,7 +424,7 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
                 }
                 if (!current.pertinentRoots.isEmpty()) {
                     int parentComponentEntryDir = currentComponentEntryDir;
-                    Node root = current.pertinentRoots.getFirstElement();
+                    Node root = current.pertinentRoots.getFirst();
 
                     if (DEBUG) {
                         System.out.printf("Descending to the root = %s\n", root.toString());
@@ -518,10 +518,10 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
                 if (newStart != end) {
                     if (rootChild.lowpoint < end.dfsIndex) {
                         // the component in externally active
-                        root.listNode = newStart.pertinentRoots.addLast(root);
+                        root.listNode = newStart.pertinentRoots.addElementLast(root);
                     } else {
                         // the component is internally active
-                        root.listNode = newStart.pertinentRoots.addFirst(root);
+                        root.listNode = newStart.pertinentRoots.addElementFirst(root);
                     }
                 } else {
                     break;
@@ -867,7 +867,9 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
                  * The iteration is performed in the reverse order since the infos are pushed on
                  * the stack and therefore will be processed in the again reverse order
                  */
-                for (Iterator<Edge> iterator = info.current.embedded.reverseIteratorFrom(info.prevEdge); iterator.hasNext(); ) {
+                Iterator<Edge> iterator =
+                    info.current.embedded.wrappingIterator(info.prevEdge, true);
+                while (iterator.hasNext()) {
                     Edge currentEdge = iterator.next();
                     Node opposite = currentEdge.getOpposite(info.current);
                     if ((!canGo.test(opposite) || opposite.visited != 0) && !isFinish.test(opposite)) {
@@ -896,7 +898,7 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
         OuterFaceCirculator circulator = componentRoot.iterator(0);
         Node current = circulator.next();
         while (current != w) {
-            if (findPathDfs(current, current.embedded.getFirstElement(), n -> !n.marked, n -> n.boundaryHeight < 0, result)) {
+            if (findPathDfs(current, current.embedded.getFirst(), n -> !n.marked, n -> n.boundaryHeight < 0, result)) {
                 return result;
             }
             current = circulator.next();
@@ -995,7 +997,7 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
             return;
         }
         Node componentParent = componentRoot.getParent();
-        Edge edgeToNext = componentRoot.embedded.getLastElement(), edgeToPrev = componentRoot.embedded.getFirstElement();
+        Edge edgeToNext = componentRoot.embedded.getLast(), edgeToPrev = componentRoot.embedded.getFirst();
         Node next = edgeToNext.getOpposite(componentParent), prev = edgeToPrev.getOpposite(componentParent);
 
         componentRoot.outerFaceNeighbors[0] = next;
@@ -1004,8 +1006,8 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
         prev.outerFaceNeighbors[0] = componentRoot;
         Node current = componentRoot.outerFaceNeighbors[0];
         do {
-            edgeToNext = current.embedded.getLastElement();
-            edgeToPrev = current.embedded.getFirstElement();
+            edgeToNext = current.embedded.getLast();
+            edgeToPrev = current.embedded.getFirst();
             next = edgeToNext.getOpposite(current);
             prev = edgeToPrev.getOpposite(current);
             if (prev != componentParent) {
@@ -1585,13 +1587,13 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
          * @return an edge from the current node to the next node
          */
         Edge edgeToNext() {
-            Edge edge = prev.embedded.getFirstElement();
+            Edge edge = prev.embedded.getFirst();
             Node target = toExistingNode(current);
             Node source = toExistingNode(prev);
             if (edge.getOpposite(source) == target) {
                 return edge;
             } else {
-                return prev.embedded.getLastElement();
+                return prev.embedded.getLast();
             }
         }
 
@@ -1958,7 +1960,7 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
          */
         boolean isExternallyActiveWrtTo(Node node) {
             return leastAncestor < node.dfsIndex ||
-                    (!separatedDfsChildList.isEmpty() && separatedDfsChildList.getFirstElement().lowpoint < node.dfsIndex);
+                    (!separatedDfsChildList.isEmpty() && separatedDfsChildList.getFirst().lowpoint < node.dfsIndex);
         }
 
         /**
@@ -2014,16 +2016,13 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
             return new OuterFaceCirculator(outerFaceNeighbors[direction], this);
         }
 
-        void removeShortCircuitEdges() {
-            List<DoublyLinkedList.ListNode<Edge>> toRemove = new ArrayList<>();
-            for (DoublyLinkedList.ListIterator<Edge> iterator = embedded.listIterator(); iterator.hasNext(); ) {
-                DoublyLinkedList.ListNode<Edge> currentNode = iterator.nextNode();
-                if (currentNode.getValue().shortCircuit) {
-                    toRemove.add(currentNode);
+        void removeShortCircuitEdges()
+        {
+            for (Iterator<Edge> iterator = embedded.iterator(); iterator.hasNext();) {
+                Edge edge = iterator.next();
+                if (edge.shortCircuit) {
+                    iterator.remove();
                 }
-            }
-            for (DoublyLinkedList.ListNode<Edge> removeNode : toRemove) {
-                embedded.remove(removeNode);
             }
         }
 
@@ -2121,7 +2120,7 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
             if (prev.isRootVertex()) {
                 prev = prev.getParent();
             }
-            Edge firstEdge = embedded.getFirstElement();
+            Edge firstEdge = embedded.getFirst();
             if (firstEdge.getOpposite(this) == prev) {
                 // edge on the new inner face is at the beginning of the list
                 embedded.addFirst(edge);
@@ -2146,7 +2145,7 @@ public class BoyerMyrvoldPlanarityInspector<V, E> implements PlanarityTestingAlg
          */
         void mergeChildEdges(DoublyLinkedList<Edge> edges, int vIn, int vOut, Node parentNext, Edge parentEdge) {
             assert !embedded.isEmpty();
-            Node firstOpposite = embedded.getFirstElement().getOpposite(this);
+            Node firstOpposite = embedded.getFirst().getOpposite(this);
             boolean alongParentTraversal = firstOpposite != parentNext;
             boolean actionAppend = false, invert = false;
             if (vIn == 0) {

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -48,8 +48,8 @@ import org.jgrapht.alg.util.*;
  * of the {@code List} nodes of this List have a reference to the List they belong to. This
  * increases the memory occupied by this list implementation compared to {@code LinkedList} for the
  * same elements. Instances of {@code LinkedList.Node} have three references each (the element, next
- * and previous), Instances {@code DoublyLinkedList.ListNode} have four (the element, next, previous
- * and the list).
+ * and previous), instances of {@code DoublyLinkedList.ListNode} have four (the element, next,
+ * previous and the list).
  * </p>
  *
  * @param <E> the list element type
@@ -118,7 +118,7 @@ public class DoublyLinkedList<E>
      * {@code size} and {@code modcount} by one.
      * </p>
      * 
-     * @param node to add to this list
+     * @param node the node to add to this list
      * @throws IllegalArgumentException if {@code node} is already contained in this or another
      *         {@code DoublyLinkedList}
      */
@@ -136,8 +136,8 @@ public class DoublyLinkedList<E>
 
     /**
      * Atomically moves all {@link ListNode ListNodes} from {@code list} to this list as if each
-     * node was removed with {@link #removeListNode(ListNode)} from {@code list} and subsequently
-     * added to this list by {@link #addListNode(ListNode)}.
+     * node was removed with {@link #removeListNode(ListNodeImpl)} from {@code list} and
+     * subsequently added to this list by {@link #addListNode(ListNodeImpl)}.
      */
     private void moveAllListNodes(DoublyLinkedList<E> list)
     { // call this before any modification of this list is done
@@ -162,7 +162,7 @@ public class DoublyLinkedList<E>
      * increases the {@code modcount} by one.
      * </p>
      * 
-     * @param node to remove from this list
+     * @param node the node to remove from this list
      * @return true if {@code node} was removed from this list, else false
      */
     private boolean removeListNode(ListNodeImpl<E> node)
@@ -180,7 +180,14 @@ public class DoublyLinkedList<E>
         return false;
     }
 
-    private static <E> void link(ListNodeImpl<E> predecessor, ListNodeImpl<E> successor)
+    /**
+     * Establishes the links between the given {@link ListNodeImpl nodes} in such a way that the
+     * {@code predecessor} is linked before the {@code successor}.
+     * 
+     * @param predecessor the first node linked before the other
+     * @param successor the second node linked after the other
+     */
+    private void link(ListNodeImpl<E> predecessor, ListNodeImpl<E> successor)
     {
         predecessor.next = successor;
         successor.prev = predecessor;
@@ -266,7 +273,7 @@ public class DoublyLinkedList<E>
      * </p>
      * 
      * @param index index at which the specified {@code node} is to be inserted
-     * @param node to add
+     * @param node the node to add
      * @throws IndexOutOfBoundsException if the index is out of range
      *         ({@code index < 0 || index > size()})
      * @throws IllegalArgumentException if {@code node} is already part of this or another
@@ -293,7 +300,7 @@ public class DoublyLinkedList<E>
      * This method has constant runtime complexity O(1).
      * </p>
      * 
-     * @param node to add
+     * @param node the node to add
      * @throws IllegalArgumentException if {@code node} is already part of this or another
      *         {@code DoublyLinkedList}
      * @throws NullPointerException if {@code node} is {@code null}
@@ -309,7 +316,7 @@ public class DoublyLinkedList<E>
      * This method has constant runtime complexity O(1).
      * </p>
      * 
-     * @param node to add
+     * @param node the node to add
      * @throws IllegalArgumentException if {@code node} is already part of this or another
      *         {@code DoublyLinkedList}
      * @throws NullPointerException if {@code node} is {@code null}
@@ -326,7 +333,7 @@ public class DoublyLinkedList<E>
      * This method has constant runtime complexity O(1).
      * </p>
      * 
-     * @param node to insert
+     * @param node the node to add
      * @param successor {@code ListNode} before which the {@code node} is inserted
      * @throws IllegalArgumentException if {@code node} is already contained in this or another
      *         {@code DoublyLinkedList} or {@code successor} is not contained in this list
@@ -386,7 +393,7 @@ public class DoublyLinkedList<E>
      * This method has linear runtime complexity O(n).
      * </p>
      * 
-     * @param index of the {@code ListNode} to return
+     * @param index index of the {@code ListNode} to return
      * @return the {@code ListNode} at the specified position in this list
      * @throws IndexOutOfBoundsException if the index is out of range
      *         ({@code index < 0 || index >= size()})
@@ -396,6 +403,14 @@ public class DoublyLinkedList<E>
         return getNodeAt(index);
     }
 
+    /**
+     * Returns the {@link ListNodeImpl node} at the specified position in this list.
+     * 
+     * @param index index of the {@code ListNodeImpl} to return
+     * @return the {@code ListNode} at the specified position in this list
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *         ({@code index < 0 || index >= size()})
+     */
     private ListNodeImpl<E> getNodeAt(int index)
     {
         if (index < 0 || size <= index) {
@@ -429,7 +444,7 @@ public class DoublyLinkedList<E>
      * time O(1) if {@code node} is not {@link #containsNode(ListNode) contained} in this list.
      * </p>
      * 
-     * @param node to search for
+     * @param node the node to search for
      * @return the index of the specified {@code node} in this list, or -1 if this list does not
      *         contain {@code node}
      * @throws NullPointerException if {@code node} is {@code null}
@@ -456,7 +471,7 @@ public class DoublyLinkedList<E>
      * This method has constant runtime complexity O(1).
      * </p>
      * 
-     * @param node whose presence in this {@code DoublyLinkedList} is to be tested
+     * @param node the node whose presence in this {@code DoublyLinkedList} is to be tested
      * @return true if this {@code DoublyLinkedList} contains the {@link ListNode}
      * @throws NullPointerException if {@code node} is {@code null}
      */
@@ -473,7 +488,7 @@ public class DoublyLinkedList<E>
      * This method has constant runtime complexity O(1).
      * </p>
      *
-     * @param node to remove from this list
+     * @param node the node to remove from this list
      * @return true if node was removed from this list
      * @throws NullPointerException if {@code node} is {@code null}
      */
@@ -490,7 +505,7 @@ public class DoublyLinkedList<E>
      * This method has linear runtime complexity O(n).
      * </p>
      * 
-     * @param element whose {@code ListNode} is to return
+     * @param element the element whose {@code ListNode} is to return
      * @return the first {@code ListNode} holding the {@code element} or null if no node was found
      */
     public ListNode<E> nodeOf(Object element)
@@ -506,7 +521,7 @@ public class DoublyLinkedList<E>
      * This method has linear runtime complexity O(n).
      * </p>
      * 
-     * @param element whose {@code ListNode} is to return
+     * @param element the element whose {@code ListNode} is to return
      * @return the last {@code ListNode} holding the {@code element} or null if no node was found
      */
     public ListNode<E> lastNodeOf(Object element)
@@ -525,7 +540,7 @@ public class DoublyLinkedList<E>
      * 
      * @param first supplier of the first node to check if this list is not empty
      * @param next {@code Function} to get from the current node the next node to check
-     * @param element for that the first node with equal value is searched.
+     * @param element the element for that the first node with equal value is searched.
      * @return a {@link Pair} of the first encountered {@code ListNode} holding a {@code value}
      *         equal to {@code element} and its index, or if no such node was found a
      *         {@code Pair.of(null, -1)}
@@ -557,7 +572,7 @@ public class DoublyLinkedList<E>
      * {@code ListNode}.
      * </p>
      * 
-     * @param element to add
+     * @param element the element to add
      * @return the {@code ListNode} allocated to store the {@code value}
      */
     public ListNode<E> addElementFirst(E element)
@@ -575,7 +590,7 @@ public class DoublyLinkedList<E>
      * {@code ListNode}.
      * </p>
      * 
-     * @param element to add
+     * @param element the element to add
      * @return the {@code ListNode} allocated to store the {@code value}
      */
     public ListNode<E> addElementLast(E element)
@@ -590,7 +605,7 @@ public class DoublyLinkedList<E>
      * Returns the {@code ListNode} allocated to store the {@code value}.
      *
      * @param successor {@code ListNode} before which the node holding {@code value} is inserted
-     * @param element to add
+     * @param element the element to add
      * @return the {@code ListNode} allocated to store the {@code value}
      * @throws IllegalArgumentException if {@code successor} is not contained in this list
      * @throws NullPointerException if {@code successor} is {@code null}
@@ -899,7 +914,8 @@ public class DoublyLinkedList<E>
      * {@code movedList} are moved to this list. When this method terminates this list contains all
      * nodes of {@code movedList} and {@code movedList} is empty.
      *
-     * @param index of the first element of {@code list} in this {@code list} after it was added
+     * @param index index of the first element of {@code list} in this {@code list} after it was
+     *        added
      * @param movedList the {@code DoublyLinkedList} to move to this one
      * @throws NullPointerException if {@code movedList} is {@code null}
      */
@@ -951,7 +967,7 @@ public class DoublyLinkedList<E>
      * would be the first one.
      * </p>
      * 
-     * @param firstElement equal to the first {@code next()}
+     * @param firstElement the element equal to the first {@code next()}
      * @return a circular {@code NodeIterator} iterating forward from {@code firstElement}
      */
     public NodeIterator<E> circularIterator(E firstElement)
@@ -977,7 +993,7 @@ public class DoublyLinkedList<E>
      * would be the first one.
      * </p>
      * 
-     * @param firstElement equal to the first {@code next()}
+     * @param firstElement the element equal to the first {@code next()}
      * @return a circular {@code NodeIterator} iterating backwards from {@code firstElement}
      */
     public NodeIterator<E> reverseCircularIterator(E firstElement)
@@ -1337,10 +1353,10 @@ public class DoublyLinkedList<E>
     }
 
     /**
-     * Node in that the elements of a {@link DoublyLinkedList}.
+     * Container for the elements stored in a {@link DoublyLinkedList}.
      * <p>
-     * A {@link ListNode} is either contain exactly once in exactly one {@code DoublyLinkedList} or
-     * contained in no {@code DoublyLinkedList}.
+     * A {@link ListNode} is either contained exactly once in exactly one {@code DoublyLinkedList}
+     * or contained in no {@code DoublyLinkedList}.
      * </p>
      * 
      * @param <V> the type of the element stored in this node
@@ -1348,9 +1364,9 @@ public class DoublyLinkedList<E>
     public interface ListNode<V>
     {
         /**
-         * Returns the value this list node stores
+         * Returns the immutable value this {@code ListNode} contains.
          *
-         * @return the value this list node stores
+         * @return the value this list node contains
          */
         V getValue();
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -326,13 +326,13 @@ public class DoublyLinkedList<E>
      * This method has constant runtime complexity O(1).
      * </p>
      * 
-     * @param successor {@code ListNode} before which the {@code node} is inserted
      * @param node to insert
+     * @param successor {@code ListNode} before which the {@code node} is inserted
      * @throws IllegalArgumentException if {@code node} is already contained in this or another
      *         {@code DoublyLinkedList} or {@code successor} is not contained in this list
      * @throws NullPointerException if {@code successor} or {@code node} is {@code null}
      */
-    public void addNodeBefore(ListNode<E> successor, ListNode<E> node)
+    public void addNodeBefore(ListNode<E> node, ListNode<E> successor)
     {
         ListNodeImpl<E> successorImpl = (ListNodeImpl<E>) successor;
         ListNodeImpl<E> nodeImpl = (ListNodeImpl<E>) node;
@@ -598,7 +598,7 @@ public class DoublyLinkedList<E>
     public ListNode<E> addElementBeforeNode(ListNode<E> successor, E element)
     {
         ListNode<E> node = new ListNodeImpl<>(element);
-        addNodeBefore(successor, node);
+        addNodeBefore(node, successor);
         return node;
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -63,10 +63,10 @@ public class DoublyLinkedList<E>
     Deque<E>
 {
     /** The first element of the list, {@code null} if this list is empty. */
-    private ListNode<E> head = null;
+    private ListNodeImpl<E> head = null;
     private int size;
 
-    private ListNode<E> tail()
+    private ListNodeImpl<E> tail()
     {
         return head.prev;
     }
@@ -96,9 +96,9 @@ public class DoublyLinkedList<E>
     public void clear()
     {
         if (!isEmpty()) {
-            ListNode<E> node = head;
+            ListNodeImpl<E> node = head;
             do {
-                ListNode<E> next = node.next;
+                ListNodeImpl<E> next = node.next;
                 boolean removed = removeListNode(node); // clears all links of removed node
                 assert removed;
                 node = next;
@@ -122,7 +122,7 @@ public class DoublyLinkedList<E>
      * @throws IllegalArgumentException if {@code node} is already contained in this or another
      *         {@code DoublyLinkedList}
      */
-    private void addListNode(ListNode<E> node)
+    private void addListNode(ListNodeImpl<E> node)
     { // call this before any modification of this list is done
         if (node.list != null) {
             String list = (node.list == this) ? "this" : "other";
@@ -142,8 +142,8 @@ public class DoublyLinkedList<E>
     private void moveAllListNodes(DoublyLinkedList<E> list)
     { // call this before any modification of this list is done
 
-        for (NodeIterator<E> iterator = list.iterator(); iterator.hasNext();) {
-            ListNode<E> node = iterator.nextNode();
+        for (ListNodeIteratorImpl it = list.new ListNodeIteratorImpl(0); it.hasNext();) {
+            ListNodeImpl<E> node = it.nextNode();
             assert node.list == list;
             node.list = this;
         }
@@ -165,7 +165,7 @@ public class DoublyLinkedList<E>
      * @param node to remove from this list
      * @return true if {@code node} was removed from this list, else false
      */
-    private boolean removeListNode(ListNode<E> node)
+    private boolean removeListNode(ListNodeImpl<E> node)
     { // call this before any modification of this list is done
         if (node.list == this) {
 
@@ -180,14 +180,14 @@ public class DoublyLinkedList<E>
         return false;
     }
 
-    private static <E> void link(ListNode<E> predecessor, ListNode<E> successor)
+    private static <E> void link(ListNodeImpl<E> predecessor, ListNodeImpl<E> successor)
     {
         predecessor.next = successor;
         successor.prev = predecessor;
     }
 
     /** Insert non null {@code node} before non null {@code successor} into the list. */
-    private void linkBefore(ListNode<E> node, ListNode<E> successor)
+    private void linkBefore(ListNodeImpl<E> node, ListNodeImpl<E> successor)
     {
         addListNode(node);
         link(successor.prev, node);
@@ -195,7 +195,7 @@ public class DoublyLinkedList<E>
     }
 
     /** Insert non null {@code node} as last node into the list. */
-    private void linkLast(ListNode<E> node)
+    private void linkLast(ListNodeImpl<E> node)
     {
         if (isEmpty()) { // node will be the first and only one
             addListNode(node);
@@ -216,9 +216,9 @@ public class DoublyLinkedList<E>
         if (previousSize == 0) {
             head = list.head; // head and tail already linked together
         } else {
-            ListNode<E> refNode = (index == previousSize) ? head : getNode(index);
+            ListNodeImpl<E> refNode = (index == previousSize) ? head : getNodeAt(index);
 
-            ListNode<E> listTail = list.tail();
+            ListNodeImpl<E> listTail = list.tail();
             link(refNode.prev, list.head); // changes list.tail()
             link(listTail, refNode);
 
@@ -231,10 +231,10 @@ public class DoublyLinkedList<E>
     }
 
     /** Remove the non null {@code node} from the list. */
-    private boolean unlink(ListNode<E> node)
+    private boolean unlink(ListNodeImpl<E> node)
     {
-        ListNode<E> prev = node.prev;
-        ListNode<E> next = node.next;
+        ListNodeImpl<E> prev = node.prev;
+        ListNodeImpl<E> next = node.next;
         if (removeListNode(node)) { // clears prev and next of node
             if (size == 0) {
                 head = null;
@@ -275,13 +275,14 @@ public class DoublyLinkedList<E>
      */
     public void addNode(int index, ListNode<E> node)
     {
+        ListNodeImpl<E> nodeImpl = (ListNodeImpl<E>) node;
         if (index == size) { // also true if this is empty
-            linkLast(node);
+            linkLast(nodeImpl);
         } else {
-            ListNode<E> successor = index == 0 ? head : getNode(index);
-            linkBefore(node, successor);
+            ListNodeImpl<E> successor = index == 0 ? head : getNodeAt(index);
+            linkBefore(nodeImpl, successor);
             if (head == successor) {
-                head = node;
+                head = nodeImpl;
             }
         }
     }
@@ -333,12 +334,15 @@ public class DoublyLinkedList<E>
      */
     public void addNodeBefore(ListNode<E> successor, ListNode<E> node)
     {
-        if (successor.list != this) {
-            throw new IllegalArgumentException("Node <" + successor + "> not in this list");
+        ListNodeImpl<E> successorImpl = (ListNodeImpl<E>) successor;
+        ListNodeImpl<E> nodeImpl = (ListNodeImpl<E>) node;
+
+        if (successorImpl.list != this) {
+            throw new IllegalArgumentException("Node <" + successorImpl + "> not in this list");
         }
-        linkBefore(node, successor);
-        if (head == successor) {
-            head = node;
+        linkBefore(nodeImpl, successorImpl);
+        if (head == successorImpl) {
+            head = nodeImpl;
         }
     }
 
@@ -389,10 +393,15 @@ public class DoublyLinkedList<E>
      */
     public ListNode<E> getNode(int index)
     {
+        return getNodeAt(index);
+    }
+
+    private ListNodeImpl<E> getNodeAt(int index)
+    {
         if (index < 0 || size <= index) {
             throw new IndexOutOfBoundsException("Index: " + index);
         }
-        ListNode<E> node;
+        ListNodeImpl<E> node;
         if (index < size / 2) {
             node = head;
             for (int i = 0; i < index; i++) {
@@ -430,7 +439,7 @@ public class DoublyLinkedList<E>
         if (!containsNode(node)) {
             return -1;
         }
-        ListNode<E> current = head;
+        ListNodeImpl<E> current = head;
         for (int i = 0; i < size; i++) {
             if (current == node) {
                 return i;
@@ -453,7 +462,7 @@ public class DoublyLinkedList<E>
      */
     public boolean containsNode(ListNode<E> node)
     {
-        return node.list == this;
+        return ((ListNodeImpl<E>) node).list == this;
     }
 
     /**
@@ -470,7 +479,7 @@ public class DoublyLinkedList<E>
      */
     public boolean removeNode(ListNode<E> node)
     {
-        return unlink(node);
+        return unlink((ListNodeImpl<E>) node);
     }
 
     /**
@@ -521,13 +530,13 @@ public class DoublyLinkedList<E>
      *         equal to {@code element} and its index, or if no such node was found a
      *         {@code Pair.of(null, -1)}
      */
-    private Pair<ListNode<E>, Integer> searchNode(
-        Supplier<ListNode<E>> first, UnaryOperator<ListNode<E>> next, Object element)
+    private Pair<ListNodeImpl<E>, Integer> searchNode(
+        Supplier<ListNodeImpl<E>> first, UnaryOperator<ListNodeImpl<E>> next, Object element)
     {
         if (!isEmpty()) {
             int index = 0;
-            ListNode<E> firstNode = first.get();
-            ListNode<E> node = firstNode;
+            ListNodeImpl<E> firstNode = first.get();
+            ListNodeImpl<E> node = firstNode;
             do {
                 if (Objects.equals(node.value, element)) {
                     return Pair.of(node, index);
@@ -553,7 +562,7 @@ public class DoublyLinkedList<E>
      */
     public ListNode<E> addElementFirst(E element)
     {
-        ListNode<E> node = new ListNode<>(element);
+        ListNode<E> node = new ListNodeImpl<>(element);
         addNode(0, node);
         return node;
     }
@@ -571,7 +580,7 @@ public class DoublyLinkedList<E>
      */
     public ListNode<E> addElementLast(E element)
     {
-        ListNode<E> node = new ListNode<>(element);
+        ListNode<E> node = new ListNodeImpl<>(element);
         addNode(size, node);
         return node;
     }
@@ -588,7 +597,7 @@ public class DoublyLinkedList<E>
      */
     public ListNode<E> addElementBeforeNode(ListNode<E> successor, E element)
     {
-        ListNode<E> node = new ListNode<>(element);
+        ListNode<E> node = new ListNodeImpl<>(element);
         addNodeBefore(successor, node);
         return node;
     }
@@ -614,7 +623,7 @@ public class DoublyLinkedList<E>
     @Override
     public E get(int index)
     {
-        return getNode(index).value;
+        return getNodeAt(index).value;
     }
 
     /**
@@ -625,7 +634,7 @@ public class DoublyLinkedList<E>
     {
         ListNode<E> node = getNode(index);
         removeNode(node);
-        return node.value;
+        return node.getValue();
     }
 
     // Deque methods
@@ -680,7 +689,7 @@ public class DoublyLinkedList<E>
 
         ListNode<E> node = head;
         removeNode(node); // changes head
-        return node.value;
+        return node.getValue();
     }
 
     /**
@@ -695,7 +704,7 @@ public class DoublyLinkedList<E>
 
         ListNode<E> node = tail();
         removeNode(node); // changes tail
-        return node.value;
+        return node.getValue();
     }
 
     /**
@@ -709,7 +718,7 @@ public class DoublyLinkedList<E>
         }
         ListNode<E> node = head;
         removeNode(node); // changes head
-        return node.value;
+        return node.getValue();
     }
 
     /**
@@ -723,7 +732,7 @@ public class DoublyLinkedList<E>
         }
         ListNode<E> node = tail();
         removeNode(node); // changes tail()
-        return node.value;
+        return node.getValue();
     }
 
     /**
@@ -732,7 +741,7 @@ public class DoublyLinkedList<E>
     @Override
     public E getFirst()
     {
-        return getFirstNode().value;
+        return getFirstNode().getValue();
     }
 
     /**
@@ -741,7 +750,7 @@ public class DoublyLinkedList<E>
     @Override
     public E getLast()
     {
-        return getLastNode().value;
+        return getLastNode().getValue();
     }
 
     /**
@@ -870,10 +879,10 @@ public class DoublyLinkedList<E>
         if (size < 2) {
             return;
         }
-        ListNode<E> newHead = tail();
-        ListNode<E> current = head;
+        ListNodeImpl<E> newHead = tail();
+        ListNodeImpl<E> current = head;
         do {
-            ListNode<E> next = current.next;
+            ListNodeImpl<E> next = current.next;
 
             current.next = current.prev;
             current.prev = next;
@@ -947,7 +956,7 @@ public class DoublyLinkedList<E>
      */
     public NodeIterator<E> circularIterator(E firstElement)
     {
-        ListNode<E> startNode = nodeOf(firstElement);
+        ListNodeImpl<E> startNode = (ListNodeImpl<E>) nodeOf(firstElement);
         if (startNode == null) {
             throw new NoSuchElementException();
         }
@@ -973,7 +982,7 @@ public class DoublyLinkedList<E>
      */
     public NodeIterator<E> reverseCircularIterator(E firstElement)
     {
-        ListNode<E> startNode = nodeOf(firstElement);
+        ListNodeImpl<E> startNode = (ListNodeImpl<E>) nodeOf(firstElement);
         if (startNode == null) {
             throw new NoSuchElementException();
         }
@@ -1028,8 +1037,8 @@ public class DoublyLinkedList<E>
      */
     public ListNodeIterator<E> listIterator(E element)
     {
-        Pair<ListNode<E>, Integer> startPair = searchNode(() -> head, n -> n.next, element);
-        ListNode<E> startNode = startPair.getFirst();
+        Pair<ListNodeImpl<E>, Integer> startPair = searchNode(() -> head, n -> n.next, element);
+        ListNodeImpl<E> startNode = startPair.getFirst();
         int startIndex = startPair.getSecond();
         if (startNode == null) {
             throw new NoSuchElementException();
@@ -1053,7 +1062,7 @@ public class DoublyLinkedList<E>
         @Override
         default E next()
         {
-            return nextNode().value;
+            return nextNode().getValue();
         }
 
         /**
@@ -1083,7 +1092,7 @@ public class DoublyLinkedList<E>
         @Override
         default E next()
         {
-            return nextNode().value;
+            return nextNode().getValue();
         }
 
         /**
@@ -1092,7 +1101,7 @@ public class DoublyLinkedList<E>
         @Override
         default E previous()
         {
-            return previousNode().value;
+            return previousNode().getValue();
         }
 
         /**
@@ -1116,9 +1125,9 @@ public class DoublyLinkedList<E>
         /** Index in this list of the ListNode returned next. */
         private int nextIndex;
         /** ListNode this iterator will return next. Null if this list is empty. */
-        private ListNode<E> next;
+        private ListNodeImpl<E> next;
         /** ListNode this iterator returned last. */
-        private ListNode<E> last = null;
+        private ListNodeImpl<E> last = null;
 
         /**
          * The number of modifications the list have had at the moment when this iterator was
@@ -1132,11 +1141,11 @@ public class DoublyLinkedList<E>
             if (startIndex == size) {
                 this.next = isEmpty() ? null : head;
             } else {
-                this.next = getNode(startIndex);
+                this.next = getNodeAt(startIndex);
             }
         }
 
-        private ListNodeIteratorImpl(int startIndex, ListNode<E> startNode)
+        private ListNodeIteratorImpl(int startIndex, ListNodeImpl<E> startNode)
         {
             this.nextIndex = startIndex;
             this.next = startNode;
@@ -1182,7 +1191,7 @@ public class DoublyLinkedList<E>
          * {@inheritDoc}
          */
         @Override
-        public ListNode<E> nextNode()
+        public ListNodeImpl<E> nextNode()
         {
             checkForComodification();
             if (!hasNext()) {
@@ -1248,9 +1257,9 @@ public class DoublyLinkedList<E>
             boolean wasLast = last == tail();
             removeNode(last);
             if (wasLast) { // or the sole node
-                last = addElementLast(e);
+                last = (ListNodeImpl<E>) addElementLast(e);
             } else {
-                last = addElementBeforeNode(nextNode, e);
+                last = (ListNodeImpl<E>) addElementBeforeNode(nextNode, e);
             }
             expectedModCount += 2; // because of unlink and add
         }
@@ -1266,7 +1275,7 @@ public class DoublyLinkedList<E>
             }
             checkForComodification();
 
-            ListNode<E> lastsNext = last.next;
+            ListNodeImpl<E> lastsNext = last.next;
             removeNode(last);
             if (next == last) { // previousNode() called before
                 // removed element after cursor (which would have been next)
@@ -1328,7 +1337,7 @@ public class DoublyLinkedList<E>
     }
 
     /**
-     * Container to store the elements of a {@link DoublyLinkedList}.
+     * Node in that the elements of a {@link DoublyLinkedList}.
      * <p>
      * A {@link ListNode} is either contain exactly once in exactly one {@code DoublyLinkedList} or
      * contained in no {@code DoublyLinkedList}.
@@ -1336,19 +1345,35 @@ public class DoublyLinkedList<E>
      * 
      * @param <V> the type of the element stored in this node
      */
-    public static class ListNode<V>
+    public interface ListNode<V>
+    {
+        /**
+         * Returns the value this list node stores
+         *
+         * @return the value this list node stores
+         */
+        V getValue();
+    }
+
+    /**
+     * The default {@link ListNode} implementation that enables checks and enforcement of a single
+     * container list policy.
+     */
+    private static class ListNodeImpl<V>
+        implements
+        ListNode<V>
     {
         private final V value;
         private DoublyLinkedList<V> list = null;
-        private ListNode<V> next = null;
-        private ListNode<V> prev = null;
+        private ListNodeImpl<V> next = null;
+        private ListNodeImpl<V> prev = null;
 
         /**
          * Creates new list node
          *
          * @param value the value this list node stores
          */
-        ListNode(V value)
+        ListNodeImpl(V value)
         {
             this.value = value;
         }
@@ -1367,10 +1392,9 @@ public class DoublyLinkedList<E>
         }
 
         /**
-         * Returns the value this list node stores
-         *
-         * @return the value this list node stores
+         * {@inheritDoc}
          */
+        @Override
         public V getValue()
         {
             return value;

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -17,428 +17,1088 @@
  */
 package org.jgrapht.util;
 
-import java.util.ConcurrentModificationException;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
+import java.util.*;
+import java.util.function.*;
 
 /**
- * This is the implementation of the doubly linked list data structure, which gives access to the internal
- * list nodes the data is stored in. The primary goal of this is to be able to delete an element from this
- * list in $\mathcal{O}(1)$ via the list node it is stored in.
+ * {@code DoublyLinkedList} implements a doubly linked {@link List} data structure, that exposes its
+ * {@link ListNode ListNodes} where the data is stored in.
  * <p>
- * The iterators over this list have a <i>fail-fast</i> behaviour meaning that they throw a
+ * An element holding {@code ListNode} can be removed or added to a {@code DoublyLinkedList} in
+ * constant time O(1). Other methods that operate on {@code ListNodes} directly also have constant
+ * runtime. This is also the case for methods that operate on the first(head) and last(tail) node or
+ * element. Random access methods have a runtime O(n) that is linearly dependent on the size of the
+ * {@code DoublyLinkedList}.
+ * </p>
+ * <p>
+ * A {@code DoublyLinkedList} supports {@code null} elements but do not support
+ * {@code null ListNodes}. This class is not thread safe and need to be synchronized externally if
+ * modified by concurrent threads.
+ * </p>
+ * <p>
+ * The iterators over this list have a <i>fail-fast</i> behavior meaning that they throw a
  * {@link ConcurrentModificationException} after they detect a structural modification of the list,
  * that they're not responsible for.
+ * </p>
+ * <p>
+ * This class is similar to {@link LinkedList}. The general difference is that the {@code ListNodes}
+ * of this {@code List} are accessible and can be removed or added directly. To ensure the integrity
+ * of the {@code List} nodes of this List have a reference to the List they belong to. This
+ * increases the memory occupied by this list implementation compared to {@code LinkedList} for the
+ * same elements. Instances of {@code LinkedList.Node} have three references each (the element, next
+ * and previous), Instances {@code DoublyLinkedList.ListNode} have four (the element, next, previous
+ * and the list). Because usually each {@code Object} has a header that also requires memory, the
+ * memory consumption of this implementation is less than 33.3% greater compared to
+ * {@code LinkedList} (the exact number depends on the executing JVM).
+ * </p>
  *
  * @param <E> the list element type
  * @author Timofey Chudakov
+ * @author Hannes Wellmann
  */
-public class DoublyLinkedList<E> implements Iterable<E> {
-    /**
-     * The first element of the list
-     */
-    private ListNode<E> head;
-    /**
-     * The size of the list
-     */
+public class DoublyLinkedList<E>
+    extends
+    AbstractSequentialList<E>
+    implements
+    Deque<E>
+{
+    /** The first element of the list, {@code null} if this list is empty. */
+    private ListNode<E> head = null;
     private int size;
-    /**
-     * The number of modifications applied to this list. This value is used to exhibit a fail-fast
-     * behavior during the iteration over the list when its structure is changed concurrently
-     */
-    private int modCount;
 
-    /**
-     * {@inheritDoc}
-     */
+    private ListNode<E> tail()
+    {
+        return head.prev;
+    }
+
     @Override
-    public Iterator<E> iterator() {
-        return listIterator();
+    public boolean isEmpty()
+    {
+        return head == null;
     }
 
-    /**
-     * Returns a list iterator starting from the beginning of this list
-     *
-     * @return a list iterator starting from the beginning of this list
-     */
-    public ListIterator<E> listIterator() {
-        return new ListIteratorImpl(head);
-    }
-
-    /**
-     * Returns an iterator over this list, which traverses the list in the reverse direction.
-     * The returned iterator will iterate over the <i>entire</i> list, that is, the list is
-     * treated as if it were cyclic. The iterator starts from {@code element}, and walks the
-     * list backwards, while wrapping around at the beginning of the list. For instance,
-     * for the list [1,2,3,4], {@code reverseIteratorFrom(3)} would return 3,2,1,4.
-     *
-     * This method throws {@link NoSuchElementException} in the case {@code element} doesn't
-     * belong to this list. This method invokes {@link #getNode(Object) getNode} to find the
-     * list node containing {@code element}.
-     *
-     * @param element an element to start an iteration from
-     * @return an iterator over this list, which starts from the {@code element}
-     */
-    public Iterator<E> reverseIteratorFrom(E element) {
-        ListNode<E> start = getNode(element);
-        if (start == null) {
-            throw new NoSuchElementException();
-        }
-        return new ListIteratorImpl(start, true);
-    }
-
-    /**
-     * Returns true if this list is empty, false otherwise
-     *
-     * @return true if this list is empty, false otherwise
-     */
-    public boolean isEmpty() {
-        return size == 0;
-    }
-
-    /**
-     * Returns the number of elements in this list
-     *
-     * @return the number of elements in this list
-     */
-    public int size() {
+    @Override
+    public int size()
+    {
         return size;
     }
 
+    @Override
+    public void clear()
+    {
+        if (!isEmpty()) {
+            ListNode<E> node = head;
+            do {
+                ListNode<E> next = node.next;
+                boolean removed = removeListNode(node); // clears all links of removed node
+                assert removed;
+                node = next;
+            } while (node != head);
+
+            head = null;
+            assert size == 0;
+        }
+    }
+
+    // internal modification methods
+
+    private void addListNode(ListNode<E> node)
+    { // call this before any modification of this list is done
+        if (node.list != null) {
+            String list = (node.list == this) ? "this" : "other";
+            throw new IllegalArgumentException(
+                "Node <" + node + "> already contained in " + list + " list");
+        }
+        node.list = this;
+        size++;
+        modCount++;
+    }
+
+    /** Atomically adds all {@link ListNode ListNodes} of {@code list} to this list. */
+    private void moveAllListNodes(DoublyLinkedList<E> list)
+    { // call this before any modification of this list is done
+
+        for (NodeIterator<E> iterator = list.iterator(); iterator.hasNext();) {
+            ListNode<E> node = iterator.nextNode();
+            assert node.list == list;
+            node.list = this;
+        }
+        size += list.size;
+        list.size = 0;
+        modCount++;
+        list.modCount++;
+    }
+
+    /** Returns true if {@code node} was successfully removed from the list. */
+    private boolean removeListNode(ListNode<E> node)
+    { // call this before any modification of this list is done
+        if (node.list == this) {
+
+            node.list = null;
+            node.next = null;
+            node.prev = null;
+
+            size--;
+            modCount++;
+            return true;
+        }
+        return false;
+    }
+
+    private static <E> void link(ListNode<E> predecessor, ListNode<E> successor)
+    {
+        predecessor.next = successor;
+        successor.prev = predecessor;
+    }
+
+    /** Insert non null {@code node} before non null {@code successor} into the list. */
+    private void linkBefore(ListNode<E> node, ListNode<E> successor)
+    {
+        addListNode(node);
+        link(successor.prev, node);
+        link(node, successor);
+    }
+
+    /** Insert non null {@code node} as last node into the list. */
+    private void linkLast(ListNode<E> node)
+    {
+        if (isEmpty()) { // node will be the first and only one
+            addListNode(node);
+            link(node, node); // self link
+            head = node;
+        } else {
+            linkBefore(node, head);
+        }
+    }
+
+    /** Insert non null {@code list} before node at {@code index} into the list. */
+    private void linkListIntoThisBefore(int index, DoublyLinkedList<E> list)
+    {
+        int previousSize = size;
+        moveAllListNodes(list);
+
+        // link list's node into this list
+        if (previousSize == 0) {
+            head = list.head; // head and tail already linked together
+        } else {
+            ListNode<E> refNode = (index == previousSize) ? head : getNode(index);
+
+            ListNode<E> listTail = list.tail();
+            link(refNode.prev, list.head); // changes list.tail()
+            link(listTail, refNode);
+
+            if (index == 0) {
+                head = list.head;
+            }
+        }
+        // clear list but do not call list.clear(), since their nodes are still used
+        list.head = null;
+    }
+
+    /** Remove the non null {@code node} from the list. */
+    private boolean unlink(ListNode<E> node)
+    {
+        ListNode<E> prev = node.prev;
+        ListNode<E> next = node.next;
+        if (removeListNode(node)) { // clears prev and next of node
+            if (size == 0) {
+                head = null;
+            } else {
+                // list is circular, don't have to worry about null values
+                link(prev, next);
+
+                if (head == node) {
+                    head = next;
+                }
+            }
+            return true;
+        }
+        return false;
+    }
+
+    // ----------------------------------------------------------------------------
+    // public modification and access methods
+
+    // ListNode methods:
+    // Base methods to access, add and remove nodes to/from this list.
+    // Used by all public methods if possible
+
     /**
-     * Appends the specified value to the end of this list. This method
-     * returns the list node the {@code value} is contained in
-     *
-     * @param value the value to append to this list
-     * @return the list node, which contains the {@code value}
+     * Inserts the specified {@link ListNode node} at the specified position in this list.
+     * <p>
+     * This method has a linear runtime complexity O(n) that depends linearly on the distance of the
+     * index to the nearest end. Adding {@code node} as first or last takes only constant time O(1).
+     * </p>
+     * 
+     * @param index index at which the specified {@code node} is to be inserted
+     * @param node to add
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *         ({@code index < 0 || index > size()})
+     * @throws IllegalArgumentException if {@code node} is already part of this or another
+     *         {@code DoublyLinkedList}
+     * @throws NullPointerException if {@code node} is {@code null}
      */
-    public ListNode<E> add(E value) {
-        return addLast(value);
+    public void addNode(int index, ListNode<E> node)
+    {
+        if (index == size) { // also true if this is empty
+            linkLast(node);
+        } else {
+            ListNode<E> successor = index == 0 ? head : getNode(index);
+            linkBefore(node, successor);
+            if (head == successor) {
+                head = node;
+            }
+        }
     }
 
     /**
-     * Inverts the list. For instance, calling this method on the list $(a,b,c,\dots,x,y,z)$
-     * will result in the list $(z,y,x,\dots,c,b,a)$. This method does only pointer manipulation,
-     * meaning that all the list nodes allocated for the previously added elements are valid after
-     * this method finishes.
+     * Inserts the specified {@link ListNode node} at the front of this list.
+     * <p>
+     * This method has constant runtime complexity O(1).
+     * </p>
+     * 
+     * @param node to add
+     * @throws IllegalArgumentException if {@code node} is already part of this or another
+     *         {@code DoublyLinkedList}
+     * @throws NullPointerException if {@code node} is {@code null}
      */
-    public void invert() {
+    public void addNodeFirst(ListNode<E> node)
+    {
+        addNode(0, node);
+    }
+
+    /**
+     * Inserts the specified {@link ListNode node} at the end of this list.
+     * <p>
+     * This method has constant runtime complexity O(1).
+     * </p>
+     * 
+     * @param node to add
+     * @throws IllegalArgumentException if {@code node} is already part of this or another
+     *         {@code DoublyLinkedList}
+     * @throws NullPointerException if {@code node} is {@code null}
+     */
+    public void addNodeLast(ListNode<E> node)
+    {
+        addNode(size, node);
+    }
+
+    /**
+     * Inserts the specified {@link ListNode node} before the specified {@code successor} in this
+     * list.
+     * <p>
+     * This method has constant runtime complexity O(1).
+     * </p>
+     * 
+     * @param successor {@code ListNode} before which the {@code node} is inserted
+     * @param node to insert
+     * @throws IllegalArgumentException if {@code node} is already contained in this or another
+     *         {@code DoublyLinkedList} or {@code successor} is not contained in this list
+     * @throws NullPointerException if {@code successor} or {@code node} is {@code null}
+     */
+    public void addNodeBefore(ListNode<E> successor, ListNode<E> node)
+    {
+        if (successor.list != this) {
+            throw new IllegalArgumentException("Node <" + successor + "> not in this list");
+        }
+        linkBefore(node, successor);
+        if (head == successor) {
+            head = node;
+        }
+    }
+
+    /**
+     * Returns the first {@link ListNode node} of this list.
+     * <p>
+     * This method has constant runtime complexity O(1).
+     * </p>
+     * 
+     * @return the first {@code ListNode} of this list
+     * @throws NoSuchElementException if this list is empty
+     */
+    public ListNode<E> getFirstNode()
+    {
+        if (isEmpty()) {
+            throw new NoSuchElementException();
+        }
+        return head;
+    }
+
+    /**
+     * Returns the last {@link ListNode node} of this list.
+     * <p>
+     * This method has constant runtime complexity O(1).
+     * </p>
+     * 
+     * @return the last {@code ListNode} of this list
+     * @throws NoSuchElementException if this list is empty
+     */
+    public ListNode<E> getLastNode()
+    {
+        if (isEmpty()) {
+            throw new NoSuchElementException();
+        }
+        return tail();
+    }
+
+    /**
+     * Returns the {@link ListNode node} at the specified position in this list.
+     * <p>
+     * This method has linear runtime complexity O(n).
+     * </p>
+     * 
+     * @param index of the {@code ListNode} to return
+     * @return the {@code ListNode} at the specified position in this list
+     * @throws IndexOutOfBoundsException if the index is out of range
+     *         ({@code index < 0 || index >= size()})
+     */
+    public ListNode<E> getNode(int index)
+    {
+        if (index < 0 || size <= index) {
+            throw new IndexOutOfBoundsException("Index: " + index);
+        }
+        ListNode<E> node;
+        if (index < size / 2) {
+            node = head;
+            for (int i = 0; i < index; i++) {
+                node = node.next;
+            }
+        } else {
+            node = tail();
+            for (int i = size - 1; index < i; i--) {
+                node = node.prev;
+            }
+        }
+        return node;
+    }
+
+    /**
+     * Returns the index of the specified {@link ListNode node} in this list, or -1 if this list
+     * does not contain the {@code node}.
+     * <p>
+     * More formally, returns the index {@code i} such that {@code node == getNode(i)}, or -1 if
+     * there is no such index. Because a {@code ListNode} is contained in at most one list exactly
+     * once, the returned index (if not -1) is the only occurrence of that {@code node}.
+     * </p>
+     * <p>
+     * This method has linear runtime complexity O(n) to find {@code node} but returns in constant
+     * time O(1) if {@code node} is not {@link #containsNode(ListNode) contained} in this list.
+     * </p>
+     * 
+     * @param node to search for
+     * @return the index of the specified {@code node} in this list, or -1 if this list does not
+     *         contain {@code node}
+     * @throws NullPointerException if {@code node} is {@code null}
+     */
+    public int indexOfNode(ListNode<E> node)
+    {
+        if (!containsNode(node)) {
+            return -1;
+        }
+        ListNode<E> current = head;
+        for (int i = 0; i < size; i++) {
+            if (current == node) {
+                return i;
+            }
+            current = current.next;
+        }
+        // should never happen:
+        throw new IllegalStateException("Node contained in list not found: " + node);
+    }
+
+    /**
+     * Returns true if this {@code DoublyLinkedList} contains the specified {@link ListNode}.
+     * <p>
+     * This method has constant runtime complexity O(1).
+     * </p>
+     * 
+     * @param node whose presence in this {@code DoublyLinkedList} is to be tested
+     * @return true if this {@code DoublyLinkedList} contains the {@link ListNode}
+     * @throws NullPointerException if {@code node} is {@code null}
+     */
+    public boolean containsNode(ListNode<E> node)
+    {
+        return node.list == this;
+    }
+
+    /**
+     * Removes the {@link ListNode node} from this list. Returns true if {@code node} was in this
+     * list and is now removed. If {@code node} is not contained in this list, the list is left
+     * unchanged.
+     * <p>
+     * This method has constant runtime complexity O(1).
+     * </p>
+     *
+     * @param node to remove from this list
+     * @return true if node was removed from this list
+     * @throws NullPointerException if {@code node} is {@code null}
+     */
+    public boolean removeNode(ListNode<E> node)
+    {
+        return unlink(node);
+    }
+
+    /**
+     * Returns the first {@link ListNode node} holding the specified {@code element} in this list.
+     * More formally, returns the first {@code ListNode} such that
+     * {@code Objects.equals(element, node.getValue())}, or {@code null} if there is no such node.
+     * <p>
+     * This method has linear runtime complexity O(n).
+     * </p>
+     * 
+     * @param element whose {@code ListNode} is to return
+     * @return the first {@code ListNode} holding the {@code element} or null if no node was found
+     */
+    public ListNode<E> nodeOf(Object element)
+    {
+        return searchNode(() -> head, n -> n.next, element, INDEX_NOT_USED);
+    }
+
+    /**
+     * Returns the last {@link ListNode node} holding the specified {@code element} in this list.
+     * More formally, returns the last {@code ListNode} such that
+     * {@code Objects.equals(element, node.getValue())}, or {@code null} if there is no such node.
+     * <p>
+     * This method has linear runtime complexity O(n).
+     * </p>
+     * 
+     * @param element whose {@code ListNode} is to return
+     * @return the last {@code ListNode} holding the {@code element} or null if no node was found
+     */
+    public ListNode<E> lastNodeOf(Object element)
+    {
+        return searchNode(this::tail, n -> n.prev, element, INDEX_NOT_USED);
+    }
+
+    /** A dummy instance used if the index of the found node is not used. */
+    private static final ModifiableInteger INDEX_NOT_USED = new ModifiableInteger(0);
+
+    private ListNode<E> searchNode(
+        Supplier<ListNode<E>> first, UnaryOperator<ListNode<E>> next, Object e,
+        ModifiableInteger index)
+    {
+        if (!isEmpty()) {
+            index.value = 0;
+            ListNode<E> firstNode = first.get();
+            ListNode<E> node = firstNode;
+            do {
+                if (Objects.equals(node.value, e)) {
+                    return node;
+                }
+                index.value++;
+                node = next.apply(node);
+            } while (node != firstNode);
+        }
+        index.value = -1;
+        return null;
+    }
+
+    /**
+     * Inserts the specified element at the front of this list. Returns the {@link ListNode}
+     * allocated to store the {@code value}. The returned {@code ListNode} is the new head of the
+     * list.
+     * <p>
+     * This method is equivalent to {@link #addFirst(Object)} but returns the allocated
+     * {@code ListNode}.
+     * </p>
+     * 
+     * @param element to add
+     * @return the {@code ListNode} allocated to store the {@code value}
+     */
+    public ListNode<E> addElementFirst(E element)
+    {
+        ListNode<E> node = new ListNode<>(element);
+        addNode(0, node);
+        return node;
+    }
+
+    /**
+     * Inserts the specified element at the end of this list. Returns the {@link ListNode} allocated
+     * to store the {@code value}. The returned {@code ListNode} is the new tail of the list.
+     * <p>
+     * This method is equivalent to {@link #addLast(Object)} but returns the allocated
+     * {@code ListNode}.
+     * </p>
+     * 
+     * @param element to add
+     * @return the {@code ListNode} allocated to store the {@code value}
+     */
+    public ListNode<E> addElementLast(E element)
+    {
+        ListNode<E> node = new ListNode<>(element);
+        addNode(size, node);
+        return node;
+    }
+
+    /**
+     * Inserts the specified element before the specified {@link ListNode successor} in this list.
+     * Returns the {@code ListNode} allocated to store the {@code value}.
+     *
+     * @param successor {@code ListNode} before which the node holding {@code value} is inserted
+     * @param element to add
+     * @return the {@code ListNode} allocated to store the {@code value}
+     * @throws IllegalArgumentException if {@code successor} is not contained in this list
+     * @throws NullPointerException if {@code successor} is {@code null}
+     */
+    public ListNode<E> addElementBeforeNode(ListNode<E> successor, E element)
+    {
+        ListNode<E> node = new ListNode<>(element);
+        addNodeBefore(successor, node);
+        return node;
+    }
+
+    // List methods (shortcut for most commonly used methods to avoid iterator creation)
+
+    @Override
+    public void add(int index, E element)
+    {
+        if (index == size) { // also true if this is empty
+            addElementLast(element);
+        } else {
+            addElementBeforeNode(getNode(index), element);
+        }
+    }
+
+    @Override
+    public E get(int index)
+    {
+        return getNode(index).value;
+    }
+
+    @Override
+    public E remove(int index)
+    {
+        ListNode<E> node = getNode(index);
+        removeNode(node);
+        return node.value;
+    }
+
+    // Deque methods
+
+    @Override
+    public void addFirst(E e)
+    {
+        addElementFirst(e);
+    }
+
+    @Override
+    public void addLast(E e)
+    {
+        addElementLast(e);
+    }
+
+    @Override
+    public boolean offerFirst(E e)
+    {
+        addElementFirst(e);
+        return true;
+    }
+
+    @Override
+    public boolean offerLast(E e)
+    {
+        addElementLast(e);
+        return true;
+    }
+
+    @Override
+    public E removeFirst()
+    {
+        if (isEmpty()) {
+            throw new NoSuchElementException();
+        }
+
+        ListNode<E> node = head;
+        removeNode(node); // changes head
+        return node.value;
+    }
+
+    @Override
+    public E removeLast()
+    {
+        if (isEmpty()) {
+            throw new NoSuchElementException();
+        }
+
+        ListNode<E> node = tail();
+        removeNode(node); // changes tail
+        return node.value;
+    }
+
+    @Override
+    public E pollFirst()
+    {
+        if (isEmpty()) {
+            return null;
+        }
+        ListNode<E> node = head;
+        removeNode(node); // changes head
+        return node.value;
+    }
+
+    @Override
+    public E pollLast()
+    {
+        if (isEmpty()) {
+            return null;
+        }
+        ListNode<E> node = tail();
+        removeNode(node); // changes tail()
+        return node.value;
+    }
+
+    @Override
+    public E getFirst()
+    {
+        return getFirstNode().value;
+    }
+
+    @Override
+    public E getLast()
+    {
+        return getLastNode().value;
+    }
+
+    @Override
+    public E peekFirst()
+    {
+        return isEmpty() ? null : getFirst();
+    }
+
+    @Override
+    public E peekLast()
+    {
+        return isEmpty() ? null : getLast();
+    }
+
+    @Override
+    public boolean removeFirstOccurrence(Object o)
+    {
+        ListNode<E> node = nodeOf(o);
+        if (node != null) {
+            removeNode(node);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean removeLastOccurrence(Object o)
+    {
+        ListNode<E> node = lastNodeOf(o);
+        if (node != null) {
+            removeNode(node);
+            return true;
+        }
+        return false;
+    }
+
+    // Queue methods
+
+    @Override
+    public boolean offer(E e)
+    {
+        return offerLast(e);
+    }
+
+    @Override
+    public E remove()
+    {
+        return removeFirst();
+    }
+
+    @Override
+    public E poll()
+    {
+        return pollFirst();
+    }
+
+    @Override
+    public E element()
+    {
+        return getFirst();
+    }
+
+    @Override
+    public E peek()
+    {
+        return peekFirst();
+    }
+
+    // Stack methods
+
+    @Override
+    public void push(E e)
+    {
+        addFirst(e);
+    }
+
+    @Override
+    public E pop()
+    {
+        return removeFirst();
+    }
+
+    // special bulk methods
+
+    /**
+     * Inverts the list. For instance, calling this method on the list $(a,b,c,\dots,x,y,z)$ will
+     * result in the list $(z,y,x,\dots,c,b,a)$. This method does only pointer manipulation, meaning
+     * that all the list nodes allocated for the previously added elements are valid after this
+     * method finishes.
+     */
+    public void invert()
+    {
         if (size < 2) {
             return;
         }
-        ListNode<E> newHead = head.prev;
+        ListNode<E> newHead = tail();
         ListNode<E> current = head;
         do {
-            ListNode<E> t = current.next;
+            ListNode<E> next = current.next;
+
             current.next = current.prev;
-            current.prev = t;
-            current = current.prev;
+            current.prev = next;
+
+            current = next;
         } while (current != head);
         head = newHead;
         ++modCount;
     }
 
     /**
-     * Appends the {@code list} to the end of this list. All the elements from {@code list}
-     * are transferred to this list, i.e. the {@code list} is empty after calling this method.
+     * Moves all {@link ListNode ListNodes} of the given {@code sourceList} to this list and inserts
+     * them all before the node previously at the given position. All the {@code nodes} of
+     * {@code movedList} are moved to this list. When this method terminates this list contains all
+     * nodes of {@code movedList} and {@code movedList} is empty.
      *
-     * @param list the list to append
+     * @param index of the first element of {@code list} in this {@code list} after it was added
+     * @param movedList the {@code DoublyLinkedList} to move to this one
+     * @throws NullPointerException if {@code movedList} is {@code null}
      */
-    public void append(DoublyLinkedList<E> list) {
-        if (!list.isEmpty()) {
-            if (isEmpty()) {
-                head = list.head;
-            } else {
-                linkBefore(head, list);
-            }
-            size += list.size;
-            list.size = 0;
-            list.head = null;
-            ++modCount;
-        }
-
+    public void moveFrom(int index, DoublyLinkedList<E> movedList)
+    {
+        linkListIntoThisBefore(index, movedList);
     }
 
     /**
-     * Prepends the {@code list} to the beginning of this list. All the elements from {@code list}
-     * are transferred to this list, i.e. the {@code list} is empty after calling this method.
+     * Appends the {@code movedList} to the end of this list. All the elements from
+     * {@code movedList} are transferred to this list, i.e. the {@code list} is empty after calling
+     * this method.
      *
-     * @param list the list to prepend
+     * @param movedList the {@code DoublyLinkedList} to append to this one
+     * @throws NullPointerException if {@code movedList} is {@code null}
      */
-    public void prepend(DoublyLinkedList<E> list) {
-        if (!list.isEmpty()) {
-            if (!isEmpty()) {
-                linkBefore(head, list);
-            }
-            head = list.head;
-            size += list.size;
-
-            list.size = 0;
-            list.head = null;
-            ++modCount;
-        }
+    public void append(DoublyLinkedList<E> movedList)
+    {
+        moveFrom(size, movedList);
     }
 
     /**
-     * Appends the {@code value} to the end of this list. Returns the list node allocated for storing
-     * the {@code value}
+     * Prepends the {@code movedList} to the beginning of this list. All the elements from
+     * {@code movedList} are transferred to this list, i.e. the {@code movedList} is empty after
+     * calling this method.
      *
-     * @param value the value to add
-     * @return the list node allocated for storing the {@code value}
+     * @param movedList the {@code DoublyLinkedList} to prepend to this one
+     * @throws NullPointerException if {@code movedList} is {@code null}
      */
-    public ListNode<E> addLast(E value) {
-        ListNode<E> result = new ListNode<>(value);
-        if (isEmpty()) {
-            insertFirst(result);
-        } else {
-            linkBefore(head, result);
-        }
-        ++size;
-        ++modCount;
-        return result;
+    public void prepend(DoublyLinkedList<E> movedList)
+    {
+        moveFrom(0, movedList);
     }
 
-    /**
-     * Adds the {@code value} to the beginning of this list. Returns the list node allocated for storing
-     * the {@code value}. The returned value is the new head of the list.
-     *
-     * @param value the value to add
-     * @return the list node allocated for storing the {@code value}
-     */
-    public ListNode<E> addFirst(E value) {
-        ListNode<E> result = addLast(value);
-        head = result;
-        ++modCount;
-        return result;
-    }
+    // ----------------------------------------------------------------------------
+    // (List)Iterators
 
     /**
-     * Removes the {@code node} from this list. The running time of this method is $\mathcal{O}(1)$.
-     * The behaviour of this method is undefined if the {@code node} doesn't belong to the list.
-     *
-     * @param node the node to remove from this list
+     * Returns a {@link NodeIterator} that starts at the first {@link ListNode} of this list that is
+     * equal to the specified {@code firstElement}, iterates in forward or reversed direction and
+     * wraps around the end of this list until the first node.
+     * <p>
+     * The first call to {@link NodeIterator#nextNode()} returns the first {@code node} that holds a
+     * value such that {@code Objects.equals(node.getValue, firstElement)} returns {@code true}. If
+     * {@code reversed} is {@code true} the returned {@code NodeIterator} iterates in reverse
+     * direction returning the respective previous element in subsequent calls to
+     * {@code next(Node)}, if {@code reversed} is {@code false} it iterates in forward direction.
+     * The returned iterator ignores the actual bounds of this {@code DoublyLinkedList} and iterates
+     * until the node before the first one is reached. Its {@link NodeIterator#hasNext() hasNext()}
+     * returns {@code false} if the next node would be the first one.
+     * </p>
+     * 
+     * @param firstElement equal to the first {@code next()}
+     * @param reversed if true the returned {@code NodeIterator} iterates in reversed direction over
+     *        this list, else it iterates in forward direction.
+     * @return a wrapping {@code NodeIterator} iterating from {@code firstElement} in the specified
+     *         direction
      */
-    public void remove(ListNode<E> node) {
-        if (size == 1) {
-            head = null;
-        } else {
-            if (node == head) {
-                head = node.next;
-            }
-        }
-        unlink(node);
-        --size;
-        ++modCount;
-    }
-
-    /**
-     * Returns the first element in this list. If this list is empty, throws {@link NoSuchElementException}.
-     *
-     * @return the first element in this list.
-     */
-    public E getFirstElement() {
-        if (isEmpty()) {
+    public NodeIterator<E> wrappingIterator(E firstElement, boolean reversed)
+    {
+        ListNode<E> startNode = nodeOf(firstElement);
+        if (startNode == null) {
             throw new NoSuchElementException();
         }
-        return head.value;
-    }
-
-    /**
-     * Returns the first element in this list. If this list is empty, throws {@link NoSuchElementException}
-     *
-     * @return the first element in this list.
-     */
-    public E getLastElement() {
-        if (isEmpty()) {
-            throw new NoSuchElementException();
+        if (!reversed) {
+            return new ListNodeIteratorImpl(0, startNode);
+        } else {
+            return reverseIterator(new ListNodeIteratorImpl(size, startNode.next));
         }
-        return head.prev.value;
     }
 
-    /**
-     * Finds and returns the list node allocate for the {@code element}. If this list doesn't contain
-     * the {@code element}, returns {@code null}. The time complexity of this method is linear in the
-     * size of the list under the assumption that the element comparison is done in constant time.
-     * Otherwise, the complexity is $\mathcal{O}(n\cdot h)$, where $n$ is the size of the list and $h$
-     * is the time needed to compare two elements stored in this list.
-     *
-     * @param element the element of this list to search the list node of.
-     * @return the list node allocate for the {@code element}, or {@code null} if this list doesn't contain
-     * the {@code element}
-     */
-    public ListNode<E> getNode(E element) {
-        for (ListIterator<E> iterator = listIterator(); iterator.hasNext(); ) {
-            ListNode<E> current = iterator.nextNode();
-            if (current.value.equals(element)) {
-                return current;
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Removes the {@code target} from the list structure
-     *
-     * @param target the list node to remove
-     */
-    private void unlink(ListNode<E> target) {
-        // list is circular, don't have to worry about null values
-        target.prev.next = target.next;
-        target.next.prev = target.prev;
-
-        target.next = target.prev = null;
-    }
-
-    /**
-     * Links the {@code target} before the {@code node} in the list structure
-     *
-     * @param node   the list node from the list to link the {@code target} before
-     * @param target the new list node to link before {@code target}
-     */
-    private void linkBefore(ListNode<E> node, ListNode<E> target) {
-        target.next = node;
-        target.prev = node.prev;
-        node.prev.next = target;
-        node.prev = target;
-    }
-
-    /**
-     * Links the {@code list} before the {@code node}
-     *
-     * @param node the node to link the {@code list} before
-     * @param list the sequence of nodes to link before {@code node}
-     */
-    private void linkBefore(ListNode<E> node, DoublyLinkedList<E> list) {
-        ListNode<E> head = list.head;
-        ListNode<E> last = head.prev;
-        head.prev = node.prev;
-        last.next = node;
-
-        node.prev.next = head;
-        node.prev = last;
-    }
-
-    /**
-     * Makes the {@code target} the first list node in this list,
-     *
-     * @param target the new first element of the list
-     */
-    private void insertFirst(ListNode<E> target) {
-        target.next = target.prev = target;
-        head = target;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public String toString() {
-        if (isEmpty()) {
-            return "{ }";
-        }
-        StringBuilder builder = new StringBuilder("{");
-        ListNode<E> current = head;
-        while (current.next != head) {
-            builder.append(current.value.toString()).append(", ");
-            current = current.next;
-        }
-        builder.append(current.value.toString()).append("}");
-        return builder.toString();
+    public NodeIterator<E> descendingIterator()
+    {
+        return reverseIterator(listIterator(size));
+    }
+
+    @Override
+    public NodeIterator<E> iterator()
+    {
+        return listIterator();
+    }
+
+    @Override
+    public ListNodeIterator<E> listIterator()
+    {
+        return listIterator(0);
+    }
+
+    @Override
+    public ListNodeIterator<E> listIterator(int index)
+    {
+        return new ListNodeIteratorImpl(index);
     }
 
     /**
-     * An interface for the iterators over the {@link DoublyLinkedList}
+     * Returns a {@link ListNodeIterator} over the elements in this list (in proper sequence)
+     * starting with the first {@link ListNode} whose value is equal to the specified
+     * {@code element}.
+     *
+     * @param element the first element to be returned from the list iterator (by a call to the
+     *        {@code next} method)
+     * @return a list iterator over the elements in this list (in proper sequence)
+     * @throws NoSuchElementException if {@code element} is not in the list
+     */
+    public ListNodeIterator<E> listIterator(E element)
+    {
+        ModifiableInteger startIndex = new ModifiableInteger(0);
+        ListNode<E> startNode = searchNode(() -> head, n -> n.next, element, startIndex);
+        if (startNode == null) {
+            throw new NoSuchElementException();
+        }
+        return new ListNodeIteratorImpl(startIndex.value, startNode);
+    }
+
+    /**
+     * An extension of the {@link Iterator} interface for {@link DoublyLinkedList DoublyLinkedLists}
+     * exposing their {@link ListNode ListNodes}.
      *
      * @param <E> the list element type
      */
-    public interface ListIterator<E> extends Iterator<E> {
+    public interface NodeIterator<E>
+        extends
+        Iterator<E>
+    {
+        @Override
+        default E next()
+        {
+            return nextNode().value;
+        }
+
         /**
-         * Returns the next list node
+         * Returns the next {@link ListNode} in the list and advances the cursor position.
          *
-         * @return the next list node
+         * @return the next {@code ListNode}
+         * @see ListIterator#next()
          */
         ListNode<E> nextNode();
 
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        default E next() {
-            return nextNode().value;
-        }
     }
 
     /**
-     * An implementation of the {@link DoublyLinkedList.ListIterator} interface.
+     * An extension of the {@link ListIterator} interface for {@link DoublyLinkedList
+     * DoublyLinkedLists} exposing their {@link ListNode ListNodes}.
+     *
+     * @param <E> the list element type
      */
-    public class ListIteratorImpl implements DoublyLinkedList.ListIterator<E> {
-        /**
-         * The list node this iterator has started from
-         */
-        ListNode<E> start;
-        /**
-         * The list node this iterator will return next. This value is {@code null} when
-         * the traversal is finished.
-         */
-        ListNode<E> current;
-        /**
-         * Whether this iterator should move in the reverse direction
-         */
-        boolean reversed;
-        /**
-         * The number of modifications the list have had at the moment when this iterator was created
-         */
-        int expectedModCount;
+    public interface ListNodeIterator<E>
+        extends
+        ListIterator<E>,
+        NodeIterator<E>
+    {
+        @Override
+        default E next()
+        {
+            return nextNode().value;
+        }
+
+        @Override
+        default E previous()
+        {
+            return previousNode().value;
+        }
 
         /**
-         * Creates new list iterator, which starts from the {@code start} node
+         * Returns the previous {@link ListNode} in the list and moves the cursor position
+         * backwards.
          *
-         * @param start the node to start the traversal from
+         * @return the previous {@code ListNode}
+         * @see ListIterator#previous()
          */
-        ListIteratorImpl(ListNode<E> start) {
-            this(start, false);
-        }
+        ListNode<E> previousNode();
 
-        ListIteratorImpl(ListNode<E> start, boolean reversed) {
-            this.start = start;
-            this.current = start;
-            this.reversed = reversed;
-            this.expectedModCount = modCount;
-        }
+    }
+
+    /**
+     * An implementation of the {@link DoublyLinkedList.ListNodeIterator} interface.
+     */
+    private class ListNodeIteratorImpl
+        implements
+        ListNodeIterator<E>
+    {
+        /** Index in this list of the ListNode returned next. */
+        private int nextIndex;
+        /** ListNode this iterator will return next. Null if this list is empty. */
+        private ListNode<E> next;
+        /** ListNode this iterator returned last. */
+        private ListNode<E> last = null;
 
         /**
-         * {@inheritDoc}
+         * The number of modifications the list have had at the moment when this iterator was
+         * created
          */
-        @Override
-        public boolean hasNext() {
-            return current != null;
+        private int expectedModCount = modCount;
+
+        private ListNodeIteratorImpl(int startIndex)
+        {
+            this.nextIndex = startIndex;
+            if (startIndex == size) {
+                this.next = isEmpty() ? null : head;
+            } else {
+                this.next = getNode(startIndex);
+            }
         }
 
-        /**
-         * {@inheritDoc}
-         */
+        private ListNodeIteratorImpl(int startIndex, ListNode<E> startNode)
+        {
+            this.nextIndex = startIndex;
+            this.next = startNode;
+        }
+
         @Override
-        public ListNode<E> nextNode() {
+        public boolean hasNext()
+        {
+            return nextIndex < size;
+        }
+
+        @Override
+        public boolean hasPrevious()
+        {
+            return nextIndex > 0;
+        }
+
+        @Override
+        public int nextIndex()
+        {
+            return nextIndex;
+        }
+
+        @Override
+        public int previousIndex()
+        {
+            return nextIndex - 1;
+        }
+
+        @Override
+        public ListNode<E> nextNode()
+        {
             checkForComodification();
             if (!hasNext()) {
                 throw new NoSuchElementException();
             }
-            ListNode<E> result = current;
-            if (reversed) {
-                current = current.prev;
+
+            last = next;
+            next = next.next;
+            nextIndex++;
+            return last;
+        }
+
+        @Override
+        public ListNode<E> previousNode()
+        {
+            checkForComodification();
+            if (!hasPrevious()) {
+                throw new NoSuchElementException();
+            }
+
+            last = next = next.prev;
+            nextIndex--;
+            return last;
+        }
+
+        @Override
+        public void add(E e)
+        {
+            checkForComodification();
+
+            if (nextIndex == size) {
+                addElementLast(e); // sets head to new node of e if was empty
+                if (size == 1) { // was empty
+                    next = head; // jump over head threshold, so cursor is at the end
+                }
             } else {
-                current = current.next;
+                addElementBeforeNode(next, e);
             }
-            if (current == start) {
-                current = null;
+            last = null;
+            nextIndex++;
+            expectedModCount++;
+        }
+
+        @Override
+        public void set(E e)
+        {
+            if (last == null) {
+                throw new IllegalStateException();
             }
-            return result;
+            checkForComodification();
+            // replace node returned last with a new node holding e
+
+            ListNode<E> nextNode = last.next;
+            boolean wasLast = last == tail();
+            removeNode(last);
+            if (wasLast) { // or the sole node
+                last = addElementLast(e);
+            } else {
+                last = addElementBeforeNode(nextNode, e);
+            }
+            expectedModCount += 2; // because of unlink and add
+        }
+
+        @Override
+        public void remove()
+        {
+            if (last == null) {
+                throw new IllegalStateException();
+            }
+            checkForComodification();
+
+            ListNode<E> lastsNext = last.next;
+            removeNode(last);
+            if (next == last) { // previousNode() called before
+                // removed element after cursor (which would have been next)
+                next = lastsNext;
+            } else { // nextNode() called before
+                // removed element before cursor (next is unaffected but the index decreases)
+                nextIndex--;
+            }
+            last = null;
+            expectedModCount++;
         }
 
         /**
          * Verifies that the list structure hasn't been changed since the iteration started
          */
-        private void checkForComodification() {
+        private void checkForComodification()
+        {
             if (expectedModCount != modCount) {
                 throw new ConcurrentModificationException();
             }
@@ -446,31 +1106,67 @@ public class DoublyLinkedList<E> implements Iterable<E> {
     }
 
     /**
-     * The container to store the elements of the list in. This class can be used to perform
-     * list operations in $\mathcal{O}(1)$ time
-     *
-     * @param <V> the list node element type
+     * Returns a {@link NodeIterator} that iterates in reversed order, assuming the cursor of the
+     * specified {@link ListNodeIterator} is behind the tail of the list.
      */
-    public static class ListNode<V> {
-        private V value;
-        private ListNode<V> next;
-        private ListNode<V> prev;
+    private static <E> NodeIterator<E> reverseIterator(ListNodeIterator<E> listIterator)
+    {
+        return new NodeIterator<E>()
+        {
+            @Override
+            public boolean hasNext()
+            {
+                return listIterator.hasPrevious();
+            }
+
+            @Override
+            public ListNode<E> nextNode()
+            {
+                return listIterator.previousNode();
+            }
+
+            @Override
+            public void remove()
+            {
+                listIterator.remove();
+            }
+        };
+    }
+
+    /**
+     * Container to store the elements of a {@link DoublyLinkedList}.
+     * <p>
+     * A {@link ListNode} is either contain exactly once in exactly one {@code DoublyLinkedList} or
+     * contained in no {@code DoublyLinkedList}.
+     * </p>
+     * 
+     * @param <V> the type of the element stored in this node
+     */
+    public static class ListNode<V>
+    {
+        private final V value;
+        private DoublyLinkedList<V> list = null;
+        private ListNode<V> next = null;
+        private ListNode<V> prev = null;
 
         /**
          * Creates new list node
          *
          * @param value the value this list node stores
          */
-        ListNode(V value) {
+        ListNode(V value)
+        {
             this.value = value;
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
-        public String toString() {
-            return String.format("%s -> %s -> %s", prev.value, value, next.value);
+        public String toString()
+        {
+            if (list == null) {
+                return " - " + value + " - "; // not in a list
+            } else {
+                return prev.value + " -> " + value + " -> " + next.value;
+            }
         }
 
         /**
@@ -478,12 +1174,9 @@ public class DoublyLinkedList<E> implements Iterable<E> {
          *
          * @return the value this list node stores
          */
-        public V getValue() {
+        public V getValue()
+        {
             return value;
         }
     }
-
 }
-
-
-

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -930,36 +930,54 @@ public class DoublyLinkedList<E>
 
     /**
      * Returns a {@link NodeIterator} that starts at the first {@link ListNode} of this list that is
-     * equal to the specified {@code firstElement}, iterates in forward or reversed direction and
-     * wraps around the end of this list until the first node.
+     * equal to the specified {@code firstElement}, iterates in forward direction over the end of
+     * this list until the first node.
      * <p>
      * The first call to {@link NodeIterator#nextNode()} returns the first {@code node} that holds a
-     * value such that {@code Objects.equals(node.getValue, firstElement)} returns {@code true}. If
-     * {@code reversed} is {@code true} the returned {@code NodeIterator} iterates in reverse
-     * direction returning the respective previous element in subsequent calls to
-     * {@code next(Node)}, if {@code reversed} is {@code false} it iterates in forward direction.
-     * The returned iterator ignores the actual bounds of this {@code DoublyLinkedList} and iterates
-     * until the node before the first one is reached. Its {@link NodeIterator#hasNext() hasNext()}
-     * returns {@code false} if the next node would be the first one.
+     * value such that {@code Objects.equals(node.getValue, firstElement)} returns {@code true}. The
+     * returned {@code NodeIterator} iterates in forward direction returning the respective next
+     * element in subsequent calls to {@code next(Node)}. The returned iterator ignores the actual
+     * bounds of this {@code DoublyLinkedList} and iterates until the node before the first one is
+     * reached. Its {@link NodeIterator#hasNext() hasNext()} returns {@code false} if the next node
+     * would be the first one.
      * </p>
      * 
      * @param firstElement equal to the first {@code next()}
-     * @param reversed if true the returned {@code NodeIterator} iterates in reversed direction over
-     *        this list, else it iterates in forward direction.
-     * @return a wrapping {@code NodeIterator} iterating from {@code firstElement} in the specified
-     *         direction
+     * @return a circular {@code NodeIterator} iterating forward from {@code firstElement}
      */
-    public NodeIterator<E> wrappingIterator(E firstElement, boolean reversed)
+    public NodeIterator<E> circularIterator(E firstElement)
     {
         ListNode<E> startNode = nodeOf(firstElement);
         if (startNode == null) {
             throw new NoSuchElementException();
         }
-        if (!reversed) {
-            return new ListNodeIteratorImpl(0, startNode);
-        } else {
-            return reverseIterator(new ListNodeIteratorImpl(size, startNode.next));
+        return new ListNodeIteratorImpl(0, startNode);
+    }
+
+    /**
+     * Returns a {@link NodeIterator} that starts at the first {@link ListNode} of this list that is
+     * equal to the specified {@code firstElement}, iterates in reverse direction over the end of
+     * this list until the first node.
+     * <p>
+     * The first call to {@link NodeIterator#nextNode()} returns the first {@code node} that holds a
+     * value such that {@code Objects.equals(node.getValue, firstElement)} returns {@code true}. The
+     * returned {@code NodeIterator} iterates in reverse direction returning the respective previous
+     * element in subsequent calls to {@code next(Node)}. The returned iterator ignores the actual
+     * bounds of this {@code DoublyLinkedList} and iterates until the node before the first one is
+     * reached. Its {@link NodeIterator#hasNext() hasNext()} returns {@code false} if the next node
+     * would be the first one.
+     * </p>
+     * 
+     * @param firstElement equal to the first {@code next()}
+     * @return a circular {@code NodeIterator} iterating backwards from {@code firstElement}
+     */
+    public NodeIterator<E> reverseCircularIterator(E firstElement)
+    {
+        ListNode<E> startNode = nodeOf(firstElement);
+        if (startNode == null) {
+            throw new NoSuchElementException();
         }
+        return reverseIterator(new ListNodeIteratorImpl(size, startNode.next));
     }
 
     /**
@@ -1273,7 +1291,7 @@ public class DoublyLinkedList<E>
     }
 
     /**
-     * Returns a {@link NodeIterator} that iterates in reversed order, assuming the cursor of the
+     * Returns a {@link NodeIterator} that iterates in reverse order, assuming the cursor of the
      * specified {@link ListNodeIterator} is behind the tail of the list.
      */
     private static <E> NodeIterator<E> reverseIterator(ListNodeIterator<E> listIterator)

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -31,8 +31,8 @@ import java.util.function.*;
  * {@code DoublyLinkedList}.
  * </p>
  * <p>
- * A {@code DoublyLinkedList} supports {@code null} elements but do not support
- * {@code null ListNodes}. This class is not thread safe and need to be synchronized externally if
+ * A {@code DoublyLinkedList} supports {@code null} elements but does not support
+ * {@code null ListNodes}. This class is not thread safe and needs to be synchronized externally if
  * modified by concurrent threads.
  * </p>
  * <p>
@@ -47,9 +47,7 @@ import java.util.function.*;
  * increases the memory occupied by this list implementation compared to {@code LinkedList} for the
  * same elements. Instances of {@code LinkedList.Node} have three references each (the element, next
  * and previous), Instances {@code DoublyLinkedList.ListNode} have four (the element, next, previous
- * and the list). Because usually each {@code Object} has a header that also requires memory, the
- * memory consumption of this implementation is less than 33.3% greater compared to
- * {@code LinkedList} (the exact number depends on the executing JVM).
+ * and the list).
  * </p>
  *
  * @param <E> the list element type
@@ -71,18 +69,27 @@ public class DoublyLinkedList<E>
         return head.prev;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean isEmpty()
     {
         return head == null;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int size()
     {
         return size;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void clear()
     {
@@ -102,6 +109,17 @@ public class DoublyLinkedList<E>
 
     // internal modification methods
 
+    /**
+     * Adds the given {@link ListNode} to this {@code List}.
+     * <p>
+     * Sets the {@code list} reference of {@code node} to this list, increases this lists
+     * {@code size} and {@code modcount} by one.
+     * </p>
+     * 
+     * @param node to add to this list
+     * @throws IllegalArgumentException if {@code node} is already contained in this or another
+     *         {@code DoublyLinkedList}
+     */
     private void addListNode(ListNode<E> node)
     { // call this before any modification of this list is done
         if (node.list != null) {
@@ -114,7 +132,11 @@ public class DoublyLinkedList<E>
         modCount++;
     }
 
-    /** Atomically adds all {@link ListNode ListNodes} of {@code list} to this list. */
+    /**
+     * Atomically moves all {@link ListNode ListNodes} from {@code list} to this list as if each
+     * node was removed with {@link #removeListNode(ListNode)} from {@code list} and subsequently
+     * added to this list by {@link #addListNode(ListNode)}.
+     */
     private void moveAllListNodes(DoublyLinkedList<E> list)
     { // call this before any modification of this list is done
 
@@ -129,7 +151,18 @@ public class DoublyLinkedList<E>
         list.modCount++;
     }
 
-    /** Returns true if {@code node} was successfully removed from the list. */
+    /**
+     * Removes the given {@link ListNode} from this {@code List}, if it is contained in this
+     * {@code List}.
+     * <p>
+     * If {@code node} is contained in this list, sets the {@code list}, {@code next} and
+     * {@code prev} reference of {@code node} to {@code null} decreases this list's {@code size} and
+     * increases the {@code modcount} by one.
+     * </p>
+     * 
+     * @param node to remove from this list
+     * @return true if {@code node} was removed from this list, else false
+     */
     private boolean removeListNode(ListNode<E> node)
     { // call this before any modification of this list is done
         if (node.list == this) {
@@ -549,6 +582,9 @@ public class DoublyLinkedList<E>
 
     // List methods (shortcut for most commonly used methods to avoid iterator creation)
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void add(int index, E element)
     {
@@ -559,12 +595,18 @@ public class DoublyLinkedList<E>
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E get(int index)
     {
         return getNode(index).value;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E remove(int index)
     {
@@ -575,18 +617,27 @@ public class DoublyLinkedList<E>
 
     // Deque methods
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void addFirst(E e)
     {
         addElementFirst(e);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void addLast(E e)
     {
         addElementLast(e);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean offerFirst(E e)
     {
@@ -594,6 +645,9 @@ public class DoublyLinkedList<E>
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean offerLast(E e)
     {
@@ -601,6 +655,9 @@ public class DoublyLinkedList<E>
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E removeFirst()
     {
@@ -613,6 +670,9 @@ public class DoublyLinkedList<E>
         return node.value;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E removeLast()
     {
@@ -625,6 +685,9 @@ public class DoublyLinkedList<E>
         return node.value;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E pollFirst()
     {
@@ -636,6 +699,9 @@ public class DoublyLinkedList<E>
         return node.value;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E pollLast()
     {
@@ -647,30 +713,45 @@ public class DoublyLinkedList<E>
         return node.value;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E getFirst()
     {
         return getFirstNode().value;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E getLast()
     {
         return getLastNode().value;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E peekFirst()
     {
         return isEmpty() ? null : getFirst();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E peekLast()
     {
         return isEmpty() ? null : getLast();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean removeFirstOccurrence(Object o)
     {
@@ -682,6 +763,9 @@ public class DoublyLinkedList<E>
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean removeLastOccurrence(Object o)
     {
@@ -695,30 +779,45 @@ public class DoublyLinkedList<E>
 
     // Queue methods
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean offer(E e)
     {
         return offerLast(e);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E remove()
     {
         return removeFirst();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E poll()
     {
         return pollFirst();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E element()
     {
         return getFirst();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E peek()
     {
@@ -727,12 +826,18 @@ public class DoublyLinkedList<E>
 
     // Stack methods
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public void push(E e)
     {
         addFirst(e);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public E pop()
     {
@@ -844,24 +949,36 @@ public class DoublyLinkedList<E>
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public NodeIterator<E> descendingIterator()
     {
         return reverseIterator(listIterator(size));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public NodeIterator<E> iterator()
     {
         return listIterator();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public ListNodeIterator<E> listIterator()
     {
         return listIterator(0);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public ListNodeIterator<E> listIterator(int index)
     {
@@ -898,6 +1015,9 @@ public class DoublyLinkedList<E>
         extends
         Iterator<E>
     {
+        /**
+         * {@inheritDoc}
+         */
         @Override
         default E next()
         {
@@ -925,12 +1045,18 @@ public class DoublyLinkedList<E>
         ListIterator<E>,
         NodeIterator<E>
     {
+        /**
+         * {@inheritDoc}
+         */
         @Override
         default E next()
         {
             return nextNode().value;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         default E previous()
         {
@@ -984,30 +1110,45 @@ public class DoublyLinkedList<E>
             this.next = startNode;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public boolean hasNext()
         {
             return nextIndex < size;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public boolean hasPrevious()
         {
             return nextIndex > 0;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public int nextIndex()
         {
             return nextIndex;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public int previousIndex()
         {
             return nextIndex - 1;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public ListNode<E> nextNode()
         {
@@ -1022,6 +1163,9 @@ public class DoublyLinkedList<E>
             return last;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public ListNode<E> previousNode()
         {
@@ -1035,6 +1179,9 @@ public class DoublyLinkedList<E>
             return last;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public void add(E e)
         {
@@ -1053,6 +1200,9 @@ public class DoublyLinkedList<E>
             expectedModCount++;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public void set(E e)
         {
@@ -1073,6 +1223,9 @@ public class DoublyLinkedList<E>
             expectedModCount += 2; // because of unlink and add
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public void remove()
         {
@@ -1113,18 +1266,27 @@ public class DoublyLinkedList<E>
     {
         return new NodeIterator<E>()
         {
+            /**
+             * {@inheritDoc}
+             */
             @Override
             public boolean hasNext()
             {
                 return listIterator.hasPrevious();
             }
 
+            /**
+             * {@inheritDoc}
+             */
             @Override
             public ListNode<E> nextNode()
             {
                 return listIterator.previousNode();
             }
 
+            /**
+             * {@inheritDoc}
+             */
             @Override
             public void remove()
             {
@@ -1159,6 +1321,9 @@ public class DoublyLinkedList<E>
             this.value = value;
         }
 
+        /**
+         * {@inheritDoc}
+         */
         @Override
         public String toString()
         {

--- a/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
@@ -1,0 +1,1740 @@
+/*
+ * (C) Copyright 2020-2020, by Hannes Wellmann and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.util;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
+
+import java.util.*;
+
+import org.jgrapht.util.DoublyLinkedList.*;
+import org.junit.*;
+import org.junit.rules.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
+import org.junit.runners.Parameterized.*;
+
+/**
+ * @author Hannes Wellmann
+ *
+ */
+@RunWith(Parameterized.class)
+public class DoublyLinkedListTest
+{
+    private static final int MAX_LIST_SIZE = 8;
+
+    @Parameters(name = "List with size {0}")
+    public static Object[] getListSizes()
+    {
+        Object[][] parameterSets = new Object[MAX_LIST_SIZE + 1][];
+        for (int size = 0; size < MAX_LIST_SIZE + 1; size++) {
+
+            List<Object> elements = new ArrayList<>(size);
+            for (int i = 0; i < size; i++) {
+                elements.add("obj" + i);
+            }
+            if (size >= 6) { // make two elements equal
+                elements.set(3, new String("obj2")); // create equal new String-object
+            }
+            parameterSets[size] = new Object[] { size, Collections.unmodifiableList(elements) };
+        }
+        return parameterSets;
+    }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    @Parameterized.Parameter(0)
+    public int size;
+    @Parameterized.Parameter(1)
+    public List<String> expectedElements;
+
+    private DoublyLinkedList<String> list;
+
+    @Before
+    public void setUp()
+    {
+        list = createDoublyLinkedList(expectedElements);
+    }
+
+    // ------------------------------------------------------------------------
+    // test cases
+
+    /** Test for {@link DoublyLinkedList#isEmpty()}. */
+    @Test
+    public void testIsEmpty()
+    {
+        assertThat(list.isEmpty(), is(equalTo(size == 0)));
+    }
+
+    /** Test for {@link DoublyLinkedList#size()}. */
+    @Test
+    public void testSize()
+    {
+        assertThat(list.size(), is(equalTo(size)));
+    }
+
+    /** Test for {@link DoublyLinkedList#clear()}. */
+    @Test
+    public void testClear()
+    {
+        List<ListNode<String>> allNodes = getListNodesOfList(list);
+
+        list.clear();
+
+        assertTrue(list.isEmpty());
+        assertThat(list.size(), is(equalTo(0)));
+
+        for (ListNode<String> listNode : allNodes) {
+            assertFalse(list.containsNode(listNode));
+        }
+    }
+
+    // test ListNode methods
+
+    /** Test for {@link DoublyLinkedList#addNodeFirst(DoublyLinkedList.ListNode)}. */
+    @Test
+    public void testAddNodeFirst_freeNode_nodeAddedToList()
+    {
+        String element = "another";
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(0, element);
+
+        ListNode<String> node = createFreeListNode(element);
+        list.addNodeFirst(node);
+
+        assertThat(list.getFirstNode(), is(equalTo(node)));
+        assertTrue(list.containsNode(node));
+        assertSameContent(list, expectedList);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddNodeFirst_nodeInOtherList_IllegalArgumentException()
+    {
+        ListNode<String> node = createListNodeInOtherList();
+
+        list.addNodeFirst(node);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddNodeFirst_nodeOfThisList_IllegalArgumentException()
+    {
+        if (size == 0) {
+            throw new IllegalArgumentException(); // throw expected exception to skip for empty list
+        }
+        ListNode<String> node = list.getNode(size / 2);
+
+        list.addNodeFirst(node);
+    }
+
+    /** Test for {@link DoublyLinkedList#addNodeLast(DoublyLinkedList.ListNode)}. */
+    @Test
+    public void testAddNodeLast_freeNode_nodeAddedToList()
+    {
+        String element = "another";
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(size, element);
+
+        ListNode<String> node = createFreeListNode(element);
+        list.addNodeLast(node);
+
+        assertThat(list.getLastNode(), is(equalTo(node)));
+        assertTrue(list.containsNode(node));
+        assertSameContent(list, expectedList);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddNodeLast_nodeInOtherList_IllegalArgumentException()
+    {
+        ListNode<String> node = createListNodeInOtherList();
+
+        list.addNodeLast(node);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddNodeLast_nodeOfThisList_IllegalArgumentException()
+    {
+        if (size == 0) {
+            throw new IllegalArgumentException(); // throw expected exception to skip for empty list
+        }
+        ListNode<String> node = list.getNode(size / 2);
+
+        list.addNodeLast(node);
+    }
+
+    /** Test for {@link DoublyLinkedList#addNode(int, DoublyLinkedList.ListNode)}. */
+    @Test
+    public void testAddNode_freeNode_nodeAddedToList()
+    {
+        String element = "another";
+        int index = size / 2;
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(index, element);
+
+        ListNode<String> node = createFreeListNode(element);
+        list.addNode(index, node);
+
+        assertTrue(list.containsNode(node));
+        assertSameContent(list, expectedList);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddNode_nodeInOtherList_IllegalArgumentException()
+    {
+        ListNode<String> node = createListNodeInOtherList();
+
+        list.addNode(size / 2, node);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddNode_nodeOfThisList_IllegalArgumentException()
+    {
+        if (size == 0) {
+            throw new IllegalArgumentException(); // throw expected exception to skip for empty list
+        }
+        ListNode<String> node = list.getLastNode();
+
+        list.addNode(size / 2, node);
+    }
+
+    /**
+     * Test for
+     * {@link DoublyLinkedList#addNodeBefore(DoublyLinkedList.ListNode, DoublyLinkedList.ListNode)}.
+     */
+    @Test
+    public void testAddNodeBefore_freeNodeBeforeNodeInList_nodeAddedToList()
+    {
+        if (size == 0) {
+            return;
+        }
+        String element = "another";
+        int index = size / 2;
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(index, element);
+
+        ListNode<String> node = createFreeListNode(element);
+        ListNode<String> beforeNode = list.getNode(index);
+        list.addNodeBefore(beforeNode, node);
+
+        assertTrue(list.containsNode(node));
+        assertSameContent(list, expectedList);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddNodeBefore_freeNodeBeforeNodeInOtherList_IllegalArgumentException()
+    {
+        ListNode<String> node = createFreeListNode("another");
+        ListNode<String> beforeNode = createListNodeInOtherList();
+
+        list.addNodeBefore(beforeNode, node);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddNodeBefore_freeNodeBeforeFreeNode_IllegalArgumentException()
+    {
+        ListNode<String> node = createFreeListNode("another");
+        ListNode<String> beforeNode = createFreeListNode("another");
+
+        list.addNodeBefore(beforeNode, node);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddNodeBefore_nodeInOtherListBeforeNodeOfList_IllegalArgumentException()
+    {
+        if (size == 0) {
+            throw new IllegalArgumentException(); // throw expected exception to skip for empty list
+        }
+        ListNode<String> node = createListNodeInOtherList();
+        ListNode<String> beforeNode = list.getNode(size / 2);
+
+        list.addNodeBefore(beforeNode, node);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddNodeBefore_nodeInThisListBeforeNodeOfList_IllegalArgumentException()
+    {
+        if (size == 0) {
+            throw new IllegalArgumentException(); // throw expected exception to skip for empty list
+        }
+        ListNode<String> node = list.getFirstNode();
+        ListNode<String> beforeNode = list.getNode(size / 2);
+
+        list.addNodeBefore(beforeNode, node);
+    }
+
+    /** Test for {@link DoublyLinkedList#getFirstNode()}. */
+    @Test
+    public void testGetFirstNode()
+    {
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+        }
+
+        ListNode<String> firstNode = list.getFirstNode();
+
+        assertThat(firstNode, is(sameInstance(list.getNode(0))));
+        assertThat(firstNode.getValue(), is(sameInstance(expectedElements.get(0))));
+    }
+
+    /** Test for {@link DoublyLinkedList#getLastNode()}. */
+    @Test
+    public void testGetLastNode()
+    {
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+        }
+
+        ListNode<String> firstNode = list.getLastNode();
+
+        assertThat(firstNode, is(sameInstance(list.getNode(size - 1))));
+        assertThat(firstNode.getValue(), is(sameInstance(expectedElements.get(size - 1))));
+    }
+
+    /** Test for {@link DoublyLinkedList#getNode(int)}. */
+    @Test
+    public void testGetNode()
+    {
+        for (int i = 0; i < size; i++) {
+            String expectedElement = expectedElements.get(i);
+
+            ListNode<String> node = list.getNode(i);
+
+            assertThat(node.getValue(), is(sameInstance(expectedElement)));
+        }
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testGetNode_indexSize_IndexOutOfBoundsException()
+    {
+        list.getNode(size);
+    }
+
+    @Test(expected = IndexOutOfBoundsException.class)
+    public void testGetNode_indexNegative_IndexOutOfBoundsException()
+    {
+        list.getNode(-1);
+    }
+
+    /** Test for {@link DoublyLinkedList#indexOfNode(DoublyLinkedList.ListNode)}. */
+    @Test
+    public void testIndexOfNode_nodeInList_indexOfNode()
+    {
+        if (size == 0) {
+            return;
+        }
+        int index = size / 3;
+        NodeIterator<String> iterator = list.iterator();
+        for (int i = 0; i < index; i++) {
+            iterator.nextNode(); // do not use getNode(int). Test another program path.
+        }
+        ListNode<String> node = iterator.nextNode();
+
+        int indexOfNode = list.indexOfNode(node);
+
+        assertThat(indexOfNode, is(equalTo(index)));
+    }
+
+    @Test
+    public void testIndexOfNode_nodeInOtherList_minusOne()
+    {
+        ListNode<String> node = createListNodeInOtherList();
+
+        int indexOfNode = list.indexOfNode(node);
+
+        assertThat(indexOfNode, is(equalTo(-1)));
+    }
+
+    @Test
+    public void testIndexOfNode_nodeInNoList_minusOne()
+    {
+        ListNode<String> node = createFreeListNode("another");
+
+        int indexOfNode = list.indexOfNode(node);
+
+        assertThat(indexOfNode, is(equalTo(-1)));
+    }
+
+    /** Test for {@link DoublyLinkedList#containsNode(DoublyLinkedList.ListNode)}. */
+    @Test
+    public void testContainsNode_nodeInList_true()
+    {
+        if (size == 0) {
+            return;
+        }
+        ListNode<String> node = list.getNode(size / 3);
+
+        boolean contains = list.containsNode(node);
+
+        assertTrue(contains);
+    }
+
+    @Test
+    public void testContainsNode_nodeInOtherList_false()
+    {
+        ListNode<String> node = createListNodeInOtherList();
+
+        boolean contains = list.containsNode(node);
+
+        assertFalse(contains);
+    }
+
+    @Test
+    public void testContainsNode_nodeInNoList_false()
+    {
+        ListNode<String> node = createFreeListNode("another");
+
+        boolean contains = list.containsNode(node);
+
+        assertFalse(contains);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#removeNode(DoublyLinkedList.ListNode)}.
+     */
+    @Test
+    public void testRemoveNode_nodeInList_nodeRemoved()
+    {
+        if (size == 0) {
+            return;
+        }
+        int index = size / 2;
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.remove(index);
+
+        ListNode<String> node = list.getNode(index);
+        boolean removed = list.removeNode(node);
+
+        assertTrue(removed);
+        assertSameContent(list, expectedList);
+        assertFalse(list.containsNode(node));
+        if (size == 1) {
+            assertTrue(list.isEmpty());
+        }
+    }
+
+    @Test
+    public void testRemoveNode_nodeNotInList_listUnchanged()
+    {
+        ListNode<String> nodeNotInList = createListNodeInOtherList();
+
+        boolean removed = list.removeNode(nodeNotInList);
+
+        assertFalse(removed);
+        assertSameContent(list, expectedElements); // ensure list did not change
+    }
+
+    @Test
+    public void testRemoveNode_removeAllNodesInListFromFront_emptyList()
+    {
+        List<ListNode<String>> allNodes = getListNodesOfList(list);
+
+        for (int i = 0; i < size; i++) {
+            // remove first node in each iteration
+            ListNode<String> nodeToRemove = allNodes.remove(0);
+
+            // test if head was updated correctly in previous remove
+            assertThat(list.getFirstNode(), is(sameInstance(nodeToRemove)));
+
+            boolean removed = list.removeNode(nodeToRemove);
+
+            assertTrue(removed);
+            assertSameNodes(list, allNodes);
+        }
+        assertThat(list.size(), is(equalTo(0)));
+        assertTrue(list.isEmpty());
+    }
+
+    @Test
+    public void testRemoveNode_removeAllNodesInListFromEnd_emptyList()
+    {
+        List<ListNode<String>> allNodes = getListNodesOfList(list);
+
+        for (int i = 0; i < size; i++) {
+            // remove last node in each iteration
+            ListNode<String> nodeToRemove = allNodes.remove(allNodes.size() - 1);
+
+            // test if tail was updated correctly in previous remove
+            assertThat(list.getLastNode(), is(sameInstance(nodeToRemove)));
+
+            boolean removed = list.removeNode(nodeToRemove);
+
+            assertTrue(removed);
+            assertSameNodes(list, allNodes);
+        }
+        assertThat(list.size(), is(equalTo(0)));
+        assertTrue(list.isEmpty());
+    }
+
+    @Test
+    public void testRemoveNode_removeAllNodesInListFromMiddle_emptyList()
+    {
+        if (size == 0) {
+            return;
+        }
+        List<ListNode<String>> allNodes = getListNodesOfList(list);
+
+        ListNode<String> head = allNodes.get(0);
+        ListNode<String> tail = allNodes.get(size - 1);
+
+        for (int i = 0; i < size; i++) {
+            // remove last node in each iteration
+            int index = allNodes.size() / 2;
+            ListNode<String> nodeToRemove = allNodes.remove(index);
+
+            // test if head and tail were updated correctly in previous remove
+            assertThat(list.getFirstNode(), is(sameInstance(head)));
+            assertThat(list.getLastNode(), is(sameInstance(tail)));
+            if (!allNodes.isEmpty()) { // if empty this is the last loop
+                if (index == 0) {
+                    head = allNodes.get(0);
+                }
+                if (index == allNodes.size()) {
+                    tail = allNodes.get(allNodes.size() - 1);
+                }
+            }
+
+            boolean removed = list.removeNode(nodeToRemove);
+
+            assertTrue(removed);
+            assertSameNodes(list, allNodes);
+        }
+        assertThat(list.size(), is(equalTo(0)));
+        assertTrue(list.isEmpty());
+    }
+
+    /** Test for {@link DoublyLinkedList#nodeOf(Object)}. */
+    @Test
+    public void testNodeOf_elementInList_nodeOfElement()
+    {
+        String obj2 = "obj2"; // equal String occurs twice in larger lists
+        ListNode<String> expectedNode = size <= 2 ? null : list.getNode(2);
+
+        ListNode<String> nodeOfElement = list.nodeOf(obj2);
+
+        assertThat(nodeOfElement, is(sameInstance(expectedNode)));
+        if (size > 2) {
+            assertThat(nodeOfElement.getValue(), is(equalTo(obj2)));
+        }
+    }
+
+    @Test
+    public void testNodeOf_elementNotInList_null()
+    {
+        String otherElement = "another";
+
+        ListNode<String> nodeOfElement = list.nodeOf(otherElement);
+
+        assertThat(nodeOfElement, is(sameInstance(null)));
+    }
+
+    /** Test for {@link DoublyLinkedList#lastNodeOf(Object)}. */
+    @Test
+    public void testLastNodeOf()
+    {
+        String obj2 = "obj2"; // equal String occurs twice in larger lists
+        ListNode<String> expectedNode;
+        if (size <= 2) {
+            expectedNode = null;
+        } else if (size < 6) {
+            expectedNode = list.getNode(2);
+        } else {
+            expectedNode = list.getNode(3);
+        }
+
+        ListNode<String> nodeOfElement = list.lastNodeOf(obj2);
+        assertThat(nodeOfElement, is(sameInstance(expectedNode)));
+        if (size > 2) {
+            assertThat(nodeOfElement.getValue(), is(equalTo(obj2)));
+        }
+    }
+
+    /** Test for {@link DoublyLinkedList#addElementFirst(Object)}. */
+    @Test
+    public void testAddElementFirst_nonNullValue_valueAdded()
+    {
+        String another = "another";
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(0, another);
+
+        ListNode<String> addedNode = list.addElementFirst(another);
+
+        assertThat(addedNode, is(sameInstance(list.getFirstNode())));
+        assertTrue(list.containsNode(addedNode));
+        assertThat(addedNode.getValue(), is(sameInstance(another)));
+        assertSameContent(list, expectedList);
+    }
+
+    @Test
+    public void testAddElementFirst_nullValue_valueAdded()
+    { // checks actually only ListNode-constructor, no need to test other addElementX()-methods
+        String another = null;
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(0, another);
+
+        ListNode<String> addedNode = list.addElementFirst(another);
+
+        assertThat(addedNode, is(sameInstance(list.getFirstNode())));
+        assertTrue(list.containsNode(addedNode));
+        assertThat(addedNode.getValue(), is(sameInstance(another)));
+        assertSameContent(list, expectedList);
+    }
+
+    /** Test for {@link DoublyLinkedList#addElementLast(Object)}. */
+    @Test
+    public void testAddElementLast()
+    {
+        String another = "another";
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(size, another);
+
+        ListNode<String> addedNode = list.addElementLast(another);
+
+        assertThat(addedNode, is(sameInstance(list.getLastNode())));
+        assertTrue(list.containsNode(addedNode));
+        assertThat(addedNode.getValue(), is(sameInstance(another)));
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#addElementBeforeNode(DoublyLinkedList.ListNode, Object)}.
+     */
+    @Test
+    public void testAddElementBeforeNode_sucessorInList_ElementAdded()
+    {
+        if (size == 0) {
+            thrown.expect(NullPointerException.class);
+        }
+        String another = "another";
+        int i = (int) (size / 2.5);
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(i, another);
+
+        ListNode<String> nodeBefore = size > 0 ? list.getNode(i) : null;
+        ListNode<String> addedNode = list.addElementBeforeNode(nodeBefore, another);
+
+        assertThat(addedNode, is(sameInstance(list.getNode(i))));
+        assertTrue(list.containsNode(addedNode));
+        assertThat(addedNode.getValue(), is(sameInstance(another)));
+
+        assertSameContent(list, expectedList);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddElementBeforeNode_sucessorInOtherList_IllegalStateException()
+    {
+        String another = "another";
+
+        ListNode<String> nodeBefore = createListNodeInOtherList();
+        list.addElementBeforeNode(nodeBefore, another);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAddElementBeforeNode_sucessorInNoList_IllegalStateException()
+    {
+        String another = "another";
+
+        ListNode<String> nodeBefore = createFreeListNode("another");
+        list.addElementBeforeNode(nodeBefore, another);
+    }
+
+    // test List methods
+
+    /** Test for {@link DoublyLinkedList#add(int, Object)}. */
+    @Test
+    public void testAddInt_atIndex0()
+    {
+        String anotherString = "another";
+
+        List<String> expected = new ArrayList<>(expectedElements);
+        expected.add(0, anotherString);
+
+        list.add(0, anotherString);
+
+        assertSameContent(list, expected);
+    }
+
+    /** Test for {@link DoublyLinkedList#add(int, Object)}. */
+    @Test
+    public void testAddInt_inTheMiddle()
+    {
+        String anotherString = "another";
+
+        List<String> expected = new ArrayList<>(expectedElements);
+        expected.add(size / 2, anotherString);
+
+        list.add(size / 2, anotherString);
+
+        assertSameContent(list, expected);
+    }
+
+    /** Test for {@link DoublyLinkedList#add(int, Object)}. */
+    @Test
+    public void testAddInt_atIndexSize()
+    {
+        String anotherString = "another";
+
+        List<String> expected = new ArrayList<>(expectedElements);
+        expected.add(size, anotherString);
+
+        list.add(size, anotherString);
+
+        assertSameContent(list, expected);
+    }
+
+    /** Test for {@link DoublyLinkedList#get(int)}. */
+    @Test
+    public void testGetInt()
+    {
+        for (int i = 0; i < size; i++) {
+            String expectedElement = expectedElements.get(i);
+
+            String element = list.get(i);
+
+            assertThat(element, is(sameInstance(expectedElement)));
+        }
+    }
+
+    /** Test for {@link DoublyLinkedList#remove(int)}. */
+    @Test
+    public void testRemoveInt_atIndex0()
+    {
+        if (size == 0) {
+            thrown.expect(IndexOutOfBoundsException.class);
+        }
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        String expectedRemoved = expectedList.remove(0);
+
+        String removed = list.remove(0);
+
+        assertThat(removed, is(sameInstance(expectedRemoved)));
+        assertSameContent(list, expectedList);
+    }
+
+    /** Test for {@link DoublyLinkedList#remove(int)}. */
+    @Test
+    public void testRemoveInt_inTheMiddle()
+    {
+        if (size == 0) {
+            thrown.expect(IndexOutOfBoundsException.class);
+        }
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        String expectedRemoved = expectedList.remove(size / 2);
+
+        String removed = list.remove(size / 2);
+
+        assertThat(removed, is(sameInstance(expectedRemoved)));
+        assertSameContent(list, expectedList);
+    }
+
+    /** Test for {@link DoublyLinkedList#remove(int)}. */
+    @Test
+    public void testRemoveInt_atIndexSizeMinusOne()
+    {
+        if (size == 0) {
+            thrown.expect(IndexOutOfBoundsException.class);
+        }
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        String expectedRemoved = expectedList.remove(size - 1);
+
+        String removed = list.remove(size - 1);
+
+        assertThat(removed, is(sameInstance(expectedRemoved)));
+        assertSameContent(list, expectedList);
+    }
+
+    // test Deque methods
+
+    /**
+     * Test for {@link DoublyLinkedList#addFirst(Object)}.
+     */
+    @Test
+    public void testAddFirst()
+    {
+        String anotherString = "another";
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(0, anotherString);
+
+        list.addFirst(anotherString);
+
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#addLast(Object)}.
+     */
+    @Test
+    public void testAddLast()
+    {
+        String anotherString = "another";
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(size, anotherString);
+
+        list.addLast(anotherString);
+
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#offerFirst(Object)}.
+     */
+    @Test
+    public void testOfferFirst()
+    {
+        String anotherString = "another";
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(0, anotherString);
+
+        list.offerFirst(anotherString);
+
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#offerLast(Object)}.
+     */
+    @Test
+    public void testOfferLast()
+    {
+        String anotherString = "another";
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(size, anotherString);
+
+        list.offerLast(anotherString);
+
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#removeFirst()}.
+     */
+    @Test
+    public void testRemoveFirst()
+    {
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+        }
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        String expectedFirst = size > 0 ? expectedList.remove(0) : null;
+
+        String first = list.removeFirst();
+
+        assertThat(first, is(sameInstance(expectedFirst)));
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#removeLast()}.
+     */
+    @Test
+    public void testRemoveLast()
+    {
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+        }
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        String expectedLast = size > 0 ? expectedList.remove(size - 1) : null;
+
+        String last = list.removeLast();
+
+        assertThat(last, is(sameInstance(expectedLast)));
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#pollFirst()}.
+     */
+    @Test
+    public void testPollFirst()
+    {
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        String expectedFirst = size > 0 ? expectedList.remove(0) : null;
+
+        String first = list.pollFirst();
+
+        assertThat(first, is(sameInstance(expectedFirst)));
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#pollLast()}.
+     */
+    @Test
+    public void testPollLast()
+    {
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        String expectedLast = size > 0 ? expectedList.remove(size - 1) : null;
+
+        String last = list.pollLast();
+
+        assertThat(last, is(sameInstance(expectedLast)));
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#getFirst()}.
+     */
+    @Test
+    public void testGetFirst()
+    {
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+        }
+        String first = list.getFirst();
+
+        assertThat(first, is(sameInstance(expectedElements.get(0))));
+        assertSameContent(list, expectedElements); // ensure content did not change
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#getLast()}.
+     */
+    @Test
+    public void testGetLast()
+    {
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+        }
+        String last = list.getLast();
+
+        assertThat(last, is(sameInstance(expectedElements.get(size - 1))));
+        assertSameContent(list, expectedElements); // ensure content did not change
+    }
+
+    /** Test for {@link DoublyLinkedList#peekFirst()}. */
+    @Test
+    public void testPeekFirst()
+    {
+        String expectedFirst = size > 0 ? expectedElements.get(0) : null;
+
+        String first = list.peekFirst();
+
+        assertThat(first, is(sameInstance(expectedFirst)));
+        assertSameContent(list, expectedElements); // ensure content did not change
+    }
+
+    /** Test for {@link DoublyLinkedList#peekLast()}. */
+    @Test
+    public void testPeekLast()
+    {
+        String expectedLast = size > 0 ? expectedElements.get(size - 1) : null;
+
+        String last = list.peekLast();
+
+        assertThat(last, is(sameInstance(expectedLast)));
+        assertSameContent(list, expectedElements); // ensure content did not change
+    }
+
+    /** Test for {@link DoublyLinkedList#removeFirstOccurrence(Object)}. */
+    @Test
+    public void testRemoveFirstOccurrence()
+    {
+        boolean expectedRemoved = size >= 3;
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        if (size >= 3) { // if size < 2 no such element, list remains unchanged
+            expectedList.remove(2);
+        }
+
+        boolean removed = list.removeFirstOccurrence("obj2");
+
+        assertThat(removed, is(equalTo(expectedRemoved)));
+        assertSameContent(list, expectedList);
+    }
+
+    /** Test for {@link DoublyLinkedList#removeLastOccurrence(Object)}. */
+    @Test
+    public void testRemoveLastOccurrence()
+    {
+        boolean expectedRemoved = size >= 3;
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        if (size >= 6) { // if size < 2 no such element, list remains unchanged
+            expectedList.remove(3);
+        } else if (size >= 3) {
+            expectedList.remove(2);
+        }
+
+        boolean removed = list.removeLastOccurrence("obj2");
+
+        assertThat(removed, is(equalTo(expectedRemoved)));
+        assertSameContent(list, expectedList);
+    }
+
+    // test Queue methods
+
+    /**
+     * Test for {@link DoublyLinkedList#offer(Object)}.
+     */
+    @Test
+    public void testOffer()
+    {
+        String anotherString = "another";
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(size, anotherString);
+
+        list.offer(anotherString);
+
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#remove()}.
+     */
+    @Test
+    public void testRemove()
+    {
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+        }
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        String expectedFirst = size > 0 ? expectedList.remove(0) : null;
+
+        String first = list.remove();
+
+        assertThat(first, is(sameInstance(expectedFirst)));
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#poll()}.
+     */
+    @Test
+    public void testPoll()
+    {
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        String expectedFirst = size > 0 ? expectedList.remove(0) : null;
+
+        String first = list.poll();
+
+        assertThat(first, is(sameInstance(expectedFirst)));
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#element()}.
+     */
+    @Test
+    public void testElement()
+    {
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+        }
+        String first = list.element();
+
+        assertThat(first, is(sameInstance(expectedElements.get(0))));
+        assertSameContent(list, expectedElements); // ensure content did not change
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#peek()}.
+     */
+    @Test
+    public void testPeek()
+    {
+        String expectedFirst = size > 0 ? expectedElements.get(0) : null;
+
+        String first = list.peek();
+
+        assertThat(first, is(sameInstance(expectedFirst)));
+        assertSameContent(list, expectedElements); // ensure content did not change
+    }
+
+    // test Stack methods
+
+    /** Test for {@link DoublyLinkedList#push(Object)}. */
+    @Test
+    public void testPush()
+    {
+        String anotherString = "another";
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(0, anotherString);
+
+        list.push(anotherString);
+
+        assertSameContent(list, expectedList);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#pop()}.
+     */
+    @Test
+    public void testPop()
+    {
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+        }
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        String expectedFirst = size > 0 ? expectedList.remove(0) : null;
+
+        String first = list.pop();
+
+        assertThat(first, is(sameInstance(expectedFirst)));
+        assertSameContent(list, expectedList);
+    }
+
+    // test special bulk methods
+
+    /**
+     * Test for {@link DoublyLinkedList#invert()}.
+     */
+    @Test
+    public void testInvert()
+    {
+        list.invert();
+
+        List<String> expected = new ArrayList<>(expectedElements);
+        Collections.reverse(expected);
+
+        assertSameContent(list, expected);
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#moveFrom(int, DoublyLinkedList)}.
+     */
+    @Test
+    public void testMoveFrom()
+    {
+        int index = size / 3;
+        List<String> other = size < 4 ? Collections.singletonList("another1")
+            : Arrays.asList("another1", "another2");
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.addAll(index, other);
+
+        DoublyLinkedList<String> sourceList = createDoublyLinkedList(other);
+
+        list.moveFrom(index, sourceList);
+
+        assertSameContent(list, expectedList);
+        assertThat(sourceList.size(), is(equalTo(0)));
+        assertTrue(sourceList.isEmpty());
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#append(DoublyLinkedList)}.
+     */
+    @Test
+    public void testAppend()
+    {
+        List<String> other = size < 4 ? Collections.singletonList("another1")
+            : Arrays.asList("another1", "another2");
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.addAll(size, other);
+
+        DoublyLinkedList<String> sourceList = createDoublyLinkedList(other);
+
+        list.append(sourceList);
+
+        assertSameContent(list, expectedList);
+        assertThat(sourceList.size(), is(equalTo(0)));
+        assertTrue(sourceList.isEmpty());
+    }
+
+    /** Test for {@link DoublyLinkedList#prepend(DoublyLinkedList)}. */
+    @Test
+    public void testPrepend()
+    {
+        List<String> other = size < 4 ? Collections.singletonList("another1")
+            : Arrays.asList("another1", "another2");
+
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.addAll(0, other);
+
+        DoublyLinkedList<String> sourceList = createDoublyLinkedList(other);
+
+        list.prepend(sourceList);
+
+        assertSameContent(list, expectedList);
+        assertThat(sourceList.size(), is(equalTo(0)));
+        assertTrue(sourceList.isEmpty());
+
+    }
+
+    // test iterator
+
+    /**
+     * Test for {@link DoublyLinkedList#wrappingIterator(Object)}.
+     */
+    @Test
+    public void testWrappingIterator_forward()
+    {
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+            list.wrappingIterator("anything", false);
+            return;
+        }
+
+        int startIndex = size / 3;
+        String firstElement = expectedElements.get(startIndex);
+        List<String> expectedList = new ArrayList<>();
+        expectedList.addAll(expectedElements.subList(startIndex, expectedElements.size()));
+        expectedList.addAll(expectedElements.subList(0, startIndex));
+
+        NodeIterator<String> wrappingIterator = list.wrappingIterator(firstElement, false);
+        for (String expectedElement : expectedList) {
+            assertTrue(wrappingIterator.hasNext());
+            assertThat(wrappingIterator.next(), is(sameInstance(expectedElement)));
+        }
+        assertFalse(wrappingIterator.hasNext());
+    }
+
+    @Test
+    public void testWrappingIterator_reversed()
+    {
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+            list.wrappingIterator("anything", false);
+            return;
+        }
+        int startIndex = size / 3;
+
+        List<String> expectedList = new ArrayList<>();
+        String firstElement = expectedElements.get(startIndex);
+
+        expectedList.addAll(expectedElements.subList(startIndex + 1, size));
+        expectedList.addAll(expectedElements.subList(0, startIndex + 1));
+        Collections.reverse(expectedList);
+
+        NodeIterator<String> wrappingIterator = list.wrappingIterator(firstElement, true);
+        for (String expectedElement : expectedList) {
+            assertTrue(wrappingIterator.hasNext());
+            assertThat(wrappingIterator.next(), is(sameInstance(expectedElement)));
+        }
+        assertFalse(wrappingIterator.hasNext());
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#descendingIterator()}.
+     */
+    @Test
+    public void testDescendingIterator()
+    {
+        NodeIterator<String> iterator = list.descendingIterator();
+        for (int i = size - 1; i >= 0; i--) {
+            assertThat(iterator.next(), is(sameInstance(expectedElements.get(i))));
+        }
+        assertFalse(iterator.hasNext());
+    }
+
+    /**
+     * Test for {@link DoublyLinkedList#iterator()}.
+     */
+    @Test
+    public void testIterator()
+    {
+        NodeIterator<String> iterator = list.iterator();
+        for (int i = 0; i < size; i++) {
+            assertThat(iterator.next(), is(sameInstance(expectedElements.get(i))));
+        }
+        assertFalse(iterator.hasNext());
+    }
+
+    /** Test for {@link DoublyLinkedList#listIterator(Object)}. */
+    @Test
+    public void testListIteratorE()
+    { // test only if returned ListIterator starts expected position beginning.
+        String element;
+        if (size == 0) {
+            thrown.expect(NoSuchElementException.class);
+            element = null;
+        } else {
+            element = expectedElements.get(size / 3);
+        }
+
+        ListNodeIterator<String> listIterator = list.listIterator(element);
+
+        assertTrue(listIterator.hasNext());
+        ListNode<String> firstNode = listIterator.nextNode();
+        assertThat(firstNode, is(sameInstance(list.getNode(size / 3))));
+        assertThat(firstNode.getValue(), is(sameInstance(element)));
+    }
+
+    /** Test for {@link DoublyLinkedList#listIterator(int)}. */
+    @Test
+    public void testListIteratorInt_indexInTheMiddle_iteratorAtCorrectIndex()
+    { // test only if returned ListIterator starts at the correct position.
+        int index = size / 2;
+
+        ListNodeIterator<String> listIterator = list.listIterator(index);
+
+        if (size == 0) {
+            assertFalse(listIterator.hasNext());
+            assertFalse(listIterator.hasPrevious());
+        } else {
+            assertThat(listIterator.nextIndex(), is(equalTo(index)));
+            assertThat(listIterator.next(), is(sameInstance(expectedElements.get(index))));
+        }
+    }
+
+    /** Test for {@link DoublyLinkedList.ListNodeIterator#nextNode()}. */
+    @Test
+    public void testListIteratorNext_iterateForwardTroughCompleteList_ListNodesInOrder()
+    { // test only if returned ListIterator starts at the beginning.
+        ListNodeIterator<String> listIterator = list.listIterator();
+        List<ListNode<String>> listNodes = getListNodesOfList(list);
+
+        assertFalse(listIterator.hasPrevious());
+        assertThat(listIterator.previousIndex(), is(equalTo(-1)));
+
+        for (int i = 0; i < size; i++) {
+            assertTrue(listIterator.hasNext());
+            assertThat(listIterator.nextIndex(), is(equalTo(i)));
+            ListNode<String> nextNode = listIterator.nextNode();
+            assertThat(nextNode, is(sameInstance(listNodes.get(i))));
+            assertThat(nextNode.getValue(), is(sameInstance(expectedElements.get(i))));
+        }
+        assertFalse(listIterator.hasNext());
+        assertThat(listIterator.nextIndex(), is(equalTo(size)));
+    }
+
+    /** Test for {@link DoublyLinkedList.ListNodeIterator#previousNode()}. */
+    @Test
+    public void testListIteratorPrevious_iterateBackwardTroughCompleteList_ListNodesInOrder()
+    { // test only if returned ListIterator starts at the beginning.
+        ListNodeIterator<String> listIterator = list.listIterator(size);
+        List<ListNode<String>> listNodes = getListNodesOfList(list);
+
+        assertFalse(listIterator.hasNext());
+        assertThat(listIterator.nextIndex(), is(equalTo(size)));
+
+        for (int i = size - 1; i >= 0; i--) {
+            assertTrue(listIterator.hasPrevious());
+            assertThat(listIterator.previousIndex(), is(equalTo(i)));
+            ListNode<String> nextNode = listIterator.previousNode();
+            assertThat(nextNode, is(sameInstance(listNodes.get(i))));
+            assertThat(nextNode.getValue(), is(sameInstance(expectedElements.get(i))));
+        }
+        assertFalse(listIterator.hasPrevious());
+        assertThat(listIterator.previousIndex(), is(equalTo(-1)));
+    }
+
+    @Test
+    public void testListIteratorNextPrevious_forwardBackwardPattern_correctElements()
+    {
+        int index = size / 3;
+        ListNodeIterator<String> listIterator = list.listIterator(index);
+
+        for (; index < size; index++) {
+            assertTrue(listIterator.hasNext());
+            assertThat(listIterator.nextIndex(), is(equalTo(index)));
+            assertThat(listIterator.next(), is(equalTo(expectedElements.get(index))));
+            // index++;
+
+            assertTrue(listIterator.hasPrevious());
+            assertThat(listIterator.previousIndex(), is(equalTo(index)));
+            assertThat(listIterator.previous(), is(equalTo(expectedElements.get(index))));
+            // index--;
+
+            assertTrue(listIterator.hasNext());
+            assertThat(listIterator.nextIndex(), is(equalTo(index)));
+            assertThat(listIterator.next(), is(equalTo(expectedElements.get(index))));
+        }
+        assertFalse(listIterator.hasNext());
+        assertThat(listIterator.nextIndex(), is(equalTo(size)));
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testListIterator_iterateBehindTail()
+    {
+        ListNodeIterator<String> iterator = list.listIterator();
+        for (int i = 0; i < size; i++) {
+            iterator.next();
+        }
+        assertFalse(iterator.hasNext());
+        iterator.next();
+    }
+
+    @Test(expected = NoSuchElementException.class)
+    public void testListIterator_iterateBeforeHead()
+    {
+        ListNodeIterator<String> iterator = list.listIterator(size);
+        for (int i = 0; i < size; i++) {
+            iterator.previous();
+        }
+        assertFalse(iterator.hasPrevious());
+        iterator.previous();
+    }
+
+    @Test(expected = ConcurrentModificationException.class)
+    public void testListIterator_concurrentAdd_ConcurrentModificationException()
+    {
+        ListNodeIterator<String> listIterator = list.listIterator();
+
+        list.add("another");
+
+        listIterator.next();
+    }
+
+    @Test
+    public void testListIterator_concurrentRemove_ConcurrentModificationException()
+    {
+        if (size == 0) {
+            return;
+        }
+        thrown.expect(ConcurrentModificationException.class);
+
+        ListNodeIterator<String> listIterator = list.listIterator();
+        list.removeLast();
+
+        listIterator.next();
+    }
+
+    /** Test for {@link DoublyLinkedList.ListNodeIterator#remove()}. */
+    @Test
+    public void testListIteratorRemove_clearListFromTheFront_emptyList()
+    {
+        List<ListNode<String>> listNodes = getListNodesOfList(list);
+        ListNodeIterator<String> listIterator = list.listIterator();
+        for (int i = 0; i < size; i++) {
+            ListNode<String> next = listIterator.nextNode();
+            assertThat(next, is(sameInstance(listNodes.get(i))));
+            listIterator.remove();
+        }
+
+        assertFalse(listIterator.hasNext());
+        assertThat(list.size(), is(equalTo(0)));
+        assertTrue(list.isEmpty());
+    }
+
+    @Test
+    public void testListIteratorRemove_clearListFromTheMiddle_emptyList()
+    {
+        List<ListNode<String>> listNodes = getListNodesOfList(list);
+        ListNodeIterator<String> listIterator = list.listIterator();
+        for (int i = 0; i < size; i++) {
+            ListNode<String> next = listIterator.nextNode();
+            assertThat(next, is(sameInstance(listNodes.get(i))));
+            listIterator.remove();
+        }
+
+        assertFalse(listIterator.hasNext());
+        assertThat(list.size(), is(equalTo(0)));
+        assertTrue(list.isEmpty());
+    }
+
+    @Test
+    public void testListIteratorRemove_clearListFromTheEnd_emptyList()
+    {
+        List<ListNode<String>> listNodes = getListNodesOfList(list);
+        ListNodeIterator<String> listIterator = list.listIterator(size);
+        for (int i = size - 1; i >= 0; i--) {
+            ListNode<String> next = listIterator.previousNode();
+            assertThat(next, is(sameInstance(listNodes.get(i))));
+            listIterator.remove();
+        }
+
+        assertFalse(listIterator.hasPrevious());
+        assertThat(list.size(), is(equalTo(0)));
+        assertTrue(list.isEmpty());
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testListIteratorRemove_notMovedListIterator_IllegalStateException()
+    {
+        list.listIterator().remove();
+    }
+
+    @Test
+    public void testListIteratorRemove_removeTwiceAfterNext_IllegalStateException()
+    {
+        if (size == 0) {
+            return;
+        }
+        ListNodeIterator<String> listIterator = list.listIterator();
+        listIterator.next();
+        listIterator.remove();
+
+        // check if the last-node of the iterator is cleared correctly
+
+        thrown.expect(IllegalStateException.class);
+
+        listIterator.remove();
+    }
+
+    @Test
+    public void testListIteratorRemove_removeAfterAdd_IllegalStateException()
+    {
+        if (size == 0) {
+            return;
+        }
+        ListNodeIterator<String> listIterator = list.listIterator();
+        listIterator.next();
+        listIterator.add("Another");
+
+        // check if the last-node of the iterator is cleared correctly in add()
+
+        thrown.expect(IllegalStateException.class);
+
+        listIterator.remove();
+    }
+
+    /** Test for {@link DoublyLinkedList.ListNodeIterator#add(Object)}. */
+    @Test
+    public void testListIteratorAdd_addElementsAtFront_listWithAdditionalElements()
+    {
+        List<String> toAdd = Arrays.asList("another1", "two", "three", "four");
+        List<String> expectedList = new ArrayList<>(expectedElements);
+
+        ListNodeIterator<String> listIterator = list.listIterator(0);
+
+        for (int i = 0; i < toAdd.size(); i++) {
+            String add = toAdd.get(i);
+            expectedList.add(i, add);
+            listIterator.add(add);
+            assertSameContent(list, expectedList);
+        }
+    }
+
+    @Test
+    public void testListIteratorAdd_addElementsInTheMiddle_listWithAdditionalElements()
+    {
+        List<String> toAdd = Arrays.asList("another1", "two", "three", "four");
+        List<String> expectedList = new ArrayList<>(expectedElements);
+
+        int index = size / 2;
+        ListNodeIterator<String> listIterator = list.listIterator(index);
+
+        for (int i = 0; i < toAdd.size(); i++) {
+            String add = toAdd.get(i);
+            expectedList.add(index + i, add);
+            listIterator.add(add);
+            assertSameContent(list, expectedList);
+        }
+    }
+
+    @Test
+    public void testListIteratorAdd_addElementsAtEnd_listWithAdditionalElements()
+    {
+
+        List<String> toAdd = Arrays.asList("another1", "two", "three", "four");
+        List<String> expectedList = new ArrayList<>(expectedElements);
+
+        ListNodeIterator<String> listIterator = list.listIterator(size);
+
+        for (int i = 0; i < toAdd.size(); i++) {
+            String add = toAdd.get(i);
+            expectedList.add(add);
+            listIterator.add(add);
+            assertSameContent(list, expectedList);
+        }
+    }
+
+    @Test
+    public void testListIteratorAdd_addElementBeforeEnd_listWithAdditionalElements()
+    {
+        if (size == 0) {
+            return;
+        }
+
+        String element = "another";
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.add(size - 1, element);
+
+        ListNodeIterator<String> listIterator = list.listIterator(size);
+        listIterator.previous();
+        listIterator.add(element);
+
+        assertSameContent(list, expectedList);
+    }
+
+    /** Test for {@link DoublyLinkedList.ListNodeIterator#set(Object)}. */
+    @Test
+    public void testListIteratorSet_replaceElementInTheMiddle_listWithReplacedElement()
+    {
+        if (size == 0) {
+            return;
+        }
+        int index = size / 2;
+        String element = "another";
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.set(index, element);
+
+        ListNodeIterator<String> listIterator = list.listIterator(index);
+
+        listIterator.next();
+        listIterator.set(element);
+        assertSameContent(list, expectedList);
+    }
+
+    @Test
+    public void testListIteratorSet_replaceElementAtFront_listWithReplacedElement()
+    {
+        if (size == 0) {
+            return;
+        }
+        String element = "another";
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.set(0, element);
+
+        ListNodeIterator<String> listIterator = list.listIterator(0);
+
+        listIterator.next();
+        listIterator.set(element);
+        assertSameContent(list, expectedList);
+    }
+
+    @Test
+    public void testListIteratorSet_replaceElementInAtEnd_listWithReplacedElement()
+    {
+        if (size == 0) {
+            return;
+        }
+        String element = "another";
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.set(size - 1, element);
+
+        ListNodeIterator<String> listIterator = list.listIterator(size);
+
+        listIterator.previous();
+        listIterator.set(element);
+        assertSameContent(list, expectedList);
+    }
+
+    @Test
+    public void testListIteratorSet_setElementWithSubsequentRemove_listWithReplacedElement()
+    { // check if the last node of the iterator is configured right
+        if (size == 0) {
+            return;
+        }
+        int index = size / 2;
+        String element = "another";
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.remove(index);
+
+        ListNodeIterator<String> listIterator = list.listIterator(index);
+
+        listIterator.next();
+        listIterator.set(element);
+
+        listIterator.remove();
+
+        assertSameContent(list, expectedList);
+    }
+
+    @Test
+    public void testListIteratorSet_setTwice_listWithReplacedElement()
+    {
+        if (size == 0) {
+            return;
+        }
+        int index = size / 2;
+        String element = "another";
+        List<String> expectedList = new ArrayList<>(expectedElements);
+        expectedList.set(index, element);
+
+        ListNodeIterator<String> listIterator = list.listIterator(index);
+
+        listIterator.next();
+        listIterator.set("anotherOne");
+        listIterator.set(element);
+
+        assertSameContent(list, expectedList);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testListIteratorSet_NotMovedListIterator_IllegalstateException()
+    {
+        ListNodeIterator<String> listIterator = list.listIterator();
+        listIterator.set("another");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testListIteratorSet_setAfterAdd_IllegalstateException()
+    {
+        ListNodeIterator<String> listIterator = list.listIterator();
+        listIterator.add("another");
+        listIterator.set("another");
+    }
+
+    @Test
+    public void testListIteratorSet_setAfterRemove_IllegalstateException()
+    {
+        if (size == 0) {
+            return;
+        } else {
+            thrown.expect(IllegalStateException.class);
+        }
+        ListNodeIterator<String> listIterator = list.listIterator();
+        listIterator.next();
+        listIterator.remove();
+        listIterator.set("another");
+    }
+
+    // utility methods
+
+    private static <E> DoublyLinkedList<E> createDoublyLinkedList(Collection<E> content)
+    {
+        DoublyLinkedList<E> list = new DoublyLinkedList<>();
+        for (E element : content) {
+            list.addLast(element); // use simplest method as possible
+        }
+        return list;
+    }
+
+    private static <E> List<ListNode<E>> getListNodesOfList(DoublyLinkedList<E> list)
+    {
+        List<ListNode<E>> allNodes = new ArrayList<>();
+        for (NodeIterator<E> iterator = list.iterator(); iterator.hasNext();) {
+            allNodes.add(iterator.nextNode());
+        }
+        return allNodes;
+    }
+
+    /** Returns a {@link ListNode} contained in another {@link DoublyLinkedList}. */
+    private static ListNode<String> createListNodeInOtherList()
+    {
+        return createDoublyLinkedList(Collections.singletonList("another")).getNode(0);
+    }
+
+    /** Returns a {@link ListNode} contained in no {@link DoublyLinkedList}. */
+    private static ListNode<String> createFreeListNode(String element)
+    {
+
+        DoublyLinkedList<String> list = createDoublyLinkedList(Collections.singletonList(element));
+
+        ListNode<String> node = list.getNode(0);
+        list.removeNode(node);
+        return node;
+    }
+
+    private static <E> void assertSameContent(DoublyLinkedList<E> list, List<E> expected)
+    {
+        assertThat(list.size(), is(equalTo(expected.size())));
+        for (int i = 0; i < list.size(); i++) {
+            assertThat(list.get(i), is(sameInstance(expected.get(i))));
+        }
+    }
+
+    private static <E> void assertSameNodes(DoublyLinkedList<E> list, List<ListNode<E>> expected)
+    {
+        assertThat(list.size(), is(equalTo(expected.size())));
+        for (int i = 0; i < list.size(); i++) {
+            assertThat(list.getNode(i), is(sameInstance(expected.get(i))));
+        }
+    }
+
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
@@ -1179,14 +1179,14 @@ public class DoublyLinkedListTest
     // test iterator
 
     /**
-     * Test for {@link DoublyLinkedList#wrappingIterator(Object)}.
+     * Test for {@link DoublyLinkedList#circularIterator(Object)}.
      */
     @Test
-    public void testWrappingIterator_forward()
+    public void testCircularIterator()
     {
         if (size == 0) {
             thrown.expect(NoSuchElementException.class);
-            list.wrappingIterator("anything", false);
+            list.circularIterator("anything");
             return;
         }
 
@@ -1196,7 +1196,7 @@ public class DoublyLinkedListTest
         expectedList.addAll(expectedElements.subList(startIndex, expectedElements.size()));
         expectedList.addAll(expectedElements.subList(0, startIndex));
 
-        NodeIterator<String> wrappingIterator = list.wrappingIterator(firstElement, false);
+        NodeIterator<String> wrappingIterator = list.circularIterator(firstElement);
         for (String expectedElement : expectedList) {
             assertTrue(wrappingIterator.hasNext());
             assertThat(wrappingIterator.next(), is(sameInstance(expectedElement)));
@@ -1204,12 +1204,15 @@ public class DoublyLinkedListTest
         assertFalse(wrappingIterator.hasNext());
     }
 
+    /**
+     * Test for {@link DoublyLinkedList#reverseCircularIterator(Object)}.
+     */
     @Test
-    public void testWrappingIterator_reversed()
+    public void testReverseCircularIterator()
     {
         if (size == 0) {
             thrown.expect(NoSuchElementException.class);
-            list.wrappingIterator("anything", false);
+            list.reverseCircularIterator("anything");
             return;
         }
         int startIndex = size / 3;
@@ -1221,7 +1224,7 @@ public class DoublyLinkedListTest
         expectedList.addAll(expectedElements.subList(0, startIndex + 1));
         Collections.reverse(expectedList);
 
-        NodeIterator<String> wrappingIterator = list.wrappingIterator(firstElement, true);
+        NodeIterator<String> wrappingIterator = list.reverseCircularIterator(firstElement);
         for (String expectedElement : expectedList) {
             assertTrue(wrappingIterator.hasNext());
             assertThat(wrappingIterator.next(), is(sameInstance(expectedElement)));

--- a/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
@@ -231,7 +231,7 @@ public class DoublyLinkedListTest
 
         ListNode<String> node = createFreeListNode(element);
         ListNode<String> beforeNode = list.getNode(index);
-        list.addNodeBefore(beforeNode, node);
+        list.addNodeBefore(node, beforeNode);
 
         assertTrue(list.containsNode(node));
         assertSameContent(list, expectedList);
@@ -243,7 +243,7 @@ public class DoublyLinkedListTest
         ListNode<String> node = createFreeListNode("another");
         ListNode<String> beforeNode = createListNodeInOtherList();
 
-        list.addNodeBefore(beforeNode, node);
+        list.addNodeBefore(node, beforeNode);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -252,7 +252,7 @@ public class DoublyLinkedListTest
         ListNode<String> node = createFreeListNode("another");
         ListNode<String> beforeNode = createFreeListNode("another");
 
-        list.addNodeBefore(beforeNode, node);
+        list.addNodeBefore(node, beforeNode);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -264,7 +264,7 @@ public class DoublyLinkedListTest
         ListNode<String> node = createListNodeInOtherList();
         ListNode<String> beforeNode = list.getNode(size / 2);
 
-        list.addNodeBefore(beforeNode, node);
+        list.addNodeBefore(node, beforeNode);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -276,7 +276,7 @@ public class DoublyLinkedListTest
         ListNode<String> node = list.getFirstNode();
         ListNode<String> beforeNode = list.getNode(size / 2);
 
-        list.addNodeBefore(beforeNode, node);
+        list.addNodeBefore(node, beforeNode);
     }
 
     /** Test for {@link DoublyLinkedList#getFirstNode()}. */

--- a/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
@@ -30,6 +30,8 @@ import org.junit.runners.*;
 import org.junit.runners.Parameterized.*;
 
 /**
+ * Tests for {@link DoublyLinkedList}.
+ * 
  * @author Hannes Wellmann
  *
  */


### PR DESCRIPTION
In order to solve issue [#830](https://github.com/jgrapht/jgrapht/issues/830) I implement the `java.util.List` interface for `DoublyLinkedList` and enable all of its optional operations. To achieve this I let `DoublyLinkedList` extend `AbstractSequentialList` implement a `ListIterator` that is able to add, remove and set elements. 
Because it was a quick win I also implemented the `Deque` interface.

To avoid name clashes and meet the signature of all List and Deque methods some methods had to be renamed.

Because it is quite similar I orientated myself towards `java.util.LinkedList` for the implementation.
The goal is to make DoublyLinkedList a general purpose linked List that exposes its `ListNodes`.
It shall be possible to freely remove and add ListNodes directly from/to a list. To ensure a `ListNode` is still contained in only one List I added another reference to the owning list and check this in add and remove methods. The number of references of a ListNode is four, while a LinkedList.Node has three (the element, next and previous). Considering that each Object has a header that also occupies memory, the memory used by a `DoublyLinkedList` is less than 33.3% larger than a `LinkedList` holding the same elements (the actual value depends on the JVM).

The implementation is structured in a way that only a few base methods really modify the list and contain the logic of the list (most of them are private). Their runtime complexity is stated in their respective Javadoc. All other public methods are build on top of these base methods and don't add any logic. These methods are more like shortcut or convenience methods. Also I added useful `add()`- and `get()`-methods for `ListNodes` that correspond to the element add/get-methods of List or Deque.

To expose the ListNodes in the Iterators too DoublyLinkedList contains a `NodeIterator` and `ListNodeIterator` that extend Iterator respectively ListIterator and have additional nextNode()/previousNode() methods. The new implementation of the ListIterator behaves like expected for a list and respects the beginning and of a list. Additionally I added a wrappingIterator method which returns a iterator that ignores the real beginning/end of the list and just iterates until the first node is reached again. It can iterate in regular or reversed direction.

Last I added tests that cover all methods of the new DoublyLinkedList. 

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
