### PR TITLE
Naive LCA bug fix and code clean-up

### DIFF
--- a/jgrapht-core/src/test/java/org/jgrapht/alg/lca/NaiveLCAFinderTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/lca/NaiveLCAFinderTest.java
@@ -193,4 +193,20 @@ public class NaiveLCAFinderTest
         checkLcas(finder, "c", "d", Arrays.asList("a", "b"));
     }
 
+    @Test
+    public void testLcaIsOneOfTheNodes(){
+        Graph<Integer, DefaultEdge> g = new DefaultDirectedGraph<>(DefaultEdge.class);
+
+        g.addVertex(0);
+        for (int i = 1; i <= 10; i++) {
+            g.addVertex(i);
+            g.addEdge(i - 1, i);
+        }
+        g.addEdge(0, 10);
+
+        NaiveLCAFinder<Integer, DefaultEdge> finder = new NaiveLCAFinder<>(g);
+
+        checkLcas(finder, 1, 10, Collections.singleton(1));
+    }
+
 }


### PR DESCRIPTION
The goal of this PR is to:
* fix the bug flagged in #839 
* add the test for the missing logic
* remove warnings and clean-up the existing code  

The logic for the case where we're looking for all LCA's of two nodes was correct. The wrong thing about the logic for the case when we're looking for some LCA of two nodes was that we're essentially looking for the first common node in the BFS frontiers of two nodes. This doesn't work when one node is an ancestor of another one. 

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
