### PR TITLE
Fixed links to the wiki pages

### DIFF
--- a/docs/_posts/2000-01-02-jumpstart.md
+++ b/docs/_posts/2000-01-02-jumpstart.md
@@ -21,7 +21,7 @@ easily add us as a dependency to your project:
 
 ## Development Environment
 
-First, find out how to set up [your favorite IDE (or the command line)](https://github.com/jgrapht/jgrapht/wiki/How-to-use-JGraphT-as-a-dependency-in-your-projects) to work with JGraphT.
+First, find out how to set up [your favorite IDE (or the command line)](https://github.com/jgrapht/jgrapht/wiki/Users:-How-to-use-JGraphT-as-a-dependency-in-your-projects) to work with JGraphT.
 
 <br>
 

--- a/docs/_posts/2000-01-04-download.md
+++ b/docs/_posts/2000-01-04-download.md
@@ -9,7 +9,7 @@ style: center
 # Latest Release
 
 For development without Maven, or for [running demos from the command
-line](https://github.com/jgrapht/jgrapht/wiki/Running-JGraphT-demos), you can download a full archive of the release:
+line](https://github.com/jgrapht/jgrapht/wiki/Users:-Running-JGraphT-demos), you can download a full archive of the release:
 
 <div style="position: relative; display: table; margin: 30px auto; font-size:20px; width: 600px;">
   <div style="width: 300px; float:left;" class="center">

--- a/docs/_posts/2000-01-05-community.md
+++ b/docs/_posts/2000-01-05-community.md
@@ -7,14 +7,14 @@ fa-icon: users
 
 ## <i class="fa fa-stack-overflow"></i>&nbsp;Get answers on [StackOverflow](https://stackoverflow.com/questions/tagged/jgrapht)
 
-## <i class="fa fa-bug"></i>&nbsp;Browse [known issues](https://github.com/jgrapht/jgrapht/issues) or report [a new issue](https://github.com/jgrapht/jgrapht/wiki/Getting-Support)
+## <i class="fa fa-bug"></i>&nbsp;Browse [known issues](https://github.com/jgrapht/jgrapht/issues) or report [a new issue](https://github.com/jgrapht/jgrapht/wiki/Users:-Getting-Support)
 
 ## <i class="fa fa-envelope"></i>&nbsp;Join [the user mailing list](https://sourceforge.net/projects/jgrapht/lists/jgrapht-users)
 
 ## <i class="fa fa-tasks"></i>&nbsp;Check out [open pull requests](https://github.com/jgrapht/jgrapht/pulls)
 
-## <i class="fa fa-graduation-cap"></i>&nbsp;Learn how to [contribute your first improvement](https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor)
+## <i class="fa fa-graduation-cap"></i>&nbsp;Learn how to [contribute your first improvement](https://github.com/jgrapht/jgrapht/wiki/Dev-guide:-Become-a-Contributor)
 
-## <i class="fa fa-trophy"></i>&nbsp;Tell us your success story: [how are you are using JGraphT?](https://github.com/jgrapht/jgrapht/wiki/Projects-Using-JGraphT)
+## <i class="fa fa-trophy"></i>&nbsp;Tell us your success story: [how are you are using JGraphT?](https://github.com/jgrapht/jgrapht/wiki/Users:-Projects-Using-JGraphT)
 
-## <i class="fa fa-flask"></i>&nbsp;Cite JGraphT [in your research](https://github.com/jgrapht/jgrapht/wiki/How-to-cite-JGraphT)
+## <i class="fa fa-flask"></i>&nbsp;Cite JGraphT [in your research](https://github.com/jgrapht/jgrapht/wiki/Users:-How-to-cite-JGraphT)

--- a/docs/guide-templates/UserOverview.md
+++ b/docs/guide-templates/UserOverview.md
@@ -13,7 +13,7 @@ your own applications.  We'll cover the following topics:
 
 ## Development Setup
 
-First, [set up your development environment](https://github.com/jgrapht/jgrapht/wiki/How-to-use-JGraphT-as-a-dependency-in-your-projects) with JGraphT as a dependency.
+First, [set up your development environment](https://github.com/jgrapht/jgrapht/wiki/Users:-How-to-use-JGraphT-as-a-dependency-in-your-projects) with JGraphT as a dependency.
 
 ## Hello JGraphT
 
@@ -437,7 +437,7 @@ visualization.  All you need to do is wrap your JGraphT graph with
 
 If you want to run the demo programs excerpted throughout this
 overview, see
-[these instructions](https://github.com/jgrapht/jgrapht/wiki/Running-JGraphT-demos).
+[these instructions](https://github.com/jgrapht/jgrapht/wiki/Users:-Running-JGraphT-demos).
 You can also find the full source code in
 [github](https://github.com/jgrapht/jgrapht/tree/master/jgrapht-demo/src/main/java/org/jgrapht/demo).
 


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, …
     Link issues by using the following pattern: [#333](https://github.com/jgrapht/jgrapht/issues/333).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->
## Links fix-up

Recent wiki sidebar customization invalidated wiki pages links in our website. The names of the wiki pages were changed to contain an appropriate category prefix. 

This PR fixes the links in the site pages. I've grepped for the wiki links in the `docs` folder and added the right prefixes. 

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
