### PR TITLE
Added vertex factories in DIMACS and sparse6 importers

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/DIMACSImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/DIMACSImporter.java
@@ -75,6 +75,12 @@ public class DIMACSImporter<V, E>
     implements
     GraphImporter<V, E>
 {
+    /**
+     * Default key used for vertex ID.
+     */
+    public static final String DEFAULT_VERTEX_ID_KEY = "ID";
+
+    private Function<Integer, V> vertexFactory;
     private final double defaultWeight;
 
     /**
@@ -94,6 +100,32 @@ public class DIMACSImporter<V, E>
     public DIMACSImporter()
     {
         this(Graph.DEFAULT_EDGE_WEIGHT);
+    }
+
+    /**
+     * Get the user custom vertex factory. This is null by default and the graph supplier is used
+     * instead.
+     * 
+     * @return the user custom vertex factory
+     */
+    public Function<Integer, V> getVertexFactory()
+    {
+        return vertexFactory;
+    }
+
+    /**
+     * Set the user custom vertex factory. The default behavior is being null in which case the
+     * graph vertex supplier is used.
+     * 
+     * If supplied the vertex factory is called every time a new vertex is encountered in the file.
+     * The method is called with parameter the vertex identifier from the file and should return the
+     * actual graph vertex to add to the graph.
+     * 
+     * @param vertexFactory a vertex factory
+     */
+    public void setVertexFactory(Function<Integer, V> vertexFactory)
+    {
+        this.vertexFactory = vertexFactory;
     }
 
     /**
@@ -117,7 +149,7 @@ public class DIMACSImporter<V, E>
         throws ImportException
     {
         DIMACSEventDrivenImporter genericImporter =
-            new DIMACSEventDrivenImporter().renumberVertices(false);
+            new DIMACSEventDrivenImporter().renumberVertices(false).zeroBasedNumbering(false);
         Consumers consumers = new Consumers(graph);
         genericImporter.addVertexCountConsumer(consumers.nodeCountConsumer);
         genericImporter.addEdgeConsumer(consumers.edgeConsumer);
@@ -139,8 +171,23 @@ public class DIMACSImporter<V, E>
 
         public final Consumer<Integer> nodeCountConsumer = (n) -> {
             this.nodeCount = n;
-            for (int i = 0; i < nodeCount; i++) {
-                map.put(Integer.valueOf(i), graph.addVertex());
+            for (int i = 1; i <= nodeCount; i++) {
+                V v;
+                if (vertexFactory != null) {
+                    v = vertexFactory.apply(i);
+                    graph.addVertex(v);
+                } else {
+                    v = graph.addVertex();
+                }
+
+                map.put(i, v);
+
+                /*
+                 * Notify the first time we create the node.
+                 */
+                notifyVertex(v);
+                notifyVertexAttribute(
+                    v, DEFAULT_VERTEX_ID_KEY, DefaultAttribute.createAttribute(i));
             }
         };
 
@@ -162,6 +209,8 @@ public class DIMACSImporter<V, E>
                 double weight = t.getThird() == null ? defaultWeight : t.getThird();
                 graph.setEdgeWeight(e, weight);
             }
+
+            notifyEdge(e);
         };
 
     }

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/dimacs/DIMACSEventDrivenImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/dimacs/DIMACSEventDrivenImporterTest.java
@@ -119,7 +119,55 @@ public class DIMACSEventDrivenImporterTest
      * Read and parse an weighted instance
      */
     @Test
-    public void testReadWeightedWithourRenumberingDIMACSInstance()
+    public void testReadWeightedWithoutZeroBasedDIMACSInstance()
+    {
+        InputStream fstream =
+            getClass().getClassLoader().getResourceAsStream("myciel3_weighted.col");
+
+        Map<Integer, Integer> nameMap = new HashMap<>();
+        nameMap.put(1, 1);
+        nameMap.put(2, 2);
+        nameMap.put(4, 3);
+        nameMap.put(7, 4);
+        nameMap.put(9, 5);
+        nameMap.put(3, 6);
+        nameMap.put(6, 7);
+        nameMap.put(8, 8);
+        nameMap.put(5, 9);
+        nameMap.put(10, 10);
+        nameMap.put(11, 11);
+
+        DIMACSEventDrivenImporter importer = new DIMACSEventDrivenImporter().zeroBasedNumbering(false);
+
+        importer.addVertexCountConsumer(count -> {
+            assertEquals(count, Integer.valueOf(11));
+        });
+        List<Triple<Integer, Integer, Double>> collected = new ArrayList<>();
+        importer.addEdgeConsumer(t -> {
+            collected.add(t);
+        });
+        importer.importInput(fstream);
+
+        int[][] edges = { { 1, 2, 1 }, { 1, 4, 2 }, { 1, 7, 3 }, { 1, 9, 4 }, { 2, 3, 5 },
+            { 2, 6, 6 }, { 2, 8, 7 }, { 3, 5, 8 }, { 3, 7, 9 }, { 3, 10, 10 }, { 4, 5, 11 },
+            { 4, 6, 12 }, { 4, 10, 13 }, { 5, 8, 14 }, { 5, 9, 15 }, { 6, 11, 16 }, { 7, 11, 17 },
+            { 8, 11, 18 }, { 9, 11, 19 }, { 10, 11, 20 } };
+
+        int i = 0;
+        for (int[] edge : edges) {
+            Triple<Integer, Integer, Double> e = collected.get(i);
+            assertEquals(nameMap.get(edge[0]), e.getFirst());
+            assertEquals(nameMap.get(edge[1]), e.getSecond());
+            assertEquals(Double.valueOf(edge[2]), e.getThird());
+            i++;
+        }
+    }
+    
+    /**
+     * Read and parse an weighted instance
+     */
+    @Test
+    public void testReadWeightedWithoutRenumberingDIMACSInstance()
     {
         InputStream fstream =
             getClass().getClassLoader().getResourceAsStream("myciel3_weighted.col");
@@ -164,4 +212,53 @@ public class DIMACSEventDrivenImporterTest
         }
     }
 
+    /**
+     * Read and parse an weighted instance
+     */
+    @Test
+    public void testReadWeightedWithoutRenumberingAndWithoutZeroBasedDIMACSInstance()
+    {
+        InputStream fstream =
+            getClass().getClassLoader().getResourceAsStream("myciel3_weighted.col");
+
+        Map<Integer, Integer> nameMap = new HashMap<>();
+        nameMap.put(1, 1);
+        nameMap.put(2, 2);
+        nameMap.put(3, 3);
+        nameMap.put(4, 4);
+        nameMap.put(5, 5);
+        nameMap.put(6, 6);
+        nameMap.put(7, 7);
+        nameMap.put(8, 8);
+        nameMap.put(9, 9);
+        nameMap.put(10, 10);
+        nameMap.put(11, 11);
+
+        DIMACSEventDrivenImporter importer = new DIMACSEventDrivenImporter();
+        importer = importer.renumberVertices(false).zeroBasedNumbering(false);
+
+        importer.addVertexCountConsumer(count -> {
+            assertEquals(count, Integer.valueOf(11));
+        });
+        List<Triple<Integer, Integer, Double>> collected = new ArrayList<>();
+        importer.addEdgeConsumer(t -> {
+            collected.add(t);
+        });
+        importer.importInput(fstream);
+
+        int[][] edges = { { 1, 2, 1 }, { 1, 4, 2 }, { 1, 7, 3 }, { 1, 9, 4 }, { 2, 3, 5 },
+            { 2, 6, 6 }, { 2, 8, 7 }, { 3, 5, 8 }, { 3, 7, 9 }, { 3, 10, 10 }, { 4, 5, 11 },
+            { 4, 6, 12 }, { 4, 10, 13 }, { 5, 8, 14 }, { 5, 9, 15 }, { 6, 11, 16 }, { 7, 11, 17 },
+            { 8, 11, 18 }, { 9, 11, 19 }, { 10, 11, 20 } };
+
+        int i = 0;
+        for (int[] edge : edges) {
+            Triple<Integer, Integer, Double> e = collected.get(i);
+            assertEquals(nameMap.get(edge[0]), e.getFirst());
+            assertEquals(nameMap.get(edge[1]), e.getSecond());
+            assertEquals(Double.valueOf(edge[2]), e.getThird());
+            i++;
+        }
+    }
+    
 }

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/dimacs/DIMACSImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/dimacs/DIMACSImporterTest.java
@@ -124,6 +124,40 @@ public class DIMACSImporterTest
             assertEquals((int) graph.getEdgeWeight(e), edge[2]);
         }
     }
+    
+    @Test
+    public void testReadDIMACSShortestPathFormatWithVertexFactory()
+    {
+        // @formatter:off
+        String input = "p sp 3 3\n" +
+                       "a 1 2\n" +
+                       "a 2 1\n" +
+                       "a 2 3\n";
+        // @formatter:on
+
+        Graph<Integer, DefaultWeightedEdge> graph = GraphTypeBuilder
+            .directed().allowingMultipleEdges(true).allowingSelfLoops(true).weighted(true)
+            .vertexSupplier(SupplierUtil.createIntegerSupplier())
+            .edgeSupplier(SupplierUtil.createDefaultWeightedEdgeSupplier()).buildGraph();
+
+        DIMACSImporter<Integer, DefaultWeightedEdge> importer = new DIMACSImporter<>();
+        importer.setVertexFactory(id->id+100);
+        try {
+            importer.importGraph(graph, new InputStreamReader(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)), "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            // cannot happen
+        }
+
+        assertEquals(3, graph.vertexSet().size());
+        assertEquals(3, graph.edgeSet().size());
+
+        int[][] edges = { { 101, 102, 1 }, { 102, 101, 1 }, { 102, 103, 1 } };
+        for (int[] edge : edges) {
+            assertTrue(graph.containsEdge(edge[0], edge[1]));
+            DefaultWeightedEdge e = graph.getEdge(edge[0], edge[1]);
+            assertEquals((int) graph.getEdgeWeight(e), edge[2]);
+        }
+    }
 
     @Test
     public void testWrongDIMACSInstance1()

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/graph6/Graph6Sparse6ImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/graph6/Graph6Sparse6ImporterTest.java
@@ -100,6 +100,38 @@ public class Graph6Sparse6ImporterTest
     }
 
     @Test
+    public void testVertexFactory()
+        throws ImportException
+    {
+        // Klein7RegularGraph
+        String input = ":B_`V";
+
+        Graph<String, DefaultEdge> graph = GraphTypeBuilder
+            .undirected().allowingMultipleEdges(true).allowingSelfLoops(true).weighted(false)
+            .vertexSupplier(SupplierUtil.createStringSupplier())
+            .edgeSupplier(SupplierUtil.DEFAULT_EDGE_SUPPLIER).buildGraph();
+
+        Graph6Sparse6Importer<String, DefaultEdge> importer = new Graph6Sparse6Importer<>();
+        importer.setVertexFactory(id->String.valueOf("node"+id));
+        try {
+            importer.importGraph(graph, new InputStreamReader(new ByteArrayInputStream(input.getBytes(StandardCharsets.UTF_8)), "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            // cannot happen
+        }
+        
+        Graph<String, DefaultEdge> orig = new Pseudograph<>(DefaultEdge.class);
+        Graphs.addAllVertices(orig, Arrays.asList("node0", "node1", "node2"));
+        orig.addEdge("node0", "node1");
+        orig.addEdge("node0", "node1");
+        orig.addEdge("node0", "node2");
+        orig.addEdge("node1", "node2");
+        orig.addEdge("node2", "node2");
+
+        this.compare(orig, graph);
+        assertEquals(orig.toString(), graph.toString());
+    }
+    
+    @Test
     public void testNumberVertices1()
         throws ImportException
     {


### PR DESCRIPTION
Final (hopefully) PR for the vertex factories. 

These last ones are not strictly needed. Especially in sparse6 format which loses all 
vertex labels during export.

Nevertheless, users seem to use them or think that they need, so better to keep a unified interface among all importers. 

I also took the opportunity to improve the DIMACS importer to have an extra option on whether the user requires to use zero or one based numbering.

----
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
