### PR TITLE
Relaxed javadoc rules in order to be compatible with multiple jdks

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/Graph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/Graph.java
@@ -22,8 +22,8 @@ import java.util.function.*;
 
 /**
  * The root interface in the graph hierarchy. A mathematical graph-theory graph object
- * <tt>G(V,E)</tt> contains a set <tt>V</tt> of vertices and a set <tt>
- * E</tt> of edges. Each edge e=(v1,v2) in E connects vertex v1 to vertex v2. for more information
+ * <code>G(V,E)</code> contains a set <code>V</code> of vertices and a set <code>
+ * E</code> of edges. Each edge e=(v1,v2) in E connects vertex v1 to vertex v2. for more information
  * about graphs and their related definitions see <a href="http://mathworld.wolfram.com/Graph.html">
  * http://mathworld.wolfram.com/Graph.html</a>.
  *
@@ -180,7 +180,7 @@ public interface Graph<V, E>
      * More formally, adds the specified edge, <code>
      * e</code>, to this graph if this graph contains no edge <code>e2</code> such that
      * <code>e2.equals(e)</code>. If this graph already contains such an edge, the call leaves this
-     * graph unchanged and returns <tt>false</tt>. Some graphs do not allow edge-multiplicity. In
+     * graph unchanged and returns <code>false</code>. Some graphs do not allow edge-multiplicity. In
      * such cases, if the graph already contains an edge from the specified source to the specified
      * target, than this method does not change the graph and returns <code>
      * false</code>. If the edge was added to the graph, returns <code>
@@ -195,7 +195,7 @@ public interface Graph<V, E>
      * @param targetVertex target vertex of the edge.
      * @param e edge to be added to this graph.
      *
-     * @return <tt>true</tt> if this graph did not already contain the specified edge.
+     * @return <code>true</code> if this graph did not already contain the specified edge.
      *
      * @throws IllegalArgumentException if source or target vertices are not found in the graph.
      * @throws ClassCastException if the specified edge is not assignment compatible with the class
@@ -246,12 +246,12 @@ public interface Graph<V, E>
      * specified vertex, <code>v</code>, to this graph if this graph contains no vertex
      * <code>u</code> such that <code>
      * u.equals(v)</code>. If this graph already contains such vertex, the call leaves this graph
-     * unchanged and returns <tt>false</tt>. In combination with the restriction on constructors,
+     * unchanged and returns <code>false</code>. In combination with the restriction on constructors,
      * this ensures that graphs never contain duplicate vertices.
      *
      * @param v vertex to be added to this graph.
      *
-     * @return <tt>true</tt> if this graph did not already contain the specified vertex.
+     * @return <code>true</code> if this graph did not already contain the specified vertex.
      *
      * @throws NullPointerException if the specified vertex is <code>
      * null</code>.
@@ -259,7 +259,7 @@ public interface Graph<V, E>
     boolean addVertex(V v);
 
     /**
-     * Returns <tt>true</tt> if and only if this graph contains an edge going from the source vertex
+     * Returns <code>true</code> if and only if this graph contains an edge going from the source vertex
      * to the target vertex. In undirected graphs the same result is obtained when source and target
      * are inverted. If any of the specified vertices does not exist in the graph, or if is <code>
      * null</code>, returns <code>false</code>.
@@ -267,31 +267,31 @@ public interface Graph<V, E>
      * @param sourceVertex source vertex of the edge.
      * @param targetVertex target vertex of the edge.
      *
-     * @return <tt>true</tt> if this graph contains the specified edge.
+     * @return <code>true</code> if this graph contains the specified edge.
      */
     boolean containsEdge(V sourceVertex, V targetVertex);
 
     /**
-     * Returns <tt>true</tt> if this graph contains the specified edge. More formally, returns
-     * <tt>true</tt> if and only if this graph contains an edge <code>e2</code> such that
+     * Returns <code>true</code> if this graph contains the specified edge. More formally, returns
+     * <code>true</code> if and only if this graph contains an edge <code>e2</code> such that
      * <code>e.equals(e2)</code>. If the specified edge is <code>null</code> returns
      * <code>false</code>.
      *
      * @param e edge whose presence in this graph is to be tested.
      *
-     * @return <tt>true</tt> if this graph contains the specified edge.
+     * @return <code>true</code> if this graph contains the specified edge.
      */
     boolean containsEdge(E e);
 
     /**
-     * Returns <tt>true</tt> if this graph contains the specified vertex. More formally, returns
-     * <tt>true</tt> if and only if this graph contains a vertex <code>u</code> such that
+     * Returns <code>true</code> if this graph contains the specified vertex. More formally, returns
+     * <code>true</code> if and only if this graph contains a vertex <code>u</code> such that
      * <code>u.equals(v)</code>. If the specified vertex is <code>null</code> returns
      * <code>false</code>.
      *
      * @param v vertex whose presence in this graph is to be tested.
      *
-     * @return <tt>true</tt> if this graph contains the specified vertex.
+     * @return <code>true</code> if this graph contains the specified vertex.
      */
     boolean containsVertex(V v);
 
@@ -418,10 +418,10 @@ public interface Graph<V, E>
      *
      * @param edges edges to be removed from this graph.
      *
-     * @return <tt>true</tt> if this graph changed as a result of the call
+     * @return <code>true</code> if this graph changed as a result of the call
      *
-     * @throws NullPointerException if the specified edge collection is <tt>
-     * null</tt>.
+     * @throws NullPointerException if the specified edge collection is <code>
+     * null</code>.
      *
      * @see #removeEdge(Object)
      * @see #containsEdge(Object)
@@ -449,10 +449,10 @@ public interface Graph<V, E>
      *
      * @param vertices vertices to be removed from this graph.
      *
-     * @return <tt>true</tt> if this graph changed as a result of the call
+     * @return <code>true</code> if this graph changed as a result of the call
      *
-     * @throws NullPointerException if the specified vertex collection is <tt>
-     * null</tt>.
+     * @throws NullPointerException if the specified vertex collection is <code>
+     * null</code>.
      *
      * @see #removeVertex(Object)
      * @see #containsVertex(Object)
@@ -474,7 +474,7 @@ public interface Graph<V, E>
      * Removes the specified edge from the graph. Removes the specified edge from this graph if it
      * is present. More formally, removes an edge <code>
      * e2</code> such that <code>e2.equals(e)</code>, if the graph contains such edge. Returns
-     * <tt>true</tt> if the graph contained the specified edge. (The graph will not contain the
+     * <code>true</code> if the graph contained the specified edge. (The graph will not contain the
      * specified edge once the call returns).
      *
      * <p>
@@ -493,7 +493,7 @@ public interface Graph<V, E>
      * More formally, if the graph contains a vertex <code>
      * u</code> such that <code>u.equals(v)</code>, the call removes all edges that touch
      * <code>u</code> and then removes <code>u</code> itself. If no such <code>u</code> is found,
-     * the call leaves the graph unchanged. Returns <tt>true</tt> if the graph contained the
+     * the call leaves the graph unchanged. Returns <code>true</code> if the graph contained the
      * specified vertex. (The graph will not contain the specified vertex once the call returns).
      *
      * <p>

--- a/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
@@ -96,7 +96,7 @@ public abstract class Graphs
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      *
-     * @return <tt>true</tt> if the target graph did not already contain the specified edge.
+     * @return <code>true</code> if the target graph did not already contain the specified edge.
      */
     public static <V,
         E> boolean addEdgeWithVertices(Graph<V, E> targetGraph, Graph<V, E> sourceGraph, E edge)
@@ -206,7 +206,7 @@ public abstract class Graphs
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      *
-     * @return <tt>true</tt> if this graph changed as a result of the call
+     * @return <code>true</code> if this graph changed as a result of the call
      */
     public static <V, E> boolean addAllEdges(
         Graph<? super V, ? super E> destination, Graph<V, E> source, Collection<? extends E> edges)
@@ -234,11 +234,11 @@ public abstract class Graphs
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      *
-     * @return <tt>true</tt> if graph changed as a result of the call
+     * @return <code>true</code> if graph changed as a result of the call
      *
      * @throws NullPointerException if the specified vertices contains one or more null vertices, or
-     *         if the specified vertex collection is <tt>
-     * null</tt>.
+     *         if the specified vertex collection is <code>
+     * null</code>.
      *
      * @see Graph#addVertex(Object)
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/HeavyPathDecomposition.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/HeavyPathDecomposition.java
@@ -510,9 +510,6 @@ public class HeavyPathDecomposition<V, E>
          * Return the internal path array. For each vertex $v$, $pathArray[normalizeVertex(v)] = i$
          * iff $v$ appears on path $i$ or $-1$ if $v$ doesn't belong to any path.
          *
-         * <p>
-         * Note: the indexing of paths is consistent with {@link PathDecomposition#getPaths()}.
-         *
          * @return internal path array
          */
         public int[] getPathArray()
@@ -535,9 +532,6 @@ public class HeavyPathDecomposition<V, E>
         /**
          * Return the internal firstNodeInPath array. For each path $i$, $firstNodeInPath[i] =
          * normalizeVertex(v)$ iff $v$ appears as the first vertex on the path.
-         *
-         * <p>
-         * Note: the indexing of paths is consistent with {@link PathDecomposition#getPaths()}.
          *
          * @return internal firstNodeInPath array
          */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
@@ -78,11 +78,11 @@ public final class EdmondsKarpMFImpl<V, E>
     private final ExtensionFactory<AnnotatedFlowEdge> edgeExtensionsFactory;
 
     /**
-     * Constructs <tt>MaximumFlow</tt> instance to work with <i>a copy of</i> <tt>network</tt>.
-     * Current source and sink are set to <tt>null</tt>. If <tt>network</tt> is weighted, then
+     * Constructs <code>MaximumFlow</code> instance to work with <i>a copy of</i> <code>network</code>.
+     * Current source and sink are set to <code>null</code>. If <code>network</code> is weighted, then
      * capacities are weights, otherwise all capacities are equal to one. Doubles are compared using
-     * <tt>
-     * DEFAULT_EPSILON</tt> tolerance.
+     * <code>
+     * DEFAULT_EPSILON</code> tolerance.
      *
      * @param network network, where maximum flow will be calculated
      */
@@ -92,8 +92,8 @@ public final class EdmondsKarpMFImpl<V, E>
     }
 
     /**
-     * Constructs <tt>MaximumFlow</tt> instance to work with <i>a copy of</i> <tt>network</tt>.
-     * Current source and sink are set to <tt>null</tt>. If <tt>network</tt> is weighted, then
+     * Constructs <code>MaximumFlow</code> instance to work with <i>a copy of</i> <code>network</code>.
+     * Current source and sink are set to <code>null</code>. If <code>network</code> is weighted, then
      * capacities are weights, otherwise all capacities are equal to one.
      *
      * @param network network, where maximum flow will be calculated
@@ -120,10 +120,10 @@ public final class EdmondsKarpMFImpl<V, E>
     }
 
     /**
-     * Sets current source to <tt>source</tt>, current sink to <tt>sink</tt>, then calculates
-     * maximum flow from <tt>source</tt> to <tt>sink</tt>. Note, that <tt>source</tt> and
-     * <tt>sink</tt> must be vertices of the <tt>
-     * network</tt> passed to the constructor, and they must be different.
+     * Sets current source to <code>source</code>, current sink to <code>sink</code>, then calculates
+     * maximum flow from <code>source</code> to <code>sink</code>. Note, that <code>source</code> and
+     * <code>sink</code> must be vertices of the <code>
+     * network</code> passed to the constructor, and they must be different.
      *
      * @param source source vertex
      * @param sink sink vertex
@@ -138,10 +138,10 @@ public final class EdmondsKarpMFImpl<V, E>
     }
 
     /**
-     * Sets current source to <tt>source</tt>, current sink to <tt>sink</tt>, then calculates
-     * maximum flow from <tt>source</tt> to <tt>sink</tt>. Note, that <tt>source</tt> and
-     * <tt>sink</tt> must be vertices of the <tt>
-     * network</tt> passed to the constructor, and they must be different. If desired, a flow map
+     * Sets current source to <code>source</code>, current sink to <code>sink</code>, then calculates
+     * maximum flow from <code>source</code> to <code>sink</code>. Note, that <code>source</code> and
+     * <code>sink</code> must be vertices of the <code>
+     * network</code> passed to the constructor, and they must be different. If desired, a flow map
      * can be queried afterwards; this will not require a new invocation of the algorithm.
      *
      * @param source source vertex

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
@@ -321,8 +321,8 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
     }
 
     /**
-     * Returns current source vertex, or <tt>null</tt> if there was no <tt>
-     * calculateMaximumFlow</tt> calls.
+     * Returns current source vertex, or <code>null</code> if there was no <code>
+     * calculateMaximumFlow</code> calls.
      *
      * @return current source
      */
@@ -332,8 +332,8 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
     }
 
     /**
-     * Returns current sink vertex, or <tt>null</tt> if there was no <tt>
-     * calculateMaximumFlow</tt> calls.
+     * Returns current sink vertex, or <code>null</code> if there was no <code>
+     * calculateMaximumFlow</code> calls.
      *
      * @return current sink
      */
@@ -343,8 +343,8 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
     }
 
     /**
-     * Returns maximum flow value, that was calculated during last <tt>
-     * calculateMaximumFlow</tt> call.
+     * Returns maximum flow value, that was calculated during last <code>
+     * calculateMaximumFlow</code> call.
      *
      * @return maximum flow value
      */
@@ -354,9 +354,9 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
     }
 
     /**
-     * Returns maximum flow, that was calculated during last <tt>
-     * calculateMaximumFlow</tt> call, or <tt>null</tt>, if there was no <tt>
-     * calculateMaximumFlow</tt> calls.
+     * Returns maximum flow, that was calculated during last <code>
+     * calculateMaximumFlow</code> call, or <code>null</code>, if there was no <code>
+     * calculateMaximumFlow</code> calls.
      *
      * @return <i>read-only</i> mapping from edges to doubles - flow values
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -196,10 +196,10 @@ public class PushRelabelMFImpl<V, E>
     }
 
     /**
-     * Sets current source to <tt>source</tt>, current sink to <tt>sink</tt>, then calculates
-     * maximum flow from <tt>source</tt> to <tt>sink</tt>. Note, that <tt>source</tt> and
-     * <tt>sink</tt> must be vertices of the <tt>
-     * network</tt> passed to the constructor, and they must be different.
+     * Sets current source to <code>source</code>, current sink to <code>sink</code>, then calculates
+     * maximum flow from <code>source</code> to <code>sink</code>. Note, that <code>source</code> and
+     * <code>sink</code> must be vertices of the <code>
+     * network</code> passed to the constructor, and they must be different.
      *
      * @param source source vertex
      * @param sink sink vertex

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MaximumFlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MaximumFlowAlgorithm.java
@@ -36,8 +36,8 @@ public interface MaximumFlowAlgorithm<V, E>
 {
 
     /**
-     * Sets current source to <tt>source</tt>, current sink to <tt>sink</tt>, then calculates
-     * maximum flow from <tt>source</tt> to <tt>sink</tt>. Returns an object containing detailed
+     * Sets current source to <code>source</code>, current sink to <code>sink</code>, then calculates
+     * maximum flow from <code>source</code> to <code>sink</code>. Returns an object containing detailed
      * information about the flow.
      *
      * @param source source of the flow inside the network
@@ -48,10 +48,10 @@ public interface MaximumFlowAlgorithm<V, E>
     MaximumFlow<E> getMaximumFlow(V source, V sink);
 
     /**
-     * Sets current source to <tt>source</tt>, current sink to <tt>sink</tt>, then calculates
-     * maximum flow from <tt>source</tt> to <tt>sink</tt>. Note, that <tt>source</tt> and
-     * <tt>sink</tt> must be vertices of the <tt>
-     * network</tt> passed to the constructor, and they must be different.
+     * Sets current source to <code>source</code>, current sink to <code>sink</code>, then calculates
+     * maximum flow from <code>source</code> to <code>sink</code>. Note, that <code>source</code> and
+     * <code>sink</code> must be vertices of the <code>
+     * network</code> passed to the constructor, and they must be different.
      *
      * @param source source vertex
      * @param sink sink vertex

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/PartitioningAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/PartitioningAlgorithm.java
@@ -69,7 +69,7 @@ public interface PartitioningAlgorithm<V>
          * @param index index of the partition to return
          * @return the index-th partition
          * @throws IndexOutOfBoundsException if the index is out of range
-         *         (<tt>index &lt; 0 || index &gt;= getNumberPartitions()</tt>)
+         *         (<code>index &lt; 0 || index &gt;= getNumberPartitions()</code>)
          */
         Set<V> getPartition(int index);
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/AhujaOrlinSharmaCapacitatedMinimumSpanningTree.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/AhujaOrlinSharmaCapacitatedMinimumSpanningTree.java
@@ -45,8 +45,7 @@ import java.util.*;
  * algorithm for subset disjoint cycles by Ahuja et al. That is, the algorithm may run in
  * exponential time. This algorithm is implemented in two different version: a local search and a
  * tabu search. In both cases we have to find the best neighbor of the current capacitated spanning
- * tree. For further information about finding such an improving neighbor
- * {@link ImprovementGraph} @see ImprovementGraph
+ * tree. 
  *
  * @param <V> the vertex type
  * @param <E> the edge type

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/ScaleFreeGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/ScaleFreeGraphGenerator.java
@@ -77,7 +77,7 @@ public class ScaleFreeGraphGenerator<V, E>
     }
 
     /**
-     * Generates scale-free network with <tt>size</tt> passed to the constructor.
+     * Generates scale-free network with <code>size</code> passed to the constructor.
      *
      * @param target receives the generated edges and vertices; if this is non-empty on entry, the
      *        result will be a disconnected graph since generated elements will not be connected to

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractGraph.java
@@ -23,7 +23,7 @@ import org.jgrapht.util.*;
 import java.util.*;
 
 /**
- * A skeletal implementation of the <tt>Graph</tt> interface, to minimize the effort required to
+ * A skeletal implementation of the <code>Graph</code> interface, to minimize the effort required to
  * implement graph interfaces. This implementation is applicable to both: directed graphs and
  * undirected graphs.
  *
@@ -139,7 +139,7 @@ public abstract class AbstractGraph<V, E>
      *
      * @param edges edges to be removed from this graph.
      *
-     * @return <tt>true</tt> if this graph changed as a result of the call.
+     * @return <code>true</code> if this graph changed as a result of the call.
      *
      * @see Graph#removeEdge(Object)
      * @see Graph#containsEdge(Object)

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUndirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUndirectedGraph.java
@@ -41,7 +41,7 @@ import java.util.*;
  *
  * <p>
  * This graph does <i>not</i> pass the hashCode and equals operations through to the backing graph,
- * but relies on <tt>Object</tt>'s <tt>equals</tt> and <tt>hashCode</tt> methods. This graph will be
+ * but relies on <code>Object</code>'s <code>equals</code> and <code>hashCode</code> methods. This graph will be
  * serializable if the backing graph is serializable.
  * </p>
  *

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnmodifiableGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnmodifiableGraph.java
@@ -30,7 +30,7 @@ import java.util.*;
  *
  * <p>
  * This graph does <i>not</i> pass the hashCode and equals operations through to the backing graph,
- * but relies on <tt>Object</tt>'s <tt>equals</tt> and <tt>hashCode</tt> methods. This graph will be
+ * but relies on <code>Object</code>'s <code>equals</code> and <code>hashCode</code> methods. This graph will be
  * serializable if the backing graph is serializable.
  * </p>
  *

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultListenableGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultListenableGraph.java
@@ -31,7 +31,7 @@ import java.util.*;
  *
  * <p>
  * This graph does <i>not</i> pass the hashCode and equals operations through to the backing graph,
- * but relies on <tt>Object</tt>'s <tt>equals</tt> and <tt>hashCode</tt> methods.
+ * but relies on <code>Object</code>'s <code>equals</code> and <code>hashCode</code> methods.
  * </p>
  *
  * @param <V> the graph vertex type

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphDelegator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphDelegator.java
@@ -30,7 +30,7 @@ import java.util.function.*;
  *
  * <p>
  * This graph does <i>not</i> pass the hashCode and equals operations through to the backing graph,
- * but relies on <tt>Object</tt>'s <tt>equals</tt> and <tt>hashCode</tt> methods.
+ * but relies on <code>Object</code>'s <code>equals</code> and <code>hashCode</code> methods.
  * </p>
  *
  * <p>

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/concurrent/AsSynchronizedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/concurrent/AsSynchronizedGraph.java
@@ -561,7 +561,7 @@ public class AsSynchronizedGraph<V, E>
      * Return whether the graph uses cache for <code>edgesOf</code>, <code>incomingEdgesOf</code>
      * and <code>outgoingEdgesOf</code> methods.
      * 
-     * @return <tt>true</tt> if cache is in use, <tt>false</tt> if cache is not in use.
+     * @return <code>true</code> if cache is in use, <code>false</code> if cache is not in use.
      */
     public boolean isCacheEnabled()
     {
@@ -576,7 +576,7 @@ public class AsSynchronizedGraph<V, E>
     /**
      * Return whether copyless mode is used for collection-returning methods.
      * 
-     * @return <tt>true</tt> if the graph uses copyless mode, <tt>false</tt> otherwise
+     * @return <code>true</code> if the graph uses copyless mode, <code>false</code> otherwise
      */
     public boolean isCopyless()
     {
@@ -587,7 +587,7 @@ public class AsSynchronizedGraph<V, E>
      * Set the cache strategy for <code>edgesOf</code>, <code>incomingEdgesOf</code> and
      * <code>outgoingEdgesOf</code> methods.
      *
-     * @param cacheEnabled a flag whether to use cache for those methods, if <tt>true</tt>, cache
+     * @param cacheEnabled a flag whether to use cache for those methods, if <code>true</code>, cache
      *        will be used for those methods, otherwise cache will not be used.
      * @return the AsSynchronizedGraph
      */
@@ -668,7 +668,7 @@ public class AsSynchronizedGraph<V, E>
     /**
      * Return whether fair mode is used for synchronizing access to this graph.
      * 
-     * @return <tt>true</tt> if the graph uses fair mode, <tt>false</tt> if non-fair mode
+     * @return <code>true</code> if the graph uses fair mode, <code>false</code> if non-fair mode
      */
     public boolean isFair()
     {
@@ -751,7 +751,7 @@ public class AsSynchronizedGraph<V, E>
         /**
          * Return whether copyless mode is used for iteration.
          * 
-         * @return <tt>true</tt> if the set uses copyless mode, <tt>false</tt> otherwise
+         * @return <code>true</code> if the set uses copyless mode, <code>false</code> otherwise
          */
         public boolean isCopyless()
         {
@@ -1112,7 +1112,7 @@ public class AsSynchronizedGraph<V, E>
          * Return whether the graph uses cache for <code>edgesOf</code>,
          * <code>incomingEdgesOf</code> and <code>outgoingEdgesOf</code> methods.
          * 
-         * @return <tt>true</tt> if cache is in use, <tt>false</tt> if cache is not in use.
+         * @return <code>true</code> if cache is in use, <code>false</code> if cache is not in use.
          */
         boolean isCacheEnabled();
     }
@@ -1467,7 +1467,7 @@ public class AsSynchronizedGraph<V, E>
         /**
          * Return whether a cache will be used for the synchronized graph being built.
          *
-         * @return <tt>true</tt> if cache will be used, <tt>false</tt> if cache will not be used
+         * @return <code>true</code> if cache will be used, <code>false</code> if cache will not be used
          */
         public boolean isCacheEnable()
         {
@@ -1499,7 +1499,7 @@ public class AsSynchronizedGraph<V, E>
         /**
          * Return whether copyless mode will be used for the synchronized graph being built.
          *
-         * @return <tt>true</tt> if constructed as copyless, <tt>false</tt> otherwise
+         * @return <code>true</code> if constructed as copyless, <code>false</code> otherwise
          */
         public boolean isCopyless()
         {
@@ -1531,7 +1531,7 @@ public class AsSynchronizedGraph<V, E>
         /**
          * Return whether fair mode will be used for the synchronized graph being built.
          *
-         * @return <tt>true</tt> if constructed as fair mode, <tt>false</tt> if non-fair
+         * @return <code>true</code> if constructed as fair mode, <code>false</code> if non-fair
          */
         public boolean isFair()
         {

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
@@ -219,11 +219,11 @@ public abstract class CrossComponentIterator<V, E, D>
     }
 
     /**
-     * Returns <tt>true</tt> if there are no more uniterated vertices in the currently iterated
-     * connected component; <tt>false</tt> otherwise.
+     * Returns <code>true</code> if there are no more uniterated vertices in the currently iterated
+     * connected component; <code>false</code> otherwise.
      *
-     * @return <tt>true</tt> if there are no more uniterated vertices in the currently iterated
-     *         connected component; <tt>false</tt> otherwise.
+     * @return <code>true</code> if there are no more uniterated vertices in the currently iterated
+     *         connected component; <code>false</code> otherwise.
      */
     protected abstract boolean isConnectedComponentExhausted();
 
@@ -264,7 +264,7 @@ public abstract class CrossComponentIterator<V, E, D>
      *
      * @param vertex vertex in question
      *
-     * @return <tt>true</tt> if vertex has already been seen
+     * @return <code>true</code> if vertex has already been seen
      */
     protected boolean isSeenVertex(V vertex)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/TopologicalOrderIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/TopologicalOrderIterator.java
@@ -26,8 +26,8 @@ import java.util.*;
  * A topological ordering iterator for a directed acyclic graph.
  * 
  * <p>
- * A topological order is a permutation <tt>p</tt> of the vertices of a graph such that an edge
- * <tt>(i,j)</tt> implies that <tt>i</tt> appears before <tt>j</tt> in <tt>p</tt>. For more
+ * A topological order is a permutation <code>p</code> of the vertices of a graph such that an edge
+ * <code>(i,j)</code> implies that <code>i</code> appears before <code>j</code> in <code>p</code>. For more
  * information see <a href="https://en.wikipedia.org/wiki/Topological_sorting">wikipedia</a> or
  * <a href="http://mathworld.wolfram.com/TopologicalSort.html">wolfram</a>.
  *

--- a/pom.xml
+++ b/pom.xml
@@ -207,11 +207,13 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.0.0</version>
+					<version>3.1.1</version>
 					<configuration>
 						<show>protected</show>
 						<windowtitle>JGraphT : a free Java graph library</windowtitle>
 						<additionalJOption>--allow-script-in-comments</additionalJOption>
+						<doclint>none</doclint>
+						<source>8</source>
 						<header>&lt;script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML,https://jgrapht.org/mathjax/mathjaxConfig.js"&gt;&lt;/script&gt;
                                                 &lt;img src="https://github.com/jgrapht/jgrapht/blob/master/etc/logo/jgrapht-logo-transparent-cropped-javadocheader.png?raw=true" style="height:55px;"&gt;
                                                 </header>


### PR DESCRIPTION
Some html tag fixed and relaxed javadoc linting in order to be compatible with newer jdks.
See #851 for discussion.

----
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
