### PR TITLE
Create .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
While reading https://github.com/jgrapht/jgrapht/pull/938, I found that some files have a final new line, some do not have. The checkstyle config demands final new lines.

With this PR a minimal [EditorConfig](https://editorconfig.org/) is created. It ensures that there is always a final new line. EditorCnfig is supported by IntelliJ out of the box. For VSCode and Eclipse, a plugin is required.

Moreover, it trims trailing white spaces in all files. Except markdown. There, two final spaces are a hard line break. This might be needed.

One point for improvement:

    indent_style = space

I saw that `java` is space, `pom.xml` is tab. 

A) all files similar
B) configure for pom: tab, for all others space
C) leave as is

I chose option C as it doesn't seem to cause issues currently so why invest time in properly configuring a checker.

