### PR TITLE
Fix bug where matching weight was not returned correctly.

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/matching/MaximumWeightBipartiteMatching.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/matching/MaximumWeightBipartiteMatching.java
@@ -334,7 +334,7 @@ public class MaximumWeightBipartiteMatching<V, E>
             V t = graph.getEdgeTarget(e);
             matchedEdge.remove(s);
             matchedEdge.remove(t);
-            matchingWeight.subtract(w);
+            matchingWeight = matchingWeight.subtract(w);
             matching.remove(e);
         }
 
@@ -344,7 +344,7 @@ public class MaximumWeightBipartiteMatching<V, E>
             V t = graph.getEdgeTarget(e);
             matchedEdge.put(s, e);
             matchedEdge.put(t, e);
-            matchingWeight.add(w);
+            matchingWeight = matchingWeight.add(w);
             matching.add(e);
         }
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/MaximumWeightBipartiteMatchingTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/MaximumWeightBipartiteMatchingTest.java
@@ -149,6 +149,7 @@ public class MaximumWeightBipartiteMatchingTest
         assertTrue(matchings.getEdges().contains(e3));
         assertTrue(matchings.getEdges().contains(e5));
         assertTrue(matchings.getEdges().contains(e7));
+        assertEquals(5d, matchings.getWeight(), 1e-9);
     }
 
     @Test


### PR DESCRIPTION
Fixed bug in `MaximumWeightBipartiteMatching` where the weight of the matching was not updated correctly.

----
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
