### PR TITLE
Improve and unify structure of TSPAlgorithms [#872]

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestInsertionHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestInsertionHeuristicTSP.java
@@ -80,7 +80,7 @@ public class NearestInsertionHeuristicTSP<V, E>
 
     /**
      * Constructor
-     * 
+     *
      * Specifies an existing sub-tour that will be augmented to form a complete tour when
      * {@link #getTour(org.jgrapht.Graph) } is called
      *
@@ -106,9 +106,7 @@ public class NearestInsertionHeuristicTSP<V, E>
     @Override
     public GraphPath<V, E> getTour(Graph<V, E> graph)
     {
-        // Check that graph is appropriate
         checkGraph(graph);
-
         if (graph.vertexSet().size() == 1) {
             return getSingletonTour(graph);
         }
@@ -149,9 +147,10 @@ public class NearestInsertionHeuristicTSP<V, E>
         }
         if (subtourVertices.isEmpty()) {
             // If no initial subtour exists, create one based on the shortest edge
-            E shortestEdge = Collections.min(
-                graph.edgeSet(),
-                (e1, e2) -> Double.compare(graph.getEdgeWeight(e1), graph.getEdgeWeight(e2)));
+            E shortestEdge = Collections
+                .min(
+                    graph.edgeSet(),
+                    (e1, e2) -> Double.compare(graph.getEdgeWeight(e1), graph.getEdgeWeight(e2)));
             subtourVertices.add(graph.getEdgeSource(shortestEdge));
             subtourVertices.add(graph.getEdgeTarget(shortestEdge));
         }
@@ -220,8 +219,10 @@ public class NearestInsertionHeuristicTSP<V, E>
             }
             return c;
         });
-        currentClosest.put(
-            chosen.getUnvisitedVertex(), getClosest(chosen.getUnvisitedVertex(), unvisited, graph));
+        currentClosest
+            .put(
+                chosen.getUnvisitedVertex(),
+                getClosest(chosen.getUnvisitedVertex(), unvisited, graph));
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestInsertionHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestInsertionHeuristicTSP.java
@@ -75,7 +75,7 @@ public class NearestInsertionHeuristicTSP<V, E>
      */
     public NearestInsertionHeuristicTSP()
     {
-        this.subtour = null;
+        this(null);
     }
 
     /**
@@ -85,29 +85,11 @@ public class NearestInsertionHeuristicTSP<V, E>
      * {@link #getTour(org.jgrapht.Graph) } is called
      *
      * @param subtour Initial sub-tour, or null to start with shortest edge
-     * @deprecated use {@link #NearestInsertionHeuristicTSP()} and {@link #setSubtour(GraphPath)}
      */
-    @Deprecated(since = "1.4.1", forRemoval = true)
     public NearestInsertionHeuristicTSP(GraphPath<V, E> subtour)
     {
         this.subtour = subtour;
     }
-
-    /**
-     * Set an existing sub-tour that will be augmented to form a complete tour when
-     * {@link #getTour(org.jgrapht.Graph) } is called.
-     *
-     * @param subtour Initial sub-tour, or null to start with shortest edge
-     * @return this algorithm object
-     *
-     */
-    public NearestInsertionHeuristicTSP<V, E> setSubtour(GraphPath<V, E> subtour)
-    {
-        this.subtour = subtour;
-        return this;
-    }
-
-    // algorithm
 
     /**
      * Computes a tour using the nearest insertion heuristic.
@@ -356,5 +338,6 @@ public class NearestInsertionHeuristicTSP<V, E>
         {
             return Double.compare(distance, o.distance);
         }
+
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestInsertionHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestInsertionHeuristicTSP.java
@@ -75,7 +75,7 @@ public class NearestInsertionHeuristicTSP<V, E>
      */
     public NearestInsertionHeuristicTSP()
     {
-        this(null);
+        this.subtour = null;
     }
 
     /**
@@ -85,11 +85,29 @@ public class NearestInsertionHeuristicTSP<V, E>
      * {@link #getTour(org.jgrapht.Graph) } is called
      *
      * @param subtour Initial sub-tour, or null to start with shortest edge
+     * @deprecated use {@link #NearestInsertionHeuristicTSP()} and {@link #setSubtour(GraphPath)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public NearestInsertionHeuristicTSP(GraphPath<V, E> subtour)
     {
         this.subtour = subtour;
     }
+
+    /**
+     * Set an existing sub-tour that will be augmented to form a complete tour when
+     * {@link #getTour(org.jgrapht.Graph) } is called.
+     *
+     * @param subtour Initial sub-tour, or null to start with shortest edge
+     * @return this algorithm object
+     *
+     */
+    public NearestInsertionHeuristicTSP<V, E> setSubtour(GraphPath<V, E> subtour)
+    {
+        this.subtour = subtour;
+        return this;
+    }
+
+    // algorithm
 
     /**
      * Computes a tour using the nearest insertion heuristic.
@@ -338,6 +356,5 @@ public class NearestInsertionHeuristicTSP<V, E>
         {
             return Double.compare(distance, o.distance);
         }
-
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSP.java
@@ -37,14 +37,6 @@ import java.util.*;
  * </p>
  *
  * <p>
- * The tour computed with a {@code Nearest-Neighbor-Heuristic} can vary depending on their first
- * vertex visited. The first vertices for the next or for multiple subsequent tour computations can
- * be controlled with {@link #setFirst(Object)} or {@link #setInitialVertices(Iterable)}.
- * Additionally the {@link #setRandomNumberGenerator(Random) random number generator} can be
- * specified used to randomly select the vertex visited first.
- * </p>
- *
- * <p>
  * The implementation of this class is based on: <br>
  * Nilsson, Christian. "Heuristics for the traveling salesman problem." Linkoping University 38
  * (2003)
@@ -77,8 +69,7 @@ public class NearestNeighborHeuristicTSP<V, E>
      */
     public NearestNeighborHeuristicTSP()
     {
-        this.rng = new Random();
-        this.initiaVertex = null;
+        this(null, new Random());
     }
 
     /**
@@ -86,10 +77,7 @@ public class NearestNeighborHeuristicTSP<V, E>
      *
      * @param first First vertex to visit, or null to choose at random
      * @throws NullPointerException if first is null
-     * @deprecated use {@link #NearestNeighborHeuristicTSP()} and {@link #setFirst(Object)}
-     *
      */
-    @Deprecated(since = "1.4.1", forRemoval = true)
     public NearestNeighborHeuristicTSP(V first)
     {
         this(
@@ -100,10 +88,7 @@ public class NearestNeighborHeuristicTSP<V, E>
      * Constructor
      *
      * @param seed seed for the random number generator
-     * @deprecated use {@link #NearestNeighborHeuristicTSP()} and
-     *             {@link #setRandomNumberGenerator(Random)}
      */
-    @Deprecated(since = "1.4.1", forRemoval = true)
     public NearestNeighborHeuristicTSP(long seed)
     {
         this(null, new Random(seed));
@@ -114,10 +99,7 @@ public class NearestNeighborHeuristicTSP<V, E>
      *
      * @param rng Random number generator
      * @throws NullPointerException if rng is null
-     * @deprecated use {@link #NearestNeighborHeuristicTSP()} and
-     *             {@link #setRandomNumberGenerator(Random)}
      */
-    @Deprecated(since = "1.4.1", forRemoval = true)
     public NearestNeighborHeuristicTSP(Random rng)
     {
         this(null, Objects.requireNonNull(rng, "Random number generator cannot be null"));
@@ -128,57 +110,13 @@ public class NearestNeighborHeuristicTSP<V, E>
      *
      * @param first First vertex to visit, or null to choose at random
      * @param rng Random number generator
-     * @deprecated use {@link #NearestNeighborHeuristicTSP()},
-     *             {@link #setRandomNumberGenerator(Random)} and {@link #setFirst(Object)}
      */
-    @Deprecated(since = "1.4.1", forRemoval = true)
     private NearestNeighborHeuristicTSP(V first, Random rng)
     {
         if (first != null) {
             setInitialVertices(Collections.singletonList(first));
         }
         this.rng = rng;
-    }
-
-    // setters
-
-    /**
-     * Set the {@link Random} used to obtain the initial vertex for subsequent tour computations.
-     * <p>
-     * Vertices previously provided via {@link #setFirst(Object)} or
-     * {@link #setInitialVertices(Iterable)} are discarded.
-     * <p>
-     *
-     * @param rng the {@code Random} to use
-     * @return this algorithm object
-     */
-    public NearestNeighborHeuristicTSP<V, E> setRandomNumberGenerator(Random rng)
-    {
-        this.rng = rng;
-        this.initiaVertex = null;
-        return this;
-    }
-
-    /**
-     * Set the {@code initial vertex} visited first in the next tour computation
-     * ({@link #getTour(Graph)}).
-     * <p>
-     * For the tour computation after the next the current {@link #setRandomNumberGenerator(Random)
-     * Random} is used to randomly select a first vertex, if no initial vertex is specified in the
-     * meantime.
-     * </p>
-     * <p>
-     * Passing {@code null} discards all vertices provided previously via {@link #setFirst(Object)}
-     * or {@link #setInitialVertices(Iterable)}.
-     * </p>
-     *
-     * @param first the vertices visited first in the next tour computation ({@link #getTour(Graph)}
-     * @return this algorithm object
-     */
-    public NearestNeighborHeuristicTSP<V, E> setFirst(V first)
-    {
-        return setInitialVertices(
-            first != null ? Collections.singleton(first) : Collections.emptyList());
     }
 
     /**
@@ -204,8 +142,6 @@ public class NearestNeighborHeuristicTSP<V, E>
         this.initiaVertex = iterator.hasNext() ? iterator : null;
         return this;
     }
-
-    // algorithm
 
     /**
      * Computes a tour using the nearest neighbour heuristic.
@@ -250,7 +186,7 @@ public class NearestNeighborHeuristicTSP<V, E>
      */
     private V first(Graph<V, E> graph)
     {
-        if (initiaVertex != null) { // not null means hasNext
+        if (initiaVertex != null) {
             V first = initiaVertex.next();
             if (!initiaVertex.hasNext()) {
                 initiaVertex = null; // release the resource backing the iterator immediately

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSP.java
@@ -252,11 +252,11 @@ public class NearestNeighborHeuristicTSP<V, E>
     {
         if (initiaVertex != null) { // not null means hasNext
             V first = initiaVertex.next();
+            if (!initiaVertex.hasNext()) {
+                initiaVertex = null; // release the resource backing the iterator immediately
+            }
             if (!graph.vertexSet().contains(first)) {
                 throw new IllegalArgumentException("Specified initial vertex is not in graph");
-            }
-            if (!initiaVertex.hasNext()) {
-                initiaVertex = null; // release resources as soon as possible
             }
             return first;
         } else {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSP.java
@@ -37,6 +37,14 @@ import java.util.*;
  * </p>
  *
  * <p>
+ * The tour computed with a {@code Nearest-Neighbor-Heuristic} can vary depending on their first
+ * vertex visited. The first vertices for the next or for multiple subsequent tour computations can
+ * be controlled with {@link #setFirst(Object)} or {@link #setInitialVertices(Iterable)}.
+ * Additionally the {@link #setRandomNumberGenerator(Random) random number generator} can be
+ * specified used to randomly select the vertex visited first.
+ * </p>
+ *
+ * <p>
  * The implementation of this class is based on: <br>
  * Nilsson, Christian. "Heuristics for the traveling salesman problem." Linkoping University 38
  * (2003)
@@ -69,7 +77,8 @@ public class NearestNeighborHeuristicTSP<V, E>
      */
     public NearestNeighborHeuristicTSP()
     {
-        this(null, new Random());
+        this.rng = new Random();
+        this.initiaVertex = null;
     }
 
     /**
@@ -77,7 +86,10 @@ public class NearestNeighborHeuristicTSP<V, E>
      *
      * @param first First vertex to visit, or null to choose at random
      * @throws NullPointerException if first is null
+     * @deprecated use {@link #NearestNeighborHeuristicTSP()} and {@link #setFirst(Object)}
+     *
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public NearestNeighborHeuristicTSP(V first)
     {
         this(
@@ -88,7 +100,10 @@ public class NearestNeighborHeuristicTSP<V, E>
      * Constructor
      *
      * @param seed seed for the random number generator
+     * @deprecated use {@link #NearestNeighborHeuristicTSP()} and
+     *             {@link #setRandomNumberGenerator(Random)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public NearestNeighborHeuristicTSP(long seed)
     {
         this(null, new Random(seed));
@@ -99,7 +114,10 @@ public class NearestNeighborHeuristicTSP<V, E>
      *
      * @param rng Random number generator
      * @throws NullPointerException if rng is null
+     * @deprecated use {@link #NearestNeighborHeuristicTSP()} and
+     *             {@link #setRandomNumberGenerator(Random)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public NearestNeighborHeuristicTSP(Random rng)
     {
         this(null, Objects.requireNonNull(rng, "Random number generator cannot be null"));
@@ -110,13 +128,57 @@ public class NearestNeighborHeuristicTSP<V, E>
      *
      * @param first First vertex to visit, or null to choose at random
      * @param rng Random number generator
+     * @deprecated use {@link #NearestNeighborHeuristicTSP()},
+     *             {@link #setRandomNumberGenerator(Random)} and {@link #setFirst(Object)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     private NearestNeighborHeuristicTSP(V first, Random rng)
     {
         if (first != null) {
             setInitialVertices(Collections.singletonList(first));
         }
         this.rng = rng;
+    }
+
+    // setters
+
+    /**
+     * Set the {@link Random} used to obtain the initial vertex for subsequent tour computations.
+     * <p>
+     * Vertices previously provided via {@link #setFirst(Object)} or
+     * {@link #setInitialVertices(Iterable)} are discarded.
+     * <p>
+     *
+     * @param rng the {@code Random} to use
+     * @return this algorithm object
+     */
+    public NearestNeighborHeuristicTSP<V, E> setRandomNumberGenerator(Random rng)
+    {
+        this.rng = rng;
+        this.initiaVertex = null;
+        return this;
+    }
+
+    /**
+     * Set the {@code initial vertex} visited first in the next tour computation
+     * ({@link #getTour(Graph)}).
+     * <p>
+     * For the tour computation after the next the current {@link #setRandomNumberGenerator(Random)
+     * Random} is used to randomly select a first vertex, if no initial vertex is specified in the
+     * meantime.
+     * </p>
+     * <p>
+     * Passing {@code null} discards all vertices provided previously via {@link #setFirst(Object)}
+     * or {@link #setInitialVertices(Iterable)}.
+     * </p>
+     *
+     * @param first the vertices visited first in the next tour computation ({@link #getTour(Graph)}
+     * @return this algorithm object
+     */
+    public NearestNeighborHeuristicTSP<V, E> setFirst(V first)
+    {
+        return setInitialVertices(
+            first != null ? Collections.singleton(first) : Collections.emptyList());
     }
 
     /**
@@ -142,6 +204,8 @@ public class NearestNeighborHeuristicTSP<V, E>
         this.initiaVertex = iterator.hasNext() ? iterator : null;
         return this;
     }
+
+    // algorithm
 
     /**
      * Computes a tour using the nearest neighbour heuristic.
@@ -186,7 +250,7 @@ public class NearestNeighborHeuristicTSP<V, E>
      */
     private V first(Graph<V, E> graph)
     {
-        if (initiaVertex != null) {
+        if (initiaVertex != null) { // not null means hasNext
             V first = initiaVertex.next();
             if (!graph.vertexSet().contains(first)) {
                 throw new IllegalArgumentException("Specified initial vertex is not in graph");

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSP.java
@@ -37,6 +37,18 @@ import java.util.*;
  * </p>
  *
  * <p>
+ * The tour computed with a {@code Nearest-Neighbor-Heuristic} can vary depending on the first
+ * vertex visited. The first vertex for the next or for multiple subsequent tour computations (calls
+ * of {@link #getTour(Graph)}) can be specified in the constructors
+ * {@link #NearestNeighborHeuristicTSP(Object)} or {@link #NearestNeighborHeuristicTSP(Iterable)}.
+ * This can be used for example to ensure that the first vertices visited are different for
+ * subsequent calls of {@code  getTour(Graph)}. Once each specified first vertex is used, the first
+ * vertex in subsequent tour computations is selected randomly from the graph. Alternatively
+ * {@link #NearestNeighborHeuristicTSP(Random)} or {@link #NearestNeighborHeuristicTSP(long)} can be
+ * used to specify a {@code Random} used to randomly select the vertex visited first.
+ * </p>
+ *
+ * <p>
  * The implementation of this class is based on: <br>
  * Nilsson, Christian. "Heuristics for the traveling salesman problem." Linkoping University 38
  * (2003)
@@ -75,13 +87,30 @@ public class NearestNeighborHeuristicTSP<V, E>
     /**
      * Constructor
      *
-     * @param first First vertex to visit, or null to choose at random
+     * @param first First vertex to visit
      * @throws NullPointerException if first is null
      */
     public NearestNeighborHeuristicTSP(V first)
     {
         this(
-            Objects.requireNonNull(first, "Specified initial vertex cannot be null"), new Random());
+            Collections
+                .singletonList(
+                    Objects.requireNonNull(first, "Specified initial vertex cannot be null")),
+            new Random());
+    }
+
+    /**
+     * Constructor
+     *
+     * @param initialVertices The Iterable of vertices visited first in subsequent tour computations
+     *        (per call of {@link #getTour(Graph)} another vertex of the Iterable is used as first)
+     * @throws NullPointerException if first is null
+     */
+    public NearestNeighborHeuristicTSP(Iterable<V> initialVertices)
+    {
+        this(
+            Objects.requireNonNull(initialVertices, "Specified initial vertices cannot be null"),
+            new Random());
     }
 
     /**
@@ -108,40 +137,20 @@ public class NearestNeighborHeuristicTSP<V, E>
     /**
      * Constructor
      *
-     * @param first First vertex to visit, or null to choose at random
+     * @param initialVertices The Iterable of vertices visited first in subsequent tour
+     *        computations, or null to choose at random
      * @param rng Random number generator
      */
-    private NearestNeighborHeuristicTSP(V first, Random rng)
+    private NearestNeighborHeuristicTSP(Iterable<V> initialVertices, Random rng)
     {
-        if (first != null) {
-            setInitialVertices(Collections.singletonList(first));
+        if (initialVertices != null) {
+            Iterator<V> iterator = initialVertices.iterator();
+            this.initiaVertex = iterator.hasNext() ? iterator : null;
         }
         this.rng = rng;
     }
 
-    /**
-     * Set the {@code initial vertices} visited first in the subsequent tour computations.
-     * <p>
-     * Each vertex returned by the {@link Iterator} of the given {@code initialVertices} is used as
-     * first vertex in a separate subsequent call to {@link #getTour(Graph)}. Once the obtained
-     * iterator is exhausted, the current {@link #setRandomNumberGenerator(Random) Random} is used
-     * to randomly select a first vertex.
-     * </p>
-     * <p>
-     * This method can be used to specify the first visited vertex for multiple subsequent calls of
-     * {@code  getTour(Graph)}, for example to ensure that the first vertices visited are different.
-     * </p>
-     *
-     * @param initialVertices the vertices visited first in separate subsequent tour computations
-     * @return this algorithm object
-     */
-    public NearestNeighborHeuristicTSP<V, E> setInitialVertices(Iterable<V> initialVertices)
-    {
-        Objects.requireNonNull(initialVertices, "Specified initial vertices cannot be null");
-        Iterator<V> iterator = initialVertices.iterator();
-        this.initiaVertex = iterator.hasNext() ? iterator : null;
-        return this;
-    }
+    // algorithm
 
     /**
      * Computes a tour using the nearest neighbour heuristic.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/RandomTourTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/RandomTourTSP.java
@@ -53,7 +53,7 @@ public class RandomTourTSP<V, E>
 
     /**
      * Construct with specified random number generator
-     * 
+     *
      * @param rng The random number generator
      */
     public RandomTourTSP(Random rng)
@@ -76,8 +76,7 @@ public class RandomTourTSP<V, E>
         // Check that graph is appropriate
         checkGraph(graph);
         List<V> vertices = new ArrayList<>(graph.vertexSet());
-        int n = vertices.size();
-        if (n == 1) {
+        if (vertices.size() == 1) {
             return getSingletonTour(graph);
         }
         // Randomly permute the vertex list

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/RandomTourTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/RandomTourTSP.java
@@ -41,41 +41,25 @@ public class RandomTourTSP<V, E>
     HamiltonianCycleAlgorithmBase<V, E>
 {
 
-    private Random rng;
+    private final Random rng;
 
     /**
      * Construct with default random number generator
      */
     public RandomTourTSP()
     {
-        this.rng = new Random();
+        this(new Random());
     }
 
     /**
      * Construct with specified random number generator
      *
      * @param rng The random number generator
-     * @deprecated use {@link #RandomTourTSP() } and {@link #setRng(Random)}
      */
-    @Deprecated(since = "1.4.1", forRemoval = true)
     public RandomTourTSP(Random rng)
     {
         this.rng = Objects.requireNonNull(rng, "Random number generator cannot be null");
     }
-
-    /**
-     * Set the {@link Random} used to create random tours.
-     *
-     * @param rng the {@code Random} to use
-     * @return this algorithm object
-     */
-    public RandomTourTSP<V, E> setRng(Random rng)
-    {
-        this.rng = Objects.requireNonNull(rng, "Random number generator cannot be null");
-        return this;
-    }
-
-    // algorithm
 
     /**
      * Computes a tour using the greedy heuristic.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/RandomTourTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/RandomTourTSP.java
@@ -41,25 +41,41 @@ public class RandomTourTSP<V, E>
     HamiltonianCycleAlgorithmBase<V, E>
 {
 
-    private final Random rng;
+    private Random rng;
 
     /**
      * Construct with default random number generator
      */
     public RandomTourTSP()
     {
-        this(new Random());
+        this.rng = new Random();
     }
 
     /**
      * Construct with specified random number generator
      *
      * @param rng The random number generator
+     * @deprecated use {@link #RandomTourTSP() } and {@link #setRng(Random)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public RandomTourTSP(Random rng)
     {
         this.rng = Objects.requireNonNull(rng, "Random number generator cannot be null");
     }
+
+    /**
+     * Set the {@link Random} used to create random tours.
+     *
+     * @param rng the {@code Random} to use
+     * @return this algorithm object
+     */
+    public RandomTourTSP<V, E> setRng(Random rng)
+    {
+        this.rng = Objects.requireNonNull(rng, "Random number generator cannot be null");
+        return this;
+    }
+
+    // algorithm
 
     /**
      * Computes a tour using the greedy heuristic.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoApproxMetricTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoApproxMetricTSP.java
@@ -18,7 +18,6 @@
 package org.jgrapht.alg.tour;
 
 import org.jgrapht.*;
-import org.jgrapht.alg.interfaces.*;
 import org.jgrapht.alg.spanning.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.traverse.*;
@@ -28,42 +27,36 @@ import java.util.*;
 
 /**
  * A 2-approximation algorithm for the metric TSP problem.
- * 
+ *
  * <p>
  * The travelling salesman problem (TSP) asks the following question: "Given a list of cities and
  * the distances between each pair of cities, what is the shortest possible route that visits each
  * city exactly once and returns to the origin city?". In the metric TSP, the intercity distances
  * satisfy the triangle inequality.
- * 
+ *
  * <p>
  * This is an implementation of the folklore algorithm which returns a depth-first ordering of the
  * minimum spanning tree. The algorithm is a 2-approximation assuming that the instance satisfies
  * the triangle inequality. The implementation requires the input graph to be undirected and
  * complete. The running time is $O(|V|^2 \log |V|)$.
- * 
+ *
  * <p>
  * See <a href="https://en.wikipedia.org/wiki/Travelling_salesman_problem">wikipedia</a> for more
  * details.
- * 
+ *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
  *
  * @author Dimitrios Michail
  */
 public class TwoApproxMetricTSP<V, E>
-    implements
-    HamiltonianCycleAlgorithm<V, E>
+    extends
+    HamiltonianCycleAlgorithmBase<V, E>
 {
-    /**
-     * Construct a new instance
-     */
-    public TwoApproxMetricTSP()
-    {
-    }
 
     /**
      * Computes a 2-approximate tour.
-     * 
+     *
      * @param graph the input graph
      * @return a tour
      * @throws IllegalArgumentException if the graph is not undirected
@@ -73,68 +66,32 @@ public class TwoApproxMetricTSP<V, E>
     @Override
     public GraphPath<V, E> getTour(Graph<V, E> graph)
     {
-        if (!graph.getType().isUndirected()) {
-            throw new IllegalArgumentException("Graph must be undirected");
-        }
-        if (!GraphTests.isComplete(graph)) {
-            throw new IllegalArgumentException("Graph is not complete");
-        }
-        if (graph.vertexSet().isEmpty()) {
-            throw new IllegalArgumentException("Graph contains no vertices");
+        checkGraph(graph);
+        Set<V> vertices = graph.vertexSet();
+        int n = vertices.size();
+        if (vertices.size() == 1) {
+            return getSingletonTour(graph);
         }
 
-        /*
-         * Special case singleton vertex
-         */
-        if (graph.vertexSet().size() == 1) {
-            V start = graph.vertexSet().iterator().next();
-            return new GraphWalk<>(
-                graph, start, start, Collections.singletonList(start), Collections.emptyList(), 0d);
-        }
-
-        /*
-         * Create MST
-         */
-        Graph<V, DefaultEdge> mst = new SimpleGraph<>(DefaultEdge.class);
-        for (V v : graph.vertexSet()) {
-            mst.addVertex(v);
-        }
+        // Create MST
+        Graph<V, DefaultEdge> mst = new SimpleGraph<>(null, DefaultEdge::new, false);
+        vertices.forEach(mst::addVertex);
         for (E e : new KruskalMinimumSpanningTree<>(graph).getSpanningTree().getEdges()) {
             mst.addEdge(graph.getEdgeSource(e), graph.getEdgeTarget(e));
         }
 
-        /*
-         * Perform a depth-first-search traversal
-         */
-        int n = graph.vertexSet().size();
+        // Perform a depth-first-search traversal
         Set<V> found = CollectionUtil.newHashSetWithExpectedSize(n);
         List<V> tour = new ArrayList<>(n + 1);
-        V start = graph.vertexSet().iterator().next();
-        DepthFirstIterator<V, DefaultEdge> dfsIt = new DepthFirstIterator<>(mst, start);
+        V start = vertices.iterator().next();
+        Iterator<V> dfsIt = new DepthFirstIterator<>(mst, start);
         while (dfsIt.hasNext()) {
             V v = dfsIt.next();
             if (found.add(v)) {
                 tour.add(v);
             }
         }
-        // repeat the start vertex
-        tour.add(start);
-
-        /*
-         * Explicitly build the path.
-         */
-        List<E> tourEdges = new ArrayList<>(n);
-        double tourWeight = 0d;
-        Iterator<V> tourIt = tour.iterator();
-        V u = tourIt.next();
-        while (tourIt.hasNext()) {
-            V v = tourIt.next();
-            E e = graph.getEdge(u, v);
-            tourEdges.add(e);
-            tourWeight += graph.getEdgeWeight(e);
-            u = v;
-        }
-        return new GraphWalk<>(graph, start, start, tour, tourEdges, tourWeight);
+        // Explicitly build the path.
+        return vertexListToTour(tour, graph);
     }
-
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
@@ -32,13 +32,13 @@ import java.util.*;
  * </p>
  *
  * <p>
- * This is an implementation of the 2-opt improvement heuristic algorithm. The algorithm generates k
- * initial tours and then iteratively improves the tours until a local minimum is reached. In each
- * iteration it applies the best possible 2-opt move which means to find the best pair of edges
- * $(i,i+1)$ and $(j,j+1)$ such that replacing them with $(i,j)$ and $(i+1,j+1)$ minimizes the tour
- * length. The default initial tours use RandomTour, however an alternative algorithm can be
- * provided to create the initial tour. Initial tours generated using NearestNeighborHeuristicTSP
- * give good results and performance.
+ * This is an implementation of the 2-opt improvement heuristic algorithm. The algorithm generates
+ * <em>passes<em> initial tours and then iteratively improves the tours until a local minimum is
+ * reached. In each iteration it applies the best possible 2-opt move which means to find the best
+ * pair of edges $(i,i+1)$ and $(j,j+1)$ such that replacing them with $(i,j)$ and $(i+1,j+1)$
+ * minimizes the tour length. The default initial tours use RandomTour, however an alternative
+ * algorithm can be provided to create the initial tour. Initial tours generated using
+ * NearestNeighborHeuristicTSP give good results and performance.
  * </p>
  *
  * <p>
@@ -59,7 +59,7 @@ public class TwoOptHeuristicTSP<V, E>
     implements
     HamiltonianCycleImprovementAlgorithm<V, E>
 {
-    private final int k;
+    private final int passes;
     private final HamiltonianCycleAlgorithm<V, E> initializer;
     private final double minCostImprovement;
 
@@ -80,45 +80,45 @@ public class TwoOptHeuristicTSP<V, E>
     /**
      * Constructor
      *
-     * @param k how many initial random tours to check
+     * @param passes how many initial random tours to check
      */
-    public TwoOptHeuristicTSP(int k)
+    public TwoOptHeuristicTSP(int passes)
     {
-        this(k, new Random());
+        this(passes, new Random());
     }
 
     /**
      * Constructor
      *
-     * @param k how many initial random tours to check
+     * @param passes how many initial random tours to check
      * @param seed seed for the random number generator
      */
-    public TwoOptHeuristicTSP(int k, long seed)
+    public TwoOptHeuristicTSP(int passes, long seed)
     {
-        this(k, new Random(seed));
+        this(passes, new Random(seed));
     }
 
     /**
      * Constructor
      *
-     * @param k how many initial random tours to check
+     * @param passes how many initial random tours to check
      * @param rng random number generator
      */
-    public TwoOptHeuristicTSP(int k, Random rng)
+    public TwoOptHeuristicTSP(int passes, Random rng)
     {
-        this(k, new RandomTourTSP<>(rng));
+        this(passes, new RandomTourTSP<>(rng));
     }
 
     /**
      * Constructor
      *
-     * @param k how many initial random tours to check
+     * @param passes how many initial random tours to check
      * @param rng random number generator
      * @param minCostImprovement Minimum cost improvement per iteration
      */
-    public TwoOptHeuristicTSP(int k, Random rng, double minCostImprovement)
+    public TwoOptHeuristicTSP(int passes, Random rng, double minCostImprovement)
     {
-        this(k, new RandomTourTSP<>(rng), minCostImprovement);
+        this(passes, new RandomTourTSP<>(rng), minCostImprovement);
     }
 
     /**
@@ -134,32 +134,34 @@ public class TwoOptHeuristicTSP<V, E>
     /**
      * Constructor
      *
-     * @param k how many initial tours to check
+     * @param passes how many initial tours to check
      * @param initializer Algorithm to generate initial tour
      */
-    public TwoOptHeuristicTSP(int k, HamiltonianCycleAlgorithm<V, E> initializer)
+    public TwoOptHeuristicTSP(int passes, HamiltonianCycleAlgorithm<V, E> initializer)
     {
-        this(k, initializer, 1e-8);
+        this(passes, initializer, 1e-8);
     }
 
     /**
      * Constructor
      *
-     * @param k how many initial tours to check
+     * @param passes how many initial tours to check
      * @param initializer Algorithm to generate initial tours
      * @param minCostImprovement Minimum cost improvement per iteration
      */
     public TwoOptHeuristicTSP(
-        int k, HamiltonianCycleAlgorithm<V, E> initializer, double minCostImprovement)
+        int passes, HamiltonianCycleAlgorithm<V, E> initializer, double minCostImprovement)
     {
-        if (k < 1) {
-            throw new IllegalArgumentException("k must be at least one");
+        if (passes < 1) {
+            throw new IllegalArgumentException("passes must be at least one");
         }
-        this.k = k;
+        this.passes = passes;
         this.initializer =
             Objects.requireNonNull(initializer, "Initial solver algorithm cannot be null");
         this.minCostImprovement = Math.abs(minCostImprovement);
     }
+
+    // algorithm
 
     /**
      * Computes a 2-approximate tour.
@@ -183,7 +185,7 @@ public class TwoOptHeuristicTSP<V, E>
 
         // Execute 2-opt from k random permutations
         GraphPath<V, E> best = tourToPath(improve(createInitialTour()));
-        for (int i = 1; i < k; i++) {
+        for (int i = 1; i < passes; i++) {
             GraphPath<V, E> other = tourToPath(improve(createInitialTour()));
             if (other.getWeight() < best.getWeight()) {
                 best = other;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
@@ -59,9 +59,9 @@ public class TwoOptHeuristicTSP<V, E>
     implements
     HamiltonianCycleImprovementAlgorithm<V, E>
 {
-    private final int k;
-    private final HamiltonianCycleAlgorithm<V, E> initializer;
-    private final double minCostImprovement;
+    private int passes;
+    private HamiltonianCycleAlgorithm<V, E> initializer;
+    private double minCostImprovement;
 
     private Graph<V, E> graph;
     private int n;
@@ -74,14 +74,18 @@ public class TwoOptHeuristicTSP<V, E>
      */
     public TwoOptHeuristicTSP()
     {
-        this(1, new Random());
+        this.passes = 1;
+        this.initializer = new RandomTourTSP<>();
+        this.minCostImprovement = 1e-8;
     }
 
     /**
      * Constructor
      *
      * @param k how many initial random tours to check
+     * @deprecated use {@link #TwoOptHeuristicTSP()} and {@link #setPasses(int)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public TwoOptHeuristicTSP(int k)
     {
         this(k, new Random());
@@ -92,7 +96,10 @@ public class TwoOptHeuristicTSP<V, E>
      *
      * @param k how many initial random tours to check
      * @param seed seed for the random number generator
+     * @deprecated use {@link #TwoOptHeuristicTSP()} , {@link #setPasses(int)} and
+     *             {@link #setInitializer(HamiltonianCycleAlgorithm)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public TwoOptHeuristicTSP(int k, long seed)
     {
         this(k, new Random(seed));
@@ -103,7 +110,10 @@ public class TwoOptHeuristicTSP<V, E>
      *
      * @param k how many initial random tours to check
      * @param rng random number generator
+     * @deprecated use {@link #TwoOptHeuristicTSP()} , {@link #setPasses(int)} and
+     *             {@link #setInitializer(HamiltonianCycleAlgorithm)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public TwoOptHeuristicTSP(int k, Random rng)
     {
         this(k, new RandomTourTSP<>(rng));
@@ -115,7 +125,11 @@ public class TwoOptHeuristicTSP<V, E>
      * @param k how many initial random tours to check
      * @param rng random number generator
      * @param minCostImprovement Minimum cost improvement per iteration
+     * @deprecated use {@link #TwoOptHeuristicTSP()} , {@link #setPasses(int)},
+     *             {@link #setInitializer(HamiltonianCycleAlgorithm)} and
+     *             {@link #setMinCostImprovement(double)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public TwoOptHeuristicTSP(int k, Random rng, double minCostImprovement)
     {
         this(k, new RandomTourTSP<>(rng), minCostImprovement);
@@ -125,7 +139,10 @@ public class TwoOptHeuristicTSP<V, E>
      * Constructor
      *
      * @param initializer Algorithm to generate initial tour
+     * @deprecated use {@link #TwoOptHeuristicTSP()} and
+     *             {@link #setInitializer(HamiltonianCycleAlgorithm)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public TwoOptHeuristicTSP(HamiltonianCycleAlgorithm<V, E> initializer)
     {
         this(1, initializer);
@@ -136,7 +153,10 @@ public class TwoOptHeuristicTSP<V, E>
      *
      * @param k how many initial tours to check
      * @param initializer Algorithm to generate initial tour
+     * @deprecated use {@link #TwoOptHeuristicTSP()} , {@link #setPasses(int)} and
+     *             {@link #setInitializer(HamiltonianCycleAlgorithm)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public TwoOptHeuristicTSP(int k, HamiltonianCycleAlgorithm<V, E> initializer)
     {
         this(k, initializer, 1e-8);
@@ -148,18 +168,72 @@ public class TwoOptHeuristicTSP<V, E>
      * @param k how many initial tours to check
      * @param initializer Algorithm to generate initial tours
      * @param minCostImprovement Minimum cost improvement per iteration
+     * @deprecated use {@link #TwoOptHeuristicTSP()} , {@link #setPasses(int)},
+     *             {@link #setInitializer(HamiltonianCycleAlgorithm)} and
+     *             {@link #setMinCostImprovement(double)}
      */
+    @Deprecated(since = "1.4.1", forRemoval = true)
     public TwoOptHeuristicTSP(
         int k, HamiltonianCycleAlgorithm<V, E> initializer, double minCostImprovement)
     {
-        if (k < 1) {
-            throw new IllegalArgumentException("k must be at least one");
+        setPasses(k);
+        setInitializer(initializer);
+        setMinCostImprovement(minCostImprovement);
+    }
+
+    // setters
+
+    /**
+     * Set the number of passes done in {@link #getTour(Graph)}.
+     * <p>
+     * In each pass an initial tour is computed with the
+     * {@link #setInitializer(HamiltonianCycleAlgorithm) initializer}, which is then improved with
+     * this {@code TwoOptHeuristicTSP}. The result with the lowest path costs respectively path
+     * length of all passes is returned as the final result of {@code getTour(Graph)}.
+     * </p>
+     *
+     * @param passes the number of passes done in {@code getTour(Graph)}
+     * @return this algorithm object
+     */
+    public TwoOptHeuristicTSP<V, E> setPasses(int passes)
+    {
+        if (passes < 1) {
+            throw new IllegalArgumentException("passes must be at least one");
         }
-        this.k = k;
+        this.passes = passes;
+        return this;
+    }
+
+    /**
+     * Set the {@link HamiltonianCycleAlgorithm} used to compute the initial tour in each pass.
+     *
+     * @param initializer the {@code HamiltonianCycleAlgorithm} to compute the initial tour
+     * @return this algorithm object
+     */
+    public TwoOptHeuristicTSP<V, E> setInitializer(HamiltonianCycleAlgorithm<V, E> initializer)
+    {
         this.initializer =
             Objects.requireNonNull(initializer, "Initial solver algorithm cannot be null");
-        this.minCostImprovement = Math.abs(minCostImprovement);
+        return this;
     }
+
+    /**
+     * Set the required {@code minimum cost improvement} a tour modification must produce in order
+     * to be considered as improvement.
+     * <p>
+     * A value to close to zero can cause an endless loop.
+     * </p>
+     *
+     * @param minCostImprovement the minimal cost improvement a tour move must produce
+     * @return this algorithm object
+     */
+    public TwoOptHeuristicTSP<V, E> setMinCostImprovement(double minCostImprovement)
+    {
+        this.minCostImprovement = Math.abs(minCostImprovement);
+        return this;
+    }
+
+    // algorithm
 
     /**
      * Computes a 2-approximate tour.
@@ -183,7 +257,7 @@ public class TwoOptHeuristicTSP<V, E>
 
         // Execute 2-opt from k random permutations
         GraphPath<V, E> best = tourToPath(improve(createInitialTour()));
-        for (int i = 1; i < k; i++) {
+        for (int i = 1; i < passes; i++) {
             GraphPath<V, E> other = tourToPath(improve(createInitialTour()));
             if (other.getWeight() < best.getWeight()) {
                 best = other;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
@@ -183,7 +183,7 @@ public class TwoOptHeuristicTSP<V, E>
         // Initialize vertex index and distances
         init(graph);
 
-        // Execute 2-opt from k random permutations
+        // Execute 2-opt for the specified number of passes and a new permutation in each pass
         GraphPath<V, E> best = tourToPath(improve(createInitialTour()));
         for (int i = 1; i < passes; i++) {
             GraphPath<V, E> other = tourToPath(improve(createInitialTour()));

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
@@ -19,19 +19,18 @@ package org.jgrapht.alg.tour;
 
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
-import org.jgrapht.graph.*;
 
 import java.util.*;
 
 /**
  * The 2-opt heuristic algorithm for the TSP problem.
- * 
+ *
  * <p>
  * The travelling salesman problem (TSP) asks the following question: "Given a list of cities and
  * the distances between each pair of cities, what is the shortest possible route that visits each
  * city exactly once and returns to the origin city?".
  * </p>
- * 
+ *
  * <p>
  * This is an implementation of the 2-opt improvement heuristic algorithm. The algorithm generates k
  * initial tours and then iteratively improves the tours until a local minimum is reached. In each
@@ -41,22 +40,23 @@ import java.util.*;
  * provided to create the initial tour. Initial tours generated using NearestNeighborHeuristicTSP
  * give good results and performance.
  * </p>
- * 
+ *
  * <p>
  * See <a href="https://en.wikipedia.org/wiki/2-opt">wikipedia</a> for more details.
- * 
+ *
  * <p>
  * This implementation can also be used in order to try to improve an existing tour. See method
  * {@link #improveTour(GraphPath)}.
- * 
+ *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
  *
  * @author Dimitrios Michail
  */
 public class TwoOptHeuristicTSP<V, E>
+    extends
+    HamiltonianCycleAlgorithmBase<V, E>
     implements
-    HamiltonianCycleAlgorithm<V, E>,
     HamiltonianCycleImprovementAlgorithm<V, E>
 {
     private final int k;
@@ -79,7 +79,7 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Constructor
-     * 
+     *
      * @param k how many initial random tours to check
      */
     public TwoOptHeuristicTSP(int k)
@@ -89,7 +89,7 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Constructor
-     * 
+     *
      * @param k how many initial random tours to check
      * @param seed seed for the random number generator
      */
@@ -100,7 +100,7 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Constructor
-     * 
+     *
      * @param k how many initial random tours to check
      * @param rng random number generator
      */
@@ -111,7 +111,7 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Constructor
-     * 
+     *
      * @param k how many initial random tours to check
      * @param rng random number generator
      * @param minCostImprovement Minimum cost improvement per iteration
@@ -123,7 +123,7 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Constructor
-     * 
+     *
      * @param initializer Algorithm to generate initial tour
      */
     public TwoOptHeuristicTSP(HamiltonianCycleAlgorithm<V, E> initializer)
@@ -133,7 +133,7 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Constructor
-     * 
+     *
      * @param k how many initial tours to check
      * @param initializer Algorithm to generate initial tour
      */
@@ -144,7 +144,7 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Constructor
-     * 
+     *
      * @param k how many initial tours to check
      * @param initializer Algorithm to generate initial tours
      * @param minCostImprovement Minimum cost improvement per iteration
@@ -163,7 +163,7 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Computes a 2-approximate tour.
-     * 
+     *
      * @param graph the input graph
      * @return a tour
      * @throws IllegalArgumentException if the graph is not undirected
@@ -173,23 +173,15 @@ public class TwoOptHeuristicTSP<V, E>
     @Override
     public GraphPath<V, E> getTour(Graph<V, E> graph)
     {
-        /*
-         * Initialize vertex index and distances
-         */
-        init(graph);
-
-        /*
-         * Special case singleton vertex
-         */
+        checkGraph(graph);
         if (graph.vertexSet().size() == 1) {
-            V start = graph.vertexSet().iterator().next();
-            return new GraphWalk<>(
-                graph, start, start, Collections.singletonList(start), Collections.emptyList(), 0d);
+            return getSingletonTour(graph);
         }
 
-        /*
-         * Execute 2-opt from k random permutations
-         */
+        // Initialize vertex index and distances
+        init(graph);
+
+        // Execute 2-opt from k random permutations
         GraphPath<V, E> best = tourToPath(improve(createInitialTour()));
         for (int i = 1; i < k; i++) {
             GraphPath<V, E> other = tourToPath(improve(createInitialTour()));
@@ -202,7 +194,7 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Try to improve a tour by running the 2-opt heuristic.
-     * 
+     *
      * @param tour a tour
      * @return a possibly improved tour
      */
@@ -215,20 +207,12 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Initialize graph and mapping to integer vertices.
-     * 
+     *
      * @param graph the input graph
      */
     private void init(Graph<V, E> graph)
     {
-        this.graph = GraphTests.requireUndirected(graph);
-
-        if (!GraphTests.isComplete(graph)) {
-            throw new IllegalArgumentException("Graph is not complete");
-        }
-        if (graph.vertexSet().isEmpty()) {
-            throw new IllegalArgumentException("Graph contains no vertices");
-        }
-
+        this.graph = graph;
         this.n = graph.vertexSet().size();
         this.dist = new double[n][n];
         this.index = new HashMap<>();
@@ -253,7 +237,7 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Create an initial tour
-     * 
+     *
      * @return a complete tour
      */
     private int[] createInitialTour()
@@ -265,10 +249,10 @@ public class TwoOptHeuristicTSP<V, E>
      * Improve the tour using the 2-opt heuristic. In each iteration it applies the best possible
      * 2-opt move which means to find the best pair of edges $(i,i+1)$ and $(j,j+1)$ such that
      * replacing them with $(i,j)$ and $(i+1,j+1)$ minimizes the tour length.
-     * 
+     *
      * <p>
      * The returned array instance might or might not be the input array.
-     * 
+     *
      * @param tour the input tour
      * @return a possibly improved tour
      */
@@ -321,33 +305,23 @@ public class TwoOptHeuristicTSP<V, E>
 
     /**
      * Transform from an array representation to a graph path.
-     * 
+     *
      * @param tour an array containing the index of the vertices of the tour
      * @return a graph path
      */
     private GraphPath<V, E> tourToPath(int[] tour)
     {
-        List<E> tourEdges = new ArrayList<>(n);
         List<V> tourVertices = new ArrayList<>(n + 1);
-        double tourWeight = 0d;
-
-        V start = revIndex.get(tour[0]);
-        tourVertices.add(start);
-        for (int i = 1; i < n + 1; i++) {
-            V u = revIndex.get(tour[i - 1]);
-            V v = revIndex.get(tour[i]);
+        for (int vi : tour) {
+            V v = revIndex.get(vi);
             tourVertices.add(v);
-            E e = graph.getEdge(u, v);
-            tourEdges.add(e);
-            tourWeight += graph.getEdgeWeight(e);
         }
-
-        return new GraphWalk<>(graph, start, start, tourVertices, tourEdges, tourWeight);
+        return closedVertexListToTour(tourVertices, graph);
     }
 
     /**
      * Transform from a path representation to an array representation.
-     * 
+     *
      * @param path graph path
      * @return an array containing the index of the vertices of the tour
      */
@@ -370,5 +344,4 @@ public class TwoOptHeuristicTSP<V, E>
         }
         return tour;
     }
-
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/CollectionUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/CollectionUtil.java
@@ -132,13 +132,13 @@ public class CollectionUtil
         if (iterable instanceof List) {
             return ((List<E>) iterable).get(index);
         }
-        try {
-            Iterator<E> it = iterable.iterator();
-            for (int i = 0; i < index; i++) {
-                it.next();
-            }
+        Iterator<E> it = iterable.iterator();
+        for (int i = 0; i < index && it.hasNext(); i++) {
+            it.next();
+        }
+        if (it.hasNext()) {
             return it.next();
-        } catch (NoSuchElementException e) {
+        } else {
             throw new IndexOutOfBoundsException(index);
         }
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/CollectionUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/CollectionUtil.java
@@ -21,7 +21,7 @@ import java.util.*;
 
 /**
  * Utility class to create {@link Collection} instances.
- * 
+ *
  * @author Hannes Wellmann
  *
  */
@@ -41,7 +41,7 @@ public class CollectionUtil
      * the maximum number of entries divided by the load factor, no rehash operations will ever
      * occur".
      * </p>
-     * 
+     *
      * @param <K> the type of keys in the returned {@code HashMap}
      * @param <V> the type of values in the returned {@code HashMap}
      * @param expectedSize of mappings that will be put into the returned {@code HashMap}
@@ -61,7 +61,7 @@ public class CollectionUtil
      * is not equivalent to the number of mappings it can hold without rehashing. See
      * {@link #newHashMapWithExpectedSize(int)} for details.
      * </p>
-     * 
+     *
      * @param <K> the type of keys in the returned {@code LinkedHashMap}
      * @param <V> the type of values in the returned {@code LinkedHashMap}
      * @param expectedSize of mappings that will be put into the returned {@code LinkedHashMap}
@@ -81,7 +81,7 @@ public class CollectionUtil
      * capacity is not equivalent to the number of elements it can hold without rehashing. See
      * {@link #newHashMapWithExpectedSize(int)} for details.
      * </p>
-     * 
+     *
      * @param <E> the type of elements in the returned {@code HashSet}
      * @param expectedSize of elements that will be add to the returned {@code HashSet}
      * @return an empty {@code HashSet} with sufficient capacity to hold expectedSize elements
@@ -100,7 +100,7 @@ public class CollectionUtil
      * capacity is not equivalent to the number of elements it can hold without rehashing. See
      * {@link #newHashMapWithExpectedSize(int)} for details.
      * </p>
-     * 
+     *
      * @param <E> the type of elements in the returned {@code LinkedHashSet}
      * @param expectedSize of elements that will be add to the returned {@code LinkedHashSet}
      * @return an empty {@code LinkedHashSet} with sufficient capacity to hold expectedSize elements
@@ -114,5 +114,32 @@ public class CollectionUtil
     private static int capacityForSize(int size)
     { // consider default load factor 0.75f of (Linked)HashMap
         return (int) (size / 0.75f + 1.0f); // let (Linked)HashMap limit it if it's too large
+    }
+
+    /**
+     * Returns from the given {@code Iterable} the element with the given {@code index}.
+     * <p>
+     * The order to which the index applies is that defined by the {@link Iterable#iterator()}.
+     * </p>
+     *
+     * @param <E> the type of elements in the {@code Iterable}
+     * @param iterable the Iterable from which the element at {@code index} is returned
+     * @param index the index of the returned element
+     * @return the element with {@code index} in the {@code iterable}
+     */
+    public static <E> E getElement(Iterable<E> iterable, int index)
+    {
+        if (iterable instanceof List) {
+            return ((List<E>) iterable).get(index);
+        }
+        try {
+            Iterator<E> it = iterable.iterator();
+            for (int i = 0; i < index; i++) {
+                it.next();
+            }
+            return it.next();
+        } catch (NoSuchElementException e) {
+            throw new IndexOutOfBoundsException(index);
+        }
     }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/tour/GeometricTSPTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/tour/GeometricTSPTest.java
@@ -17,6 +17,8 @@
  */
 package org.jgrapht.alg.tour;
 
+import static org.jgrapht.alg.tour.TwoApproxMetricTSPTest.*;
+
 import org.apache.commons.math3.geometry.euclidean.twod.*;
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
@@ -29,8 +31,6 @@ import org.junit.runners.*;
 
 import java.util.*;
 import java.util.PrimitiveIterator.*;
-
-import static org.jgrapht.alg.tour.TwoApproxMetricTSPTest.assertHamiltonian;
 
 /**
  * Tests of Travelling Salesman Problem algorithms based on a random set of 2D points, with graphs
@@ -124,14 +124,16 @@ public class GeometricTSPTest
     public void testTwoOptNearestNeighbour()
     {
         testWith(
-            "Two-opt of nearest neighbour",
-            new TwoOptHeuristicTSP<>(new NearestNeighborHeuristicTSP<>()));
+            "Two-opt of nearest neighbour", new TwoOptHeuristicTSP<Vector2D, DefaultWeightedEdge>()
+                .setInitializer(new NearestNeighborHeuristicTSP<>()));
     }
 
     @Test
     public void testTwoOpt1()
     {
-        testWith("Two-opt, 1 attempt from random", new TwoOptHeuristicTSP<>(1));
+        testWith(
+            "Two-opt, 1 attempt from random",
+            new TwoOptHeuristicTSP<Vector2D, DefaultWeightedEdge>().setPasses(1));
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/tour/GeometricTSPTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/tour/GeometricTSPTest.java
@@ -17,8 +17,6 @@
  */
 package org.jgrapht.alg.tour;
 
-import static org.jgrapht.alg.tour.TwoApproxMetricTSPTest.*;
-
 import org.apache.commons.math3.geometry.euclidean.twod.*;
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
@@ -31,6 +29,8 @@ import org.junit.runners.*;
 
 import java.util.*;
 import java.util.PrimitiveIterator.*;
+
+import static org.jgrapht.alg.tour.TwoApproxMetricTSPTest.assertHamiltonian;
 
 /**
  * Tests of Travelling Salesman Problem algorithms based on a random set of 2D points, with graphs
@@ -124,16 +124,14 @@ public class GeometricTSPTest
     public void testTwoOptNearestNeighbour()
     {
         testWith(
-            "Two-opt of nearest neighbour", new TwoOptHeuristicTSP<Vector2D, DefaultWeightedEdge>()
-                .setInitializer(new NearestNeighborHeuristicTSP<>()));
+            "Two-opt of nearest neighbour",
+            new TwoOptHeuristicTSP<>(new NearestNeighborHeuristicTSP<>()));
     }
 
     @Test
     public void testTwoOpt1()
     {
-        testWith(
-            "Two-opt, 1 attempt from random",
-            new TwoOptHeuristicTSP<Vector2D, DefaultWeightedEdge>().setPasses(1));
+        testWith("Two-opt, 1 attempt from random", new TwoOptHeuristicTSP<>(1));
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSPTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSPTest.java
@@ -32,6 +32,18 @@ import java.io.*;
 import java.net.*;
 import java.util.*;
 
+/**
+ * Tests for {@link NearestNeighborHeuristicTSP}.
+ * <p>
+ * The test data used in this test are designed so that for one vertex, the weight of each touching
+ * edges is distinct to the other touching edges of that vertex. This has the intended consequence
+ * that for a given first vertex the expected tour computed with the
+ * {@code NearestNeighborHeuristic} is unambiguous and the result must never change.
+ * </p>
+ *
+ * @author Hannes Wellmann
+ *
+ */
 public class NearestNeighborHeuristicTSPTest
 {
     private static List<Vector2D> locations;

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSPTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSPTest.java
@@ -1,0 +1,192 @@
+/*
+ * (C) Copyright 2020-2020, by Hannes Wellmann and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.tour;
+
+import static java.util.stream.Collectors.*;
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.Matchers.*;
+
+import org.apache.commons.math3.geometry.euclidean.twod.*;
+import org.jgrapht.*;
+import org.jgrapht.alg.interfaces.*;
+import org.jgrapht.generate.*;
+import org.jgrapht.graph.*;
+import org.junit.*;
+
+import java.io.*;
+import java.net.*;
+import java.util.*;
+
+public class NearestNeighborHeuristicTSPTest
+{
+    private static List<Vector2D> locations;
+    private static Graph<Vector2D, DefaultWeightedEdge> graph;
+    private static List<GraphPath<Vector2D, DefaultWeightedEdge>> expectedTours;
+
+    @BeforeClass
+    public static void setUpBeforeClass()
+        throws Exception
+    {
+        List<Vector2D> loc = new ArrayList<>();
+        loc.add(new Vector2D(235, 170));
+        loc.add(new Vector2D(326, 212));
+        loc.add(new Vector2D(215, 430));
+        loc.add(new Vector2D(511, 693));
+        loc.add(new Vector2D(806, 463));
+        loc.add(new Vector2D(504, 62));
+        loc.add(new Vector2D(434, 742));
+        loc.add(new Vector2D(487, 614));
+        loc.add(new Vector2D(719, 147));
+        loc.add(new Vector2D(182, 449));
+        locations = Collections.unmodifiableList(loc);
+
+        // build complete graph
+        Graph<Vector2D, DefaultWeightedEdge> g =
+            new SimpleWeightedGraph<>(loc.iterator()::next, DefaultWeightedEdge::new);
+
+        new CompleteGraphGenerator<Vector2D, DefaultWeightedEdge>(loc.size()).generateGraph(g);
+
+        // compute edge weights
+        for (DefaultWeightedEdge edge : g.edgeSet()) {
+            Vector2D source = g.getEdgeSource(edge);
+            Vector2D target = g.getEdgeTarget(edge);
+            double weight = source.distance(target);
+            g.setEdgeWeight(edge, weight);
+        }
+
+        graph = new AsUnmodifiableGraph<>(g);
+
+        // build expected tours:
+        // For each of the above specified locations the distances to each other location are
+        // different. Therefore for a given start-vertex the resulting tour computed according to
+        // the NearestNeighbour heuristic is unambiguous.
+        List<GraphPath<Vector2D, DefaultWeightedEdge>> tours = new ArrayList<>();
+        tours.add(buildTourPath(new int[] { 0, 1, 5, 8, 4, 7, 3, 6, 2, 9 }, graph, loc));
+        tours.add(buildTourPath(new int[] { 1, 0, 2, 9, 7, 3, 6, 4, 8, 5 }, graph, loc));
+        tours.add(buildTourPath(new int[] { 2, 9, 1, 0, 5, 8, 4, 7, 3, 6 }, graph, loc));
+        tours.add(buildTourPath(new int[] { 3, 7, 6, 2, 9, 1, 0, 5, 8, 4 }, graph, loc));
+        tours.add(buildTourPath(new int[] { 4, 8, 5, 1, 0, 2, 9, 7, 3, 6 }, graph, loc));
+        tours.add(buildTourPath(new int[] { 5, 8, 4, 7, 3, 6, 2, 9, 1, 0 }, graph, loc));
+        tours.add(buildTourPath(new int[] { 6, 3, 7, 2, 9, 1, 0, 5, 8, 4 }, graph, loc));
+        tours.add(buildTourPath(new int[] { 7, 3, 6, 2, 9, 1, 0, 5, 8, 4 }, graph, loc));
+        tours.add(buildTourPath(new int[] { 8, 5, 1, 0, 2, 9, 7, 3, 6, 4 }, graph, loc));
+        tours.add(buildTourPath(new int[] { 9, 2, 1, 0, 5, 8, 4, 7, 3, 6 }, graph, loc));
+        expectedTours = Collections.unmodifiableList(tours);
+    }
+
+    @Test
+    public void testSetRandomNumberGenerator()
+        throws URISyntaxException,
+        IOException
+    {
+        int randomSeed = 0;
+        int tours = graph.vertexSet().size();
+        // the following order is used in within the heuristic
+        List<Vector2D> orderedVertices = new ArrayList<>(graph.vertexSet());
+
+        Random testRnd = new Random(randomSeed);
+
+        HamiltonianCycleAlgorithm<Vector2D, DefaultWeightedEdge> alg =
+            new NearestNeighborHeuristicTSP<Vector2D, DefaultWeightedEdge>()
+                .setRandomNumberGenerator(new Random(randomSeed));
+
+        for (int i = 0; i < tours; i++) {
+            Vector2D expectedStartVertex = orderedVertices.get(testRnd.nextInt(tours));
+
+            GraphPath<Vector2D, DefaultWeightedEdge> tour = alg.getTour(graph);
+
+            assertStartVertex(tour, expectedStartVertex);
+        }
+    }
+
+    @Test
+    public void testSetFirst()
+    {
+        Vector2D first = locations.get(2);
+        HamiltonianCycleAlgorithm<Vector2D, DefaultWeightedEdge> alg =
+            new NearestNeighborHeuristicTSP<Vector2D, DefaultWeightedEdge>().setFirst(first);
+
+        GraphPath<Vector2D, DefaultWeightedEdge> tour = alg.getTour(graph);
+        assertStartVertex(tour, first);
+    }
+
+    @Test
+    public void testSetInitialVertices()
+    {
+        List<Vector2D> initalVertices = new ArrayList<>(graph.vertexSet());
+        long seed = stringBytesAsLong("JGraphT"); // a fixed seed
+        Collections.shuffle(initalVertices, new Random(seed));
+
+        HamiltonianCycleAlgorithm<Vector2D, DefaultWeightedEdge> alg =
+            new NearestNeighborHeuristicTSP<Vector2D, DefaultWeightedEdge>()
+                .setInitialVertices(initalVertices);
+
+        for (Vector2D expectedStartVertex : initalVertices) {
+            GraphPath<Vector2D, DefaultWeightedEdge> tour = alg.getTour(graph);
+            assertStartVertex(tour, expectedStartVertex);
+        }
+    }
+
+    @Test
+    public void testGetTour()
+    {
+        NearestNeighborHeuristicTSP<Vector2D, DefaultWeightedEdge> alg =
+            new NearestNeighborHeuristicTSP<>();
+
+        for (int i = 0; i < locations.size(); i++) {
+            Vector2D startVertex = locations.get(i);
+            GraphPath<Vector2D, DefaultWeightedEdge> expectedTour = expectedTours.get(i);
+
+            GraphPath<Vector2D, DefaultWeightedEdge> tour =
+                alg.setFirst(startVertex).getTour(graph);
+
+            assertThat(tour, is(equalTo(expectedTour)));
+        }
+    }
+
+    // utilities
+
+    private static <V, E> void assertStartVertex(GraphPath<V, E> tour, V expectedStartVertex)
+    {
+        assertThat(tour.getStartVertex(), is(sameInstance(expectedStartVertex)));
+    }
+
+    private static <V, E> GraphPath<V, E> buildTourPath(
+        int[] tourVertexIndices, Graph<V, E> graph, List<V> vertexList)
+    {
+        List<V> tour = Arrays.stream(tourVertexIndices).mapToObj(vertexList::get).collect(toList());
+        tour.add(tour.get(0)); // close path
+
+        double weight = 0;
+        for (int i = 1; i < tourVertexIndices.length; i++) {
+            E edge = graph.getEdge(tour.get(i - 1), tour.get(i));
+            weight += graph.getEdgeWeight(edge);
+        }
+        return new GraphWalk<>(graph, tour, weight);
+    }
+
+    private static long stringBytesAsLong(String str)
+    {
+        int length = str.length(); // if longer than 8, bytes are lost
+        long l = 0;
+        for (int i = 0; i < length; i++) {
+            l += ((long) str.charAt(length - 1 - i)) << (8 * i);
+        }
+        return l;
+    }
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSPTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/tour/NearestNeighborHeuristicTSPTest.java
@@ -90,7 +90,7 @@ public class NearestNeighborHeuristicTSPTest
     }
 
     @Test
-    public void testSetRandomNumberGenerator()
+    public void testConstructorWithRandomNumberGenerator()
         throws URISyntaxException,
         IOException
     {
@@ -102,8 +102,7 @@ public class NearestNeighborHeuristicTSPTest
         Random testRnd = new Random(randomSeed);
 
         HamiltonianCycleAlgorithm<Vector2D, DefaultWeightedEdge> alg =
-            new NearestNeighborHeuristicTSP<Vector2D, DefaultWeightedEdge>()
-                .setRandomNumberGenerator(new Random(randomSeed));
+            new NearestNeighborHeuristicTSP<>(new Random(randomSeed));
 
         for (int i = 0; i < tours; i++) {
             Vector2D expectedStartVertex = orderedVertices.get(testRnd.nextInt(tours));
@@ -115,26 +114,25 @@ public class NearestNeighborHeuristicTSPTest
     }
 
     @Test
-    public void testSetFirst()
+    public void testConstructorWithFirst()
     {
         Vector2D first = locations.get(2);
         HamiltonianCycleAlgorithm<Vector2D, DefaultWeightedEdge> alg =
-            new NearestNeighborHeuristicTSP<Vector2D, DefaultWeightedEdge>().setFirst(first);
+            new NearestNeighborHeuristicTSP<>(first);
 
         GraphPath<Vector2D, DefaultWeightedEdge> tour = alg.getTour(graph);
         assertStartVertex(tour, first);
     }
 
     @Test
-    public void testSetInitialVertices()
+    public void testConstructorWithInitialVertices()
     {
         List<Vector2D> initalVertices = new ArrayList<>(graph.vertexSet());
         long seed = stringBytesAsLong("JGraphT"); // a fixed seed
         Collections.shuffle(initalVertices, new Random(seed));
 
         HamiltonianCycleAlgorithm<Vector2D, DefaultWeightedEdge> alg =
-            new NearestNeighborHeuristicTSP<Vector2D, DefaultWeightedEdge>()
-                .setInitialVertices(initalVertices);
+            new NearestNeighborHeuristicTSP<>(initalVertices);
 
         for (Vector2D expectedStartVertex : initalVertices) {
             GraphPath<Vector2D, DefaultWeightedEdge> tour = alg.getTour(graph);
@@ -145,15 +143,13 @@ public class NearestNeighborHeuristicTSPTest
     @Test
     public void testGetTour()
     {
-        NearestNeighborHeuristicTSP<Vector2D, DefaultWeightedEdge> alg =
-            new NearestNeighborHeuristicTSP<>();
-
         for (int i = 0; i < locations.size(); i++) {
             Vector2D startVertex = locations.get(i);
             GraphPath<Vector2D, DefaultWeightedEdge> expectedTour = expectedTours.get(i);
 
             GraphPath<Vector2D, DefaultWeightedEdge> tour =
-                alg.setFirst(startVertex).getTour(graph);
+                new NearestNeighborHeuristicTSP<Vector2D, DefaultWeightedEdge>(startVertex)
+                    .getTour(graph);
 
             assertThat(tour, is(equalTo(expectedTour)));
         }


### PR DESCRIPTION
1. As suggested and discussed in issue [#872](https://github.com/jgrapht/jgrapht/issues/872), I unified and improved the structure of the HamiltonianCycleAlgorithm implementations.
All implementations now extend HamiltonianCycleAlgorithmBase and use the provided methods as far as possible. I also made some minor code and code structure improvements or simplifications.

2. In `NearestNeighborHeuristicTSP` I replaced the `first`-vertex field by an Iterator for initial vertices that is used in subsequent calls to `getTour()`, as long there is a next available.
Now it is possible to compute multiple tours in a row with specified start-vertices.
This is especially handy when using `NearestNeighborHeuristicTSP` as initializer for a TwoOptHeuristicTSP-instance that performs multiple passes (`k>1`). Because previously only the first start-vertex of the first pass could be specified in _NearestNeighbor_, one either had to hope that the `rng` used other start-vertices in subsequent passes or had to do the passes _manually_ and create and especially initialize a new `TwoOptHeuristicTSP`-instance in each pass.
Now the `NearestNeighbor` can be used as initializer with specified start-vertices for multiple passes. For example this can be used to ensure that another start-vertex is used in each pass or to use certain initial vertices that a user expectes, for whatever reason that, better results.
The first example can be achieved with the following code:
```
HamiltonianCycleAlgorithm<V,E> initializer = new NearestNeighborHeuristicTSP<V, E>().setInitialVertices(graph.vertexSet());
new TwoOptHeuristicTSP<V, E>().setInitializer(initializer).setPasses(5).getTour();
```

3. Furthermore I added fluent setters for the fields of all HamiltonianCycleAlgorithm-implementations and deprecated all constructors except the default one. Mainly because of `TwoOptHeuristicTSP` and also `NearestNeighborHeuristicTSP`, since they have multiple configurable fields which leads to numerous constructors (eight for 2-opt!). To be consistent I did the same for the other implementations with instance-fields.
Beside less constructors, the (fluent) setters also have the advantage that they name what is set, not like in the constructor where the arguments are unnamed when the constructor is called. Additionally this avoids repetitions of documentation and each configurable field can be precisely explained once in its setter. I kept the default constructor, so the default initial values of the fields can be stated.
Also renamed  the field "k" in `TwoOptHeuristicTSP` since the the "2-opt" heuristic is the simplest representative of the more generic class of algorithms which is usually referred as _k-opt_, with k greater-equals two. Therefore the name "k" could be misinterpreted.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
