### PR TITLE
Trivial optimization to isFeasiblePair

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2GraphIsomorphismState.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2GraphIsomorphismState.java
@@ -62,7 +62,7 @@ class VF2GraphIsomorphismState<V, E>
                 if (!g2.hasEdge(addVertex2, other2)
                     || !areCompatibleEdges(addVertex1, other1, addVertex2, other2))
                 {
-                    showLog(
+                    if (DEBUG) showLog(
                         "isFeasiblePair", abortmsg + ": edge from " + g2.getVertex(addVertex2)
                             + " to " + g2.getVertex(other2) + " is missing in the 2nd graph");
                     return false;
@@ -85,7 +85,7 @@ class VF2GraphIsomorphismState<V, E>
             if (core2[other2] != NULL_NODE) {
                 int other1 = core2[other2];
                 if (!g1.hasEdge(addVertex1, other1)) {
-                    showLog(
+                    if (DEBUG) showLog(
                         "isFeasbilePair", abortmsg + ": edge from " + g1.getVertex(addVertex1)
                             + " to " + g1.getVertex(other1) + " is missing in the 1st graph");
                     return false;
@@ -133,7 +133,7 @@ class VF2GraphIsomorphismState<V, E>
                 if (!g2.hasEdge(other2, addVertex2)
                     || !areCompatibleEdges(other1, addVertex1, other2, addVertex2))
                 {
-                    showLog(
+                    if (DEBUG) showLog(
                         "isFeasbilePair", abortmsg + ": edge from " + g2.getVertex(other2) + " to "
                             + g2.getVertex(addVertex2) + " is missing in the 2nd graph");
                     return false;
@@ -156,7 +156,7 @@ class VF2GraphIsomorphismState<V, E>
             if (core2[other2] != NULL_NODE) {
                 int other1 = core2[other2];
                 if (!g1.hasEdge(other1, addVertex1)) {
-                    showLog(
+                    if (DEBUG) showLog(
                         "isFeasiblePair", abortmsg + ": edge from " + g1.getVertex(other1) + " to "
                             + g1.getVertex(addVertex1) + " is missing in the 1st graph");
                     return false;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2GraphIsomorphismState.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2GraphIsomorphismState.java
@@ -43,8 +43,8 @@ class VF2GraphIsomorphismState<V, E>
     @Override
     public boolean isFeasiblePair()
     {
-        String pairstr = "(" + g1.getVertex(addVertex1) + ", " + g2.getVertex(addVertex2) + ")",
-            abortmsg = pairstr + " does not fit in the current matching";
+        final String pairstr = (DEBUG) ? "(" + g1.getVertex(addVertex1) + ", " + g2.getVertex(addVertex2) + ")" : null;
+        final String abortmsg = (DEBUG) ? pairstr + " does not fit in the current matching" : null;
 
         // check for semantic equality of both vertexes
         if (!areCompatibleVertexes(addVertex1, addVertex2)) {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2GraphIsomorphismState.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2GraphIsomorphismState.java
@@ -177,7 +177,7 @@ class VF2GraphIsomorphismState<V, E>
         if ((termInPred1 == termInPred2) && (termOutPred1 == termOutPred2)
             && (newPred1 == newPred2))
         {
-            showLog("isFeasiblePair", pairstr + " fits");
+            if (DEBUG) showLog("isFeasiblePair", pairstr + " fits");
             return true;
         } else {
             if (DEBUG) {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2State.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2State.java
@@ -317,7 +317,7 @@ abstract class VF2State<V, E>
     {
         int addedVertex2 = core1[addedVertex1];
 
-        showLog(
+        if (DEBUG) showLog(
             "backtrack", "remove (" + g1.getVertex(addedVertex1) + ", " + g2.getVertex(addedVertex2)
                 + ") from the matching");
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2State.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2State.java
@@ -194,14 +194,14 @@ abstract class VF2State<V, E>
         }
 
         if ((addVertex1 < n1) && (addVertex2 < n2)) {
-            showLog(
+            if (DEBUG) showLog(
                 "nextPair", "next candidate pair: (" + g1.getVertex(addVertex1) + ", "
                     + g2.getVertex(addVertex2) + ")");
             return true;
         }
 
         // there are no more pairs..
-        showLog("nextPair", "no more candidate pairs");
+        if (DEBUG) showLog("nextPair", "no more candidate pairs");
 
         addVertex1 = addVertex2 = NULL_NODE;
         return false;
@@ -212,7 +212,7 @@ abstract class VF2State<V, E>
      */
     public void addPair()
     {
-        showLog(
+        if (DEBUG) showLog(
             "addPair",
             "(" + g1.getVertex(addVertex1) + ", " + g2.getVertex(addVertex2) + ") added");
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismState.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismState.java
@@ -62,7 +62,7 @@ class VF2SubgraphIsomorphismState<V, E>
                 if (!g2.hasEdge(addVertex2, other2)
                     || !areCompatibleEdges(addVertex1, other1, addVertex2, other2))
                 {
-                    showLog(
+                    if (DEBUG) showLog(
                         "isFeasiblePair", abortmsg + ": edge from " + g2.getVertex(addVertex2)
                             + " to " + g2.getVertex(other2) + " is missing in the 2nd graph");
                     return false;
@@ -85,7 +85,7 @@ class VF2SubgraphIsomorphismState<V, E>
             if (core2[other2] != NULL_NODE) {
                 int other1 = core2[other2];
                 if (!g1.hasEdge(addVertex1, other1)) {
-                    showLog(
+                    if (DEBUG) showLog(
                         "isFeasbilePair", abortmsg + ": edge from " + g1.getVertex(addVertex1)
                             + " to " + g1.getVertex(other1) + " is missing in the 1st graph");
                     return false;
@@ -130,7 +130,7 @@ class VF2SubgraphIsomorphismState<V, E>
                 if (!g2.hasEdge(other2, addVertex2)
                     || !areCompatibleEdges(other1, addVertex1, other2, addVertex2))
                 {
-                    showLog(
+                    if (DEBUG) showLog(
                         "isFeasbilePair", abortmsg + ": edge from " + g2.getVertex(other2) + " to "
                             + g2.getVertex(addVertex2) + " is missing in the 2nd graph");
                     return false;
@@ -153,7 +153,7 @@ class VF2SubgraphIsomorphismState<V, E>
             if (core2[other2] != NULL_NODE) {
                 int other1 = core2[other2];
                 if (!g1.hasEdge(other1, addVertex1)) {
-                    showLog(
+                    if (DEBUG) showLog(
                         "isFeasiblePair", abortmsg + ": edge from " + g1.getVertex(other1) + " to "
                             + g1.getVertex(addVertex1) + " is missing in the 1st graph");
                     return false;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismState.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismState.java
@@ -43,8 +43,8 @@ class VF2SubgraphIsomorphismState<V, E>
     @Override
     public boolean isFeasiblePair()
     {
-        String pairstr = "(" + g1.getVertex(addVertex1) + ", " + g2.getVertex(addVertex2) + ")",
-            abortmsg = pairstr + " does not fit in the current matching";
+        final String pairstr = (DEBUG) ? "(" + g1.getVertex(addVertex1) + ", " + g2.getVertex(addVertex2) + ")" : null;
+        final String abortmsg = (DEBUG) ? pairstr + " does not fit in the current matching" : null;
 
         // check for semantic equality of both vertexes
         if (!areCompatibleVertexes(addVertex1, addVertex2)) {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismState.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismState.java
@@ -174,7 +174,7 @@ class VF2SubgraphIsomorphismState<V, E>
         if ((termInPred1 >= termInPred2) && (termOutPred1 >= termOutPred2)
             && (newPred1 >= newPred2))
         {
-            showLog("isFeasiblePair", pairstr + " fits");
+            if (DEBUG) showLog("isFeasiblePair", pairstr + " fits");
             return true;
         } else {
             if (DEBUG) {


### PR DESCRIPTION
Hide the message strings that are only used in DEBUG case behind DEBUG.

This will eschew expensive String manipulations which show up as more than 50% of time in profiling subgraph isomorphism detection of an undirected graph with 38 nodes with a subgraph of 10 nodes and similarly for full isomorphism.

----

- [X] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [X] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [X] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [X] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [X] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
