### PR TITLE
Change the cache from a Boolean array to a byte array for GraphOrdering

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
@@ -39,7 +39,13 @@ class GraphOrdering<V, E>
 
     private int[][] outgoingEdges;
     private int[][] incomingEdges;
-    private Boolean[][] adjMatrix;
+    /*
+     * if caching is enabled, this contains cached information on edges existing, values:
+     * 0 - no cached value
+     * 1 - edge exists
+     * -1 - no edge exists
+     */
+    private short[][] adjMatrix;
 
     private boolean cacheEdges;
 
@@ -67,7 +73,7 @@ class GraphOrdering<V, E>
         if (cacheEdges) {
             outgoingEdges = new int[vertexCount][];
             incomingEdges = new int[vertexCount][];
-            adjMatrix = new Boolean[vertexCount][vertexCount];
+            adjMatrix = new short[vertexCount][vertexCount];
         }
 
         Integer i = 0;
@@ -161,21 +167,19 @@ class GraphOrdering<V, E>
      */
     public boolean hasEdge(int v1Number, int v2Number)
     {
-        V v1, v2;
-        Boolean containsEdge = null;
-
+        
         if (cacheEdges) {
-            containsEdge = adjMatrix[v1Number][v2Number];
+            final short cache = adjMatrix[v1Number][v2Number];
+            if(cache != 0){
+                return cache > 0;
+            }
         }
-
-        if (!cacheEdges || (containsEdge == null)) {
-            v1 = getVertex(v1Number);
-            v2 = getVertex(v2Number);
-            containsEdge = graph.containsEdge(v1, v2);
-        }
-
-        if (cacheEdges && (adjMatrix[v1Number][v2Number] == null)) {
-            adjMatrix[v1Number][v2Number] = containsEdge;
+        
+        V v1 = getVertex(v1Number);
+        V v2 = getVertex(v2Number);
+        boolean containsEdge = graph.containsEdge(v1, v2);
+        if(cacheEdges) {
+            adjMatrix[v1Number][v2Number] = (short) ((containsEdge) ? 1 : -1);
         }
 
         return containsEdge;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
@@ -40,7 +40,7 @@ class GraphOrdering<V, E>
     private int[][] outgoingEdges;
     private int[][] incomingEdges;
     /**
-     * if caching is enabled, adjMatrix contains cached information on existing edges, values:
+     * if caching is enabled, adjMatrix contains cached information on existing edges, valid values:
      * <ul>
      * <li>0 - no cached value</li>
      * <li>1 - edge exists</li>

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
@@ -40,17 +40,14 @@ class GraphOrdering<V, E>
     private int[][] outgoingEdges;
     private int[][] incomingEdges;
     /**
-     * If caching is enabled, adjMatrix contains cached information on existing edges. Its a flattened
-     * bitset of size 2 times vertexCount squared. Each element is hence represented with two bits.
-     * Possible patterns are
+     * if caching is enabled, adjMatrix contains cached information on existing edges, values:
      * <ul>
-     * <li>00 - no cached information</li>
-     * <li>10 - edge exists</li>
-     * <li>-11 - no edge exists</li>
-     * <li>01 - not a valid pattern</li>
+     * <li>0 - no cached value</li>
+     * <li>1 - edge exists</li>
+     * <li>-1 - no edge exists</li>
      * </ul>
      */
-    private BitSet adjMatrix;
+    private byte[] adjMatrix;
 
     private boolean cacheEdges;
 
@@ -78,7 +75,7 @@ class GraphOrdering<V, E>
         if (cacheEdges) {
             outgoingEdges = new int[vertexCount][];
             incomingEdges = new int[vertexCount][];
-            adjMatrix = new BitSet(2*vertexCount*vertexCount);
+            adjMatrix = new byte[vertexCount*vertexCount];
         }
 
         Integer i = 0;
@@ -175,10 +172,10 @@ class GraphOrdering<V, E>
         
         int cacheIndex = 0;
         if (cacheEdges) {
-            cacheIndex = 2*(v1Number*vertexCount+v2Number);
-            final boolean isCached = adjMatrix.get(cacheIndex);
-            if(isCached){
-                return adjMatrix.get(cacheIndex+1);
+            cacheIndex = v1Number*vertexCount+v2Number;
+            final byte cache = adjMatrix[cacheIndex];
+            if(cache != 0){
+                return cache > 0;
             }
         }
         
@@ -186,8 +183,7 @@ class GraphOrdering<V, E>
         V v2 = getVertex(v2Number);
         boolean containsEdge = graph.containsEdge(v1, v2);
         if(cacheEdges) {
-            adjMatrix.set(cacheIndex, true);
-            adjMatrix.set(cacheIndex+1, containsEdge);
+            adjMatrix[cacheIndex] = (byte) ((containsEdge) ? 1 : -1);
         }
 
         return containsEdge;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
@@ -39,11 +39,13 @@ class GraphOrdering<V, E>
 
     private int[][] outgoingEdges;
     private int[][] incomingEdges;
-    /*
-     * if caching is enabled, this contains cached information on edges existing, values:
-     * 0 - no cached value
-     * 1 - edge exists
-     * -1 - no edge exists
+    /**
+     * if caching is enabled, adjMatrix contains cached information on existing edges, values:
+     * <ul>
+     * <li>0 - no cached value</li>
+     * <li>1 - edge exists</li>
+     * <li>-1 - no edge exists</li>
+     * </ul>
      */
     private byte[] adjMatrix;
 
@@ -168,8 +170,9 @@ class GraphOrdering<V, E>
     public boolean hasEdge(int v1Number, int v2Number)
     {
         
+        final int cacheIndex = v1Number*vertexCount+v2Number;
         if (cacheEdges) {
-            final byte cache = adjMatrix[v1Number*vertexCount+v2Number];
+            final byte cache = adjMatrix[cacheIndex];
             if(cache != 0){
                 return cache > 0;
             }
@@ -179,7 +182,7 @@ class GraphOrdering<V, E>
         V v2 = getVertex(v2Number);
         boolean containsEdge = graph.containsEdge(v1, v2);
         if(cacheEdges) {
-            adjMatrix[v1Number*vertexCount+v2Number] = (byte) ((containsEdge) ? 1 : -1);
+            adjMatrix[cacheIndex] = (byte) ((containsEdge) ? 1 : -1);
         }
 
         return containsEdge;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
@@ -173,8 +173,9 @@ class GraphOrdering<V, E>
     public boolean hasEdge(int v1Number, int v2Number)
     {
         
-        final int cacheIndex = 2*(v1Number*vertexCount+v2Number);
+        int cacheIndex = 0;
         if (cacheEdges) {
+            cacheIndex = 2*(v1Number*vertexCount+v2Number);
             final boolean isCached = adjMatrix.get(cacheIndex);
             if(isCached){
                 return adjMatrix.get(cacheIndex+1);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
@@ -45,7 +45,7 @@ class GraphOrdering<V, E>
      * 1 - edge exists
      * -1 - no edge exists
      */
-    private short[][] adjMatrix;
+    private byte[][] adjMatrix;
 
     private boolean cacheEdges;
 
@@ -73,7 +73,7 @@ class GraphOrdering<V, E>
         if (cacheEdges) {
             outgoingEdges = new int[vertexCount][];
             incomingEdges = new int[vertexCount][];
-            adjMatrix = new short[vertexCount][vertexCount];
+            adjMatrix = new byte[vertexCount][vertexCount];
         }
 
         Integer i = 0;
@@ -169,7 +169,7 @@ class GraphOrdering<V, E>
     {
         
         if (cacheEdges) {
-            final short cache = adjMatrix[v1Number][v2Number];
+            final byte cache = adjMatrix[v1Number][v2Number];
             if(cache != 0){
                 return cache > 0;
             }
@@ -179,7 +179,7 @@ class GraphOrdering<V, E>
         V v2 = getVertex(v2Number);
         boolean containsEdge = graph.containsEdge(v1, v2);
         if(cacheEdges) {
-            adjMatrix[v1Number][v2Number] = (short) ((containsEdge) ? 1 : -1);
+            adjMatrix[v1Number][v2Number] = (byte) ((containsEdge) ? 1 : -1);
         }
 
         return containsEdge;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
@@ -45,7 +45,7 @@ class GraphOrdering<V, E>
      * 1 - edge exists
      * -1 - no edge exists
      */
-    private byte[][] adjMatrix;
+    private byte[] adjMatrix;
 
     private boolean cacheEdges;
 
@@ -73,7 +73,7 @@ class GraphOrdering<V, E>
         if (cacheEdges) {
             outgoingEdges = new int[vertexCount][];
             incomingEdges = new int[vertexCount][];
-            adjMatrix = new byte[vertexCount][vertexCount];
+            adjMatrix = new byte[vertexCount*vertexCount];
         }
 
         Integer i = 0;
@@ -169,7 +169,7 @@ class GraphOrdering<V, E>
     {
         
         if (cacheEdges) {
-            final byte cache = adjMatrix[v1Number][v2Number];
+            final byte cache = adjMatrix[v1Number*vertexCount+v2Number];
             if(cache != 0){
                 return cache > 0;
             }
@@ -179,7 +179,7 @@ class GraphOrdering<V, E>
         V v2 = getVertex(v2Number);
         boolean containsEdge = graph.containsEdge(v1, v2);
         if(cacheEdges) {
-            adjMatrix[v1Number][v2Number] = (byte) ((containsEdge) ? 1 : -1);
+            adjMatrix[v1Number*vertexCount+v2Number] = (byte) ((containsEdge) ? 1 : -1);
         }
 
         return containsEdge;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
@@ -40,14 +40,17 @@ class GraphOrdering<V, E>
     private int[][] outgoingEdges;
     private int[][] incomingEdges;
     /**
-     * if caching is enabled, adjMatrix contains cached information on existing edges, values:
+     * If caching is enabled, adjMatrix contains cached information on existing edges. Its a flattened
+     * bitset of size 2 times vertexCount squared. Each element is hence represented with two bits.
+     * Possible patterns are
      * <ul>
-     * <li>0 - no cached value</li>
-     * <li>1 - edge exists</li>
-     * <li>-1 - no edge exists</li>
+     * <li>00 - no cached information</li>
+     * <li>10 - edge exists</li>
+     * <li>-11 - no edge exists</li>
+     * <li>01 - not a valid pattern</li>
      * </ul>
      */
-    private byte[] adjMatrix;
+    private BitSet adjMatrix;
 
     private boolean cacheEdges;
 
@@ -75,7 +78,7 @@ class GraphOrdering<V, E>
         if (cacheEdges) {
             outgoingEdges = new int[vertexCount][];
             incomingEdges = new int[vertexCount][];
-            adjMatrix = new byte[vertexCount*vertexCount];
+            adjMatrix = new BitSet(2*vertexCount*vertexCount);
         }
 
         Integer i = 0;
@@ -170,11 +173,11 @@ class GraphOrdering<V, E>
     public boolean hasEdge(int v1Number, int v2Number)
     {
         
-        final int cacheIndex = v1Number*vertexCount+v2Number;
+        final int cacheIndex = 2*(v1Number*vertexCount+v2Number);
         if (cacheEdges) {
-            final byte cache = adjMatrix[cacheIndex];
-            if(cache != 0){
-                return cache > 0;
+            final boolean isCached = adjMatrix.get(cacheIndex);
+            if(isCached){
+                return adjMatrix.get(cacheIndex+1);
             }
         }
         
@@ -182,7 +185,8 @@ class GraphOrdering<V, E>
         V v2 = getVertex(v2Number);
         boolean containsEdge = graph.containsEdge(v1, v2);
         if(cacheEdges) {
-            adjMatrix[cacheIndex] = (byte) ((containsEdge) ? 1 : -1);
+            adjMatrix.set(cacheIndex, true);
+            adjMatrix.set(cacheIndex+1, containsEdge);
         }
 
         return containsEdge;


### PR DESCRIPTION
This eschews object overhead and resulting boxing/unboxing while retaining the ability
to cache per-entry in the adjacency matrix (by using a byte with effectively three
states per entry)

Due to the missing object header, this reduces the memory expense per entry to 1 byte from 16 bytes (64bit JVM).

<!-- describe the changes you have made here: what, why, …
     Link issues by using the following pattern: [#333](https://github.com/jgrapht/jgrapht/issues/333).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

----

- [X] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [X] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [X] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [X] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [X] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
