### PR TITLE
Add TSPLIB95-importer

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/TSPLIBImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/TSPLIBImporter.java
@@ -17,13 +17,15 @@
  */
 package org.jgrapht.nio.tsplib;
 
+import static java.util.Arrays.*;
+
 import java.io.*;
 import java.util.*;
 import java.util.function.*;
+import java.util.stream.*;
 
 import org.jgrapht.*;
 import org.jgrapht.generate.*;
-import org.jgrapht.graph.*;
 import org.jgrapht.nio.*;
 import org.jgrapht.util.*;
 
@@ -37,14 +39,10 @@ import org.jgrapht.util.*;
  * </p>
  * <p>
  * This implementation does not cover the full TSPLIB95 standard and only implements the subset of
- * capabilities required at the time of creation. The following keywords of <em>The specification
- * part</em> in chapter 1.1 of the <em>TSPLIB95</em> standard are supported:
- * <ul>
- * <li>NAME</li>
- * <li>TYPE</li>
- * <li>COMMENT</li>
- * <li>DIMENSION</li>
- * <li>EDGE_WEIGHT_TYPE</li> Only the following edge weight types are supported
+ * capabilities required at the time of creation. All keywords of <em>The specification part</em> in
+ * chapter 1.1 of the <em>TSPLIB95</em> standard are considered. Their values can be obtained from
+ * the corresponding getters of the {@link Specification}. But only the following
+ * <li>EDGE_WEIGHT_TYPE</li> values are supported for a NODE_DATA_SECTION:
  * <ul>
  * <li>EUC_2D</li>
  * <li>EUC_3D</li>
@@ -56,14 +54,13 @@ import org.jgrapht.util.*;
  * <li>GEO</li>
  * <li>ATT</li>
  * </ul>
- * </ul>
- * The values of all supported keywords can be obtained from corresponding getters.
  * </p>
  * <p>
  * The following data sections of <em>The data part</em> in chapter 1.2 of the <em>TSPLIB95</em>
  * standard are supported:
  * <ul>
  * <li>NODE_COORD_SECTION</li>
+ * <li>TOUR_SECTION</li>
  * </ul>
  * </p>
  * <p>
@@ -81,35 +78,64 @@ import org.jgrapht.util.*;
  * </p>
  * 
  * @author Hannes Wellmann
- * @param <V> the type of vertices created by this importer
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
  *
  */
-public class TSPLIBImporter<V>
+public class TSPLIBImporter<V, E>
     implements
-    GraphImporter<V, DefaultWeightedEdge>
+    GraphImporter<V, E>
 {
+    private static final String NAME = "NAME";
+    private static final String TYPE = "TYPE";
+    private static final String COMMENT = "COMMENT";
+    private static final String DIMENSION = "DIMENSION";
+    private static final String CAPACITY = "CAPACITY";
+    private static final String EDGE_WEIGHT_TYPE = "EDGE_WEIGHT_TYPE";
+    private static final String EDGE_WEIGHT_FORMAT = "EDGE_WEIGHT_FORMAT";
+    private static final String EDGE_DATA_FORMAT = "EDGE_DATA_FORMAT";
+    private static final String NODE_COORD_TYPE = "NODE_COORD_TYPE";
+    private static final String DISPLAY_DATA_TYPE = "DISPLAY_DATA_TYPE";
+
+    private static final String NODE_COORD_SECTION = "NODE_COORD_SECTION";
+    private static final String TOUR_SECTION = "TOUR_SECTION";
+
+    private static final List<String> VALID_TYPES =
+        asList("TSP", "ATSP", "SOP", "HCP", "CVRP", "TOUR");
+    private static final List<String> VALID_EDGE_WEIGHT_TYPES = asList(
+        "EXPLICIT", "EUC_2D", "EUC_3D", "MAX_2D", "MAX_3D", "MAN_2D", "MAN_3D", "CEIL_2D", "GEO",
+        "ATT", "XRAY1", "XRAY2", "SPECIAL");
+    private static final List<String> VALID_EDGE_WEIGHT_FORMATS = asList(
+        "FUNCTION", "FULL_MATRIX", "UPPER_ROW", "LOWER_ROW", "UPPER_DIAG_ROW", "LOWER_DIAG_ROW",
+        "UPPER_COL", "LOWER_COL", "UPPER_DIAG_COL", "LOWER_DIAG_COL");
+    private static final List<String> VALID_EDGE_DATA_FORMATS = asList("EDGE_LIST", "ADJ_LIST");
+    private static final List<String> VALID_NODE_COORD_TYPES =
+        asList("TWOD_COORDS", "THREED_COORDS", "NO_COORDS");
+    private static final List<String> VALID_DISPLAY_DATA_TYPE =
+        asList("COORD_DISPLAY", "TWOD_DISPLAY", "NO_DISPLAY");
+
     /**
-     * Container for data of an imported <em>TSPLIB95</em> file.
+     * Container for the entry values read from <em>the specification part</em> of a file in
+     * <em>TSPLIB95</em> format.
      * 
      * @author Hannes Wellmann
-     * @param <V> the type of vertices in the imported graph
      */
-    public static class TSPLIBFileData<V>
+    public static class Specification
     {
-
         private String name;
         private String type;
-        private String comment;
+        private final List<String> comment = new ArrayList<>();
         private Integer dimension;
+        private Integer capacity;
         private String edgeWeightType;
+        private String edgeWeightFormat;
+        private String edgeDataFormat;
         private String nodeCoordType;
-        private boolean hasDistinctLocations;
-        private Boolean hasDistinctEdges;
+        private String displayDataType;
 
-        private Graph<V, DefaultWeightedEdge> graph;
-        private List<Integer> tour;
-
-        // getters for read public data
+        Specification()
+        {
+        }
 
         /**
          * Returns the value of the <em>NAME</em> keyword in the imported file.
@@ -132,13 +158,13 @@ public class TSPLIBImporter<V>
         }
 
         /**
-         * Returns the joined value of the <em>COMMENT</em> keyword in the imported file.
+         * Returns the {@link List} of values for the <em>COMMENT</em> keyword in the imported file.
          * 
          * @return the value of the <em>COMMENT</em> keyword
          */
-        public String getComment()
+        public List<String> getComments()
         {
-            return comment;
+            return Collections.unmodifiableList(comment);
         }
 
         /**
@@ -152,6 +178,16 @@ public class TSPLIBImporter<V>
         }
 
         /**
+         * Returns the value of the <em>CAPACITY</em> keyword in the imported file.
+         * 
+         * @return the value of the <em>CAPACITY</em> keyword
+         */
+        public Integer getCapacity()
+        {
+            return capacity;
+        }
+
+        /**
          * Returns the value of the <em>EDGE_WEIGHT_TYPE</em> keyword in the imported file.
          * 
          * @return the value of the <em>EDGE_WEIGHT_TYPE</em> keyword
@@ -159,6 +195,26 @@ public class TSPLIBImporter<V>
         public String getEdgeWeightType()
         {
             return edgeWeightType;
+        }
+
+        /**
+         * Returns the value of the <em>EDGE_WEIGHT_FORMAT</em> keyword in the imported file.
+         * 
+         * @return the value of the <em>EDGE_WEIGHT_FORMAT</em> keyword
+         */
+        public String getEdgeWeightFormat()
+        {
+            return edgeWeightFormat;
+        }
+
+        /**
+         * Returns the value of the <em>EDGE_DATA_FORMAT</em> keyword in the imported file.
+         * 
+         * @return the value of the <em>EDGE_DATA_FORMAT</em> keyword
+         */
+        public String getEdgeDataFormat()
+        {
+            return edgeDataFormat;
         }
 
         /**
@@ -172,45 +228,112 @@ public class TSPLIBImporter<V>
         }
 
         /**
-         * Returns the complete {@link Graph} of location connections built from the imported file
-         * or null if no graph was imported.
+         * Returns the value of the <em>DISPLAY_DATA_TYPE</em> keyword in the imported file.
          * 
-         * @return the complete {@code Graph} of location connections
+         * @return the value of the <em>DISPLAY_DATA_TYPE</em> keyword
          */
-        public Graph<V, DefaultWeightedEdge> getGraph()
+        public String getDisplayDataType()
         {
-            return graph;
+            return displayDataType;
+        }
+    }
+
+    /**
+     * Container for the meta data of an imported <em>TSPLIB95</em> file.
+     * 
+     * @author Hannes Wellmann
+     * @param <V> the graph vertex type
+     * @param <E> the graph edge type
+     */
+    public static class Metadata<V, E>
+    {
+        private final Specification spec = new Specification();
+        private Map<V, Node> vertex2node;
+        private Graph<V, E> graph;
+        private List<V> tour;
+
+        private Boolean hasDistinctLocations;
+        private Boolean hasDistinctNeighborDistances;
+
+        private Metadata()
+        {
         }
 
         /**
-         * Returns the {@link List} of {@link Integer Integers} describing vertex order of the tour
-         * from the imported file or null if no tour was imported.
+         * Returns the {@link Specification} instance containing all values from the specification
+         * part of a <em>TSPLIB95</em> file.
          * 
-         * @return the tour described by the list of vertex indices
+         * @return the {@code Specification} of an imported <em>TSPLIB95</em> file
          */
-        public List<Integer> getTour()
+        public Specification getSpecification()
+        {
+            return spec;
+        }
+
+        /**
+         * Returns the mapping of vertex to corresponding node imported from the
+         * <em>NODE_COORD_SECTION<em> of a <em>TSPLIB95</em> file.
+         * 
+         * @return
+         */
+        public Map<V, Node> getVertexToNodeMapping()
+        {
+            return vertex2node;
+        }
+
+        /**
+         * Returns the {@link List} of vertices in the order of the tour defined in an imported
+         * <em>TSPLIB95</em> file or null if no tour was imported.
+         * <p>
+         * Note that a tour can be imported by {@link TSPLIBImporter#importGraph(Graph, Reader)} or
+         * {@link TSPLIBImporter#importTour(Metadata, Reader)} .
+         * </p>
+         * 
+         * @return the vertex tour from the file or null
+         */
+        public List<V> getTour()
         {
             return tour;
         }
 
         /**
-         * Returns true if all read vertices were distinct and non of them were
-         * {@link Object#equals(Object) equal}, else false.
-         * <p>
-         * The read {@link #getGraph() Graph} does not contain equal vertices because the vertices
-         * are stored in a {@link Set}. So in case the imported file contains duplicated locations
-         * all duplicates are discarded. This method tells if this was the case.
-         * </p>
+         * Returns true if for the imported graph all vertices have distinct coordinates and non of
+         * them have {@link Arrays#equals(Object) equal} {@link Node#getCoordinates() coordinate
+         * values} , else false.
          * 
-         * @return true if only not equal vertices were imported from the file, else false
+         * @return true if no equally located nodes were imported from the file, else false
+         * @throws IllegalStateException if no graph was imported
          */
-        public boolean hasDistinctVertices()
+        public boolean hasDistinctNodeLocations()
         {
+            if (graph == null) {
+                throw new IllegalStateException("No graph imported");
+            }
+            if (hasDistinctLocations == null) {
+                hasDistinctLocations = Boolean.TRUE;
+
+                Set<List<Double>> distinctCoordinates =
+                    CollectionUtil.newHashSetWithExpectedSize(vertex2node.size());
+                for (Node node : vertex2node.values()) {
+                    double[] coordinates = node.getCoordinates();
+                    // Arrays.equals checks identity. Conversion to a List<Double> and use of a
+                    // HashSet has linear runtime. Unlike with a TreeSet using a comparator.
+                    Double[] coordinateObj = new Double[coordinates.length];
+                    for (int i = 0; i < coordinates.length; i++) {
+                        coordinateObj[i] = Double.valueOf(coordinates[i]);
+                    }
+                    if (!distinctCoordinates.add(Arrays.asList(coordinateObj))) {
+                        hasDistinctLocations = Boolean.FALSE;
+                        return hasDistinctLocations;
+                    }
+                }
+            }
             return hasDistinctLocations;
         }
 
         /**
-         * Returns true if for each vertex all touching edges have different weights.
+         * Returns true if for the imported graph each vertex all touching edges have different
+         * weights.
          * <p>
          * If this method returns true this means for the TSP that for each location each other
          * location has a different distance, so there are no two other locations that have the same
@@ -218,255 +341,516 @@ public class TSPLIBImporter<V>
          * </p>
          * 
          * @return true if all touching edges of each vertex have different weight, else false
+         * @throws IllegalStateException if no graph was imported
          */
-        public boolean hasDistinctEdgesPerVertex()
+        public boolean hasDistinctNeighborDistances()
         {
-            if (hasDistinctEdges != null) {
-                return hasDistinctEdges;
+            if (graph == null) {
+                throw new IllegalStateException("No graph imported");
             }
-            hasDistinctEdges = Boolean.TRUE;
+            if (hasDistinctNeighborDistances == null) {
+                hasDistinctNeighborDistances = Boolean.TRUE;
 
-            if (graph != null) {
-                for (V v : graph.vertexSet()) {
-                    Set<DefaultWeightedEdge> edgesOf = graph.edgesOf(v);
-
-                    Set<Double> weights = CollectionUtil.newHashSetWithExpectedSize(edgesOf.size());
-                    for (DefaultWeightedEdge edge : edgesOf) {
-                        weights.add(graph.getEdgeWeight(edge));
-                    }
-                    if (weights.size() != edgesOf.size()) {
-                        hasDistinctEdges = Boolean.FALSE;
-                        break;
+                Set<V> vertices = graph.vertexSet(); // each vertex has vertices.size()-1 edges
+                Set<Double> weights =
+                    CollectionUtil.newHashSetWithExpectedSize(vertices.size() - 1);
+                for (V v : vertices) {
+                    weights.clear();
+                    for (E edge : graph.edgesOf(v)) {
+                        if (!weights.add(graph.getEdgeWeight(edge))) {
+                            hasDistinctNeighborDistances = Boolean.FALSE;
+                            return hasDistinctNeighborDistances;
+                        }
                     }
                 }
             }
-            return hasDistinctEdges;
+            return hasDistinctNeighborDistances;
         }
     }
 
     /**
-     * A getter to obtain element values of Vector data structures.
+     * A node imported from the <em>NODE_COORD_SECTION</em> of a <em>TSPLIB95</em>-file.
      * 
      * @author Hannes Wellmann
-     *
-     * @param <V> the type of handled vectors
      */
-    public interface ElementGetter<V>
+    public static class Node
     {
+        /** The one based number of this node. */
+        private final int number;
+        /** The coordinates of this node. */
+        private final double[] coordinates;
+
+        Node(int number, double[] coordinates)
+        {
+            this.number = number;
+            this.coordinates = coordinates;
+        }
+
         /**
-         * Returns the value of the element at the specified {@code index} in the given {@link V
-         * vector}.
+         * Returns the number of this node as specified in the source <em>TSPLIB95</em>-file.
          * 
-         * @param vector from which an element value is to return
-         * @param index of the element to return
-         * @return the value of the specified element in the given vector
+         * @return the number of this node
          */
-        double getElement(V vector, int index);
+        public int getNumber()
+        {
+            return number;
+        }
+
+        /**
+         * Returns the number of elements the coordinates of this node have (either two or three).
+         * 
+         * @return the number of coordinate elements of this node
+         */
+        public int getCoordinatesLength()
+        {
+            return coordinates.length;
+        }
+
+        /**
+         * Returns the value of the coordinate element with zero-based index <em>i</em> of this
+         * node.
+         * 
+         * @param i the index of the coordinate element
+         * @return the value of the <em>i-th</em> coordinate element
+         */
+        public double getCoordinateValue(int i)
+        {
+            return coordinates[i];
+        }
+
+        /**
+         * Returns a copy of the coordinates of this node.
+         * 
+         * @return the coordinates of this node
+         */
+        public double[] getCoordinates()
+        {
+            return Arrays.copyOf(coordinates, coordinates.length);
+        }
+
+        @Override
+        public String toString()
+        {
+            return number + " " + Arrays
+                .stream(coordinates).mapToObj(Double::toString).collect(Collectors.joining(" "));
+        }
     }
 
-    private final Function<double[], V> vectorFactory;
-    private final ElementGetter<V> elementGetter;
     private int vectorLength = -1;
+    private Metadata<V, E> metadata;
 
-    /**
-     * Create a {@link TSPLIBImporter} that uses the given {@code vectorFactory} to create its
-     * vertices with certain element values and later uses the specified {@code elementGetter} to
-     * obtain the element values and compute the distances between the vertices.
-     * 
-     * @param vectorFactory used to create vector vertices with certain element values
-     * @param elementGetter used to obtain element values from the created vertex-objects
-     */
-    public TSPLIBImporter(Function<double[], V> vectorFactory, ElementGetter<V> elementGetter)
-    {
-        this.vectorFactory = vectorFactory;
-        this.elementGetter = elementGetter;
+    /** Constructs a new importer. */
+    public TSPLIBImporter()
+    { // NoOp
     }
 
-    // import data
-
-    private TSPLIBFileData<V> lastImportData = null;
-
     /**
-     * Returns the {@link TSPLIBFileData} of the latest imported file or null, if no import
-     * completed yet or the latest import failed.
+     * Returns the {@link Metadata} of the latest imported file or null, if no import completed yet
+     * or the latest import failed.
      * 
      * @return {@code TSPLIBFileData} of the latest import
      */
-    public TSPLIBFileData<V> getLastImportData()
+    public Metadata<V, E> getMetadata()
     {
-        return lastImportData;
+        return metadata;
     }
+
+    // read of node data section
 
     /**
      * {@inheritDoc}
      * <p>
-     * The given {@link Graph}, if not null, must have a {@link GraphType#isSimple() simple type}
-     * and must be weighted and empty. If the given {@code Graph} is null, a suitable one is
-     * created.
+     * The given {@link Graph} must be weighted. Also the graph should be empty, otherwise the
+     * behavior is unspecified which could lead to exceptions.
+     * </p>
+     * <p>
+     * The source of the given Reader should contain a <em>NODE_COORD_SECTION</em> (if not the graph
+     * is not changed) and can contain a <em>TOUR_SECTION</em>. If a <em>TOUR_SECTION</em> is
+     * present a corresponding <em>NODE_COORD_SECTION</em> is mandatory and the read vertex numbers
+     * are referred to the <em>NODE_COORD_SECTION</em> in the same source.
+     * </p>
+     * <p>
+     * {@link Metadata} of the import can be obtained with {@link #getLastImportData()} after this
+     * method returned. If the readers source contains a <em>TOUR_SECTION</em> the imported tour can
+     * be obtained from {@link Metadata#getTour()}.
      * </p>
      * <p>
      * This implementation is not thread-safe and must be synchronized externally if called by
      * concurrent threads.
      * </p>
-     * <p>
-     * {@link TSPLIBFileData} of the previous import can be obtained from
-     * {@link #getLastImportData()}.
-     * </p>
      * 
-     * @param graph into which this importer writes, must be simple, weighted and empty or may be
-     *        null.
-     * @throws IllegalArgumentException if the specified {@code graph} is not simple or is not empty
+     * @param graph the graph into which this importer writes, must weighted.
+     * @throws IllegalArgumentException if the specified {@code graph} is not weighted
      */
     @Override
-    public void importGraph(Graph<V, DefaultWeightedEdge> graph, Reader in)
+    public void importGraph(Graph<V, E> graph, Reader in)
     {
-        lastImportData = null;
-        vectorLength = -1;
-        if (graph == null) {
-            @SuppressWarnings("unchecked") Supplier<DefaultWeightedEdge> edgeSupplier =
-                (Supplier<DefaultWeightedEdge> & Serializable) DefaultWeightedEdge::new;
-            graph = new SimpleWeightedGraph<>(null, edgeSupplier);
-        } else if (!graph.getType().isSimple() || !graph.getType().isWeighted()
-            || !graph.vertexSet().isEmpty())
-        {
-            throw new IllegalArgumentException(
-                "Provided graph must be empty and must have simple weighted type");
-        }
-
-        try (BufferedReader reader = new BufferedReader(in)) {
-            lastImportData = readContent(reader, graph);
-        } catch (IOException e) {
-            throw new ImportException("Import of TSPLib file failed", e);
+        metadata = null;
+        try {
+            Iterator<String> lines = getLineIterator(in);
+            metadata = readContentForGraph(lines, graph);
+        } catch (Exception e) {
+            throw getImportException(e, "graph");
         }
     }
 
-    private TSPLIBFileData<V> readContent(
-        BufferedReader reader, Graph<V, DefaultWeightedEdge> graph)
-        throws IOException
+    private Metadata<V, E> readContentForGraph(Iterator<String> lines, Graph<V, E> graph)
     {
-        TSPLIBFileData<V> data = new TSPLIBFileData<>();
+        if (!graph.getType().isWeighted()) {
+            throw new IllegalArgumentException("Graph must be weighted");
+        }
+        vectorLength = -1;
+        Metadata<V, E> data = new Metadata<>();
+        List<Integer> tour = null;
 
-        StringJoiner multiLineComment = new StringJoiner(System.lineSeparator());
-        Function<String, V> vertexFactory = null;
-        ToIntBiFunction<V, V> edgeWeightFunction = null;
+        while (lines.hasNext()) {
+            String[] keyValue = lines.next().split(":");
+            String key = getKey(keyValue);
 
-        for (String line; (line = reader.readLine()) != null;) {
-            String[] keyValue = line.trim().split(":");
+            if (readSpecificationSection(key, data.spec, keyValue)) {
+                // some specification element was read. Continue with next line.
 
-            switch (getKey(keyValue)) {
-            case "NAME":
-                requireNotSet(data.name, "NAME");
-                data.name = getValue(keyValue);
-                break;
+            } else if (NODE_COORD_SECTION.equals(key)) {
+                requireNotSet(data.graph, NODE_COORD_SECTION);
+                data.graph = graph;
+                data.vertex2node = readNodeCoordinateSection(lines, data);
 
-            case "TYPE":
-                requireNotSet(data.type, "TYPE");
-                data.type = getValue(keyValue);
-                break;
-
-            case "COMMENT":
-                multiLineComment.add(getValue(keyValue));
-                break;
-
-            case "DIMENSION":
-                requireNotSet(data.dimension, "DIMENSION");
-                data.dimension = Integer.parseInt(getValue(keyValue));
-                break;
-
-            case "EDGE_WEIGHT_TYPE":
-                requireNotSet(data.edgeWeightType, "EDGE_WEIGHT_TYPE");
-                data.edgeWeightType = getValue(keyValue);
-
-                switch (data.edgeWeightType) {
-                case "EUC_2D":
-                    vectorLength = 2;
-                    vertexFactory = this::createVector2D;
-                    edgeWeightFunction = this::computeEuclideanDistance;
-                    break;
-
-                case "EUC_3D":
-                    vectorLength = 3;
-                    vertexFactory = this::createVector3D;
-                    edgeWeightFunction = this::computeEuclideanDistance;
-                    break;
-
-                case "MAX_2D":
-                    vectorLength = 2;
-                    vertexFactory = this::createVector2D;
-                    edgeWeightFunction = this::computeMaximumDistance;
-                    break;
-
-                case "MAX_3D":
-                    vectorLength = 3;
-                    vertexFactory = this::createVector3D;
-                    edgeWeightFunction = this::computeMaximumDistance;
-                    break;
-
-                case "MAN_2D":
-                    vectorLength = 2;
-                    vertexFactory = this::createVector2D;
-                    edgeWeightFunction = this::computeManhattanDistance;
-                    break;
-
-                case "MAN_3D":
-                    vectorLength = 3;
-                    vertexFactory = this::createVector3D;
-                    edgeWeightFunction = this::computeManhattanDistance;
-                    break;
-
-                case "CEIL_2D":
-                    vectorLength = 2;
-                    vertexFactory = this::createVector2D;
-                    edgeWeightFunction = this::compute2DCeilingEuclideanDistance;
-                    break;
-
-                case "GEO":
-                    vectorLength = 2;
-                    vertexFactory = this::createVector2D;
-                    edgeWeightFunction = this::compute2DGeographicalDistance;
-                    break;
-
-                case "ATT":
-                    vectorLength = 2;
-                    vertexFactory = this::createVector2D;
-                    edgeWeightFunction = this::compute2DPseudoEuclideanDistance;
-                    break;
-
-                default:
-                    throw new IllegalStateException(
-                        "Unsupported EDGE_WEIGHT_TYPE <" + data.edgeWeightType + ">");
-                }
-                break;
-
-            case "NODE_COORD_TYPE":
-                requireNotSet(data.nodeCoordType, "NODE_COORD_TYPE");
-                data.nodeCoordType = getValue(keyValue);
-                break;
-
-            case "NODE_COORD_SECTION":
-                requireNotSet(data.graph, "NODE_COORD_SECTION");
-                if (vertexFactory != null && edgeWeightFunction != null) {
-                    data.hasDistinctLocations = readCompleteNodeGraphData(
-                        graph, reader, vertexFactory, edgeWeightFunction, data.dimension);
-                    data.graph = graph;
-                } else {
-                    throw new IllegalStateException("Missing data to read <NODE_COORD_SECTION>");
-                }
-                break;
-
-            case "TOUR_SECTION":
-                requireNotSet(data.tour, "TOUR_SECTION");
-                data.tour = readTourData(reader, data.dimension);
-                break;
-
-            default:
-                break;
+            } else if (TOUR_SECTION.equals(key)) {
+                requireNotSet(tour, TOUR_SECTION);
+                tour = readTourSection(lines, data.spec.dimension);
             }
         }
-        if (multiLineComment.length() > 0) {
-            data.comment = multiLineComment.toString();
+        if (tour != null) {
+            data.tour = getVertexTour(tour, data.vertex2node);
         }
         return data;
+    }
+
+    /**
+     * Reads all nodes of the NODE_COORD_SECTION and fills the graph of the data accordingly.
+     * 
+     * @return a mapping from created graph {@link V vertex} to corresponding imported {@link Node}
+     */
+    private Map<V, Node> readNodeCoordinateSection(Iterator<String> lines, Metadata<V, E> data)
+    {
+        requireSet(data.spec.edgeWeightType, NODE_COORD_SECTION);
+        requireSet(data.spec.dimension, DIMENSION); // DIMENSION specifies the number of nodes
+
+        ToIntBiFunction<Node, Node> edgeWeightFunction =
+            getEdgeWeightFunction(data.spec.edgeWeightType);
+
+        List<Node> nodes = readNodes(lines, data.spec.dimension);
+
+        // create vertices for all imported nodes
+        Map<V, Node> vertex2node = CollectionUtil.newHashMapWithExpectedSize(nodes.size());
+        Graph<V, E> graph = data.graph;
+        for (Node node : nodes) {
+            V v = graph.addVertex();
+            vertex2node.put(v, node);
+        }
+
+        // create edges for each possible pair of vertices and compute their weights
+        new CompleteGraphGenerator<V, E>().generateGraph(graph, null);
+
+        graph.edgeSet().forEach(e -> {
+            Node s = vertex2node.get(graph.getEdgeSource(e));
+            Node t = vertex2node.get(graph.getEdgeTarget(e));
+
+            double weight = edgeWeightFunction.applyAsInt(s, t);
+            graph.setEdgeWeight(e, weight);
+        });
+        return Collections.unmodifiableMap(vertex2node);
+    }
+
+    private ToIntBiFunction<Node, Node> getEdgeWeightFunction(String edgeWeightType)
+    {
+        switch (edgeWeightType) {
+        case "EUC_2D":
+            vectorLength = 2;
+            return this::computeEuclideanDistance;
+
+        case "EUC_3D":
+            vectorLength = 3;
+            return this::computeEuclideanDistance;
+
+        case "MAX_2D":
+            vectorLength = 2;
+            return this::computeMaximumDistance;
+
+        case "MAX_3D":
+            vectorLength = 3;
+            return this::computeMaximumDistance;
+
+        case "MAN_2D":
+            vectorLength = 2;
+            return this::computeManhattanDistance;
+
+        case "MAN_3D":
+            vectorLength = 3;
+            return this::computeManhattanDistance;
+
+        case "CEIL_2D":
+            vectorLength = 2;
+            return this::compute2DCeilingEuclideanDistance;
+
+        case "GEO":
+            vectorLength = 2;
+            return this::compute2DGeographicalDistance;
+
+        case "ATT":
+            vectorLength = 2;
+            return this::compute2DPseudoEuclideanDistance;
+
+        default:
+            throw new IllegalStateException(
+                "Unsupported EDGE_WEIGHT_TYPE <" + edgeWeightType + ">");
+        }
+    }
+
+    private List<Node> readNodes(Iterator<String> lines, int dimension)
+    {
+        List<Node> nodes = new ArrayList<>(dimension);
+        for (int i = 0; i < dimension && lines.hasNext(); i++) {
+            String line = lines.next();
+            Node node = parseNode(line);
+            nodes.add(node);
+        }
+        return nodes;
+    }
+
+    private Node parseNode(String line)
+    {
+        String[] elements = line.split(" ");
+        if (elements.length != vectorLength + 1) {
+            throw new IllegalArgumentException(
+                "Unexpected number of elements <" + elements.length + "> in line: " + line);
+        }
+        int number = Integer.parseInt(elements[0]);
+        double[] coordinates =
+            Arrays.stream(elements, 1, elements.length).mapToDouble(Double::parseDouble).toArray();
+
+        return new Node(number, coordinates);
+    }
+
+    // read of tour data section
+
+    /**
+     * Imports a tour described by a {@link List} of {@link V vertices} using the given Reader.
+     * <p>
+     * It is the callers responsibility to ensure the {@code Reader} is closed after this method
+     * returned.
+     * </p>
+     * <p>
+     * The source of the given Reader should contain a <em>TOUR_SECTION</em> (if not null is
+     * returned). The vertices specified by their number in the <em>TOUR_SECTION</em> are referred
+     * to the nodes respectively vertices in the given {@code metadata}.
+     * </p>
+     * <p>
+     * The {@link Metadata} of the import can be obtained with {@link #getLastImportData()} after
+     * this method returned. The {@code Metadata#getVertexToNodeMapping() vertexToNodeMapping} in
+     * the metadata of this import is the same as in the given {@code metadata}.
+     * </p>
+     * <p>
+     * This implementation is not thread-safe and must be synchronized externally if called by
+     * concurrent threads.
+     * </p>
+     * 
+     * @param referenceMetadata the {@code Metadata} defining the available vertices and their
+     *        {@code Nodes}.
+     * @param in the input reader
+     * @return the imported tour or null, if no tour was imported
+     */
+    public List<V> importTour(Metadata<V, E> referenceMetadata, Reader in)
+    {
+        metadata = null;
+        try {
+            Iterator<String> lines = getLineIterator(in);
+            metadata = readContentForTour(lines, referenceMetadata.vertex2node);
+            return metadata.tour;
+        } catch (Exception e) {
+            throw getImportException(e, "tour");
+        }
+    }
+
+    private Metadata<V, E> readContentForTour(Iterator<String> lines, Map<V, Node> vertex2node)
+    {
+        Metadata<V, E> data = new Metadata<>();
+
+        while (lines.hasNext()) {
+            String[] keyValue = lines.next().split(":");
+            String key = getKey(keyValue);
+
+            if (readSpecificationSection(key, data.spec, keyValue)) {
+                // some specification element was read. Continue with next line.
+
+            } else if (TOUR_SECTION.equals(key)) {
+                requireNotSet(data.tour, TOUR_SECTION);
+                List<Integer> tour = readTourSection(lines, data.spec.dimension);
+                data.tour = getVertexTour(tour, vertex2node);
+            }
+        }
+        data.vertex2node = vertex2node;
+        return data;
+    }
+
+    /**
+     * Reads a tour of the TOUR_SECTION and returns the List of ordered vertex numbers describing
+     * the tour.
+     * 
+     * @return the list of vertex number describing the tour
+     */
+    private List<Integer> readTourSection(Iterator<String> lines, Integer dimension)
+    {
+        List<Integer> tour = dimension != null ? new ArrayList<>(dimension) : new ArrayList<>();
+
+        while (lines.hasNext()) {
+            String lineContent = lines.next();
+            if ("-1".equals(lineContent)) {
+                break;
+            }
+            tour.add(Integer.valueOf(lineContent));
+        }
+        return tour;
+    }
+
+    private List<V> getVertexTour(List<Integer> tour, Map<V, Node> vertex2node)
+    {
+        requireSet(vertex2node, TOUR_SECTION);
+        List<V> orderedVertices = getOrderedVertices(vertex2node);
+
+        List<V> vertexTour = new ArrayList<>(orderedVertices.size());
+        for (Integer vertexNumber : tour) { // number may be zero or one based (its more a id)
+            V v = vertexNumber < orderedVertices.size() ? orderedVertices.get(vertexNumber) : null;
+            if (v == null) {
+                throw new IllegalStateException("Missing vertex with number " + vertexNumber);
+            }
+            vertexTour.add(v);
+        }
+        return vertexTour;
+    }
+
+    private List<V> getOrderedVertices(Map<V, Node> vertex2node)
+    {
+        int maxNumber = vertex2node.values().stream().mapToInt(Node::getNumber).max().getAsInt();
+        @SuppressWarnings("unchecked") V[] orderedVertices = (V[]) new Object[maxNumber + 1];
+        vertex2node.forEach((v, n) -> orderedVertices[n.number] = v);
+        return asList(orderedVertices);
+    }
+
+    // read of specification
+
+    private boolean readSpecificationSection(String key, Specification spec, String[] lineElements)
+    {
+        // only read value if it is sure that there should be a value
+        switch (key) {
+        case NAME:
+            requireNotSet(spec.name, NAME);
+            spec.name = getValue(lineElements);
+            return true;
+
+        case TYPE:
+            requireNotSet(spec.type, TYPE);
+            String type = getValue(lineElements);
+            spec.type = requireValidValue(type, VALID_TYPES, TYPE);
+            return true;
+
+        case COMMENT:
+            String comment = getValue(lineElements);
+            spec.comment.add(comment);
+            return true;
+
+        case DIMENSION:
+            requireNotSet(spec.dimension, DIMENSION);
+            String dimension = getValue(lineElements);
+            spec.dimension = parseInteger(dimension, DIMENSION);
+            return true;
+
+        case CAPACITY:
+            requireNotSet(spec.capacity, CAPACITY);
+            String capacity = getValue(lineElements);
+            spec.capacity = parseInteger(capacity, CAPACITY);
+            return true;
+
+        case EDGE_WEIGHT_TYPE:
+            requireNotSet(spec.edgeWeightType, EDGE_WEIGHT_TYPE);
+            String edgeWeightType = getValue(lineElements);
+            spec.edgeWeightType =
+                requireValidValue(edgeWeightType, VALID_EDGE_WEIGHT_TYPES, EDGE_WEIGHT_TYPE);
+            return true;
+
+        case EDGE_WEIGHT_FORMAT:
+            requireNotSet(spec.edgeWeightFormat, EDGE_WEIGHT_FORMAT);
+            String edgeWeightFormat = getValue(lineElements);
+            spec.edgeWeightFormat =
+                requireValidValue(edgeWeightFormat, VALID_EDGE_WEIGHT_FORMATS, EDGE_WEIGHT_FORMAT);
+            return true;
+
+        case EDGE_DATA_FORMAT:
+            requireNotSet(spec.edgeDataFormat, EDGE_DATA_FORMAT);
+            String edgeDataFormat = getValue(lineElements);
+            spec.edgeDataFormat =
+                requireValidValue(edgeDataFormat, VALID_EDGE_DATA_FORMATS, EDGE_DATA_FORMAT);
+            return true;
+
+        case NODE_COORD_TYPE:
+            requireNotSet(spec.nodeCoordType, NODE_COORD_TYPE);
+            String nodeCoordType = getValue(lineElements);
+            spec.nodeCoordType =
+                requireValidValue(nodeCoordType, VALID_NODE_COORD_TYPES, NODE_COORD_TYPE);
+            return true;
+
+        case DISPLAY_DATA_TYPE:
+            requireNotSet(spec.displayDataType, DISPLAY_DATA_TYPE);
+            String displayDataType = getValue(lineElements);
+            spec.displayDataType =
+                requireValidValue(displayDataType, VALID_DISPLAY_DATA_TYPE, DISPLAY_DATA_TYPE);
+            return true;
+
+        default:
+            return false;
+        }
+    }
+
+    private String requireValidValue(String value, List<String> validValues, String valueType)
+    {
+        for (String validValue : validValues) {
+            if (validValue.equalsIgnoreCase(value)) {
+                return validValue; // always use the upper case version
+            }
+        }
+        throw new IllegalArgumentException("Invalid " + valueType + " value <" + value + ">");
+    }
+
+    private Integer parseInteger(String valueStr, String valueType)
+    {
+        try {
+            return Integer.valueOf(valueStr);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException(
+                "Invalid " + valueType + " integer value <" + valueStr + ">", e);
+        }
+    }
+
+    // read utilities
+
+    private static Iterator<String> getLineIterator(Reader in)
+    {
+        BufferedReader reader = new BufferedReader(in);
+        return Stream.iterate(readLine(reader), Objects::nonNull, l -> readLine(reader)).iterator();
+    }
+
+    private static String readLine(BufferedReader reader)
+    {
+        try {
+            String line = reader.readLine();
+            if (line != null) {
+                line = line.trim();
+                return "EOF".equals(line) ? null : line;
+            }
+            return null;
+        } catch (IOException e) {
+            throw new IllegalStateException("I/O exception while reading line of TSPLIB file", e);
+        }
     }
 
     private static String getKey(String[] keyValue)
@@ -489,82 +873,95 @@ public class TSPLIBImporter<V>
         }
     }
 
+    private void requireSet(Object requirement, String target)
+    {
+        if (requirement == null) {
+            throw new IllegalStateException("Missing data to read <" + target + ">");
+        }
+    }
+
+    private static ImportException getImportException(Exception e, String target)
+    {
+        return new ImportException(
+            "Failed to import " + target + " from TSPLIB-file: " + e.getMessage(), e);
+    }
+
     // distance computations
 
     // all of the following methods are implemented in accordance to
     // section "2. The distance functions" of TSPLIB95
 
     /**
-     * Computes the distance of two positions p1 and p2 according to the {@code EUC_2D} or
+     * Computes the distance of the two nodes n1 and n2 according to the {@code EUC_2D} or
      * {@code EUC_3D} metric depending on their dimension. The used metric is also known as L2-norm.
      * 
-     * @param p1 a two or three dimensional point
-     * @param p2 a two or three dimensional point
-     * @return the {@code EUC_2D} or {@code EUC_3D} edge weight for points p1 and p2
+     * @param n1 a {@code Node} with two or three dimensional coordinates
+     * @param n2 a {@code Node} with two or three dimensional coordinates
+     * @return the {@code EUC_2D} or {@code EUC_3D} edge weight for nodes n1 and n2
      */
-    int computeEuclideanDistance(V p1, V p2)
+    int computeEuclideanDistance(Node n1, Node n2)
     { // according to TSPLIB95 distances are rounded to next integer value
-        return (int) Math.round(getL2Distance(p1, p2));
+        return (int) Math.round(getL2Distance(n1, n2));
     }
 
     /**
-     * Computes the distance of two positions p1 and p2 according to the {@code MAX_2D} or
+     * Computes the distance of the two nodes n1 and n2 according to the {@code MAX_2D} or
      * {@code MAX_3D} metric depending on their dimension. The used metric is also known as
      * L&infin;-norm.
      * 
-     * @param p1 a two or three dimensional point
-     * @param p2 a two or three dimensional point
-     * @return the {@code MAX_2D} or {@code MAX_3D} edge weight for points p1 and p2
+     * @param n1 a {@code Node} with two or three dimensional coordinates
+     * @param n2 a {@code Node} with two or three dimensional coordinates
+     * @return the {@code MAX_2D} or {@code MAX_3D} edge weight for nodes n1 and n2
      */
-    int computeMaximumDistance(V p1, V p2)
+    int computeMaximumDistance(Node n1, Node n2)
     { // according to TSPLIB95 distances are rounded to next integer value
-        return (int) Math.round(getLInfDistance(p1, p2));
+        return (int) Math.round(getLInfDistance(n1, n2));
     }
 
     /**
-     * Computes the distance of two positions p1 and p2 according to the {@code MAN_2D} or
+     * Computes the distance of the two nodes n1 and n2 according to the {@code MAN_2D} or
      * {@code MAN_3D} metric depending on their dimension. The used metric is also known as L1-norm.
      * 
-     * @param p1 a two or three dimensional point
-     * @param p2 a two or three dimensional point
-     * @return the {@code MAN_2D} or {@code MAN_3D} edge weight for points p1 and p2
+     * @param n1 a {@code Node} with two or three dimensional coordinates
+     * @param n2 a {@code Node} with two or three dimensional coordinates
+     * @return the {@code MAN_2D} or {@code MAN_3D} edge weight for nodes n1 and n2
      */
-    int computeManhattanDistance(V p1, V p2)
+    int computeManhattanDistance(Node n1, Node n2)
     { // according to TSPLIB95 distances are rounded to next integer value
-        return (int) Math.round(getL1Distance(p1, p2));
+        return (int) Math.round(getL1Distance(n1, n2));
     }
 
     /**
-     * Computes the distance of two positions p1 and p2 according to the {@code CEIL_2D} metric, the
+     * Computes the distance of the two nodes n1 and n2 according to the {@code CEIL_2D} metric, the
      * round up version of {@code EUC_2D}. The points must have dimension two.
      * 
-     * @param p1 a two or three dimensional point
-     * @param p2 a two or three dimensional point
-     * @return the {@code CEIL_2D} edge weight for points p1 and p2
+     * @param n1 a {@code Node} with two or three dimensional coordinates
+     * @param n2 a {@code Node} with two or three dimensional coordinates
+     * @return the {@code CEIL_2D} edge weight for nodes n1 and n2
      * @see #computeEuclideanDistance(RealVector, RealVector)
      */
-    int compute2DCeilingEuclideanDistance(V p1, V p2)
+    int compute2DCeilingEuclideanDistance(Node n1, Node n2)
     {
-        return (int) Math.ceil(getL2Distance(p1, p2));
+        return (int) Math.ceil(getL2Distance(n1, n2));
     }
 
     /**
-     * Computes the distance of two positions p1 and p2 according to the {@code GEO} metric. The
+     * Computes the distance of the two nodes n1 and n2 according to the {@code GEO} metric. The
      * used metric computes the distance between two points on a earth-like sphere, while the point
      * coordinates describe their geographical latitude and longitude. The points must have
      * dimension two.
      * 
-     * @param p1 a two or three dimensional point
-     * @param p2 a two or three dimensional point
-     * @return the {@code GEO} edge weight for points p1 and p2
+     * @param n1 a {@code Node} with two or three dimensional coordinates
+     * @param n2 a {@code Node} with two or three dimensional coordinates
+     * @return the {@code GEO} edge weight for nodes n1 and n2
      */
-    int compute2DGeographicalDistance(V p1, V p2)
+    int compute2DGeographicalDistance(Node n1, Node n2)
     {
-        double latitude1 = computeRadiansAngle(elementGetter.getElement(p1, 0));
-        double longitude1 = computeRadiansAngle(elementGetter.getElement(p1, 1));
+        double latitude1 = computeRadiansAngle(n1.getCoordinateValue(0));
+        double longitude1 = computeRadiansAngle(n1.getCoordinateValue(1));
 
-        double latitude2 = computeRadiansAngle(elementGetter.getElement(p2, 0));
-        double longitude2 = computeRadiansAngle(elementGetter.getElement(p2, 1));
+        double latitude2 = computeRadiansAngle(n2.getCoordinateValue(0));
+        double longitude2 = computeRadiansAngle(n2.getCoordinateValue(1));
 
         double q1 = Math.cos(longitude1 - longitude2);
         double q2 = Math.cos(latitude1 - latitude2);
@@ -584,17 +981,17 @@ public class TSPLIBImporter<V>
     }
 
     /**
-     * Computes the distance of two positions p1 and p2 according to the {@code ATT} metric. The
-     * points must have dimension two.
+     * Computes the distance of two the two nodes n1 and n2 according to the {@code ATT} metric. The
+     * nodes must have two dimensional coordinates.
      * 
-     * @param p1 a two or three dimensional point
-     * @param p2 a two or three dimensional point
-     * @return the {@code ATT} edge weight for points p1 and p2
+     * @param n1 a {@code Node} with two dimensional coordinates
+     * @param n2 a {@code Node} with two dimensional coordinates
+     * @return the {@code ATT} edge weight for nodes n1 and n2
      */
-    int compute2DPseudoEuclideanDistance(V p1, V p2)
+    int compute2DPseudoEuclideanDistance(Node n1, Node n2)
     {
-        double xd = elementGetter.getElement(p1, 0) - elementGetter.getElement(p2, 0);
-        double yd = elementGetter.getElement(p1, 1) - elementGetter.getElement(p2, 1);
+        double xd = n1.getCoordinateValue(0) - n2.getCoordinateValue(0);
+        double yd = n1.getCoordinateValue(1) - n2.getCoordinateValue(1);
         double rij = Math.sqrt((xd * xd + yd * yd) / 10.0);
         double tij = Math.round(rij);
         if (tij < rij) {
@@ -604,132 +1001,33 @@ public class TSPLIBImporter<V>
         }
     }
 
-    private double getL1Distance(V p1, V p2)
+    private double getL1Distance(Node n1, Node n2)
     {
         double elementSum = 0;
         for (int i = 0; i < vectorLength; i++) {
-            double delta = elementGetter.getElement(p1, i) - elementGetter.getElement(p2, i);
+            double delta = n1.getCoordinateValue(i) - n2.getCoordinateValue(i);
             elementSum += Math.abs(delta);
         }
         return elementSum;
     }
 
-    private double getL2Distance(V p1, V p2)
+    private double getL2Distance(Node n1, Node n2)
     {
         double elementSum = 0;
         for (int i = 0; i < vectorLength; i++) {
-            double delta = elementGetter.getElement(p1, i) - elementGetter.getElement(p2, i);
+            double delta = n1.getCoordinateValue(i) - n2.getCoordinateValue(i);
             elementSum += delta * delta;
         }
         return Math.sqrt(elementSum);
     }
 
-    private double getLInfDistance(V p1, V p2)
+    private double getLInfDistance(Node n1, Node n2)
     {
         double maxElement = 0;
         for (int i = 0; i < vectorLength; i++) {
-            double delta = elementGetter.getElement(p1, i) - elementGetter.getElement(p2, i);
+            double delta = n1.getCoordinateValue(i) - n2.getCoordinateValue(i);
             maxElement = Math.max(maxElement, Math.abs(delta));
         }
         return maxElement;
-    }
-
-    // node build
-
-    private V createVector2D(String line)
-    {
-        String[] elements = splitLineElements(line, 3);
-        // index of the point in elements[0] is not necessary
-        double x = Double.parseDouble(elements[1]);
-        double y = Double.parseDouble(elements[2]);
-        return vectorFactory.apply(new double[] { x, y });
-    }
-
-    private V createVector3D(String line)
-    {
-        String[] elements = splitLineElements(line, 4);
-        // index of the point in elements[0] is not necessary
-        double x = Double.parseDouble(elements[1]);
-        double y = Double.parseDouble(elements[2]);
-        double z = Double.parseDouble(elements[3]);
-        return vectorFactory.apply(new double[] { x, y, z });
-    }
-
-    private static String[] splitLineElements(String line, int expectedLineElements)
-    {
-        String[] elements = line.split(" ");
-        if (elements.length != expectedLineElements) {
-            throw new IllegalArgumentException(
-                "Unexpected number of line elements: " + elements.length + " in line: " + line);
-        }
-        return elements;
-    }
-
-    // read of coordinates and graph computation
-
-    /**
-     * Read the complete {@link Graph} of node locations and returns true if all locations are
-     * distinct.
-     */
-    private boolean readCompleteNodeGraphData(
-        Graph<V, DefaultWeightedEdge> graph, BufferedReader reader,
-        Function<String, V> vectorFactory, ToIntBiFunction<V, V> edgeWeightFunction,
-        Integer dimension)
-        throws IOException
-    {
-        List<V> nodeCoordinates = readNodeCoordinateData(reader, vectorFactory, dimension);
-
-        buildCompleteGraph(graph, nodeCoordinates, edgeWeightFunction);
-        return graph.vertexSet().size() == nodeCoordinates.size();
-    }
-
-    private List<V> readNodeCoordinateData(
-        BufferedReader reader, Function<String, V> vectorFactory, Integer dimension)
-        throws IOException
-    {
-        List<V> coordinates = dimension != null ? new ArrayList<>(dimension) : new ArrayList<>();
-
-        for (String line; (line = reader.readLine()) != null;) {
-            String lineContent = line.trim();
-            if ("EOF".equals(lineContent)) {
-                break;
-            }
-            coordinates.add(vectorFactory.apply(lineContent));
-        }
-        return coordinates;
-    }
-
-    private static <V, E> void buildCompleteGraph(
-        Graph<V, E> graph, List<V> locations, ToIntBiFunction<V, V> edgeWeightFunction)
-    {
-        locations.forEach(graph::addVertex);
-
-        new CompleteGraphGenerator<V, E>().generateGraph(graph, null);
-
-        // Compute edge weights:
-        // Enable parallel streams. Synchronization not necessary, because DefaultWeightedEdge are
-        // IntrusiveEdges and modified directly.
-
-        graph.edgeSet().parallelStream().forEach(e -> {
-            V s = graph.getEdgeSource(e);
-            V t = graph.getEdgeTarget(e);
-            double weight = edgeWeightFunction.applyAsInt(s, t);
-            graph.setEdgeWeight(e, weight);
-        });
-    }
-
-    private List<Integer> readTourData(BufferedReader reader, Integer dimension)
-        throws IOException
-    {
-        List<Integer> tour = dimension != null ? new ArrayList<>(dimension) : new ArrayList<>();
-
-        for (String line; (line = reader.readLine()) != null;) {
-            String lineContent = line.trim();
-            if ("-1".equals(lineContent)) {
-                break;
-            }
-            tour.add(Integer.valueOf(lineContent));
-        }
-        return tour;
     }
 }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/TSPLIBImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/TSPLIBImporter.java
@@ -1,0 +1,735 @@
+/*
+ * (C) Copyright 2020-2020, by Hannes Wellmann and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.nio.tsplib;
+
+import java.io.*;
+import java.util.*;
+import java.util.function.*;
+
+import org.jgrapht.*;
+import org.jgrapht.generate.*;
+import org.jgrapht.graph.*;
+import org.jgrapht.nio.*;
+import org.jgrapht.util.*;
+
+/**
+ * Importer for files in the
+ * <a href="http://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/">TSPLIB95</a> format.
+ * <p>
+ * This importer reads the nodes of a <em>Symmetric travelling salesman problem</em> instance from a
+ * file and creates a {@link GraphTests#isComplete(Graph) complete graph} and provides further data
+ * from the file and about the imported graph.
+ * </p>
+ * <p>
+ * This implementation does not cover the full TSPLIB95 standard and only implements the subset of
+ * capabilities required at the time of creation. The following keywords of <em>The specification
+ * part</em> in chapter 1.1 of the <em>TSPLIB95</em> standard are supported:
+ * <ul>
+ * <li>NAME</li>
+ * <li>TYPE</li>
+ * <li>COMMENT</li>
+ * <li>DIMENSION</li>
+ * <li>EDGE_WEIGHT_TYPE</li> Only the following edge weight types are supported
+ * <ul>
+ * <li>EUC_2D</li>
+ * <li>EUC_3D</li>
+ * <li>MAX_2D</li>
+ * <li>MAX_3D</li>
+ * <li>MAN_2D</li>
+ * <li>MAN_3D</li>
+ * <li>CEIL2D</li>
+ * <li>GEO</li>
+ * <li>ATT</li>
+ * </ul>
+ * </ul>
+ * The values of all supported keywords can be obtained from corresponding getters.
+ * </p>
+ * <p>
+ * The following data sections of <em>The data part</em> in chapter 1.2 of the <em>TSPLIB95</em>
+ * standard are supported:
+ * <ul>
+ * <li>NODE_COORD_SECTION</li>
+ * </ul>
+ * </p>
+ * <p>
+ * It was attempted to make the structure of this implementation generic so further keywords from
+ * the specification part or other data sections can be considered if required by broaden this
+ * class. Currently this implementation only reads <em>Symmetric travelling salesman problems</em>
+ * with a NODE_COORD_SECTION and on of the supported EDGE_WEIGHT_TYPE.
+ * </p>
+ * <p>
+ * The website of the TSPLIB standard already contains a large library of different TSP instances
+ * provided as files in TSPLIB format. The
+ * <a href="http://www.math.uwaterloo.ca/tsp/data/index.html">TSPLIB library of the University of
+ * Waterlo</a> provides more problem instances, among others a World TSP and instances based on
+ * cities of different countries.
+ * </p>
+ * 
+ * @author Hannes Wellmann
+ * @param <V> the type of vertices created by this importer
+ *
+ */
+public class TSPLIBImporter<V>
+    implements
+    GraphImporter<V, DefaultWeightedEdge>
+{
+    /**
+     * Container for data of an imported <em>TSPLIB95</em> file.
+     * 
+     * @author Hannes Wellmann
+     * @param <V> the type of vertices in the imported graph
+     */
+    public static class TSPLIBFileData<V>
+    {
+
+        private String name;
+        private String type;
+        private String comment;
+        private Integer dimension;
+        private String edgeWeightType;
+        private String nodeCoordType;
+        private boolean hasDistinctLocations;
+        private Boolean hasDistinctEdges;
+
+        private Graph<V, DefaultWeightedEdge> graph;
+        private List<Integer> tour;
+
+        // getters for read public data
+
+        /**
+         * Returns the value of the <em>NAME</em> keyword in the imported file.
+         * 
+         * @return the value of the <em>NAME</em> keyword
+         */
+        public String getName()
+        {
+            return name;
+        }
+
+        /**
+         * Returns the value of the <em>TYPE</em> keyword in the imported file.
+         * 
+         * @return the value of the <em>TYPE</em> keyword
+         */
+        public String getType()
+        {
+            return type;
+        }
+
+        /**
+         * Returns the joined value of the <em>COMMENT</em> keyword in the imported file.
+         * 
+         * @return the value of the <em>COMMENT</em> keyword
+         */
+        public String getComment()
+        {
+            return comment;
+        }
+
+        /**
+         * Returns the value of the <em>DIMENSION</em> keyword in the imported file.
+         * 
+         * @return the value of the <em>DIMENSION</em> keyword
+         */
+        public Integer getDimension()
+        {
+            return dimension;
+        }
+
+        /**
+         * Returns the value of the <em>EDGE_WEIGHT_TYPE</em> keyword in the imported file.
+         * 
+         * @return the value of the <em>EDGE_WEIGHT_TYPE</em> keyword
+         */
+        public String getEdgeWeightType()
+        {
+            return edgeWeightType;
+        }
+
+        /**
+         * Returns the value of the <em>NODE_COORD_TYPE</em> keyword in the imported file.
+         * 
+         * @return the value of the <em>NODE_COORD_TYPE</em> keyword
+         */
+        public String getNodeCoordType()
+        {
+            return nodeCoordType;
+        }
+
+        /**
+         * Returns the complete {@link Graph} of location connections built from the imported file
+         * or null if no graph was imported.
+         * 
+         * @return the complete {@code Graph} of location connections
+         */
+        public Graph<V, DefaultWeightedEdge> getGraph()
+        {
+            return graph;
+        }
+
+        /**
+         * Returns the {@link List} of {@link Integer Integers} describing vertex order of the tour
+         * from the imported file or null if no tour was imported.
+         * 
+         * @return the tour described by the list of vertex indices
+         */
+        public List<Integer> getTour()
+        {
+            return tour;
+        }
+
+        /**
+         * Returns true if all read vertices were distinct and non of them were
+         * {@link Object#equals(Object) equal}, else false.
+         * <p>
+         * The read {@link #getGraph() Graph} does not contain equal vertices because the vertices
+         * are stored in a {@link Set}. So in case the imported file contains duplicated locations
+         * all duplicates are discarded. This method tells if this was the case.
+         * </p>
+         * 
+         * @return true if only not equal vertices were imported from the file, else false
+         */
+        public boolean hasDistinctVertices()
+        {
+            return hasDistinctLocations;
+        }
+
+        /**
+         * Returns true if for each vertex all touching edges have different weights.
+         * <p>
+         * If this method returns true this means for the TSP that for each location each other
+         * location has a different distance, so there are no two other locations that have the same
+         * distance from that location.
+         * </p>
+         * 
+         * @return true if all touching edges of each vertex have different weight, else false
+         */
+        public boolean hasDistinctEdgesPerVertex()
+        {
+            if (hasDistinctEdges != null) {
+                return hasDistinctEdges;
+            }
+            hasDistinctEdges = Boolean.TRUE;
+
+            if (graph != null) {
+                for (V v : graph.vertexSet()) {
+                    Set<DefaultWeightedEdge> edgesOf = graph.edgesOf(v);
+
+                    Set<Double> weights = CollectionUtil.newHashSetWithExpectedSize(edgesOf.size());
+                    for (DefaultWeightedEdge edge : edgesOf) {
+                        weights.add(graph.getEdgeWeight(edge));
+                    }
+                    if (weights.size() != edgesOf.size()) {
+                        hasDistinctEdges = Boolean.FALSE;
+                        break;
+                    }
+                }
+            }
+            return hasDistinctEdges;
+        }
+    }
+
+    /**
+     * A getter to obtain element values of Vector data structures.
+     * 
+     * @author Hannes Wellmann
+     *
+     * @param <V> the type of handled vectors
+     */
+    public interface ElementGetter<V>
+    {
+        /**
+         * Returns the value of the element at the specified {@code index} in the given {@link V
+         * vector}.
+         * 
+         * @param vector from which an element value is to return
+         * @param index of the element to return
+         * @return the value of the specified element in the given vector
+         */
+        double getElement(V vector, int index);
+    }
+
+    private final Function<double[], V> vectorFactory;
+    private final ElementGetter<V> elementGetter;
+    private int vectorLength = -1;
+
+    /**
+     * Create a {@link TSPLIBImporter} that uses the given {@code vectorFactory} to create its
+     * vertices with certain element values and later uses the specified {@code elementGetter} to
+     * obtain the element values and compute the distances between the vertices.
+     * 
+     * @param vectorFactory used to create vector vertices with certain element values
+     * @param elementGetter used to obtain element values from the created vertex-objects
+     */
+    public TSPLIBImporter(Function<double[], V> vectorFactory, ElementGetter<V> elementGetter)
+    {
+        this.vectorFactory = vectorFactory;
+        this.elementGetter = elementGetter;
+    }
+
+    // import data
+
+    private TSPLIBFileData<V> lastImportData = null;
+
+    /**
+     * Returns the {@link TSPLIBFileData} of the latest imported file or null, if no import
+     * completed yet or the latest import failed.
+     * 
+     * @return {@code TSPLIBFileData} of the latest import
+     */
+    public TSPLIBFileData<V> getLastImportData()
+    {
+        return lastImportData;
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * The given {@link Graph}, if not null, must have a {@link GraphType#isSimple() simple type}
+     * and must be weighted and empty. If the given {@code Graph} is null, a suitable one is
+     * created.
+     * </p>
+     * <p>
+     * This implementation is not thread-safe and must be synchronized externally if called by
+     * concurrent threads.
+     * </p>
+     * <p>
+     * {@link TSPLIBFileData} of the previous import can be obtained from
+     * {@link #getLastImportData()}.
+     * </p>
+     * 
+     * @param graph into which this importer writes, must be simple, weighted and empty or may be
+     *        null.
+     * @throws IllegalArgumentException if the specified {@code graph} is not simple or is not empty
+     */
+    @Override
+    public void importGraph(Graph<V, DefaultWeightedEdge> graph, Reader in)
+    {
+        lastImportData = null;
+        vectorLength = -1;
+        if (graph == null) {
+            @SuppressWarnings("unchecked") Supplier<DefaultWeightedEdge> edgeSupplier =
+                (Supplier<DefaultWeightedEdge> & Serializable) DefaultWeightedEdge::new;
+            graph = new SimpleWeightedGraph<>(null, edgeSupplier);
+        } else if (!graph.getType().isSimple() || !graph.getType().isWeighted()
+            || !graph.vertexSet().isEmpty())
+        {
+            throw new IllegalArgumentException(
+                "Provided graph must be empty and must have simple weighted type");
+        }
+
+        try (BufferedReader reader = new BufferedReader(in)) {
+            lastImportData = readContent(reader, graph);
+        } catch (IOException e) {
+            throw new ImportException("Import of TSPLib file failed", e);
+        }
+    }
+
+    private TSPLIBFileData<V> readContent(
+        BufferedReader reader, Graph<V, DefaultWeightedEdge> graph)
+        throws IOException
+    {
+        TSPLIBFileData<V> data = new TSPLIBFileData<>();
+
+        StringJoiner multiLineComment = new StringJoiner(System.lineSeparator());
+        Function<String, V> vertexFactory = null;
+        ToIntBiFunction<V, V> edgeWeightFunction = null;
+
+        for (String line; (line = reader.readLine()) != null;) {
+            String[] keyValue = line.trim().split(":");
+
+            switch (getKey(keyValue)) {
+            case "NAME":
+                requireNotSet(data.name, "NAME");
+                data.name = getValue(keyValue);
+                break;
+
+            case "TYPE":
+                requireNotSet(data.type, "TYPE");
+                data.type = getValue(keyValue);
+                break;
+
+            case "COMMENT":
+                multiLineComment.add(getValue(keyValue));
+                break;
+
+            case "DIMENSION":
+                requireNotSet(data.dimension, "DIMENSION");
+                data.dimension = Integer.parseInt(getValue(keyValue));
+                break;
+
+            case "EDGE_WEIGHT_TYPE":
+                requireNotSet(data.edgeWeightType, "EDGE_WEIGHT_TYPE");
+                data.edgeWeightType = getValue(keyValue);
+
+                switch (data.edgeWeightType) {
+                case "EUC_2D":
+                    vectorLength = 2;
+                    vertexFactory = this::createVector2D;
+                    edgeWeightFunction = this::computeEuclideanDistance;
+                    break;
+
+                case "EUC_3D":
+                    vectorLength = 3;
+                    vertexFactory = this::createVector3D;
+                    edgeWeightFunction = this::computeEuclideanDistance;
+                    break;
+
+                case "MAX_2D":
+                    vectorLength = 2;
+                    vertexFactory = this::createVector2D;
+                    edgeWeightFunction = this::computeMaximumDistance;
+                    break;
+
+                case "MAX_3D":
+                    vectorLength = 3;
+                    vertexFactory = this::createVector3D;
+                    edgeWeightFunction = this::computeMaximumDistance;
+                    break;
+
+                case "MAN_2D":
+                    vectorLength = 2;
+                    vertexFactory = this::createVector2D;
+                    edgeWeightFunction = this::computeManhattanDistance;
+                    break;
+
+                case "MAN_3D":
+                    vectorLength = 3;
+                    vertexFactory = this::createVector3D;
+                    edgeWeightFunction = this::computeManhattanDistance;
+                    break;
+
+                case "CEIL_2D":
+                    vectorLength = 2;
+                    vertexFactory = this::createVector2D;
+                    edgeWeightFunction = this::compute2DCeilingEuclideanDistance;
+                    break;
+
+                case "GEO":
+                    vectorLength = 2;
+                    vertexFactory = this::createVector2D;
+                    edgeWeightFunction = this::compute2DGeographicalDistance;
+                    break;
+
+                case "ATT":
+                    vectorLength = 2;
+                    vertexFactory = this::createVector2D;
+                    edgeWeightFunction = this::compute2DPseudoEuclideanDistance;
+                    break;
+
+                default:
+                    throw new IllegalStateException(
+                        "Unsupported EDGE_WEIGHT_TYPE <" + data.edgeWeightType + ">");
+                }
+                break;
+
+            case "NODE_COORD_TYPE":
+                requireNotSet(data.nodeCoordType, "NODE_COORD_TYPE");
+                data.nodeCoordType = getValue(keyValue);
+                break;
+
+            case "NODE_COORD_SECTION":
+                requireNotSet(data.graph, "NODE_COORD_SECTION");
+                if (vertexFactory != null && edgeWeightFunction != null) {
+                    data.hasDistinctLocations = readCompleteNodeGraphData(
+                        graph, reader, vertexFactory, edgeWeightFunction, data.dimension);
+                    data.graph = graph;
+                } else {
+                    throw new IllegalStateException("Missing data to read <NODE_COORD_SECTION>");
+                }
+                break;
+
+            case "TOUR_SECTION":
+                requireNotSet(data.tour, "TOUR_SECTION");
+                data.tour = readTourData(reader, data.dimension);
+                break;
+
+            default:
+                break;
+            }
+        }
+        if (multiLineComment.length() > 0) {
+            data.comment = multiLineComment.toString();
+        }
+        return data;
+    }
+
+    private static String getKey(String[] keyValue)
+    {
+        return keyValue[0].trim().toUpperCase();
+    }
+
+    private String getValue(String[] keyValue)
+    {
+        if (keyValue.length < 2) {
+            throw new IllegalStateException("Missing value for key " + getKey(keyValue));
+        }
+        return keyValue[1].trim();
+    }
+
+    private void requireNotSet(Object target, String keyName)
+    {
+        if (target != null) {
+            throw new IllegalStateException("Multiple values for key " + keyName);
+        }
+    }
+
+    // distance computations
+
+    // all of the following methods are implemented in accordance to
+    // section "2. The distance functions" of TSPLIB95
+
+    /**
+     * Computes the distance of two positions p1 and p2 according to the {@code EUC_2D} or
+     * {@code EUC_3D} metric depending on their dimension. The used metric is also known as L2-norm.
+     * 
+     * @param p1 a two or three dimensional point
+     * @param p2 a two or three dimensional point
+     * @return the {@code EUC_2D} or {@code EUC_3D} edge weight for points p1 and p2
+     */
+    int computeEuclideanDistance(V p1, V p2)
+    { // according to TSPLIB95 distances are rounded to next integer value
+        return (int) Math.round(getL2Distance(p1, p2));
+    }
+
+    /**
+     * Computes the distance of two positions p1 and p2 according to the {@code MAX_2D} or
+     * {@code MAX_3D} metric depending on their dimension. The used metric is also known as
+     * L&infin;-norm.
+     * 
+     * @param p1 a two or three dimensional point
+     * @param p2 a two or three dimensional point
+     * @return the {@code MAX_2D} or {@code MAX_3D} edge weight for points p1 and p2
+     */
+    int computeMaximumDistance(V p1, V p2)
+    { // according to TSPLIB95 distances are rounded to next integer value
+        return (int) Math.round(getLInfDistance(p1, p2));
+    }
+
+    /**
+     * Computes the distance of two positions p1 and p2 according to the {@code MAN_2D} or
+     * {@code MAN_3D} metric depending on their dimension. The used metric is also known as L1-norm.
+     * 
+     * @param p1 a two or three dimensional point
+     * @param p2 a two or three dimensional point
+     * @return the {@code MAN_2D} or {@code MAN_3D} edge weight for points p1 and p2
+     */
+    int computeManhattanDistance(V p1, V p2)
+    { // according to TSPLIB95 distances are rounded to next integer value
+        return (int) Math.round(getL1Distance(p1, p2));
+    }
+
+    /**
+     * Computes the distance of two positions p1 and p2 according to the {@code CEIL_2D} metric, the
+     * round up version of {@code EUC_2D}. The points must have dimension two.
+     * 
+     * @param p1 a two or three dimensional point
+     * @param p2 a two or three dimensional point
+     * @return the {@code CEIL_2D} edge weight for points p1 and p2
+     * @see #computeEuclideanDistance(RealVector, RealVector)
+     */
+    int compute2DCeilingEuclideanDistance(V p1, V p2)
+    {
+        return (int) Math.ceil(getL2Distance(p1, p2));
+    }
+
+    /**
+     * Computes the distance of two positions p1 and p2 according to the {@code GEO} metric. The
+     * used metric computes the distance between two points on a earth-like sphere, while the point
+     * coordinates describe their geographical latitude and longitude. The points must have
+     * dimension two.
+     * 
+     * @param p1 a two or three dimensional point
+     * @param p2 a two or three dimensional point
+     * @return the {@code GEO} edge weight for points p1 and p2
+     */
+    int compute2DGeographicalDistance(V p1, V p2)
+    {
+        double latitude1 = computeRadiansAngle(elementGetter.getElement(p1, 0));
+        double longitude1 = computeRadiansAngle(elementGetter.getElement(p1, 1));
+
+        double latitude2 = computeRadiansAngle(elementGetter.getElement(p2, 0));
+        double longitude2 = computeRadiansAngle(elementGetter.getElement(p2, 1));
+
+        double q1 = Math.cos(longitude1 - longitude2);
+        double q2 = Math.cos(latitude1 - latitude2);
+        double q3 = Math.cos(latitude1 + latitude2);
+        return (int) (RRR * Math.acos(0.5 * ((1.0 + q1) * q2 - (1.0 - q1) * q3)) + 1.0);
+    }
+
+    static final double PI = 3.141592; // constants according to TSPLIB95
+    static final double RRR = 6378.388; // constants according to TSPLIB95
+
+    private static double computeRadiansAngle(double x)
+    { // computation according to TSPLIB95 chapter 2.4 - Geographical distance
+      // First computes decimal angle from degrees and minutes, then converts it into radian
+        double deg = Math.round(x);
+        double min = x - deg;
+        return PI * (deg + 5.0 * min / 3.0) / 180.0;
+    }
+
+    /**
+     * Computes the distance of two positions p1 and p2 according to the {@code ATT} metric. The
+     * points must have dimension two.
+     * 
+     * @param p1 a two or three dimensional point
+     * @param p2 a two or three dimensional point
+     * @return the {@code ATT} edge weight for points p1 and p2
+     */
+    int compute2DPseudoEuclideanDistance(V p1, V p2)
+    {
+        double xd = elementGetter.getElement(p1, 0) - elementGetter.getElement(p2, 0);
+        double yd = elementGetter.getElement(p1, 1) - elementGetter.getElement(p2, 1);
+        double rij = Math.sqrt((xd * xd + yd * yd) / 10.0);
+        double tij = Math.round(rij);
+        if (tij < rij) {
+            return (int) (tij + 1);
+        } else {
+            return (int) tij;
+        }
+    }
+
+    private double getL1Distance(V p1, V p2)
+    {
+        double elementSum = 0;
+        for (int i = 0; i < vectorLength; i++) {
+            double delta = elementGetter.getElement(p1, i) - elementGetter.getElement(p2, i);
+            elementSum += Math.abs(delta);
+        }
+        return elementSum;
+    }
+
+    private double getL2Distance(V p1, V p2)
+    {
+        double elementSum = 0;
+        for (int i = 0; i < vectorLength; i++) {
+            double delta = elementGetter.getElement(p1, i) - elementGetter.getElement(p2, i);
+            elementSum += delta * delta;
+        }
+        return Math.sqrt(elementSum);
+    }
+
+    private double getLInfDistance(V p1, V p2)
+    {
+        double maxElement = 0;
+        for (int i = 0; i < vectorLength; i++) {
+            double delta = elementGetter.getElement(p1, i) - elementGetter.getElement(p2, i);
+            maxElement = Math.max(maxElement, Math.abs(delta));
+        }
+        return maxElement;
+    }
+
+    // node build
+
+    private V createVector2D(String line)
+    {
+        String[] elements = splitLineElements(line, 3);
+        // index of the point in elements[0] is not necessary
+        double x = Double.parseDouble(elements[1]);
+        double y = Double.parseDouble(elements[2]);
+        return vectorFactory.apply(new double[] { x, y });
+    }
+
+    private V createVector3D(String line)
+    {
+        String[] elements = splitLineElements(line, 4);
+        // index of the point in elements[0] is not necessary
+        double x = Double.parseDouble(elements[1]);
+        double y = Double.parseDouble(elements[2]);
+        double z = Double.parseDouble(elements[3]);
+        return vectorFactory.apply(new double[] { x, y, z });
+    }
+
+    private static String[] splitLineElements(String line, int expectedLineElements)
+    {
+        String[] elements = line.split(" ");
+        if (elements.length != expectedLineElements) {
+            throw new IllegalArgumentException(
+                "Unexpected number of line elements: " + elements.length + " in line: " + line);
+        }
+        return elements;
+    }
+
+    // read of coordinates and graph computation
+
+    /**
+     * Read the complete {@link Graph} of node locations and returns true if all locations are
+     * distinct.
+     */
+    private boolean readCompleteNodeGraphData(
+        Graph<V, DefaultWeightedEdge> graph, BufferedReader reader,
+        Function<String, V> vectorFactory, ToIntBiFunction<V, V> edgeWeightFunction,
+        Integer dimension)
+        throws IOException
+    {
+        List<V> nodeCoordinates = readNodeCoordinateData(reader, vectorFactory, dimension);
+
+        buildCompleteGraph(graph, nodeCoordinates, edgeWeightFunction);
+        return graph.vertexSet().size() == nodeCoordinates.size();
+    }
+
+    private List<V> readNodeCoordinateData(
+        BufferedReader reader, Function<String, V> vectorFactory, Integer dimension)
+        throws IOException
+    {
+        List<V> coordinates = dimension != null ? new ArrayList<>(dimension) : new ArrayList<>();
+
+        for (String line; (line = reader.readLine()) != null;) {
+            String lineContent = line.trim();
+            if ("EOF".equals(lineContent)) {
+                break;
+            }
+            coordinates.add(vectorFactory.apply(lineContent));
+        }
+        return coordinates;
+    }
+
+    private static <V, E> void buildCompleteGraph(
+        Graph<V, E> graph, List<V> locations, ToIntBiFunction<V, V> edgeWeightFunction)
+    {
+        locations.forEach(graph::addVertex);
+
+        new CompleteGraphGenerator<V, E>().generateGraph(graph, null);
+
+        // Compute edge weights:
+        // Enable parallel streams. Synchronization not necessary, because DefaultWeightedEdge are
+        // IntrusiveEdges and modified directly.
+
+        graph.edgeSet().parallelStream().forEach(e -> {
+            V s = graph.getEdgeSource(e);
+            V t = graph.getEdgeTarget(e);
+            double weight = edgeWeightFunction.applyAsInt(s, t);
+            graph.setEdgeWeight(e, weight);
+        });
+    }
+
+    private List<Integer> readTourData(BufferedReader reader, Integer dimension)
+        throws IOException
+    {
+        List<Integer> tour = dimension != null ? new ArrayList<>(dimension) : new ArrayList<>();
+
+        for (String line; (line = reader.readLine()) != null;) {
+            String lineContent = line.trim();
+            if ("-1".equals(lineContent)) {
+                break;
+            }
+            tour.add(Integer.valueOf(lineContent));
+        }
+        return tour;
+    }
+}

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * TSPLIB95 importers/exporters
+ */
+package org.jgrapht.nio.tsplib;

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/tsplib/TSPLIBImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/tsplib/TSPLIBImporterTest.java
@@ -1,0 +1,557 @@
+/*
+ * (C) Copyright 2020-2020, by Hannes Wellmann and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
+package org.jgrapht.nio.tsplib;
+
+import static org.junit.Assert.*;
+
+import java.io.*;
+import java.text.*;
+import java.util.*;
+import java.util.stream.*;
+
+import org.apache.commons.lang3.mutable.*;
+import org.jgrapht.*;
+import org.jgrapht.graph.*;
+import org.jgrapht.nio.tsplib.TSPLIBImporter.*;
+import org.junit.*;
+import org.junit.rules.*;
+
+public class TSPLIBImporterTest
+{
+
+    private static String get3DPointsFileContent(String edgeWeightType)
+    {
+        StringJoiner c = new StringJoiner(System.lineSeparator());
+        c.add("NAME : theNameOfThisFile");
+        c.add("COMMENT : The first line of the comment");
+        c.add("COMMENT : A second line");
+        c.add("TYPE : TSP");
+        c.add("DIMENSION : 4");
+        c.add("EDGE_WEIGHT_TYPE : " + edgeWeightType);
+        c.add("NODE_COORD_TYPE : THREED_COORDS");
+        c.add("NODE_COORD_SECTION");
+        c.add("1 10.0 15.0 3.7");
+        c.add("2 14.0 15.0 3.7");
+        c.add("3 14.0 20.0 3.7");
+        c.add("4 14.0 20.0 3.7");
+        return c.toString();
+    }
+
+    private static String get2DPointsFileContent(String edgeWeightType)
+    {
+        StringJoiner c = new StringJoiner(System.lineSeparator());
+        c.add("NAME : theNameOfThisFile");
+        c.add("COMMENT : The first line of the comment");
+        c.add("COMMENT : A second line");
+        c.add("TYPE : TSP");
+        c.add("DIMENSION : 4");
+        c.add("EDGE_WEIGHT_TYPE : " + edgeWeightType);
+        c.add("NODE_COORD_TYPE : TWOD_COORDS");
+        c.add("NODE_COORD_SECTION");
+        c.add("1 10.2 15.0");
+        c.add("2 14.2 15.0");
+        c.add("3 14.8 20.0");
+        c.add("4 10.8 20.0");
+        c.add("EOF");
+        return c.toString();
+    }
+
+    private static class ArrayVector
+    {
+        private final int index;
+        private final double[] elements;
+
+        public ArrayVector(int index, double... elements)
+        {
+            this.index = index;
+            this.elements = elements;
+        }
+
+        public ArrayVector(double... elements)
+        {
+            this(-1, elements);
+        }
+
+        public double getElementValue(int i)
+        {
+            return elements[i];
+        }
+
+        @Override
+        public int hashCode()
+        {
+            return 31 + Arrays.hashCode(elements);
+        }
+
+        @Override
+        public boolean equals(Object obj)
+        {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof ArrayVector)) {
+                return false;
+            }
+            return Arrays.equals(elements, ((ArrayVector) obj).elements);
+        }
+
+        private static DecimalFormat indexFormat = new DecimalFormat("0000");
+        private static DecimalFormat coordinateFormat =
+            new DecimalFormat("0.00", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+
+        @Override
+        public String toString()
+        {
+            String indexStr = index >= 0 ? indexFormat.format(index) + " " : "";
+            return indexStr + Arrays
+                .stream(elements).mapToObj(coordinateFormat::format)
+                .collect(Collectors.joining(" "));
+        }
+    }
+
+    private static List<ArrayVector> getExpected2DPoints()
+    {
+        return Arrays
+            .asList(vector(10.2, 15.0), vector(14.2, 15.0), vector(14.8, 20.0), vector(10.8, 20.0));
+    }
+
+    private static List<ArrayVector> getExpected3DPoints()
+    {
+        return Arrays
+            .asList(
+                vector(10.0, 15.0, 3.7), vector(14.0, 15.0, 3.7), vector(14.0, 20.0, 3.7),
+                vector(14.0, 20.0, 3.7));
+    }
+
+    private static ArrayVector vector(double... elements)
+    {
+        return new ArrayVector(elements);
+    }
+
+    /** Assert content equal graphs */
+    private static <V, E> void assertEqualGraphs(Graph<V, E> expectedGraph, Graph<V, E> actualGraph)
+    {
+        assertEquals(actualGraph.vertexSet(), expectedGraph.vertexSet());
+
+        Set<E> actualEdgeSet = actualGraph.edgeSet();
+        Set<E> expectedEdgeSet = expectedGraph.edgeSet();
+        assertEquals("Unequal edgeSet size", expectedEdgeSet.size(), actualEdgeSet.size());
+
+        for (E expectedEdge : expectedEdgeSet) {
+
+            E actualEdge = actualGraph
+                .getEdge(
+                    expectedGraph.getEdgeSource(expectedEdge),
+                    expectedGraph.getEdgeTarget(expectedEdge));
+
+            assertTrue(actualEdge != null);
+
+            assertEquals(
+                expectedGraph.getEdgeWeight(expectedEdge), actualGraph.getEdgeWeight(actualEdge),
+                1e-5);
+        }
+    }
+
+    // ----------------------------------------------------------------------
+    // Tests
+
+    @Test
+    public void testTSPLIBFileDataValues()
+    {
+        String fileContent = get3DPointsFileContent("EUC_3D");
+
+        TSPLIBImporter<ArrayVector> importer =
+            new TSPLIBImporter<>(ArrayVector::new, ArrayVector::getElementValue);
+        importer
+            .importGraph(
+                new SimpleWeightedGraph<>(null, DefaultWeightedEdge::new),
+                new StringReader(fileContent));
+        TSPLIBFileData<ArrayVector> fileData = importer.getLastImportData();
+
+        assertEquals("theNameOfThisFile", fileData.getName());
+        assertEquals("TSP", fileData.getType());
+        assertEquals(
+            "The first line of the comment" + System.lineSeparator() + "A second line",
+            fileData.getComment());
+        assertEquals(Integer.valueOf(4), fileData.getDimension());
+        assertEquals("EUC_3D", fileData.getEdgeWeightType());
+        assertEquals("THREED_COORDS", fileData.getNodeCoordType());
+
+        assertFalse(fileData.hasDistinctVertices());
+        assertTrue(fileData.hasDistinctEdgesPerVertex());
+    }
+
+    // edge weight functions tests
+
+    @Test
+    public void testImportGraph_EUC2DEdgeWeightType()
+    {
+        List<ArrayVector> vertices = getExpected2DPoints();
+        Graph<ArrayVector, DefaultWeightedEdge> expectedGraph = getExpectedGraph(vertices);
+
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(1), 4.);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(2), 7.); // round sqrt(46.16)
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(3), 5.); // round sqrt(25.36)
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(2), 5.); // round sqrt(25.36)
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(3), 6.); // round sqrt(36.56)
+        Graphs.addEdge(expectedGraph, vertices.get(2), vertices.get(3), 4.);
+
+        TSPLIBFileData<ArrayVector> fileData = importFile(get2DPointsFileContent("EUC_2D"));
+
+        // Check weights and complete connection
+        assertEqualGraphs(expectedGraph, fileData.getGraph());
+
+        assertTrue(fileData.hasDistinctVertices());
+        assertTrue(fileData.hasDistinctEdgesPerVertex());
+    }
+
+    @Test
+    public void testImportGraph_EUC3DEdgeWeightType()
+    {
+        List<ArrayVector> vertices = getExpected3DPoints();
+        Graph<ArrayVector, DefaultWeightedEdge> expectedGraph = getExpectedGraph(vertices);
+
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(1), 4.);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(2), 6.); // round sqrt(41)
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(2), 5.);
+
+        TSPLIBFileData<ArrayVector> fileData = importFile(get3DPointsFileContent("EUC_3D"));
+
+        // Check weights
+        assertEqualGraphs(expectedGraph, fileData.getGraph());
+
+        assertFalse(fileData.hasDistinctVertices());
+        assertTrue(fileData.hasDistinctEdgesPerVertex());
+
+    }
+
+    @Test
+    public void testImportGraph_MAX2DEdgeWeightType()
+    {
+        List<ArrayVector> vertices = getExpected2DPoints();
+        Graph<ArrayVector, DefaultWeightedEdge> expectedGraph = getExpectedGraph(vertices);
+
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(1), 4.);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(2), 5.);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(3), 5.);
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(2), 5.);
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(3), 5.);
+        Graphs.addEdge(expectedGraph, vertices.get(2), vertices.get(3), 4.);
+
+        TSPLIBFileData<ArrayVector> fileData = importFile(get2DPointsFileContent("MAX_2D"));
+
+        // Check weights
+        assertEqualGraphs(expectedGraph, fileData.getGraph());
+
+        assertTrue(fileData.hasDistinctVertices());
+        assertFalse(fileData.hasDistinctEdgesPerVertex());
+
+    }
+
+    @Test
+    public void testImportGraph_MAX3DEdgeWeightType()
+    {
+        List<ArrayVector> vertices = getExpected3DPoints();
+        Graph<ArrayVector, DefaultWeightedEdge> expectedGraph = getExpectedGraph(vertices);
+
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(1), 4.);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(2), 5.);
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(2), 5.);
+
+        TSPLIBFileData<ArrayVector> fileData = importFile(get3DPointsFileContent("MAX_3D"));
+
+        // Check weights
+        assertEqualGraphs(expectedGraph, fileData.getGraph());
+
+        assertFalse(fileData.hasDistinctVertices());
+        assertFalse(fileData.hasDistinctEdgesPerVertex());
+
+    }
+
+    @Test
+    public void testImportGraph_MAN2DEdgeWeightType()
+    {
+        List<ArrayVector> vertices = getExpected2DPoints();
+        Graph<ArrayVector, DefaultWeightedEdge> expectedGraph = getExpectedGraph(vertices);
+
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(1), 4.);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(2), 10.0);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(3), 6.);
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(2), 6.);
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(3), 8.);
+        Graphs.addEdge(expectedGraph, vertices.get(2), vertices.get(3), 4.);
+
+        TSPLIBFileData<ArrayVector> fileData = importFile(get2DPointsFileContent("MAN_2D"));
+
+        // Check weights
+        assertEqualGraphs(expectedGraph, fileData.getGraph());
+
+        assertTrue(fileData.hasDistinctVertices());
+        assertTrue(fileData.hasDistinctEdgesPerVertex());
+
+    }
+
+    @Test
+    public void testImportGraph_MAN3DEdgeWeightType()
+    {
+        List<ArrayVector> vertices = getExpected3DPoints();
+        Graph<ArrayVector, DefaultWeightedEdge> expectedGraph = getExpectedGraph(vertices);
+
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(1), 4.);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(2), 9.);
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(2), 5.);
+
+        TSPLIBFileData<ArrayVector> fileData = importFile(get3DPointsFileContent("MAN_3D"));
+
+        // Check weights
+        assertEqualGraphs(expectedGraph, fileData.getGraph());
+
+        assertFalse(fileData.hasDistinctVertices());
+        assertTrue(fileData.hasDistinctEdgesPerVertex());
+    }
+
+    @Test
+    public void testImportGraph_CEIL2DEdgeWeightType()
+    {
+        List<ArrayVector> vertices = getExpected2DPoints();
+        Graph<ArrayVector, DefaultWeightedEdge> expectedGraph = getExpectedGraph(vertices);
+
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(1), 4.);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(2), 7.); // round sqrt(46.16)
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(3), 6.); // round sqrt(25.36)
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(2), 6.); // round sqrt(25.36)
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(3), 7.); // round sqrt(36.56)
+        Graphs.addEdge(expectedGraph, vertices.get(2), vertices.get(3), 4.);
+
+        TSPLIBFileData<ArrayVector> fileData = importFile(get2DPointsFileContent("CEIL_2D"));
+
+        // Check weights and complete connection
+        assertEqualGraphs(expectedGraph, fileData.getGraph());
+
+        assertTrue(fileData.hasDistinctVertices());
+        assertTrue(fileData.hasDistinctEdgesPerVertex());
+    }
+
+    @Test
+    public void testImportGraph_GEOEdgeWeightType()
+    {
+        List<ArrayVector> vertices = getExpected2DPoints();
+        Graph<ArrayVector, DefaultWeightedEdge> expectedGraph = getExpectedGraph(vertices);
+
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(1), 446);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(2), 727);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(3), 549);
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(2), 541);
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(3), 680);
+        Graphs.addEdge(expectedGraph, vertices.get(2), vertices.get(3), 446);
+
+        TSPLIBFileData<ArrayVector> fileData = importFile(get2DPointsFileContent("GEO"));
+
+        // Check weights and complete connection
+        assertEqualGraphs(expectedGraph, fileData.getGraph());
+
+        assertTrue(fileData.hasDistinctVertices());
+        assertTrue(fileData.hasDistinctEdgesPerVertex());
+    }
+
+    @Test
+    public void testCompute2DGeographicalDistance()
+    {
+        MutableInt index = new MutableInt(0);
+        TSPLIBImporter<ArrayVector> importer = new TSPLIBImporter<>(
+            e -> new ArrayVector(index.getAndIncrement(), e), ArrayVector::getElementValue);
+
+        int halfCircleCircumfence = (int) (TSPLIBImporter.PI * TSPLIBImporter.RRR);
+        int quarterCircleCircumfence = (int) (TSPLIBImporter.PI * TSPLIBImporter.RRR / 2);
+
+        int d0 = importer.compute2DGeographicalDistance(vector(0.0, 0.0), vector(0.0, 90.0));
+        assertEquals(quarterCircleCircumfence, d0, 1.0);
+
+        int d1 = importer.compute2DGeographicalDistance(vector(23.0, 15.0), vector(-23.0, 105.0));
+        assertEquals(10997, d1, 1.0);
+
+        int d2 = importer.compute2DGeographicalDistance(vector(0.0, -90.2), vector(0.0, 89.8));
+        assertEquals(halfCircleCircumfence, d2, 1.0);
+
+        int d3 = importer.compute2DGeographicalDistance(vector(20.0, -90.7), vector(-20.0, 89.3));
+        assertEquals(halfCircleCircumfence, d3, 1.0);
+
+        int d4 = importer.compute2DGeographicalDistance(vector(20.0, -70.0), vector(-20.0, 110.0));
+        assertEquals(halfCircleCircumfence, d4, 1.0);
+
+        int d5 = importer.compute2DGeographicalDistance(vector(40.48, -74.0), vector(52.3, 13.24));
+        assertEquals(6386, d5, 1.0);
+
+        int d6 =
+            importer.compute2DGeographicalDistance(vector(1.48, 113.24), vector(-6.36, -65.24));
+        assertEquals(19488, d6, 1.0);
+    }
+
+    @Test
+    public void testImportGraph_ATTEdgeWeightType()
+    {
+        List<ArrayVector> vertices = getExpected2DPoints();
+        Graph<ArrayVector, DefaultWeightedEdge> expectedGraph = getExpectedGraph(vertices);
+
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(1), 2.);
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(2), 3.); // round sqrt(46.16)
+        Graphs.addEdge(expectedGraph, vertices.get(0), vertices.get(3), 2.); // round sqrt(25.36)
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(2), 2.); // round sqrt(25.36)
+        Graphs.addEdge(expectedGraph, vertices.get(1), vertices.get(3), 2.); // round sqrt(36.56)
+        Graphs.addEdge(expectedGraph, vertices.get(2), vertices.get(3), 2.);
+
+        TSPLIBFileData<ArrayVector> fileData = importFile(get2DPointsFileContent("ATT"));
+
+        // Check weights and complete connection
+        assertEqualGraphs(expectedGraph, fileData.getGraph());
+
+        assertTrue(fileData.hasDistinctVertices());
+        assertFalse(fileData.hasDistinctEdgesPerVertex());
+    }
+
+    // exception tests
+
+    @Rule
+    public final ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void testImportGraph_NotSupportedEdgeWeightType_IllegalStateException()
+    {
+        String fileContent = "EDGE_WEIGHT_TYPE : XRAY1";
+
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("Unsupported EDGE_WEIGHT_TYPE <XRAY1>");
+
+        importFile(fileContent);
+    }
+
+    @Test
+    public void testImportGraph_OnlyNodeCoordSection_IllegalStateException()
+    {
+        StringJoiner c = new StringJoiner(System.lineSeparator());
+        c.add("NODE_COORD_SECTION");
+        c.add("1 10.2 15.0");
+        c.add("2 14.2 15.0");
+
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("Missing data to read <NODE_COORD_SECTION>");
+
+        importFile(c.toString());
+    }
+
+    @Test
+    public void testImportGraph_MissingValue_IllegalStateException()
+    {
+        String fileContent = "NAME : ";
+
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("Missing value for key NAME");
+
+        importFile(fileContent);
+    }
+
+    @Test
+    public void testImportGraph_MultipleValues_IllegalStateException()
+    {
+        StringJoiner c = new StringJoiner(System.lineSeparator());
+        c.add("TYPE : TSP");
+        c.add("TYPE : TSP");
+
+        thrown.expect(IllegalStateException.class);
+        thrown.expectMessage("Multiple values for key TYPE");
+
+        importFile(c.toString());
+    }
+
+    @Test
+    public void testImportGraph_WrongNodeCoordinateElementCount_IllegalArgumentException()
+    {
+        StringJoiner c = new StringJoiner(System.lineSeparator());
+        c.add("EDGE_WEIGHT_TYPE : EUC_3D");
+        c.add("NODE_COORD_SECTION");
+        c.add("1 10.2 15.0");
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Unexpected number of line elements: 3 in line: 1 10.2 15.0");
+
+        importFile(c.toString());
+    }
+
+    @Test
+    public void testImportGraph_ProvidePseudograph_IllegalArgumentException()
+    {
+        Graph<ArrayVector, DefaultWeightedEdge> graph =
+            new Pseudograph<>(null, DefaultWeightedEdge::new, true);
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Provided graph must be empty and must have simple weighted type");
+
+        new TSPLIBImporter<>(ArrayVector::new, ArrayVector::getElementValue)
+            .importGraph(graph, new StringReader(""));
+    }
+
+    @Test
+    public void testImportGraph_ProvideSimpleNotWeightedGraph_IllegalArgumentException()
+    {
+        Graph<ArrayVector, DefaultWeightedEdge> graph =
+            new SimpleGraph<>(null, DefaultWeightedEdge::new, false);
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Provided graph must be empty and must have simple weighted type");
+
+        new TSPLIBImporter<>(ArrayVector::new, ArrayVector::getElementValue)
+            .importGraph(graph, new StringReader(""));
+    }
+
+    @Test
+    public void testImportGraph_ProvideNotEmptySimpleWeightedGraph_IllegalArgumentException()
+    {
+        Graph<ArrayVector, DefaultWeightedEdge> graph =
+            new SimpleWeightedGraph<>(null, DefaultWeightedEdge::new);
+        graph.addVertex(new ArrayVector(0, 0, 0));
+
+        thrown.expect(IllegalArgumentException.class);
+        thrown.expectMessage("Provided graph must be empty and must have simple weighted type");
+
+        new TSPLIBImporter<>(ArrayVector::new, ArrayVector::getElementValue)
+            .importGraph(graph, new StringReader(""));
+    }
+
+    // utility methods
+
+    private static TSPLIBFileData<ArrayVector> importFile(String fileContent)
+    {
+        TSPLIBImporter<ArrayVector> importer =
+            new TSPLIBImporter<>(ArrayVector::new, ArrayVector::getElementValue);
+
+        importer.importGraph(null, new StringReader(fileContent));
+
+        return importer.getLastImportData();
+    }
+
+    private static Graph<ArrayVector, DefaultWeightedEdge> getExpectedGraph(
+        List<ArrayVector> vertices)
+    {
+        Graph<ArrayVector, DefaultWeightedEdge> expectedGraph =
+            new SimpleWeightedGraph<>(null, DefaultWeightedEdge::new);
+        Graphs.addAllVertices(expectedGraph, vertices);
+
+        return expectedGraph;
+    }
+}


### PR DESCRIPTION
I created an importer to read symmetric `travelling salesman problem` instances from files in the `TSPLIB95` format.
Files in TSPLIB95 format contain exactly defined TSP instances. As stated in the Javadoc of the importer there are large TSPLIB95 libraries containing problem instances of different magnitudes provided by the University of [Heidelberg](http://comopt.ifi.uni-heidelberg.de/software/TSPLIB95/) or [Waterloo](http://www.math.uwaterloo.ca/tsp/data/index.html).

The instances provided there can be used as unified benchmarks or tests for TSP algorithms. 
Additionally the importer could be used to improve the tests of JGraphT's TSP algorithms. At the moment some tests use randomly created instances that are therefore different for each test run. Such instances could be stored in a TSPLIB95 file and then load each time the test is executed to have the same instance every time. Also TSP test instances with special properties could be defined to test certain aspects or corner cases of an algorithm.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
