### PR TITLE
[GraphImporter/GraphExporter] Close File-Stream in default implementations

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/GraphExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/GraphExporter.java
@@ -37,7 +37,11 @@ public interface GraphExporter<V, E>
 {
 
     /**
-     * Export a graph
+     * Export a graph to the given {@link OutputStream}.
+     * <p>
+     * It is the callers responsibility to ensure the {@code OutputStream} is closed after this
+     * method returned.
+     * </p>
      * 
      * @param g the graph to export
      * @param out the output stream
@@ -49,7 +53,11 @@ public interface GraphExporter<V, E>
     }
 
     /**
-     * Export a graph
+     * Export a graph using the given {@link Writer}.
+     * <p>
+     * It is the callers responsibility to ensure the {@code Writer} is closed after this method
+     * returned.
+     * </p>
      * 
      * @param g the graph to export
      * @param writer the output writer
@@ -58,7 +66,7 @@ public interface GraphExporter<V, E>
     void exportGraph(Graph<V, E> g, Writer writer);
 
     /**
-     * Export a graph
+     * Export a graph to the given {@link File}.
      * 
      * @param g the graph to export
      * @param file the file to write to
@@ -66,11 +74,10 @@ public interface GraphExporter<V, E>
      */
     default void exportGraph(Graph<V, E> g, File file)
     {
-        try {
-            exportGraph(g, new FileWriter(file));
+        try (FileWriter writer = new FileWriter(file)) {
+            exportGraph(g, writer);
         } catch (IOException e) {
             throw new ExportException(e);
         }
     }
-
 }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/GraphImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/GraphImporter.java
@@ -32,7 +32,11 @@ public interface GraphImporter<V, E>
 {
 
     /**
-     * Import a graph
+     * Import a graph from the given {@link InputStream}.
+     * <p>
+     * It is the callers responsibility to ensure the {@code InputStream} is closed after this
+     * method returned.
+     * </p>
      * 
      * @param g the graph
      * @param in the input stream
@@ -44,7 +48,11 @@ public interface GraphImporter<V, E>
     }
 
     /**
-     * Import a graph
+     * Import a graph using the given {@link Reader}.
+     * <p>
+     * It is the callers responsibility to ensure the {@code Reader} is closed after this method
+     * returned.
+     * </p>
      * 
      * @param g the graph
      * @param in the input reader
@@ -53,7 +61,7 @@ public interface GraphImporter<V, E>
     void importGraph(Graph<V, E> g, Reader in);
 
     /**
-     * Import a graph
+     * Import a graph from the given {@link file}.
      * 
      * @param g the graph
      * @param file the file to read from
@@ -61,12 +69,10 @@ public interface GraphImporter<V, E>
      */
     default void importGraph(Graph<V, E> g, File file)
     {
-        try {
-            importGraph(
-                g, new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
+        try (InputStreamReader reader = new FileReader(file, StandardCharsets.UTF_8)) {
+            importGraph(g, reader);
         } catch (IOException e) {
             throw new ImportException(e);
         }
     }
-
 }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/GraphImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/GraphImporter.java
@@ -61,7 +61,7 @@ public interface GraphImporter<V, E>
     void importGraph(Graph<V, E> g, Reader in);
 
     /**
-     * Import a graph from the given {@link file}.
+     * Import a graph from the given {@link File}.
      * 
      * @param g the graph
      * @param file the file to read from

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/GraphImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/GraphImporter.java
@@ -69,7 +69,10 @@ public interface GraphImporter<V, E>
      */
     default void importGraph(Graph<V, E> g, File file)
     {
-        try (InputStreamReader reader = new FileReader(file, StandardCharsets.UTF_8)) {
+        try (
+            InputStreamReader reader =
+                new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))
+        {
             importGraph(g, reader);
         } catch (IOException e) {
             throw new ImportException(e);


### PR DESCRIPTION
In the `File`-argument default implementations of `GraphImporter` and `GraphExporter` a FileReader respectively a FileWriter and implicitly a `FileInputStream` or `FileOutputStream` are created but never closed. This is a potential resource leak.
Maybe the reader/writers are closed in some subclasses that implement the `Reader/Writer`-argument methods but for example `DIMACSExporter` does it not. Even if some implementations close them, I think it is good practice to close a resource at the place where it was created. If it the second time, it isn't a problem, but ensures the resource is closed.

To solve the described issue I modified the default implementations in `GraphImporter` and `GraphExporter` so that Reader respectively `Writer` are created as a resource of a _try-with- resources_ statement, so they are closed automatically when the try-block is left.

Also I replaced the `FileInputStream`-creation wrapped in a InputStreamReader by a single `FileReader` creation, which is equivalent but shorter and corresponds to `GraphExporter` where a `FileWriter` is used.

Additionally I updated the Javadoc of the Reader/Writer- and InputStream/OutputStream-argument methods to raise awareness that the caller is responsible for closing the Stream or Reader/Writer.

EDIT:
Discarded the use of `FileReader` because the Charset-argument constructor is only available from Java 11. I accidentally used it because Eclipse provides the Java Library of my installed JDK13 even if the workspace is set up to use Java 1.8.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
