### PR TITLE
Avoid import of own jgrapht-packages in MANIFEST.MF

### DIFF
--- a/jgrapht-core/pom.xml
+++ b/jgrapht-core/pom.xml
@@ -31,9 +31,9 @@
             <version>0.13</version>
         </dependency>
         <dependency>
-               <groupId>com.googlecode.junit-toolbox</groupId>
-               <artifactId>junit-toolbox</artifactId>
-               <scope>test</scope>
+            <groupId>com.googlecode.junit-toolbox</groupId>
+            <artifactId>junit-toolbox</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.openjdk.jmh</groupId>
@@ -62,6 +62,11 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Import-Package>!org.jgrapht.*,*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -88,7 +93,7 @@
                     <groups>org.jgrapht.SlowTests</groups>
                     <excludedGroups>org.jgrapht.OptionalTests</excludedGroups>
                 </configuration>
-                  </plugin>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jgrapht-core/pom.xml
+++ b/jgrapht-core/pom.xml
@@ -64,6 +64,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
+                        <!-- Suppress import of own exported packages -->
                         <Import-Package>!org.jgrapht.*,*</Import-Package>
                     </instructions>
                 </configuration>

--- a/jgrapht-dist/pom.xml
+++ b/jgrapht-dist/pom.xml
@@ -86,11 +86,6 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
-                <configuration>
-                    <instructions>
-                        <Import-Package>!org.jgrapht.dist.*,*</Import-Package>
-                    </instructions>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/jgrapht-dist/pom.xml
+++ b/jgrapht-dist/pom.xml
@@ -86,6 +86,11 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Import-Package>!org.jgrapht.dist.*,*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -43,6 +43,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
+                        <!-- Suppress import of own exported packages -->
                         <Import-Package>!org.jgrapht.ext.*,*</Import-Package>
                     </instructions>
                 </configuration>

--- a/jgrapht-ext/pom.xml
+++ b/jgrapht-ext/pom.xml
@@ -41,6 +41,11 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Import-Package>!org.jgrapht.ext.*,*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/jgrapht-guava/pom.xml
+++ b/jgrapht-guava/pom.xml
@@ -41,6 +41,11 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Import-Package>!org.jgrapht.guava.*,*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>
@@ -86,7 +91,7 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>listenablefuture</artifactId>
                 </exclusion>
-                  </exclusions>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/jgrapht-guava/pom.xml
+++ b/jgrapht-guava/pom.xml
@@ -43,6 +43,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
+                        <!-- Suppress import of own exported packages -->
                         <Import-Package>!org.jgrapht.guava.*,*</Import-Package>
                     </instructions>
                 </configuration>

--- a/jgrapht-io/pom.xml
+++ b/jgrapht-io/pom.xml
@@ -41,6 +41,11 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Import-Package>!org.jgrapht.nio.*,*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.antlr</groupId>

--- a/jgrapht-io/pom.xml
+++ b/jgrapht-io/pom.xml
@@ -43,6 +43,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
+                        <!-- Suppress import of own exported packages -->
                         <Import-Package>!org.jgrapht.nio.*,*</Import-Package>
                     </instructions>
                 </configuration>

--- a/jgrapht-opt/pom.xml
+++ b/jgrapht-opt/pom.xml
@@ -43,6 +43,7 @@
                 <artifactId>maven-bundle-plugin</artifactId>
                 <configuration>
                     <instructions>
+                        <!-- Suppress import of own exported packages -->
                         <Import-Package>!org.jgrapht.opt.*,*</Import-Package>
                     </instructions>
                 </configuration>

--- a/jgrapht-opt/pom.xml
+++ b/jgrapht-opt/pom.xml
@@ -41,6 +41,11 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Import-Package>!org.jgrapht.opt.*,*</Import-Package>
+                    </instructions>
+                </configuration>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
1. In order to solve issue #736 I added to the `org.apache.felix` plugin in the pom.xml of each jgrapht module the following lines:
```    
    <configuration>
        <instructions>
            <Import-Package>!org.jgrapht.*,*</Import-Package>
        </instructions>
    </configuration>
```
In all modules but core, the exclusion pattern additionally contains the root package of that module too (like `org.jgrapht.dist.*` or `org.jgrapht.nio.*`). So all required packages that are not contained in the resulting jar are imported, but the packages in the jar are not.

2. Additionally I fixed the line terminator in `jgrapht-io/pom.xml`. It contained two lines with Windows-style line-endings ("\r\n"), which let Eclipse-EGit go crazy. It shows a changed pom in the staging area that appears automatically but has no differences in the compare editor. Additionally it's very hard to get rid of the change. Now the line-endings are UNIX-style ("\n") like the rest of this and all other files.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
