### PR TITLE
Fix to make json importer symmetric to json exporter.

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONEventDrivenImporter.java
@@ -17,16 +17,33 @@
  */
 package org.jgrapht.nio.json;
 
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.misc.*;
-import org.antlr.v4.runtime.tree.*;
-import org.jgrapht.*;
-import org.jgrapht.alg.util.Triple;
-import org.jgrapht.nio.*;
-import org.jgrapht.nio.json.JsonParser.*;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
-import java.io.*;
-import java.util.*;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.apache.commons.text.StringEscapeUtils;
+import org.jgrapht.Graph;
+import org.jgrapht.alg.util.Triple;
+import org.jgrapht.nio.Attribute;
+import org.jgrapht.nio.AttributeType;
+import org.jgrapht.nio.BaseEventDrivenImporter;
+import org.jgrapht.nio.DefaultAttribute;
+import org.jgrapht.nio.EventDrivenImporter;
+import org.jgrapht.nio.ImportEvent;
+import org.jgrapht.nio.ImportException;
+import org.jgrapht.nio.json.JsonParser.JsonContext;
 
 /**
  * Imports a graph from a <a href="https://tools.ietf.org/html/rfc8259">JSON</a> file.
@@ -377,8 +394,9 @@ public class JSONEventDrivenImporter
         private String unquote(String value)
         {
             if (value.startsWith("\"") && value.endsWith("\"")) {
-                return value.substring(1, value.length() - 1);
+                value = value.substring(1, value.length() - 1);
             }
+            value = StringEscapeUtils.unescapeJson(value);
             return value;
         }
 


### PR DESCRIPTION
While we escape json in the exporter, we do not unescape in the importer. This fix makes them symmetric.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
