### PR TITLE
Added support for vertex factory on all importers.

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
@@ -79,7 +79,7 @@ public class BreadthFirstIterator<V, E>
     }
 
     /**
-     * @see CrossComponentIterator#isConnectedComponentExhausted()
+     * {@inheritDoc}
      */
     @Override
     protected boolean isConnectedComponentExhausted()
@@ -88,7 +88,7 @@ public class BreadthFirstIterator<V, E>
     }
 
     /**
-     * @see CrossComponentIterator#encounterVertex(Object, Object)
+     * {@inheritDoc}
      */
     @Override
     protected void encounterVertex(V vertex, E edge)
@@ -100,7 +100,7 @@ public class BreadthFirstIterator<V, E>
     }
 
     /**
-     * @see CrossComponentIterator#encounterVertexAgain(Object, Object)
+     * {@inheritDoc}
      */
     @Override
     protected void encounterVertexAgain(V vertex, E edge)
@@ -164,14 +164,32 @@ public class BreadthFirstIterator<V, E>
         return queue.removeFirst();
     }
 
+    /**
+     * Data kept for discovered vertices.
+     *
+     * @param <E> the graph edge type
+     */
     protected static class SearchNodeData<E>
     {
-
         private final E edge;
         private final int depth;
 
         /**
+         * Constructor
+         * 
+         * @param edge edge to parent
+         * @param depth depth of node in search tree
+         */
+        public SearchNodeData(E edge, int depth)
+        {
+            this.edge = edge;
+            this.depth = depth;
+        }
+
+        /**
          * Edge to parent
+         * 
+         * @return the edge to the parent
          */
         public E getEdge()
         {
@@ -180,20 +198,12 @@ public class BreadthFirstIterator<V, E>
 
         /**
          * Depth of node in search tree
+         * 
+         * @return the depth of the node in the search tree
          */
         public int getDepth()
         {
             return depth;
-        }
-
-        /**
-         * @param edge  Edge to parent
-         * @param depth Depth of node in search tree
-         */
-        public SearchNodeData(E edge, int depth)
-        {
-            this.edge = edge;
-            this.depth = depth;
         }
     }
 }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTImporter.java
@@ -47,9 +47,10 @@ import java.util.function.*;
  * multiple times.
  * 
  * <p>
- * The user can also bypass vertex creation by providing a custom vertex factory method using
- * {@link #setVertexFactory(Function)}. The factory receives the vertex identifier and should
- * provide a graph vertex.
+ * The default behavior of the importer is to use the graph vertex supplier in order to create
+ * vertices. The user can also bypass vertex creation by providing a custom vertex factory method
+ * using {@link #setVertexFactory(Function)}. The factory method is responsible to create a new
+ * graph vertex given the vertex identifier read from file.
  *
  * @author Dimitrios Michail
  *
@@ -62,7 +63,10 @@ public class DOTImporter<V, E>
     implements
     GraphImporter<V, E>
 {
-    private static final String DEFAULT_VERTEX_ID_KEY = "ID";
+    /**
+     * Default key used for vertex ID.
+     */
+    public static final String DEFAULT_VERTEX_ID_KEY = "ID";
 
     private Function<String, V> vertexFactory;
 
@@ -84,9 +88,6 @@ public class DOTImporter<V, E>
         genericImporter.addEdgeConsumer(consumers.edgeConsumer);
         genericImporter.addEdgeAttributeConsumer(consumers.edgeAttributeConsumer);
         genericImporter.addGraphAttributeConsumer(consumers.graphAttributeConsumer);
-        if (vertexFactory != null) {
-            consumers.vertexFactory = vertexFactory;
-        }
         genericImporter.importInput(input);
     }
 
@@ -105,8 +106,9 @@ public class DOTImporter<V, E>
      * Set the user custom vertex factory. The default behavior is being null in which case the
      * graph vertex supplier is used.
      * 
-     * The vertex factory will receive as input the vertex identifier from the input and return a
-     * graph vertex.
+     * If supplied the vertex factory is called every time a new vertex is encountered in the file.
+     * The method is called with parameter the vertex identifier from the file and should return the
+     * actual graph vertex to add to the graph.
      * 
      * @param vertexFactory a vertex factory
      */
@@ -117,12 +119,10 @@ public class DOTImporter<V, E>
 
     private class Consumers
     {
-
         private Graph<V, E> graph;
         private Map<String, V> map;
         private Pair<String, String> lastPair;
         private E lastEdge;
-        public Function<String, V> vertexFactory;
 
         public Consumers(Graph<V, E> graph)
         {

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/graphml/GraphMLImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/graphml/GraphMLImporter.java
@@ -106,6 +106,18 @@ import java.util.function.*;
  * <a href="http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">GraphML Schema</a>. The user can
  * (not recommended) disable the validation by calling {@link #setSchemaValidation(boolean)}.
  *
+ * <p>
+ * The graph vertices and edges are build using the corresponding graph suppliers. The id of the
+ * vertices in the original dot file are reported as a vertex attribute named "ID". Thus, in case
+ * vertices in the dot file also contain an "ID" attribute, such an attribute will be reported
+ * multiple times.
+ * 
+ * <p>
+ * The default behavior of the importer is to use the graph vertex supplier in order to create
+ * vertices. The user can also bypass vertex creation by providing a custom vertex factory method
+ * using {@link #setVertexFactory(Function)}. The factory method is responsible to create a new
+ * graph vertex given the vertex identifier read from file.
+ * 
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
  * 
@@ -117,13 +129,16 @@ public class GraphMLImporter<V, E>
     implements
     GraphImporter<V, E>
 {
-    private static final String DEFAULT_VERTEX_ID_KEY = "ID";
+    /**
+     * Default key used for vertex ID.
+     */
+    public static final String DEFAULT_VERTEX_ID_KEY = "ID";
 
     // special attributes
     private static final String EDGE_WEIGHT_DEFAULT_ATTRIBUTE_NAME = "weight";
     private String edgeWeightAttributeName = EDGE_WEIGHT_DEFAULT_ATTRIBUTE_NAME;
-
     private boolean schemaValidation;
+    private Function<String, V> vertexFactory;
 
     /**
      * Constructs a new importer.
@@ -174,6 +189,32 @@ public class GraphMLImporter<V, E>
     public void setSchemaValidation(boolean schemaValidation)
     {
         this.schemaValidation = schemaValidation;
+    }
+
+    /**
+     * Get the user custom vertex factory. This is null by default and the graph supplier is used
+     * instead.
+     * 
+     * @return the user custom vertex factory
+     */
+    public Function<String, V> getVertexFactory()
+    {
+        return vertexFactory;
+    }
+
+    /**
+     * Set the user custom vertex factory. The default behavior is being null in which case the
+     * graph vertex supplier is used.
+     * 
+     * If supplied the vertex factory is called every time a new vertex is encountered in the file.
+     * The method is called with parameter the vertex identifier from the file and should return the
+     * actual graph vertex to add to the graph.
+     * 
+     * @param vertexFactory a vertex factory
+     */
+    public void setVertexFactory(Function<String, V> vertexFactory)
+    {
+        this.vertexFactory = vertexFactory;
     }
 
     /**
@@ -280,7 +321,12 @@ public class GraphMLImporter<V, E>
         {
             V vertex = nodesMap.get(vId);
             if (vertex == null) {
-                vertex = graph.addVertex();
+                if (vertexFactory != null) {
+                    vertex = vertexFactory.apply(vId);
+                    graph.addVertex(vertex);
+                } else {
+                    vertex = graph.addVertex();
+                }
                 nodesMap.put(vId, vertex);
             }
             return vertex;

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/gml/GmlImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/gml/GmlImporterTest.java
@@ -145,6 +145,40 @@ public class GmlImporterTest
     }
 
     @Test
+    public void testVertexFactory()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "graph [\n"
+                     + "  directed 1\n"
+                     + "  node [\n"
+                     + "    id 1\n"
+                     + "  ]\n"
+                     + "  node [\n"
+                     + "    id 8\n"
+                     + "  ]\n"
+                     + "]";
+        // @formatter:on
+
+        Graph<String, DefaultEdge> g;
+        g = GraphTypeBuilder
+                .directed().weighted(false).allowingSelfLoops(true).allowingMultipleEdges(true)
+                .edgeSupplier(SupplierUtil.DEFAULT_EDGE_SUPPLIER)
+                .vertexSupplier(SupplierUtil.createStringSupplier(1))
+                .buildGraph();
+
+        GmlImporter<String, DefaultEdge> importer = new GmlImporter<>();
+        importer.setVertexFactory(id->String.valueOf(id+100));
+        
+        importer.importGraph(g, new StringReader(input));
+        
+        assertEquals(2, g.vertexSet().size());
+        assertEquals(0, g.edgeSet().size());
+        assertTrue(g.containsVertex("101"));
+        assertTrue(g.containsVertex("108"));
+    }
+    
+    @Test
     public void testIgnore()
         throws ImportException
     {

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/graphml/GraphMLImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/graphml/GraphMLImporterTest.java
@@ -75,6 +75,48 @@ public class GraphMLImporterTest
     }
 
     @Test
+    public void testVertexFactory()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL +  
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String,
+            DefaultEdge> g = GraphTypeBuilder
+                .undirected().weighted(false).allowingMultipleEdges(true).allowingSelfLoops(true)
+                .vertexSupplier(SupplierUtil.createStringSupplier())
+                .edgeSupplier(SupplierUtil.createDefaultEdgeSupplier()).buildGraph();
+
+        GraphMLImporter<String, DefaultEdge> importer = new GraphMLImporter<>();
+        importer.setVertexFactory(id->String.valueOf("node"+id));
+        importer.importGraph(g, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("node1"));
+        assertTrue(g.containsVertex("node2"));
+        assertTrue(g.containsVertex("node3"));
+        assertTrue(g.containsEdge("node1", "node2"));
+        assertTrue(g.containsEdge("node2", "node3"));
+        assertTrue(g.containsEdge("node3", "node1"));
+    }
+    
+    @Test
     public void testUndirectedUnweightedFromInputStream()
         throws ImportException
     {

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/graphml/SimpleGraphMLImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/graphml/SimpleGraphMLImporterTest.java
@@ -84,6 +84,48 @@ public class SimpleGraphMLImporterTest
     }
 
     @Test
+    public void testVertexFactory()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = 
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + NL + 
+            "<graphml xmlns=\"http://graphml.graphdrawing.org/xmlns\"" + NL +  
+            "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + NL +
+            "xsi:schemaLocation=\"http://graphml.graphdrawing.org/xmlns " + 
+            "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL + 
+            "<graph id=\"G\" edgedefault=\"undirected\">" + NL + 
+            "<edge source=\"2\" target=\"3\"/>" + NL + 
+            "<node id=\"1\"/>" + NL +
+            "<node id=\"2\"/>" + NL + 
+            "<node id=\"3\"/>" + NL +  
+            "<edge source=\"1\" target=\"2\"/>" + NL + 
+            "<edge source=\"3\" target=\"1\"/>"+ NL + 
+            "</graph>" + NL + 
+            "</graphml>";
+        // @formatter:on
+
+        Graph<String,
+            DefaultEdge> g = GraphTypeBuilder
+                .undirected().weighted(false).allowingMultipleEdges(true).allowingSelfLoops(true)
+                .vertexSupplier(SupplierUtil.createStringSupplier())
+                .edgeSupplier(SupplierUtil.createDefaultEdgeSupplier()).buildGraph();
+
+        SimpleGraphMLImporter<String, DefaultEdge> importer = new SimpleGraphMLImporter<String, DefaultEdge>();
+        importer.setVertexFactory(id->String.valueOf("node"+id));
+        importer.importGraph(g, new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)));
+
+        assertEquals(3, g.vertexSet().size());
+        assertEquals(3, g.edgeSet().size());
+        assertTrue(g.containsVertex("node1"));
+        assertTrue(g.containsVertex("node2"));
+        assertTrue(g.containsVertex("node3"));
+        assertTrue(g.containsEdge("node1", "node2"));
+        assertTrue(g.containsEdge("node2", "node3"));
+        assertTrue(g.containsEdge("node3", "node1"));
+    }
+    
+    @Test
     public void testUndirectedUnweightedWithConsumers()
         throws ImportException
     {

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/json/JSONImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/json/JSONImporterTest.java
@@ -74,6 +74,45 @@ public class JSONImporterTest
         assertTrue(g.containsEdge("1", "2"));
         assertTrue(g.containsEdge("1", "3"));
     }
+    
+    @Test
+    public void testVertexFactory()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "{\n"
+                     + "  \"nodes\": [\n"    
+                     + "  { \"id\":\"1\" },\n"
+                     + "  { \"id\":\"2\" },\n"
+                     + "  { \"id\":\"3\" },\n"
+                     + "  { \"id\":\"4\" }\n"
+                     + "  ],\n"
+                     + "  \"edges\": [\n"    
+                     + "  { \"source\":\"1\", \"target\":\"2\" },\n"
+                     + "  { \"source\":\"1\", \"target\":\"3\" }\n"
+                     + "  ]\n"
+                     + "}";
+        // @formatter:on
+
+        Graph<String,
+            DefaultEdge> g = GraphTypeBuilder
+                .undirected().allowingMultipleEdges(true).allowingSelfLoops(true)
+                .vertexSupplier(SupplierUtil.createStringSupplier(1))
+                .edgeSupplier(SupplierUtil.DEFAULT_EDGE_SUPPLIER).buildGraph();
+
+        JSONImporter<String, DefaultEdge> importer = new JSONImporter<>();
+        importer.setVertexFactory(id->String.valueOf("node"+id));
+        importer.importGraph(g, new StringReader(input));
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(2, g.edgeSet().size());
+        assertTrue(g.containsVertex("node1"));
+        assertTrue(g.containsVertex("node2"));
+        assertTrue(g.containsVertex("node3"));
+        assertTrue(g.containsVertex("node4"));
+        assertTrue(g.containsEdge("node1", "node2"));
+        assertTrue(g.containsEdge("node1", "node3"));
+    }
 
     @Test
     public void testMixedStringAndIntegerIds()


### PR DESCRIPTION
Same as #881 on all importers that makes sense.

This is just a "user-friendliness" feature in order to allow users to
bypass the vertex supplier of the graph and provide directly a user defined
factory method for the vertices.

Also improved the docs a bit.
----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x]  I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
