### PR TITLE
VertexToIntegerMapping: Merge and simplify constructors

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/util/VertexToIntegerMapping.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/VertexToIntegerMapping.java
@@ -33,28 +33,8 @@ import java.util.*;
  */
 public class VertexToIntegerMapping<V>
 {
-
     private final Map<V, Integer> vertexMap;
     private final List<V> indexList;
-
-    /**
-     * Create a new mapping from a set of vertices.
-     *
-     * @param vertices the input set of vertices
-     * @throws NullPointerException if {@code vertices} is {@code null}
-     */
-    public VertexToIntegerMapping(Set<V> vertices)
-    {
-        Objects.requireNonNull(vertices, "the input collection of vertices cannot be null");
-
-        vertexMap = CollectionUtil.newHashMapWithExpectedSize(vertices.size());
-        indexList = new ArrayList<>(vertices.size());
-
-        for (V v : vertices) {
-            vertexMap.put(v, vertexMap.size());
-            indexList.add(v);
-        }
-    }
 
     /**
      * Create a new mapping from a list of vertices. The input list will be used as the
@@ -71,12 +51,8 @@ public class VertexToIntegerMapping<V>
         vertexMap = CollectionUtil.newHashMapWithExpectedSize(vertices.size());
         indexList = vertices;
 
-        for (int i = 0; i < vertices.size(); i++) {
-            V v = vertices.get(i);
-
-            if (!vertexMap.containsKey(v)) {
-                vertexMap.put(v, i);
-            } else {
+        for (V v : vertices) {
+            if (vertexMap.put(v, vertexMap.size()) != null) {
                 throw new IllegalArgumentException("vertices are not distinct");
             }
         }
@@ -91,19 +67,10 @@ public class VertexToIntegerMapping<V>
      */
     public VertexToIntegerMapping(Collection<V> vertices)
     {
-        Objects.requireNonNull(vertices, "the input collection of vertices cannot be null");
-
-        vertexMap = CollectionUtil.newHashMapWithExpectedSize(vertices.size());
-        indexList = new ArrayList<>(vertices.size());
-
-        for (V v : vertices) {
-            if (!vertexMap.containsKey(v)) {
-                vertexMap.put(v, vertexMap.size());
-                indexList.add(v);
-            } else {
-                throw new IllegalArgumentException("vertices are not distinct");
-            }
-        }
+        this(
+            new ArrayList<>(
+                Objects
+                    .requireNonNull(vertices, "the input collection of vertices cannot be null")));
     }
 
     /**


### PR DESCRIPTION
Merged the constructors of `VertexToIntegerMapping` into one working constructor in order to avoid code duplications and simplify that one.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
