### PR TITLE
Fail on javac warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,6 +140,8 @@
 					<version>3.8.1</version>
 					<configuration>
 						<release>11</release>
+						<compilerArgument>-Werror</compilerArgument>
+						<fork>true</fork>
 					</configuration>
 				</plugin>
 				<plugin>


### PR DESCRIPTION
[Dev guide: Contributor Guidelines](https://github.com/jgrapht/jgrapht/wiki/Dev-guide%3A-Contributor-Guidelines):

> Unfortunately, there is no way to get the build to stop on warnings for javac and javadoc, so please scan the output carefully. (If you know of a way to fix this, please contribute a buildfile change.)

Here you go.

- JavaC hint is from the question https://stackoverflow.com/q/9192613/873282
- JavaDoc always fails since Java 1.8. See https://stackoverflow.com/a/16743137/873282

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
