### PR TITLE
Fix testNoOutDegreeZero

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/generate/DirectedScaleFreeGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/DirectedScaleFreeGraphGenerator.java
@@ -414,7 +414,7 @@ public class DirectedScaleFreeGraphGenerator<V, E>
         float indicatorAccumulator = 0;
         V ret;
         float denominator = allNewEdgesSet.size() + allNewNodesSize * bias;
-        float nominator;
+        float numerator;
 
         float r = rng.nextFloat();
         // multiply r by denominator instead of dividing all individual values by it.
@@ -422,9 +422,9 @@ public class DirectedScaleFreeGraphGenerator<V, E>
         Iterator<V> verticesIterator = allNewNodes.iterator();
         do {
             ret = verticesIterator.next();
-            nominator = (direction == Direction.IN) ? (target.inDegreeOf(ret) + bias)
+            numerator = (direction == Direction.IN) ? (target.inDegreeOf(ret) + bias)
                 : (target.outDegreeOf(ret) + bias);
-            indicatorAccumulator += nominator;
+            indicatorAccumulator += numerator;
         } while (verticesIterator.hasNext() && indicatorAccumulator < r);
 
         return ret;

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/DirectedScaleFreeGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/DirectedScaleFreeGraphGeneratorTest.java
@@ -1,10 +1,7 @@
 package org.jgrapht.generate;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
-import java.util.Random;
 
 import org.jgrapht.Graph;
 import org.jgrapht.graph.DefaultDirectedGraph;
@@ -134,27 +131,14 @@ public class DirectedScaleFreeGraphGeneratorTest
     @Test
     public void testNoOutDegreeZero()
     {
-        int success = 0, total = 100;
-        final double threshold = 0.95;
-        final Random random = new Random();
-        for (int i = 0; i < total; i++) {
-            long seed = random.nextLong();
-            DirectedScaleFreeGraphGenerator<Integer, DefaultEdge> generator =
-                new DirectedScaleFreeGraphGenerator<>(0.1f, 0.0f, 0.5f, 0.5f, -1, 1000, seed);
-            generator.setAllowingMultipleEdges(false);
-            Graph<Integer, DefaultEdge> g = new DefaultDirectedGraph<>(
-                SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
-            generator.generateGraph(g);
-            long outDegreeZero = g.vertexSet().stream().filter(v -> g.outDegreeOf(v) == 0).count();
-            if (outDegreeZero == 0) {
-                success++;
-            }
-//            else {
-//                System.err.println("Failed with seed = "+ seed + ", outDegreeZero = "+ outDegreeZero);
-//            }
-        }
-        final float successRate = success * 1.0f / total;
-        assertTrue("success rate is only" + successRate + "! Must be >=" + threshold, successRate >= threshold);
+        DirectedScaleFreeGraphGenerator<Integer, DefaultEdge> generator =
+            new DirectedScaleFreeGraphGenerator<>(0.3f, 0.0f, 0.5f, 0.5f, -1, 1000, 12345);
+        generator.setAllowingMultipleEdges(false);
+        Graph<Integer, DefaultEdge> g = new DefaultDirectedGraph<>(
+            SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        generator.generateGraph(g);
+        long outDegreeZero = g.vertexSet().stream().filter(v -> g.outDegreeOf(v) == 0).count();
+        assertEquals(0, outDegreeZero);
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/DirectedScaleFreeGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/DirectedScaleFreeGraphGeneratorTest.java
@@ -1,7 +1,10 @@
 package org.jgrapht.generate;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
+import java.util.Random;
 
 import org.jgrapht.Graph;
 import org.jgrapht.graph.DefaultDirectedGraph;
@@ -131,14 +134,27 @@ public class DirectedScaleFreeGraphGeneratorTest
     @Test
     public void testNoOutDegreeZero()
     {
-        DirectedScaleFreeGraphGenerator<Integer, DefaultEdge> generator =
-            new DirectedScaleFreeGraphGenerator<>(0.3f, 0.0f, 0.5f, 0.5f, -1, 1000);
-        generator.setAllowingMultipleEdges(false);
-        Graph<Integer, DefaultEdge> g = new DefaultDirectedGraph<>(
-            SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
-        generator.generateGraph(g);
-        long outDegreeZero = g.vertexSet().stream().filter(v -> g.outDegreeOf(v) == 0).count();
-        assertEquals(0, outDegreeZero);
+        int success = 0, total = 100;
+        final double threshold = 0.95;
+        final Random random = new Random();
+        for (int i = 0; i < total; i++) {
+            long seed = random.nextLong();
+            DirectedScaleFreeGraphGenerator<Integer, DefaultEdge> generator =
+                new DirectedScaleFreeGraphGenerator<>(0.1f, 0.0f, 0.5f, 0.5f, -1, 1000, seed);
+            generator.setAllowingMultipleEdges(false);
+            Graph<Integer, DefaultEdge> g = new DefaultDirectedGraph<>(
+                SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+            generator.generateGraph(g);
+            long outDegreeZero = g.vertexSet().stream().filter(v -> g.outDegreeOf(v) == 0).count();
+            if (outDegreeZero == 0) {
+                success++;
+            }
+//            else {
+//                System.err.println("Failed with seed = "+ seed + ", outDegreeZero = "+ outDegreeZero);
+//            }
+        }
+        final float successRate = success * 1.0f / total;
+        assertTrue("success rate is only" + successRate + "! Must be >=" + threshold, successRate >= threshold);
     }
 
     @Test


### PR DESCRIPTION
Decreasing the probability of alpha to 0.1, and allowing a number of failures up to 0.05.

Fixing [#853] by :
1. Decreasing the \alpha value to 0.1

1. allowing a small probability of failures.

I am against fixing a succeeding seed. Instead, we can accept a small probability of failure, because this is a stochastic distribution after all.

Although decreasing alpha value should be enough, I allowed this small failure rate, as a more accurate and trusted measure.
One example of a failing seed was "2814361998868693469L", if anybody has better ideas.


----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
