### PR TITLE
Fix typos

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/Graph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/Graph.java
@@ -140,7 +140,7 @@ public interface Graph<V, E>
     /**
      * Creates a new edge in this graph, going from the source vertex to the target vertex, and
      * returns the created edge. Some graphs do not allow edge-multiplicity. In such cases, if the
-     * graph already contains an edge from the specified source to the specified target, than this
+     * graph already contains an edge from the specified source to the specified target, then this
      * method does not change the graph and returns <code>null</code>.
      *
      * <p>
@@ -182,7 +182,7 @@ public interface Graph<V, E>
      * <code>e2.equals(e)</code>. If this graph already contains such an edge, the call leaves this
      * graph unchanged and returns <code>false</code>. Some graphs do not allow edge-multiplicity.
      * In such cases, if the graph already contains an edge from the specified source to the
-     * specified target, than this method does not change the graph and returns <code>
+     * specified target, then this method does not change the graph and returns <code>
      * false</code>. If the edge was added to the graph, returns <code>
      * true</code>.
      *

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
@@ -686,7 +686,7 @@ public class CapacityScalingMinimumCostFlow<V, E>
         int labelType;
         /**
          * The excess of this node. If this value is positive, then this is a source node. If this
-         * value is 0, than this is a transhipment node. If this value if negative, this is a sink
+         * value is 0, then this is a transhipment node. If this value if negative, this is a sink
          * node.
          */
         int excess;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/planar/BoyerMyrvoldPlanarityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/planar/BoyerMyrvoldPlanarityInspector.java
@@ -1943,7 +1943,7 @@ public class BoyerMyrvoldPlanarityInspector<V, E>
         /**
          * Stores some value to indicate whether this node is visited in the current context or not.
          * During the testing phase, if this value if equal to the dfs index of the currently
-         * processed node $v$, than this node is visited, otherwise not. During the Kuratowski
+         * processed node $v$, then this node is visited, otherwise not. During the Kuratowski
          * subdivision extraction phase, the value of $0$ indicates that the node isn't visited,
          * otherwise, the node is considered to be visited.
          */
@@ -1972,7 +1972,7 @@ public class BoyerMyrvoldPlanarityInspector<V, E>
          */
         Edge parentEdge;
         /**
-         * If this node has a back edge incident to the currently processed node $v$, than this
+         * If this node has a back edge incident to the currently processed node $v$, then this
          * variable stores this edge
          */
         Edge edgeToEmbed;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/extension/Extension.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/extension/Extension.java
@@ -22,7 +22,7 @@ package org.jgrapht.alg.util.extension;
  * denoted as original,can be encapsulated in or extended by another object. An example would be the
  * relation between an edge (original) and an annotated edge. The annotated edge
  * encapsulates/extends an edge, thereby augmenting it with additional data. In symbolic form, if b
- * is the original class, than a(b) would be its extension. This concept is similar to java's
+ * is the original class, then a(b) would be its extension. This concept is similar to java's
  * extension where one class is derived from (extends) another class (original).
  */
 public interface Extension

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/extension/ExtensionManager.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/extension/ExtensionManager.java
@@ -24,7 +24,7 @@ import java.util.*;
  * extensions and encapsulations. An object, from here on denoted as 'original', can be encapsulated
  * in or extended by another object. An example would be the relation between an edge (original) and
  * an annotated edge. The annotated edge encapsulates/extends an edge, thereby augmenting it with
- * additional data. In symbolic form, if b is the original class, than a(b) would be its extension.
+ * additional data. In symbolic form, if b is the original class, then a(b) would be its extension.
  * This concept is similar to java's extension where one class is derived from (extends) another
  * class (original).
  *

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsSubgraph.java
@@ -62,7 +62,7 @@ import java.util.stream.*;
  * such identity, at a severe performance cost. Currently it is no longer enforced. If you want to
  * achieve a "live-window" functionality, your safest tactics would be to NOT override the
  * <code>equals()</code> methods of your vertices and edges. If you use a class that has already
- * overridden the <code>equals()</code> method, such as <code>String</code>, than you can use a
+ * overridden the <code>equals()</code> method, such as <code>String</code>, then you can use a
  * wrapper around it, or else use it directly but exercise a great care to avoid having
  * different-but-equal instances in the subgraph and the base graph.
  * </p>


### PR DESCRIPTION
While reading some JavaDoc, I found a simple typo. This fixes it.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
