### PR TITLE
Simple GraphML Importer: fixed issue with unreported edge attributes

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/graphml/SimpleGraphMLEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/graphml/SimpleGraphMLEventDrivenImporter.java
@@ -474,6 +474,10 @@ public class SimpleGraphMLEventDrivenImporter
                         } catch (NumberFormatException e) {
                             // ignore
                         }
+                    } else {
+                        notifyEdgeAttribute(
+                            currentEdge, key.attributeName,
+                            new DefaultAttribute<>(currentDataValue.toString(), key.type));
                     }
                 }
             }

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/graphml/SimpleGraphMLEventDrivenImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/graphml/SimpleGraphMLEventDrivenImporterTest.java
@@ -90,6 +90,7 @@ public class SimpleGraphMLEventDrivenImporterTest
             "http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd\">" + NL +
             "<key id=\"d0\" for=\"node\" attr.name=\"color\" attr.type=\"string\"/>" + NL +
             "<key id=\"d1\" for=\"edge\" attr.name=\"weight\" attr.type=\"double\"/>" + NL +
+            "<key id=\"d2\" for=\"edge\" attr.name=\"cost\" attr.type=\"double\"/>" + NL +
             "<graph id=\"G\" edgedefault=\"undirected\">" + NL +
             "<node id=\"n0\">" + NL +
             "<data key=\"d0\">green</data>" + NL +
@@ -103,6 +104,7 @@ public class SimpleGraphMLEventDrivenImporterTest
             "</edge>" + NL +
             "<edge id=\"e1\" source=\"n0\" target=\"n1\">" + NL +
             "<data key=\"d1\">3.0</data>" + NL +
+            "<data key=\"d2\">13.0</data>" + NL +
             "</edge>" + NL +
             "<edge id=\"e2\" source=\"n1\" target=\"n2\"/>" + NL +
             "</graph>" + NL +
@@ -110,6 +112,15 @@ public class SimpleGraphMLEventDrivenImporterTest
         // @formatter:on
 
         SimpleGraphMLEventDrivenImporter importer = new SimpleGraphMLEventDrivenImporter();
+        
+        importer.addEdgeAttributeConsumer((p,a)->{
+            String key = p.getSecond();
+            String value = a.getValue();
+            
+            if (key.equals("cost")) { 
+                assertEquals(value, "13.0");
+            }
+        });
 
         List<Triple<String, String, Double>> collected = new ArrayList<>();
         importer.addEdgeConsumer(q -> {


### PR DESCRIPTION
Fixed a bug where edge attributes were not reported to the user. 

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
