### PR TITLE
Fixed bug in DijkstraManyToManyShortestPath with handling reversed search space

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPaths.java
@@ -147,6 +147,9 @@ public class DijkstraManyToManyShortestPaths<V, E>
         public double getWeight(V source, V target)
         {
             assertCorrectSourceAndTarget(source, target);
+            if(reversed){
+                return searchSpaces.get(target).getWeight(source);
+            }
             return searchSpaces.get(source).getWeight(target);
         }
     }


### PR DESCRIPTION
Currently, `DijkstraManyToManyShortestPathsImpl` in `DijkstraManyToManyShortestPaths` does not tarke into account the value `reversed` field in its `getPathWeight()` method. This PR resolves this issue.


----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
