### PR TITLE
Bring back old functionality of vertex factory

### DIFF
--- a/jgrapht-io/src/test/java/org/jgrapht/nio/dot/DOTImporter2Test.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/dot/DOTImporter2Test.java
@@ -272,6 +272,34 @@ public class DOTImporter2Test
     }
 
     @Test
+    public void testDOT5()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "digraph {" + NL +
+                       "  a -- b -- c;" + NL +
+                       "  k:1 -- q:a:3 -- d:3;" + NL +
+                       "}";
+        // @formatter:on
+
+        DOTImporter<String, DefaultEdge> importer = new DOTImporter<>();
+        importer.setVertexFactory(id->id);
+        DirectedPseudograph<String, DefaultEdge> graph = new DirectedPseudograph<>(
+            SupplierUtil.createStringSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        importer.importGraph(graph, new StringReader(input));
+
+        DirectedPseudograph<String, DefaultEdge> expected = new DirectedPseudograph<>(
+            SupplierUtil.createStringSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        Graphs.addAllVertices(expected, Arrays.asList("a", "b", "c", "k", "q", "d"));
+        expected.addEdge("a", "b");
+        expected.addEdge("b", "c");
+        expected.addEdge("k", "q");
+        expected.addEdge("q", "d");
+
+        assertEquals(expected.toString(), graph.toString());
+    }
+    
+    @Test
     public void testNodeSubgraphEdges()
         throws ImportException
     {


### PR DESCRIPTION
Gives back the ability to override vertex creation in `DOTImporter`.

The new importers rely on graph vertex suppliers for vertex creation. As Joris pointed out in the project's group, some users want to read for example DOT files and retain the vertex identifiers as vertices.

This PR adds a property in the `DOTImporter` which allows the user to bypass the vertex supplier and rely on a vertex factory.

Before merging, we should discuss
  - do we want such a behavior
  - are the names ok?
  - is the documentation clear?
  - should we add similar functionality to other importers? (at least when it makes sense)

My opinion is that this functionality is somewhat intuitive and while not strictly necessary (since we are returning the original ID as an attribute) it is a nice to have feature.

Note that our new importers allow advanced users to perform almost anything with the graph, since they can use the `DOTEventDrivenImporter` to parse the input and build the graph themselves. However, reading a graph with 4-5 lines of code is also something we want to support.

----
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
