### PR TITLE
Fixed silently ignored error in `AsWeightedGraph`

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
@@ -188,10 +188,12 @@ public class AsWeightedGraph<V, E>
     @Override
     public void setEdgeWeight(E e, double weight)
     {
-        assert weightFunction == null
-            || cacheWeights : "Cannot set an edge weight when a weight function is used and caching is disabled";
         assert e != null;
-
+        
+        if (weightFunction != null && !cacheWeights) { 
+            throw new UnsupportedOperationException("Cannot set an edge weight when a weight function is used and caching is disabled");
+        }
+        
         this.weights.put(e, weight);
 
         if (this.writeWeightsThrough)


### PR DESCRIPTION
A small but vital fix in the `AsWeightedGraph` view. In case the user provides a weight function and caching is disabled, the `set_edge_weight` should not work. Previously, this check was an assertion (which in production code was silently ignored). This PR throws a UnsupportedOperationException. 

This is more inline with the rest of the library. Moreover, it does not force the user to keep the state externally.

----
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
