### PR TITLE
Fixed bug with shutting down executor service in DeltaSteppingShortestPath

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
@@ -381,20 +381,6 @@ public class DeltaSteppingShortestPath<V, E>
                 ++firstNonEmptyBucket;
             }
         }
-        shutDownExecutor();
-    }
-
-    /**
-     * Shuts down the {@link #executor}.
-     */
-    private void shutDownExecutor()
-    {
-        executor.shutdown();
-        try { // wait till the executor is shut down
-            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
@@ -17,24 +17,15 @@ d *
  */
 package org.jgrapht.alg.shortestpath;
 
-import org.jgrapht.Graph;
-import org.jgrapht.GraphPath;
-import org.jgrapht.Graphs;
-import org.jgrapht.alg.interfaces.ShortestPathAlgorithm;
-import org.jgrapht.generate.GnmRandomGraphGenerator;
-import org.jgrapht.generate.GraphGenerator;
-import org.jgrapht.graph.DefaultUndirectedWeightedGraph;
-import org.jgrapht.graph.DefaultWeightedEdge;
-import org.jgrapht.graph.DirectedWeightedPseudograph;
-import org.jgrapht.util.CollectionUtil;
-import org.jgrapht.util.SupplierUtil;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.ExpectedException;
+import org.jgrapht.*;
+import org.jgrapht.alg.interfaces.*;
+import org.jgrapht.generate.*;
+import org.jgrapht.graph.*;
+import org.jgrapht.util.*;
+import org.junit.*;
+import org.junit.rules.*;
 
-import java.util.Arrays;
-import java.util.Random;
-import java.util.Set;
+import java.util.*;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;


### PR DESCRIPTION
Currently, the `DeltaSteppingShortestPath` uses `ExecutorCompletionService` for parallelisation. This completion service gets shut down in every call to `getPaths()` methods. This behavior leads to a situation where a `DeltaSteppingShortestPath` object can be used only once and every consequent call to either of the following methods

- getPaths()
- getPath()
- getWeight()

results in `RejectedExecutionException`. This is not the desired behavior. 

In this pull request:

- the `shutdownExecutor()` method is removed from `DeltaSteppingShortestPath`
- the tests for `DeltaSteppingShortestPath` are adjusted to assert the new behaviour. 


----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
