### PR TITLE
DOTExporter attributes without quotes

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/AttributeType.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/AttributeType.java
@@ -33,7 +33,7 @@ public enum AttributeType
     STRING("string"),
     HTML("html"),
     UNKNOWN("unknown"),
-    GENERIC("generic");
+    IDENTIFIER("identifier");
 
     private String name;
 
@@ -79,8 +79,8 @@ public enum AttributeType
             return HTML;
         case "unknown":
             return UNKNOWN;
-        case "generic":
-            return GENERIC;
+        case "identifier":
+            return IDENTIFIER;
         }
         throw new IllegalArgumentException("Type " + value + " is unknown");
     }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/AttributeType.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/AttributeType.java
@@ -32,7 +32,8 @@ public enum AttributeType
     DOUBLE("double"),
     STRING("string"),
     HTML("html"),
-    UNKNOWN("unknown");
+    UNKNOWN("unknown"),
+    GENERIC("generic");
 
     private String name;
 
@@ -78,6 +79,8 @@ public enum AttributeType
             return HTML;
         case "unknown":
             return UNKNOWN;
+        case "generic":
+            return GENERIC;
         }
         throw new IllegalArgumentException("Type " + value + " is unknown");
     }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTExporter.java
@@ -222,6 +222,8 @@ public class DOTExporter<V, E>
         final String attrValue = attribute.getValue();
         if (AttributeType.HTML.equals(attribute.getType())) {
             out.print("<" + attrValue + ">");
+        } else if(AttributeType.GENERIC.equals(attribute.getType())) {
+            out.print(attrValue);
         } else {
             out.print("\"" + escapeDoubleQuotes(attrValue) + "\"");
         }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTExporter.java
@@ -222,7 +222,7 @@ public class DOTExporter<V, E>
         final String attrValue = attribute.getValue();
         if (AttributeType.HTML.equals(attribute.getType())) {
             out.print("<" + attrValue + ">");
-        } else if(AttributeType.GENERIC.equals(attribute.getType())) {
+        } else if(AttributeType.IDENTIFIER.equals(attribute.getType())) {
             out.print(attrValue);
         } else {
             out.print("\"" + escapeDoubleQuotes(attrValue) + "\"");


### PR DESCRIPTION
<!-- describe the changes you have made here: what, why, …
     Link issues by using the following pattern: [#333](https://github.com/jgrapht/jgrapht/issues/333).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

Adds an attribute type without quotes for the DOTExporter

See #922 

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
