### PR TITLE
Parameterized ThreadPoolExecutor in parallel algorithms.

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPaths.java
@@ -22,6 +22,7 @@ import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.*;
 
 import java.util.*;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.*;
 
 import static org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.*;
@@ -47,7 +48,7 @@ import static org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.*;
  * restored actual path from the information in the shortest paths trees.
  *
  * <p>
- * Additionally if $|S|$ > $|T|$ the algorithm is executed on the reversed graph. This allows
+ * Additionally if $|S| > |T|$ the algorithm is executed on the reversed graph. This allows
  * to reduce the number of buckets and optimize memory usage of the algorithm.
  *
  * <p>
@@ -86,10 +87,23 @@ public class CHManyToManyShortestPaths<V, E>
      * Constructs an instance of the algorithm for a given {@code graph}.
      *
      * @param graph a graph
+     * @deprecated replaced with {@link #CHManyToManyShortestPaths(Graph, ThreadPoolExecutor)}
      */
+    @Deprecated
     public CHManyToManyShortestPaths(Graph<V, E> graph)
     {
         this(new ContractionHierarchyPrecomputation<>(graph).computeContractionHierarchy());
+    }
+
+    /**
+     * Constructs an instance of the algorithm for a given {@code graph} and {@code executor}.
+     *
+     * @param graph a graph
+     * @param executor executor which will be used to compute {@link ContractionHierarchy}
+     */
+    public CHManyToManyShortestPaths(Graph<V, E> graph, ThreadPoolExecutor executor)
+    {
+        this(new ContractionHierarchyPrecomputation<>(graph, executor).computeContractionHierarchy());
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPaths.java
@@ -84,12 +84,14 @@ public class CHManyToManyShortestPaths<V, E>
     private Map<V, ContractionVertex<V>> contractionMapping;
 
     /**
-     * Constructs an instance of the algorithm for a given {@code graph}.
+     * Constructs an instance of the algorithm for a given {@code graph}. This constructor
+     * computes Contraction Hierarchy with an internal instance of {@link ThreadPoolExecutor}.
+     * This instance is not shut down after Contraction Hierarchy is computed. If you want to
+     * use a custom instance of {@link ThreadPoolExecutor} please use
+     * {@link #CHManyToManyShortestPaths(Graph, ThreadPoolExecutor)} instead.
      *
      * @param graph a graph
-     * @deprecated replaced with {@link #CHManyToManyShortestPaths(Graph, ThreadPoolExecutor)}
      */
-    @Deprecated
     public CHManyToManyShortestPaths(Graph<V, E> graph)
     {
         this(new ContractionHierarchyPrecomputation<>(graph).computeContractionHierarchy());

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPaths.java
@@ -99,7 +99,7 @@ public class CHManyToManyShortestPaths<V, E>
     /**
      * Constructs an instance of the algorithm for a given {@code graph} and {@code executor}.
      * It is up to a user of this algorithm to handle the creation and termination of the
-     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * provided {@code executor}. For utility methods to manage a {@code ThreadPoolExecutor} see
      * {@link ConcurrencyUtil}.
      *
      * @param graph a graph

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPaths.java
@@ -20,6 +20,7 @@ package org.jgrapht.alg.shortestpath;
 import org.jgrapht.*;
 import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.*;
+import org.jgrapht.util.ConcurrencyUtil;
 
 import java.util.*;
 import java.util.concurrent.ThreadPoolExecutor;
@@ -84,14 +85,12 @@ public class CHManyToManyShortestPaths<V, E>
     private Map<V, ContractionVertex<V>> contractionMapping;
 
     /**
-     * Constructs an instance of the algorithm for a given {@code graph}. This constructor
-     * computes Contraction Hierarchy with an internal instance of {@link ThreadPoolExecutor}.
-     * This instance is not shut down after Contraction Hierarchy is computed. If you want to
-     * use a custom instance of {@link ThreadPoolExecutor} please use
-     * {@link #CHManyToManyShortestPaths(Graph, ThreadPoolExecutor)} instead.
+     * Constructs an instance of the algorithm for a given {@code graph}.
      *
      * @param graph a graph
+     * @deprecated replaced with {@link #CHManyToManyShortestPaths(Graph, ThreadPoolExecutor)}
      */
+    @Deprecated
     public CHManyToManyShortestPaths(Graph<V, E> graph)
     {
         this(new ContractionHierarchyPrecomputation<>(graph).computeContractionHierarchy());
@@ -99,6 +98,9 @@ public class CHManyToManyShortestPaths<V, E>
 
     /**
      * Constructs an instance of the algorithm for a given {@code graph} and {@code executor}.
+     * It is up to a user of this algorithm to handle the creation and termination of the
+     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * {@link ConcurrencyUtil}.
      *
      * @param graph a graph
      * @param executor executor which will be used to compute {@link ContractionHierarchy}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstra.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstra.java
@@ -24,6 +24,7 @@ import org.jheaps.*;
 import org.jheaps.tree.*;
 
 import java.util.*;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.*;
 
 import static org.jgrapht.alg.shortestpath.BidirectionalDijkstraShortestPath.DijkstraSearchFrontier;
@@ -114,10 +115,23 @@ public class ContractionHierarchyBidirectionalDijkstra<V, E>
      * Constructs a new instance of the algorithm for a given {@code graph}.
      *
      * @param graph the graph
+     * @deprecated replaced with {@link #ContractionHierarchyBidirectionalDijkstra(Graph, ThreadPoolExecutor)}
      */
+    @Deprecated
     public ContractionHierarchyBidirectionalDijkstra(Graph<V, E> graph)
     {
         this(new ContractionHierarchyPrecomputation<>(graph).computeContractionHierarchy());
+    }
+
+    /**
+     * Constructs a new instance of the algorithm for a given {@code graph} and {@code executor}.
+     *
+     * @param graph the graph
+     * @param executor executor which is used for computing the {@link ContractionHierarchy}
+     */
+    public ContractionHierarchyBidirectionalDijkstra(Graph<V, E> graph, ThreadPoolExecutor executor)
+    {
+        this(new ContractionHierarchyPrecomputation<>(graph, executor).computeContractionHierarchy());
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstra.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstra.java
@@ -20,6 +20,7 @@ package org.jgrapht.alg.shortestpath;
 import org.jgrapht.*;
 import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.*;
+import org.jgrapht.util.ConcurrencyUtil;
 import org.jheaps.*;
 import org.jheaps.tree.*;
 
@@ -112,14 +113,12 @@ public class ContractionHierarchyBidirectionalDijkstra<V, E>
     private double radius;
 
     /**
-     * Constructs a new instance of the algorithm for a given {@code graph}. This constructor
-     * computes Contraction Hierarchy with an internal instance of {@link ThreadPoolExecutor}.
-     * This instance is not shut down after Contraction Hierarchy is computed. If you want to
-     * use a custom instance of {@link ThreadPoolExecutor} use
-     * {@link #ContractionHierarchyBidirectionalDijkstra(Graph, ThreadPoolExecutor)} instead.
+     * Constructs a new instance of the algorithm for a given {@code graph}.
      *
      * @param graph the graph
+     * @deprecated replaced with {@link #ContractionHierarchyBidirectionalDijkstra(Graph, ThreadPoolExecutor)}
      */
+    @Deprecated
     public ContractionHierarchyBidirectionalDijkstra(Graph<V, E> graph)
     {
         this(new ContractionHierarchyPrecomputation<>(graph).computeContractionHierarchy());
@@ -127,6 +126,9 @@ public class ContractionHierarchyBidirectionalDijkstra<V, E>
 
     /**
      * Constructs a new instance of the algorithm for a given {@code graph} and {@code executor}.
+     * It is up to a user of this algorithm to handle the creation and termination of the
+     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * {@link ConcurrencyUtil}.
      *
      * @param graph the graph
      * @param executor executor which is used for computing the {@link ContractionHierarchy}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstra.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstra.java
@@ -127,7 +127,7 @@ public class ContractionHierarchyBidirectionalDijkstra<V, E>
     /**
      * Constructs a new instance of the algorithm for a given {@code graph} and {@code executor}.
      * It is up to a user of this algorithm to handle the creation and termination of the
-     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * provided {@code executor}. For utility methods to manage a {@code ThreadPoolExecutor} see
      * {@link ConcurrencyUtil}.
      *
      * @param graph the graph

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstra.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstra.java
@@ -112,12 +112,14 @@ public class ContractionHierarchyBidirectionalDijkstra<V, E>
     private double radius;
 
     /**
-     * Constructs a new instance of the algorithm for a given {@code graph}.
+     * Constructs a new instance of the algorithm for a given {@code graph}. This constructor
+     * computes Contraction Hierarchy with an internal instance of {@link ThreadPoolExecutor}.
+     * This instance is not shut down after Contraction Hierarchy is computed. If you want to
+     * use a custom instance of {@link ThreadPoolExecutor} use
+     * {@link #ContractionHierarchyBidirectionalDijkstra(Graph, ThreadPoolExecutor)} instead.
      *
      * @param graph the graph
-     * @deprecated replaced with {@link #ContractionHierarchyBidirectionalDijkstra(Graph, ThreadPoolExecutor)}
      */
-    @Deprecated
     public ContractionHierarchyBidirectionalDijkstra(Graph<V, E> graph)
     {
         this(new ContractionHierarchyPrecomputation<>(graph).computeContractionHierarchy());

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputation.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputation.java
@@ -17,18 +17,32 @@
  */
 package org.jgrapht.alg.shortestpath;
 
-import org.jgrapht.*;
-import org.jgrapht.util.*;
-import org.jgrapht.alg.util.*;
-import org.jgrapht.graph.*;
-import org.jgrapht.graph.builder.*;
-import org.jheaps.*;
-import org.jheaps.tree.*;
+import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.graph.MaskSubgraph;
+import org.jgrapht.graph.builder.GraphTypeBuilder;
+import org.jgrapht.util.ConcurrentUtil;
+import org.jheaps.AddressableHeap;
+import org.jheaps.tree.PairingHeap;
 
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
-import java.util.function.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Parallel implementation of the <a href="https://en.wikipedia.org/wiki/Contraction_hierarchies">
@@ -165,12 +179,15 @@ public class ContractionHierarchyPrecomputation<V, E>
     private Consumer<ContractionVertex<V>> markUpwardEdgesConsumer;
 
     /**
-     * Constructs a new instance of the algorithm for a given {@code graph}.
+     * Constructs a new instance of the algorithm for a given {@code graph}. This constructor
+     * initializes the algorithm with an instance of {@link ThreadPoolExecutor} which has the
+     * maximum number of threads set to {@code Runtime.getRuntime().availableProcessors()}.
+     * This executor will not be shut down by this algorithm. If you want to use a custom instance
+     * of {@link ThreadPoolExecutor} and be able to manage its lifecycle use
+     * {@link #ContractionHierarchyPrecomputation(Graph, ThreadPoolExecutor)} instead.
      *
      * @param graph graph
-     * @deprecated replaced with {@link #ContractionHierarchyPrecomputation(Graph, ThreadPoolExecutor)}
      */
-    @Deprecated
     public ContractionHierarchyPrecomputation(Graph<V, E> graph)
     {
         this(graph, Runtime.getRuntime().availableProcessors());
@@ -189,12 +206,15 @@ public class ContractionHierarchyPrecomputation<V, E>
 
     /**
      * Constructs a new instance of the algorithm for a given {@code graph} and {@code parallelism}.
+     * This constructor initializes the algorithm with an instance of {@link ThreadPoolExecutor} which
+     * has the maximum number of threads set to {@code parallelism}. This executor will not be shut
+     * down by this algorithm. If you want to use a custom instance of {@link ThreadPoolExecutor}
+     * and be able to manage its lifecycle use
+     * {@link #ContractionHierarchyPrecomputation(Graph, ThreadPoolExecutor)} instead.
      *
      * @param graph graph
      * @param parallelism maximum number of threads used in the computations
-     * @deprecated replaced with {@link #ContractionHierarchyPrecomputation(Graph, ThreadPoolExecutor)}
      */
-    @Deprecated
     public ContractionHierarchyPrecomputation(Graph<V, E> graph, int parallelism)
     {
         this(graph, parallelism, Random::new, PairingHeap::new);
@@ -204,15 +224,19 @@ public class ContractionHierarchyPrecomputation<V, E>
     /**
      * Constructs a new instance of the algorithm for a given {@code graph} and
      * {@code randomSupplier}. Provided {@code randomSupplier} should return different random
-     * generators instances, because they are used by different threads.
+     * generators instances, because they are used by different threads. This constructor
+     * initializes the algorithm with an instance of {@link ThreadPoolExecutor} which has the
+     * maximum number of threads set to {@code Runtime.getRuntime().availableProcessors()}.
+     * This executor will not be shut down by this algorithm. If you want to use a custom instance
+     * of {@link ThreadPoolExecutor} and be able to manage its lifecycle use
+     * {@link #ContractionHierarchyPrecomputation(Graph, Supplier, ThreadPoolExecutor)} instead.
      *
      * @param graph graph
      * @param randomSupplier supplier for preferable instances of {@link Random}
      */
-    @Deprecated
     public ContractionHierarchyPrecomputation(Graph<V, E> graph, Supplier<Random> randomSupplier)
     {
-        this(graph, Runtime.getRuntime().availableProcessors(), randomSupplier);
+        this(graph, randomSupplier, ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors()));
     }
 
     /**
@@ -231,33 +255,37 @@ public class ContractionHierarchyPrecomputation<V, E>
 
     /**
      * Constructs a new instance of the algorithm for a given {@code graph}, {@code parallelism} and
-     * {@code randomSupplier}.
+     * {@code randomSupplier}. This constructor initializes the algorithm with an instance of
+     * {@link ThreadPoolExecutor} which has the maximum number of threads set to {@code parallelism}.
+     * This executor will not be shut down by this algorithm. If you want to use a custom instance of
+     * {@link ThreadPoolExecutor} and be able to manage its lifecycle use
+     * {@link #ContractionHierarchyPrecomputation(Graph, Supplier, ThreadPoolExecutor)} instead.
      *
      * @param graph graph
      * @param parallelism maximum number of threads used in the computations
      * @param randomSupplier supplier for preferable instances of {@link Random}
-     * @deprecated replaced with {@link #ContractionHierarchyPrecomputation(Graph, Supplier, ThreadPoolExecutor)}
      */
-    @Deprecated
     public ContractionHierarchyPrecomputation(
         Graph<V, E> graph, int parallelism, Supplier<Random> randomSupplier)
     {
-        this(graph, parallelism, randomSupplier, PairingHeap::new);
+        this(graph, randomSupplier, ConcurrentUtil.createThreadPoolExecutor(parallelism));
     }
 
     /**
      * Constructs a new instance of the algorithm for a given {@code graph}, {@code parallelism},
-     * {@code randomSupplier} and {@code shortcutsSearchHeapSupplier}. Provided
-     * {@code randomSupplier} should return different random generators instances, because they are
-     * used by different threads.
+     * {@code randomSupplier} and {@code shortcutsSearchHeapSupplier}. Provided {@code randomSupplier}
+     * should return different random generators instances, because they are used by different threads.
+     * This constructor initializes the algorithm with an instance of {@link ThreadPoolExecutor} which
+     * has the maximum number of threads set to {@code parallelism}. This executor will not be shut down
+     * by this algorithm. If you want to use a custom instance of {@link ThreadPoolExecutor} and be able
+     * to manage its lifecycle use
+     * {@link #ContractionHierarchyPrecomputation(Graph, Supplier, Supplier, ThreadPoolExecutor)} instead.
      *
      * @param graph graph
      * @param parallelism maximum number of threads used in the computations
      * @param randomSupplier supplier for preferable instances of {@link Random}
      * @param shortcutsSearchHeapSupplier supplier for the preferable heap implementation.
-     * @deprecated replaced with {@link #ContractionHierarchyPrecomputation(Graph, Supplier, Supplier, ThreadPoolExecutor)}
      */
-    @Deprecated
     public ContractionHierarchyPrecomputation(
         Graph<V, E> graph, int parallelism, Supplier<Random> randomSupplier,
         Supplier<AddressableHeap<Double, ContractionVertex<V>>> shortcutsSearchHeapSupplier)

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputation.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputation.java
@@ -17,17 +17,32 @@
  */
 package org.jgrapht.alg.shortestpath;
 
-import org.jgrapht.*;
-import org.jgrapht.alg.util.*;
-import org.jgrapht.graph.*;
-import org.jgrapht.graph.builder.*;
-import org.jheaps.*;
-import org.jheaps.tree.*;
+import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.graph.MaskSubgraph;
+import org.jgrapht.graph.builder.GraphTypeBuilder;
+import org.jgrapht.util.ConcurrentUtil;
+import org.jheaps.AddressableHeap;
+import org.jheaps.tree.PairingHeap;
 
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
-import java.util.function.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Parallel implementation of the <a href="https://en.wikipedia.org/wiki/Contraction_hierarchies">
@@ -67,7 +82,11 @@ import java.util.function.*;
  * comparing to the sequential approach.
  *
  * <p>
- * For parallelization, this implementation relies on the {@link ExecutorService}.
+ * For parallelization, this implementation relies on the {@link ThreadPoolExecutor}
+ * which is supplied to this algorithm from without. This algorithm does not manages the
+ * lifecycle of the supplied executor instance. For auxiliary methods for creating and
+ * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrentUtil}.
+ *
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -122,12 +141,8 @@ public class ContractionHierarchyPrecomputation<V, E>
     private Supplier<AddressableHeap<Double, ContractionVertex<V>>> shortcutsSearchHeapSupplier;
 
     /**
-     * Executor to which contraction tasks are submitted.
-     */
-    private ExecutorService executor;
-    /**
-     * Decorator for {@code executor} that enables to keep track of when all submitted tasks are
-     * finished.
+     * Decorator for {@code executor} supplied to this algorithm that enables to
+     * keep track of when all submitted tasks are finished.
      */
     private ExecutorCompletionService<Void> completionService;
     /**
@@ -167,10 +182,23 @@ public class ContractionHierarchyPrecomputation<V, E>
      * Constructs a new instance of the algorithm for a given {@code graph}.
      *
      * @param graph graph
+     * @deprecated replaced with {@link #ContractionHierarchyPrecomputation(Graph, ThreadPoolExecutor)}
      */
+    @Deprecated
     public ContractionHierarchyPrecomputation(Graph<V, E> graph)
     {
         this(graph, Runtime.getRuntime().availableProcessors());
+    }
+
+    /**
+     * Constructs a new instance of the algorithm for a given {@code graph} and {@code executor}.
+     *
+     * @param graph graph
+     * @param executor executor which will be used for parallelization
+     */
+    public ContractionHierarchyPrecomputation(Graph<V, E> graph, ThreadPoolExecutor executor)
+    {
+        this(graph,  Random::new, executor);
     }
 
     /**
@@ -178,11 +206,14 @@ public class ContractionHierarchyPrecomputation<V, E>
      *
      * @param graph graph
      * @param parallelism maximum number of threads used in the computations
+     * @deprecated replaced with {@link #ContractionHierarchyPrecomputation(Graph, ThreadPoolExecutor)}
      */
+    @Deprecated
     public ContractionHierarchyPrecomputation(Graph<V, E> graph, int parallelism)
     {
         this(graph, parallelism, Random::new, PairingHeap::new);
     }
+
 
     /**
      * Constructs a new instance of the algorithm for a given {@code graph} and
@@ -192,9 +223,24 @@ public class ContractionHierarchyPrecomputation<V, E>
      * @param graph graph
      * @param randomSupplier supplier for preferable instances of {@link Random}
      */
+    @Deprecated
     public ContractionHierarchyPrecomputation(Graph<V, E> graph, Supplier<Random> randomSupplier)
     {
         this(graph, Runtime.getRuntime().availableProcessors(), randomSupplier);
+    }
+
+    /**
+     * Constructs a new instance of the algorithm for a given {@code graph}, {@code randomSupplier}
+     * and {@code executor}. Provided {@code randomSupplier} should return different random
+     * generators instances, because they are used by different threads.
+     *
+     * @param graph graph
+     * @param randomSupplier supplier for preferable instances of {@link Random}
+     * @param executor executor which will be used to parallelization
+     */
+    public ContractionHierarchyPrecomputation(Graph<V, E> graph, Supplier<Random> randomSupplier, ThreadPoolExecutor executor)
+    {
+        this(graph, randomSupplier, PairingHeap::new, executor);
     }
 
     /**
@@ -204,7 +250,9 @@ public class ContractionHierarchyPrecomputation<V, E>
      * @param graph graph
      * @param parallelism maximum number of threads used in the computations
      * @param randomSupplier supplier for preferable instances of {@link Random}
+     * @deprecated replaced with {@link #ContractionHierarchyPrecomputation(Graph, Supplier, ThreadPoolExecutor)}
      */
+    @Deprecated
     public ContractionHierarchyPrecomputation(
         Graph<V, E> graph, int parallelism, Supplier<Random> randomSupplier)
     {
@@ -221,16 +269,51 @@ public class ContractionHierarchyPrecomputation<V, E>
      * @param parallelism maximum number of threads used in the computations
      * @param randomSupplier supplier for preferable instances of {@link Random}
      * @param shortcutsSearchHeapSupplier supplier for the preferable heap implementation.
+     * @deprecated replaced with {@link #ContractionHierarchyPrecomputation(Graph, Supplier, Supplier, ThreadPoolExecutor)}
      */
+    @Deprecated
     public ContractionHierarchyPrecomputation(
         Graph<V, E> graph, int parallelism, Supplier<Random> randomSupplier,
         Supplier<AddressableHeap<Double, ContractionVertex<V>>> shortcutsSearchHeapSupplier)
     {
+        init(graph, randomSupplier, shortcutsSearchHeapSupplier, ConcurrentUtil.createThreadPoolExecutor(parallelism));
+    }
+
+    /**
+     * Constructs a new instance of the algorithm for a given {@code graph}, {@code parallelism},
+     * {@code randomSupplier}, {@code shortcutsSearchHeapSupplier} and {@code executor}. Provided
+     * {@code randomSupplier} should return different random generators instances, because they are
+     * used by different threads.
+     *
+     * @param graph graph
+     * @param randomSupplier supplier for preferable instances of {@link Random}
+     * @param shortcutsSearchHeapSupplier supplier for the preferable heap implementation.
+     * @param executor executor which will be used to parallelization
+     */
+    public ContractionHierarchyPrecomputation(
+            Graph<V, E> graph, Supplier<Random> randomSupplier,
+            Supplier<AddressableHeap<Double, ContractionVertex<V>>> shortcutsSearchHeapSupplier,
+            ThreadPoolExecutor executor)
+    {
+        init(graph, randomSupplier, shortcutsSearchHeapSupplier, executor);
+    }
+
+    /**
+     * Initialized field of this algorithm.
+     *
+     * @param graph                       a graph
+     * @param randomSupplier              supplier for preferable instances of {@link Random}
+     * @param shortcutsSearchHeapSupplier supplier for the preferable heap implementation.
+     * @param executor                    executor which will be used to parallelization
+     */
+    private void init(Graph<V, E> graph, Supplier<Random> randomSupplier,
+                      Supplier<AddressableHeap<Double, ContractionVertex<V>>> shortcutsSearchHeapSupplier,
+                      ThreadPoolExecutor executor){
         this.graph = graph;
         this.contractionGraph = GraphTypeBuilder
-            .<ContractionVertex<V>, ContractionEdge<E>> directed().weighted(true)
-            .allowingMultipleEdges(false).allowingSelfLoops(false).buildGraph();
-        this.parallelism = parallelism;
+                .<ContractionVertex<V>, ContractionEdge<E>> directed().weighted(true)
+                .allowingMultipleEdges(false).allowingSelfLoops(false).buildGraph();
+        this.parallelism = executor.getMaximumPoolSize();
         this.shortcutsSearchHeapSupplier = shortcutsSearchHeapSupplier;
 
         vertices = new ArrayList<>(graph.vertexSet().size());
@@ -240,40 +323,37 @@ public class ContractionHierarchyPrecomputation<V, E>
         contractionLevelCounter = new AtomicInteger();
 
         maskedContractionGraph = new MaskSubgraph<>(
-            contractionGraph,
-            v -> verticesData.get(v.vertexId) != null && verticesData.get(v.vertexId).isContracted,
-            e -> false);
+                contractionGraph,
+                v -> verticesData.get(v.vertexId) != null && verticesData.get(v.vertexId).isContracted,
+                e -> false);
         contractionMapping = new HashMap<>();
 
-        executor = Executors.newFixedThreadPool(parallelism);
         completionService = new ExecutorCompletionService<>(executor);
 
         tasks = new ArrayList<>(parallelism);
         computeInitialPrioritiesConsumers = new ArrayList<>(parallelism);
         for (int i = 0; i < parallelism; ++i) {
             tasks.add(new ContractionTask(i));
-            computeInitialPrioritiesConsumers.add(new Consumer<ContractionVertex<V>>()
-            {
+            computeInitialPrioritiesConsumers.add(new Consumer<>() {
                 Random random = randomSupplier.get();
 
                 @Override
-                public void accept(ContractionVertex<V> vertex)
-                {
+                public void accept(ContractionVertex<V> vertex) {
                     verticesData.set(vertex.vertexId, getVertexData(vertex, random.nextInt()));
                 }
             });
         }
 
         computeIndependentSetConsumer =
-            vertex -> verticesData.get(vertex.vertexId).isIndependent = vertexIsIndependent(vertex);
+                vertex -> verticesData.get(vertex.vertexId).isIndependent = vertexIsIndependent(vertex);
         computeShortcutsConsumer =
-            vertex -> shortcutEdges.set(vertex.vertexId, getShortcuts(vertex));
+                vertex -> shortcutEdges.set(vertex.vertexId, getShortcuts(vertex));
         updateNeighboursConsumer = vertex -> updateNeighboursData(vertex);
         markUpwardEdgesConsumer = vertex -> contractionGraph
-            .outgoingEdgesOf(vertex).forEach(
-                e -> e.isUpward =
-                    contractionGraph.getEdgeSource(e).contractionLevel < contractionGraph
-                        .getEdgeTarget(e).contractionLevel);
+                .outgoingEdgesOf(vertex).forEach(
+                        e -> e.isUpward =
+                                contractionGraph.getEdgeSource(e).contractionLevel < contractionGraph
+                                        .getEdgeTarget(e).contractionLevel);
     }
 
     /**
@@ -291,7 +371,6 @@ public class ContractionHierarchyPrecomputation<V, E>
 
         // mark upward edges in parallel
         submitTasks(0, contractionGraph.vertexSet().size(), markUpwardEdgesConsumer);
-        shutdownExecutor();
 
         return new ContractionHierarchy<>(graph, contractionGraph, contractionMapping);
     }
@@ -878,18 +957,6 @@ public class ContractionHierarchyPrecomputation<V, E>
         }
     }
 
-    /**
-     * Shuts down the {@link #executor}.
-     */
-    private void shutdownExecutor()
-    {
-        executor.shutdown();
-        try {
-            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-    }
 
     /**
      * Return type of this algorithm. Contains {@code contractionGraph} and

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputation.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputation.java
@@ -17,32 +17,18 @@
  */
 package org.jgrapht.alg.shortestpath;
 
-import org.jgrapht.Graph;
-import org.jgrapht.Graphs;
-import org.jgrapht.alg.util.Pair;
-import org.jgrapht.graph.MaskSubgraph;
-import org.jgrapht.graph.builder.GraphTypeBuilder;
-import org.jgrapht.util.ConcurrentUtil;
-import org.jheaps.AddressableHeap;
-import org.jheaps.tree.PairingHeap;
+import org.jgrapht.*;
+import org.jgrapht.util.*;
+import org.jgrapht.alg.util.*;
+import org.jgrapht.graph.*;
+import org.jgrapht.graph.builder.*;
+import org.jheaps.*;
+import org.jheaps.tree.*;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Random;
-import java.util.Set;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorCompletionService;
-import java.util.concurrent.ThreadPoolExecutor;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.*;
+import java.util.function.*;
 
 /**
  * Parallel implementation of the <a href="https://en.wikipedia.org/wiki/Contraction_hierarchies">
@@ -83,7 +69,7 @@ import java.util.function.Supplier;
  *
  * <p>
  * For parallelization, this implementation relies on the {@link ThreadPoolExecutor}
- * which is supplied to this algorithm from without. This algorithm does not manages the
+ * which is supplied to this algorithm from outside. This algorithm does not manages the
  * lifecycle of the supplied executor instance. For auxiliary methods for creating and
  * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrentUtil}.
  *
@@ -141,7 +127,7 @@ public class ContractionHierarchyPrecomputation<V, E>
     private Supplier<AddressableHeap<Double, ContractionVertex<V>>> shortcutsSearchHeapSupplier;
 
     /**
-     * Decorator for {@code executor} supplied to this algorithm that enables to
+     * Decorator for {@link ThreadPoolExecutor} supplied to this algorithm that enables to
      * keep track of when all submitted tasks are finished.
      */
     private ExecutorCompletionService<Void> completionService;
@@ -236,7 +222,7 @@ public class ContractionHierarchyPrecomputation<V, E>
      *
      * @param graph graph
      * @param randomSupplier supplier for preferable instances of {@link Random}
-     * @param executor executor which will be used to parallelization
+     * @param executor executor which will be used for parallelization
      */
     public ContractionHierarchyPrecomputation(Graph<V, E> graph, Supplier<Random> randomSupplier, ThreadPoolExecutor executor)
     {
@@ -288,7 +274,7 @@ public class ContractionHierarchyPrecomputation<V, E>
      * @param graph graph
      * @param randomSupplier supplier for preferable instances of {@link Random}
      * @param shortcutsSearchHeapSupplier supplier for the preferable heap implementation.
-     * @param executor executor which will be used to parallelization
+     * @param executor executor which will be used for parallelization
      */
     public ContractionHierarchyPrecomputation(
             Graph<V, E> graph, Supplier<Random> randomSupplier,
@@ -304,7 +290,7 @@ public class ContractionHierarchyPrecomputation<V, E>
      * @param graph                       a graph
      * @param randomSupplier              supplier for preferable instances of {@link Random}
      * @param shortcutsSearchHeapSupplier supplier for the preferable heap implementation.
-     * @param executor                    executor which will be used to parallelization
+     * @param executor                    executor which will be used for parallelization
      */
     private void init(Graph<V, E> graph, Supplier<Random> randomSupplier,
                       Supplier<AddressableHeap<Double, ContractionVertex<V>>> shortcutsSearchHeapSupplier,

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputation.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputation.java
@@ -17,18 +17,32 @@
  */
 package org.jgrapht.alg.shortestpath;
 
-import org.jgrapht.*;
-import org.jgrapht.util.*;
-import org.jgrapht.alg.util.*;
-import org.jgrapht.graph.*;
-import org.jgrapht.graph.builder.*;
-import org.jheaps.*;
-import org.jheaps.tree.*;
+import org.jgrapht.Graph;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.graph.MaskSubgraph;
+import org.jgrapht.graph.builder.GraphTypeBuilder;
+import org.jgrapht.util.ConcurrencyUtil;
+import org.jheaps.AddressableHeap;
+import org.jheaps.tree.PairingHeap;
 
-import java.util.*;
-import java.util.concurrent.*;
-import java.util.concurrent.atomic.*;
-import java.util.function.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 /**
  * Parallel implementation of the <a href="https://en.wikipedia.org/wiki/Contraction_hierarchies">
@@ -69,10 +83,7 @@ import java.util.function.*;
  *
  * <p>
  * For parallelization, this implementation relies on the {@link ThreadPoolExecutor}
- * which is supplied to this algorithm from outside. This algorithm does not manages the
- * lifecycle of the supplied executor instance. For auxiliary methods for creating and
- * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrencyUtil}.
- *
+ * which is supplied to this algorithm from outside.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -179,7 +190,7 @@ public class ContractionHierarchyPrecomputation<V, E>
     /**
      * Constructs a new instance of the algorithm for a given {@code graph} and {@code executor}.
      * It is up to a user of this algorithm to handle the creation and termination of the
-     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * provided {@code executor}. For utility methods to manage a {@code ThreadPoolExecutor} see
      * {@link ConcurrencyUtil}.
      *
      * @param graph graph
@@ -276,7 +287,7 @@ public class ContractionHierarchyPrecomputation<V, E>
      * {@code randomSupplier}, {@code shortcutsSearchHeapSupplier} and {@code executor}. Provided
      * {@code randomSupplier} should return different random generators instances, because they are
      * used by different threads. It is up to a user of this algorithm to handle the creation and
-     * termination of the provided {@code executor}. Utility methods to manage a
+     * termination of the provided {@code executor}. For utility methods to manage a
      * {@code ThreadPoolExecutor} see {@link ConcurrencyUtil}.
      *
      * @param graph graph

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
@@ -66,7 +66,7 @@ import java.util.concurrent.*;
  * For parallelization, this implementation relies on the {@link ThreadPoolExecutor}
  * which is supplied to this algorithm from outside. This algorithm does not manages the
  * lifecycle of the supplied executor instance. For auxiliary methods for creating and
- * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrentUtil}.
+ * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrencyUtil}.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -147,21 +147,22 @@ public class DeltaSteppingShortestPath<V, E>
     private volatile boolean allVerticesAdded;
 
     /**
-     * Constructs a new instance of the algorithm for a given graph. This constructor initializes
-     * the algorithm with an instance of {@link ThreadPoolExecutor} which has the maximum number
-     * of threads set to {@code Runtime.getRuntime().availableProcessors()}. This executor will
-     * not be shut down by this algorithm. If you want to use a custom instance of {@link ThreadPoolExecutor}
-     * and be able to manage its lifecycle use {@link #DeltaSteppingShortestPath(Graph, ThreadPoolExecutor)} instead.
+     * Constructs a new instance of the algorithm for a given graph.
      *
      * @param graph graph
+     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, ThreadPoolExecutor)}
      */
+    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph)
     {
-        this(graph, ConcurrentUtil.createThreadPoolExecutor(DEFAULT_PARALLELISM));
+        this(graph, DEFAULT_PARALLELISM);
     }
 
     /**
      * Constructs a new instance of the algorithm for a given graph and {@code executor}.
+     * It is up to a user of this algorithm to handle the creation and termination of the
+     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * {@link ConcurrencyUtil}.
      *
      * @param graph graph
      * @param executor executor which will be used for parallelization
@@ -172,23 +173,23 @@ public class DeltaSteppingShortestPath<V, E>
     }
 
     /**
-     * Constructs a new instance of the algorithm for a given graph, delta. This constructor
-     * initializes the algorithm with an instance of {@link ThreadPoolExecutor} which has the
-     * maximum number of threads set to {@code Runtime.getRuntime().availableProcessors()}.
-     * This executor will not be shut down by this algorithm. If you want to use a custom instance
-     * of {@link ThreadPoolExecutor} and be able to manage its lifecycle use
-     * {@link #DeltaSteppingShortestPath(Graph, double, ThreadPoolExecutor)} instead.
+     * Constructs a new instance of the algorithm for a given graph, delta.
      *
      * @param graph the graph
      * @param delta bucket width
+     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, double, ThreadPoolExecutor)}
      */
+    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph, double delta)
     {
-        this(graph, delta, ConcurrentUtil.createThreadPoolExecutor(DEFAULT_PARALLELISM));
+        this(graph, delta, DEFAULT_PARALLELISM);
     }
 
     /**
      * Constructs a new instance of the algorithm for a given graph, delta and {@code executor}.
+     * It is up to a user of this algorithm to handle the creation and termination of the
+     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * {@link ConcurrencyUtil}.
      *
      * @param graph the graph
      * @param delta bucket width
@@ -201,16 +202,13 @@ public class DeltaSteppingShortestPath<V, E>
     }
 
     /**
-     * Constructs a new instance of the algorithm for a given graph, parallelism. This constructor
-     * initializes the algorithm with an instance of {@link ThreadPoolExecutor} which has the
-     * maximum number of threads set to {@code parallelism}. This executor will not be shut down by
-     * this algorithm. If you want to use a custom instance of {@link ThreadPoolExecutor} and be
-     * able to manage its lifecycle use {@link #DeltaSteppingShortestPath(Graph, ThreadPoolExecutor)}
-     * instead.
+     * Constructs a new instance of the algorithm for a given graph, parallelism.
      *
      * @param graph the graph
      * @param parallelism maximum number of threads used in the computations
+     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, ThreadPoolExecutor)}
      */
+    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph, int parallelism)
     {
         this(graph, 0.0, parallelism);
@@ -222,20 +220,18 @@ public class DeltaSteppingShortestPath<V, E>
      * $0.0$ it will be computed during the algorithm execution. In general if the value of
      * $\frac{maximum edge weight}{maximum outdegree}$ is known beforehand, it is preferable to
      * specify it via this constructor, because processing the whole graph to compute this value may
-     * significantly slow down the algorithm. This constructor initializes the algorithm with an instance
-     * of {@link ThreadPoolExecutor} which has the maximum number of threads set to {@code parallelism}.
-     * This executor will not be shut down by this algorithm. If you want to use a custom instance of
-     * {@link ThreadPoolExecutor} and be able to manage its lifecycle use
-     * {@link #DeltaSteppingShortestPath(Graph, double, ThreadPoolExecutor)} instead.
+     * significantly slow down the algorithm.
      *
      * @param graph the graph
      * @param delta bucket width
      * @param parallelism maximum number of threads used in the computations
+     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, double, ThreadPoolExecutor)}
      */
+    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph, double delta, int parallelism)
     {
         super(graph);
-        init(graph, delta, ConcurrentUtil.createThreadPoolExecutor(parallelism));
+        init(graph, delta, ConcurrencyUtil.createThreadPoolExecutor(parallelism));
     }
 
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
@@ -64,9 +64,7 @@ import java.util.concurrent.*;
  *
  * <p>
  * For parallelization, this implementation relies on the {@link ThreadPoolExecutor}
- * which is supplied to this algorithm from outside. This algorithm does not manages the
- * lifecycle of the supplied executor instance. For auxiliary methods for creating and
- * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrencyUtil}.
+ * which is supplied to this algorithm from outside.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -161,7 +159,7 @@ public class DeltaSteppingShortestPath<V, E>
     /**
      * Constructs a new instance of the algorithm for a given graph and {@code executor}.
      * It is up to a user of this algorithm to handle the creation and termination of the
-     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * provided {@code executor}. For utility methods to manage a {@code ThreadPoolExecutor} see
      * {@link ConcurrencyUtil}.
      *
      * @param graph graph
@@ -188,7 +186,7 @@ public class DeltaSteppingShortestPath<V, E>
     /**
      * Constructs a new instance of the algorithm for a given graph, delta and {@code executor}.
      * It is up to a user of this algorithm to handle the creation and termination of the
-     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * provided {@code executor}. For utility methods to manage a {@code ThreadPoolExecutor} see
      * {@link ConcurrencyUtil}.
      *
      * @param graph the graph

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
@@ -147,15 +147,17 @@ public class DeltaSteppingShortestPath<V, E>
     private volatile boolean allVerticesAdded;
 
     /**
-     * Constructs a new instance of the algorithm for a given graph.
+     * Constructs a new instance of the algorithm for a given graph. This constructor initializes
+     * the algorithm with an instance of {@link ThreadPoolExecutor} which has the maximum number
+     * of threads set to {@code Runtime.getRuntime().availableProcessors()}. This executor will
+     * not be shut down by this algorithm. If you want to use a custom instance of {@link ThreadPoolExecutor}
+     * and be able to manage its lifecycle use {@link #DeltaSteppingShortestPath(Graph, ThreadPoolExecutor)} instead.
      *
      * @param graph graph
-     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, ThreadPoolExecutor)}
      */
-    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph)
     {
-        this(graph, DEFAULT_PARALLELISM);
+        this(graph, ConcurrentUtil.createThreadPoolExecutor(DEFAULT_PARALLELISM));
     }
 
     /**
@@ -170,16 +172,19 @@ public class DeltaSteppingShortestPath<V, E>
     }
 
     /**
-     * Constructs a new instance of the algorithm for a given graph, delta.
+     * Constructs a new instance of the algorithm for a given graph, delta. This constructor
+     * initializes the algorithm with an instance of {@link ThreadPoolExecutor} which has the
+     * maximum number of threads set to {@code Runtime.getRuntime().availableProcessors()}.
+     * This executor will not be shut down by this algorithm. If you want to use a custom instance
+     * of {@link ThreadPoolExecutor} and be able to manage its lifecycle use
+     * {@link #DeltaSteppingShortestPath(Graph, double, ThreadPoolExecutor)} instead.
      *
      * @param graph the graph
      * @param delta bucket width
-     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, double, ThreadPoolExecutor)}
      */
-    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph, double delta)
     {
-        this(graph, delta, DEFAULT_PARALLELISM);
+        this(graph, delta, ConcurrentUtil.createThreadPoolExecutor(DEFAULT_PARALLELISM));
     }
 
     /**
@@ -196,13 +201,16 @@ public class DeltaSteppingShortestPath<V, E>
     }
 
     /**
-     * Constructs a new instance of the algorithm for a given graph, parallelism.
+     * Constructs a new instance of the algorithm for a given graph, parallelism. This constructor
+     * initializes the algorithm with an instance of {@link ThreadPoolExecutor} which has the
+     * maximum number of threads set to {@code parallelism}. This executor will not be shut down by
+     * this algorithm. If you want to use a custom instance of {@link ThreadPoolExecutor} and be
+     * able to manage its lifecycle use {@link #DeltaSteppingShortestPath(Graph, ThreadPoolExecutor)}
+     * instead.
      *
      * @param graph the graph
      * @param parallelism maximum number of threads used in the computations
-     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, ThreadPoolExecutor)}
      */
-    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph, int parallelism)
     {
         this(graph, 0.0, parallelism);
@@ -214,14 +222,16 @@ public class DeltaSteppingShortestPath<V, E>
      * $0.0$ it will be computed during the algorithm execution. In general if the value of
      * $\frac{maximum edge weight}{maximum outdegree}$ is known beforehand, it is preferable to
      * specify it via this constructor, because processing the whole graph to compute this value may
-     * significantly slow down the algorithm.
+     * significantly slow down the algorithm. This constructor initializes the algorithm with an instance
+     * of {@link ThreadPoolExecutor} which has the maximum number of threads set to {@code parallelism}.
+     * This executor will not be shut down by this algorithm. If you want to use a custom instance of
+     * {@link ThreadPoolExecutor} and be able to manage its lifecycle use
+     * {@link #DeltaSteppingShortestPath(Graph, double, ThreadPoolExecutor)} instead.
      *
      * @param graph the graph
      * @param delta bucket width
      * @param parallelism maximum number of threads used in the computations
-     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, double, ThreadPoolExecutor)}
      */
-    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph, double delta, int parallelism)
     {
         super(graph);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
@@ -64,7 +64,7 @@ import java.util.concurrent.*;
  *
  * <p>
  * For parallelization, this implementation relies on the {@link ThreadPoolExecutor}
- * which is supplied to this algorithm from without. This algorithm does not manages the
+ * which is supplied to this algorithm from outside. This algorithm does not manages the
  * lifecycle of the supplied executor instance. For auxiliary methods for creating and
  * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrentUtil}.
  *
@@ -124,7 +124,7 @@ public class DeltaSteppingShortestPath<V, E>
     private Set<V>[] bucketStructure;
 
     /**
-     * Decorator for {@code executor} supplied to this algorithm that enables to
+     * Decorator for {@link ThreadPoolExecutor} supplied to this algorithm that enables to
      * keep track of when all submitted tasks are finished.
      */
     private ExecutorCompletionService<Void> completionService;
@@ -162,7 +162,7 @@ public class DeltaSteppingShortestPath<V, E>
      * Constructs a new instance of the algorithm for a given graph and {@code executor}.
      *
      * @param graph graph
-     * @param executor executor which will be used to parallelization
+     * @param executor executor which will be used for parallelization
      */
     public DeltaSteppingShortestPath(Graph<V, E> graph, ThreadPoolExecutor executor)
     {
@@ -187,7 +187,7 @@ public class DeltaSteppingShortestPath<V, E>
      *
      * @param graph the graph
      * @param delta bucket width
-     * @param executor executor which will be used to parallelization
+     * @param executor executor which will be used for parallelization
      */
     public DeltaSteppingShortestPath(Graph<V, E> graph, double delta, ThreadPoolExecutor executor)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPath.java
@@ -63,7 +63,10 @@ import java.util.concurrent.*;
  * </ul>
  *
  * <p>
- * For parallelization, this implementation relies on the {@link ExecutorService}.
+ * For parallelization, this implementation relies on the {@link ThreadPoolExecutor}
+ * which is supplied to this algorithm from without. This algorithm does not manages the
+ * lifecycle of the supplied executor instance. For auxiliary methods for creating and
+ * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrentUtil}.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -121,12 +124,8 @@ public class DeltaSteppingShortestPath<V, E>
     private Set<V>[] bucketStructure;
 
     /**
-     * Executor to which relax tasks will be submitted.
-     */
-    private ExecutorService executor;
-    /**
-     * Decorator for {@link #executor} that enables to keep track of when all submitted tasks are
-     * finished.
+     * Decorator for {@code executor} supplied to this algorithm that enables to
+     * keep track of when all submitted tasks are finished.
      */
     private ExecutorCompletionService<Void> completionService;
     /**
@@ -151,33 +150,64 @@ public class DeltaSteppingShortestPath<V, E>
      * Constructs a new instance of the algorithm for a given graph.
      *
      * @param graph graph
+     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, ThreadPoolExecutor)}
      */
+    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph)
     {
         this(graph, DEFAULT_PARALLELISM);
     }
 
     /**
-     * Constructs a new instance of the algorithm for a given graph and delta.
+     * Constructs a new instance of the algorithm for a given graph and {@code executor}.
+     *
+     * @param graph graph
+     * @param executor executor which will be used to parallelization
+     */
+    public DeltaSteppingShortestPath(Graph<V, E> graph, ThreadPoolExecutor executor)
+    {
+        this(graph, 0.0, executor);
+    }
+
+    /**
+     * Constructs a new instance of the algorithm for a given graph, delta.
      *
      * @param graph the graph
      * @param delta bucket width
+     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, double, ThreadPoolExecutor)}
      */
+    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph, double delta)
     {
         this(graph, delta, DEFAULT_PARALLELISM);
     }
 
     /**
-     * Constructs a new instance of the algorithm for a given graph and parallelism.
+     * Constructs a new instance of the algorithm for a given graph, delta and {@code executor}.
+     *
+     * @param graph the graph
+     * @param delta bucket width
+     * @param executor executor which will be used to parallelization
+     */
+    public DeltaSteppingShortestPath(Graph<V, E> graph, double delta, ThreadPoolExecutor executor)
+    {
+        super(graph);
+        init(graph, delta, executor);
+    }
+
+    /**
+     * Constructs a new instance of the algorithm for a given graph, parallelism.
      *
      * @param graph the graph
      * @param parallelism maximum number of threads used in the computations
+     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, ThreadPoolExecutor)}
      */
+    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph, int parallelism)
     {
         this(graph, 0.0, parallelism);
     }
+
 
     /**
      * Constructs a new instance of the algorithm for a given graph, delta, parallelism. If delta is
@@ -189,17 +219,31 @@ public class DeltaSteppingShortestPath<V, E>
      * @param graph the graph
      * @param delta bucket width
      * @param parallelism maximum number of threads used in the computations
+     * @deprecated replaced with {@link #DeltaSteppingShortestPath(Graph, double, ThreadPoolExecutor)}
      */
+    @Deprecated
     public DeltaSteppingShortestPath(Graph<V, E> graph, double delta, int parallelism)
     {
         super(graph);
+        init(graph, delta, ConcurrentUtil.createThreadPoolExecutor(parallelism));
+    }
+
+    /**
+     * Initializes {@code delta}, {@code parallelism}, {@code distanceAndPredecessorMap},
+     * {@code completionService}, {@code verticesQueue}, {@code lightRelaxTask} and
+     * {@code heavyRelaxTask} fields.
+     *
+     * @param graph a graph
+     * @param delta bucket width
+     * @param executor executor which will be used for parallelization
+     */
+    private void init(Graph<V, E> graph, double delta, ThreadPoolExecutor executor){
         if (delta < 0) {
             throw new IllegalArgumentException(DELTA_MUST_BE_NON_NEGATIVE);
         }
         this.delta = delta;
-        this.parallelism = parallelism;
+        this.parallelism = executor.getMaximumPoolSize();
         distanceAndPredecessorMap = new ConcurrentHashMap<>(graph.vertexSet().size());
-        executor = Executors.newFixedThreadPool(parallelism);
         completionService = new ExecutorCompletionService<>(executor);
         verticesQueue = new ConcurrentLinkedQueue<>();
         lightRelaxTask = new LightRelaxTask(verticesQueue);
@@ -381,21 +425,8 @@ public class DeltaSteppingShortestPath<V, E>
                 ++firstNonEmptyBucket;
             }
         }
-        shutDownExecutor();
     }
 
-    /**
-     * Shuts down the {@link #executor}.
-     */
-    private void shutDownExecutor()
-    {
-        executor.shutdown();
-        try { // wait till the executor is shut down
-            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
-    }
 
     /**
      * Manages edge relaxations. Adds all elements from {@code vertices} to the

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputation.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputation.java
@@ -86,7 +86,7 @@ import static org.jgrapht.alg.shortestpath.DefaultManyToManyShortestPaths.Defaul
  *
  * <p>
  * For parallelization, this implementation relies on the {@link ThreadPoolExecutor}
- * which is supplied to this algorithm from without. This algorithm does not manages the
+ * which is supplied to this algorithm from outside. This algorithm does not manages the
  * lifecycle of the supplied executor instance. For auxiliary methods for creating and
  * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrentUtil}.
  *

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputation.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputation.java
@@ -25,7 +25,7 @@ import org.jgrapht.alg.util.Pair;
 import org.jgrapht.graph.EdgeReversedGraph;
 import org.jgrapht.graph.MaskSubgraph;
 import org.jgrapht.util.CollectionUtil;
-import org.jgrapht.util.ConcurrentUtil;
+import org.jgrapht.util.ConcurrencyUtil;
 import org.jheaps.AddressableHeap;
 import org.jheaps.tree.PairingHeap;
 
@@ -88,7 +88,7 @@ import static org.jgrapht.alg.shortestpath.DefaultManyToManyShortestPaths.Defaul
  * For parallelization, this implementation relies on the {@link ThreadPoolExecutor}
  * which is supplied to this algorithm from outside. This algorithm does not manages the
  * lifecycle of the supplied executor instance. For auxiliary methods for creating and
- * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrentUtil}.
+ * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrencyUtil}.
  *
  * @param <V> graph vertex type
  * @param <E> graph edge type

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputation.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputation.java
@@ -25,6 +25,7 @@ import org.jgrapht.alg.util.Pair;
 import org.jgrapht.graph.EdgeReversedGraph;
 import org.jgrapht.graph.MaskSubgraph;
 import org.jgrapht.util.CollectionUtil;
+import org.jgrapht.util.ConcurrentUtil;
 import org.jheaps.AddressableHeap;
 import org.jheaps.tree.PairingHeap;
 
@@ -41,8 +42,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -85,7 +85,10 @@ import static org.jgrapht.alg.shortestpath.DefaultManyToManyShortestPaths.Defaul
  * of this TNR work please refer to the original paper.
  *
  * <p>
- * For parallelization, this implementation relies on the {@link ExecutorService}.
+ * For parallelization, this implementation relies on the {@link ThreadPoolExecutor}
+ * which is supplied to this algorithm from without. This algorithm does not manages the
+ * lifecycle of the supplied executor instance. For auxiliary methods for creating and
+ * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrentUtil}.
  *
  * @param <V> graph vertex type
  * @param <E> graph edge type
@@ -171,61 +174,54 @@ class TransitNodeRoutingPrecomputation<V, E> {
 
 
     /**
-     * Constructs an instance of the algorithm for a given {@code graph}.
+     * Constructs an instance of the algorithm for a given {@code graph} and {@code executor}.
      *
      * @param graph graph
+     * @param executor executor which will be used for parallelization
      */
-    public TransitNodeRoutingPrecomputation(Graph<V, E> graph) {
-        this(new ContractionHierarchyPrecomputation<>(graph).computeContractionHierarchy());
+    public TransitNodeRoutingPrecomputation(Graph<V, E> graph, ThreadPoolExecutor executor) {
+        this(new ContractionHierarchyPrecomputation<>(graph, executor).computeContractionHierarchy(), executor);
     }
 
-    /**
-     * Constructs an instance of the algorithm for a given {@code graph}
-     * and {@code parallelism}.
-     *
-     * @param graph       graph
-     * @param parallelism maximum number of threads used in the computations
-     */
-    public TransitNodeRoutingPrecomputation(Graph<V, E> graph, int parallelism) {
-        this(new ContractionHierarchyPrecomputation<>(graph).computeContractionHierarchy(), parallelism,
-                (int) Math.sqrt(graph.vertexSet().size()), PairingHeap::new);
-    }
 
     /**
-     * Constructs an instance of the algorithm for the given {@code contractionHierarchy}.
+     * Constructs an instance of the algorithm for the given {@code contractionHierarchy} and {@code executor}.
      *
      * @param hierarchy contraction hierarchy
+     * @param executor executor which will be used for parallelization
      */
-    public TransitNodeRoutingPrecomputation(ContractionHierarchy<V, E> hierarchy) {
-        this(hierarchy, (int) Math.sqrt(hierarchy.getGraph().vertexSet().size()));
+    public TransitNodeRoutingPrecomputation(ContractionHierarchy<V, E> hierarchy, ThreadPoolExecutor executor) {
+        this(hierarchy, (int) Math.sqrt(hierarchy.getGraph().vertexSet().size()), executor);
     }
 
     /**
-     * Constructs an instance of the algorithm for a given {@code contractionHierarchy} and {@code numberOfTransitVertices}.
+     * Constructs an instance of the algorithm for a given
+     * {@code contractionHierarchy}, {@code numberOfTransitVertices} and {@code executor}.
      *
      * @param hierarchy               contraction hierarchy
      * @param numberOfTransitVertices number of transit vertices
+     * @param executor executor which will be used for parallelization
      */
     public TransitNodeRoutingPrecomputation(ContractionHierarchy<V, E> hierarchy,
-                                            int numberOfTransitVertices) {
-        this(hierarchy, Runtime.getRuntime().availableProcessors(), numberOfTransitVertices, PairingHeap::new);
+                                            int numberOfTransitVertices, ThreadPoolExecutor executor) {
+        this(hierarchy, numberOfTransitVertices, PairingHeap::new, executor);
     }
 
     /**
      * Constructs an instance of the algorithm for a given {@code contractionHierarchy},
-     * {@code parallelism}, {@code numberOfTransitVertices} and {@code heapSupplier}.
+     * {@code parallelism}, {@code numberOfTransitVertices}, {@code heapSupplier} and {@code executor}.
      * Heap provided by the {@code heapSupplier} is used which computing the
      * Voronoi diagram.
      *
      * @param hierarchy               contraction hierarchy
-     * @param parallelism             maximum number of threads to be used in the computations
      * @param numberOfTransitVertices number of transit vertices
      * @param heapSupplier            supplier for preferable heap implementation
+     * @param executor                executor which will be used for parallelization
      */
     public TransitNodeRoutingPrecomputation(ContractionHierarchy<V, E> hierarchy,
-                                            int parallelism,
                                             int numberOfTransitVertices,
-                                            Supplier<AddressableHeap<Double, ContractionVertex<V>>> heapSupplier) {
+                                            Supplier<AddressableHeap<Double, ContractionVertex<V>>> heapSupplier,
+                                            ThreadPoolExecutor executor) {
         if (numberOfTransitVertices > hierarchy.getGraph().vertexSet().size()) {
             throw new IllegalArgumentException("number of transit vertices is larger than the number of vertices in the graph");
         }
@@ -233,14 +229,14 @@ class TransitNodeRoutingPrecomputation<V, E> {
         this.contractionGraph = hierarchy.getContractionGraph();
         this.contractionMapping = hierarchy.getContractionMapping();
         this.numberOfTransitVertices = numberOfTransitVertices;
-        this.parallelism = parallelism;
+        this.parallelism = executor.getMaximumPoolSize();
         this.heapSupplier = heapSupplier;
 
         this.contractionVertices = new ArrayList<>(Collections.nCopies(contractionGraph.vertexSet().size(), null));
         this.manyToManyShortestPathsAlgorithm = new CHManyToManyShortestPaths<>(hierarchy);
 
-        this.executor = Executors.newFixedThreadPool(parallelism);
-        this.completionService = new ExecutorCompletionService<>(executor);
+        this.executor = executor;
+        this.completionService = new ExecutorCompletionService<>(this.executor);
     }
 
 
@@ -265,7 +261,6 @@ class TransitNodeRoutingPrecomputation<V, E> {
         transitVerticesPaths = unpackPaths(contractedPaths);
 
         Pair<AccessVertices<V, E>, LocalityFilter<V>> avAndLf = computeAVAndLF();
-        shutdownExecutor();
 
         return new TransitNodeRouting<>(contractionHierarchy, contractedTransitVerticesSet,
                 transitVerticesPaths, voronoiDiagram, avAndLf.getFirst(), avAndLf.getSecond());
@@ -361,18 +356,6 @@ class TransitNodeRoutingPrecomputation<V, E> {
             } catch (InterruptedException | ExecutionException e) {
                 e.printStackTrace();
             }
-        }
-    }
-
-    /**
-     * Shuts down the {@code executor}.
-     */
-    private void shutdownExecutor() {
-        executor.shutdown();
-        try {
-            executor.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
         }
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputation.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputation.java
@@ -86,9 +86,7 @@ import static org.jgrapht.alg.shortestpath.DefaultManyToManyShortestPaths.Defaul
  *
  * <p>
  * For parallelization, this implementation relies on the {@link ThreadPoolExecutor}
- * which is supplied to this algorithm from outside. This algorithm does not manages the
- * lifecycle of the supplied executor instance. For auxiliary methods for creating and
- * terminating the {@link ThreadPoolExecutor} please refer to {@link ConcurrencyUtil}.
+ * which is supplied to this algorithm from outside.
  *
  * @param <V> graph vertex type
  * @param <E> graph edge type
@@ -175,6 +173,9 @@ class TransitNodeRoutingPrecomputation<V, E> {
 
     /**
      * Constructs an instance of the algorithm for a given {@code graph} and {@code executor}.
+     * It is up to a user of this algorithm to handle the creation and termination of the
+     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * {@link org.jgrapht.util.ConcurrencyUtil}.
      *
      * @param graph graph
      * @param executor executor which will be used for parallelization
@@ -186,6 +187,9 @@ class TransitNodeRoutingPrecomputation<V, E> {
 
     /**
      * Constructs an instance of the algorithm for the given {@code contractionHierarchy} and {@code executor}.
+     * It is up to a user of this algorithm to handle the creation and termination of the
+     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * {@link org.jgrapht.util.ConcurrencyUtil}.
      *
      * @param hierarchy contraction hierarchy
      * @param executor executor which will be used for parallelization
@@ -195,8 +199,11 @@ class TransitNodeRoutingPrecomputation<V, E> {
     }
 
     /**
-     * Constructs an instance of the algorithm for a given
-     * {@code contractionHierarchy}, {@code numberOfTransitVertices} and {@code executor}.
+     * Constructs an instance of the algorithm for a given {@code contractionHierarchy},
+     * {@code numberOfTransitVertices} and {@code executor}. It is up to a user of this
+     * algorithm to handle the creation and termination of the provided {@code executor}.
+     * Utility methods to manage a {@code ThreadPoolExecutor} see
+     * {@link org.jgrapht.util.ConcurrencyUtil}.
      *
      * @param hierarchy               contraction hierarchy
      * @param numberOfTransitVertices number of transit vertices
@@ -211,7 +218,9 @@ class TransitNodeRoutingPrecomputation<V, E> {
      * Constructs an instance of the algorithm for a given {@code contractionHierarchy},
      * {@code parallelism}, {@code numberOfTransitVertices}, {@code heapSupplier} and {@code executor}.
      * Heap provided by the {@code heapSupplier} is used which computing the
-     * Voronoi diagram.
+     * Voronoi diagram. It is up to a user of this algorithm to handle the creation and termination of the
+     * provided {@code executor}. Utility methods to manage a {@code ThreadPoolExecutor} see
+     * {@link org.jgrapht.util.ConcurrencyUtil}.
      *
      * @param hierarchy               contraction hierarchy
      * @param numberOfTransitVertices number of transit vertices

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPath.java
@@ -26,6 +26,8 @@ import org.jgrapht.graph.GraphWalk;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.jgrapht.alg.interfaces.ManyToManyShortestPathsAlgorithm.ManyToManyShortestPaths;
 import static org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.ContractionHierarchy;
@@ -75,6 +77,11 @@ import static org.jgrapht.alg.shortestpath.TransitNodeRoutingPrecomputation.Tran
 public class TransitNodeRoutingShortestPath<V, E> extends BaseShortestPathAlgorithm<V, E> {
 
     /**
+     * Executor which is used for parallelization in this algorithm.
+     */
+    private ThreadPoolExecutor executor;
+
+    /**
      * Contraction hierarchy which is used to compute shortest paths.
      */
     private ContractionHierarchy<V, E> contractionHierarchy;
@@ -99,12 +106,14 @@ public class TransitNodeRoutingShortestPath<V, E> extends BaseShortestPathAlgori
     private LocalityFilter<V> localityFilter;
 
     /**
-     * Constructs a new instance for the given {@code graph}.
+     * Constructs a new instance for the given {@code graph} and {@code executor}.
      *
-     * @param graph graph
+     * @param graph    graph
+     * @param executor executor which will be used for computing {@code TransitNodeRouting}
      */
-    public TransitNodeRoutingShortestPath(Graph<V, E> graph) {
+    public TransitNodeRoutingShortestPath(Graph<V, E> graph, ThreadPoolExecutor executor) {
         super(graph);
+        this.executor = Objects.requireNonNull(executor, "executor cannot be null!");
     }
 
     /**
@@ -129,7 +138,7 @@ public class TransitNodeRoutingShortestPath<V, E> extends BaseShortestPathAlgori
         if (contractionHierarchy != null) {
             return;
         }
-        TransitNodeRouting<V, E> routing = new TransitNodeRoutingPrecomputation<>(graph).computeTransitNodeRouting();
+        TransitNodeRouting<V, E> routing = new TransitNodeRoutingPrecomputation<>(graph, executor).computeTransitNodeRouting();
         initialize(routing);
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPath.java
@@ -107,6 +107,9 @@ public class TransitNodeRoutingShortestPath<V, E> extends BaseShortestPathAlgori
 
     /**
      * Constructs a new instance for the given {@code graph} and {@code executor}.
+     * It is up to a user of this algorithm to handle the creation and termination of the
+     * provided {@code executor}. For utility methods to manage a {@code ThreadPoolExecutor} see
+     * {@link org.jgrapht.util.ConcurrencyUtil}.
      *
      * @param graph    graph
      * @param executor executor which will be used for computing {@code TransitNodeRouting}

--- a/jgrapht-core/src/main/java/org/jgrapht/util/ConcurrencyUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/ConcurrencyUtil.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Utility class to manage creation and shutting down instance
- * if the {@link ThreadPoolExecutor}.
+ * of the {@link ThreadPoolExecutor}.
  */
 public class ConcurrencyUtil {
     /**
@@ -40,14 +40,30 @@ public class ConcurrencyUtil {
 
     /**
      * Shuts down the {@code executor}. This operation puts the {@code service}
-     * into a state where every subsequented task to the {@code service} will be rejected.
+     * into a state where every subsequent task submitted to the {@code service}
+     * will be rejected. This method calls
+     * {@link #shutdownExecutionService(ExecutorService, long, TimeUnit)} with
+     * $time = Long.MAX_VALUE$ and $timeUnit = TimeUnit.MILLISECONDS$.
      *
      * @param service service to be shut down
      */
     public static void shutdownExecutionService(ExecutorService service) {
+        shutdownExecutionService(service,Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Shuts down the {@code executor}. This operation puts the {@code service}
+     * into a state where every subsequent task submitted to the {@code service}
+     * will be rejected.
+     *
+     * @param service service to be shut down
+     * @param time period of time to wait for the completion of the termination
+     * @param timeUnit time duration granularity for the provided {@code time}
+     */
+    public static void shutdownExecutionService(ExecutorService service, long time, TimeUnit timeUnit) {
         service.shutdown();
         try {
-            service.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+            service.awaitTermination(time, timeUnit);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/ConcurrencyUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/ConcurrencyUtil.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
  * Utility class to manage creation and shutting down instance
  * if the {@link ThreadPoolExecutor}.
  */
-public class ConcurrentUtil {
+public class ConcurrencyUtil {
     /**
      * Creates a {@link ThreadPoolExecutor} with fixed number of threads which is
      * equal to {@code parallelism}.

--- a/jgrapht-core/src/main/java/org/jgrapht/util/ConcurrencyUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/ConcurrencyUtil.java
@@ -47,7 +47,7 @@ public class ConcurrencyUtil {
      *
      * @param service service to be shut down
      */
-    public static void shutdownExecutionService(ExecutorService service) {
+    public static void shutdownExecutionService(ExecutorService service) throws InterruptedException {
         shutdownExecutionService(service,Long.MAX_VALUE, TimeUnit.MILLISECONDS);
     }
 
@@ -60,12 +60,8 @@ public class ConcurrencyUtil {
      * @param time period of time to wait for the completion of the termination
      * @param timeUnit time duration granularity for the provided {@code time}
      */
-    public static void shutdownExecutionService(ExecutorService service, long time, TimeUnit timeUnit) {
+    public static void shutdownExecutionService(ExecutorService service, long time, TimeUnit timeUnit) throws InterruptedException {
         service.shutdown();
-        try {
-            service.awaitTermination(time, timeUnit);
-        } catch (InterruptedException e) {
-            e.printStackTrace();
-        }
+        service.awaitTermination(time, timeUnit);
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/ConcurrentUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/ConcurrentUtil.java
@@ -1,0 +1,55 @@
+/*
+ * (C) Copyright 2020-2020, by Semen Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.util;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Utility class to manage creation and shutting down instance
+ * if the {@link ThreadPoolExecutor}.
+ */
+public class ConcurrentUtil {
+    /**
+     * Creates a {@link ThreadPoolExecutor} with fixed number of threads which is
+     * equal to {@code parallelism}.
+     *
+     * @param parallelism number of thread for the executor
+     * @return created executor
+     */
+    public static ThreadPoolExecutor createThreadPoolExecutor(int parallelism) {
+        return (ThreadPoolExecutor) Executors.newFixedThreadPool(parallelism);
+    }
+
+    /**
+     * Shuts down the {@code executor}. This operation puts the {@code service}
+     * into a state where every subsequented task to the {@code service} will be rejected.
+     *
+     * @param service service to be shut down
+     */
+    public static void shutdownExecutionService(ExecutorService service) {
+        service.shutdown();
+        try {
+            service.awaitTermination(Long.MAX_VALUE, TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
@@ -20,7 +20,7 @@ package org.jgrapht.alg.shortestpath;
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
 import org.jgrapht.graph.*;
-import org.jgrapht.util.ConcurrentUtil;
+import org.jgrapht.util.ConcurrencyUtil;
 import org.junit.*;
 
 import java.util.*;
@@ -45,12 +45,12 @@ public class CHManyToManyShortestPathsTest
 
     @BeforeClass
     public static void createExecutor(){
-        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+        executor = ConcurrencyUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
     }
 
     @AfterClass
     public static void shutdownExecutor(){
-        ConcurrentUtil.shutdownExecutionService(executor);
+        ConcurrencyUtil.shutdownExecutionService(executor);
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
@@ -20,9 +20,11 @@ package org.jgrapht.alg.shortestpath;
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
 import org.jgrapht.graph.*;
+import org.jgrapht.util.ConcurrentUtil;
 import org.junit.*;
 
 import java.util.*;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.ContractionHierarchy;
 import static org.junit.Assert.assertEquals;
@@ -36,6 +38,20 @@ public class CHManyToManyShortestPathsTest
     extends
     BaseManyToManyShortestPathsTest
 {
+    /**
+     * Executor which is supplied to the {@link CHManyToManyShortestPaths} in this test case.
+     */
+    private static ThreadPoolExecutor executor;
+
+    @BeforeClass
+    public static void createExecutor(){
+        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+    }
+
+    @AfterClass
+    public static void shutdownExecutor(){
+        ConcurrentUtil.shutdownExecutionService(executor);
+    }
 
     @Test
     public void testEmptyGraph()
@@ -91,7 +107,7 @@ public class CHManyToManyShortestPathsTest
         Graph<Integer, DefaultWeightedEdge> graph = getSimpleGraph();
 
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED))
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor)
                 .computeContractionHierarchy();
 
         ManyToManyShortestPathsAlgorithm.ManyToManyShortestPaths<Integer,
@@ -119,7 +135,7 @@ public class CHManyToManyShortestPathsTest
         Graph<Integer, DefaultWeightedEdge> graph = getMultigraph();
 
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED))
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED),executor)
                 .computeContractionHierarchy();
 
         ManyToManyShortestPathsAlgorithm.ManyToManyShortestPaths<Integer,
@@ -155,7 +171,7 @@ public class CHManyToManyShortestPathsTest
         Graph<Integer, DefaultWeightedEdge> graph)
     {
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED))
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED),executor)
                 .computeContractionHierarchy();
         return new CHManyToManyShortestPaths<>(hierarchy);
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
@@ -49,7 +49,7 @@ public class CHManyToManyShortestPathsTest
     }
 
     @AfterClass
-    public static void shutdownExecutor(){
+    public static void shutdownExecutor() throws InterruptedException {
         ConcurrencyUtil.shutdownExecutionService(executor);
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstraTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstraTest.java
@@ -49,12 +49,12 @@ public class ContractionHierarchyBidirectionalDijkstraTest
 
     @BeforeClass
     public static void createExecutor(){
-        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+        executor = ConcurrencyUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
     }
 
     @AfterClass
     public static void shutdownExecutor(){
-        ConcurrentUtil.shutdownExecutionService(executor);
+        ConcurrencyUtil.shutdownExecutionService(executor);
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstraTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstraTest.java
@@ -53,7 +53,7 @@ public class ContractionHierarchyBidirectionalDijkstraTest
     }
 
     @AfterClass
-    public static void shutdownExecutor(){
+    public static void shutdownExecutor() throws InterruptedException {
         ConcurrencyUtil.shutdownExecutionService(executor);
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstraTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstraTest.java
@@ -25,6 +25,7 @@ import org.jgrapht.util.*;
 import org.junit.*;
 
 import java.util.*;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.ContractionHierarchy;
 import static org.junit.Assert.assertEquals;
@@ -41,6 +42,22 @@ public class ContractionHierarchyBidirectionalDijkstraTest
     private static final long SEED = 19L;
 
     /**
+     * Executor which is supplied to the {@link ContractionHierarchyBidirectionalDijkstra}
+     * algorithm in this test case.
+     */
+    private static ThreadPoolExecutor executor;
+
+    @BeforeClass
+    public static void createExecutor(){
+        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+    }
+
+    @AfterClass
+    public static void shutdownExecutor(){
+        ConcurrentUtil.shutdownExecutionService(executor);
+    }
+
+    /**
      * This test asserts that not exception is thrown when an algorithm object is initialized with
      * an empty graph.
      */
@@ -50,7 +67,7 @@ public class ContractionHierarchyBidirectionalDijkstraTest
         Graph<Integer, DefaultWeightedEdge> graph =
             new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
         ContractionHierarchyBidirectionalDijkstra<Integer, DefaultWeightedEdge> dijkstra =
-            new ContractionHierarchyBidirectionalDijkstra<>(graph);
+            new ContractionHierarchyBidirectionalDijkstra<>(graph, executor);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -60,7 +77,7 @@ public class ContractionHierarchyBidirectionalDijkstraTest
             new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
         graph.addVertex(2);
         ContractionHierarchyBidirectionalDijkstra<Integer, DefaultWeightedEdge> dijkstra =
-            new ContractionHierarchyBidirectionalDijkstra<>(graph);
+            new ContractionHierarchyBidirectionalDijkstra<>(graph, executor);
         dijkstra.getPath(1, 2);
     }
 
@@ -71,7 +88,7 @@ public class ContractionHierarchyBidirectionalDijkstraTest
             new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
         graph.addVertex(1);
         ContractionHierarchyBidirectionalDijkstra<Integer, DefaultWeightedEdge> dijkstra =
-            new ContractionHierarchyBidirectionalDijkstra<>(graph);
+            new ContractionHierarchyBidirectionalDijkstra<>(graph, executor);
         dijkstra.getPath(1, 2);
     }
 
@@ -83,7 +100,7 @@ public class ContractionHierarchyBidirectionalDijkstraTest
         graph.addVertex(1);
         graph.addVertex(2);
         ContractionHierarchyBidirectionalDijkstra<Integer, DefaultWeightedEdge> dijkstra =
-            new ContractionHierarchyBidirectionalDijkstra<>(graph);
+            new ContractionHierarchyBidirectionalDijkstra<>(graph, executor);
         GraphPath<Integer, DefaultWeightedEdge> path = dijkstra.getPath(1, 2);
         assertNull(path);
     }
@@ -114,7 +131,7 @@ public class ContractionHierarchyBidirectionalDijkstraTest
         Graphs.addEdgeWithVertices(graph, 8, 9, 3);
 
         ContractionHierarchyBidirectionalDijkstra<Integer, DefaultWeightedEdge> dijkstra =
-            new ContractionHierarchyBidirectionalDijkstra<>(graph);
+            new ContractionHierarchyBidirectionalDijkstra<>(graph, executor);
 
         assertEquals(Collections.singletonList(1), dijkstra.getPath(1, 1).getVertexList());
         assertEquals(Arrays.asList(1, 2), dijkstra.getPath(1, 2).getVertexList());
@@ -180,7 +197,7 @@ public class ContractionHierarchyBidirectionalDijkstraTest
                 new DijkstraShortestPath<>(graph).getPaths(source);
 
         ContractionHierarchy<Integer, DefaultWeightedEdge> data =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED))
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor)
                 .computeContractionHierarchy();
 
         ShortestPathAlgorithm.SingleSourcePaths<Integer, DefaultWeightedEdge> contractionDijkstra =

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputationTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputationTest.java
@@ -25,6 +25,7 @@ import org.jgrapht.util.*;
 import org.junit.*;
 
 import java.util.*;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.*;
 import static org.junit.Assert.*;
@@ -39,13 +40,29 @@ public class ContractionHierarchyPrecomputationTest
      */
     private static final long SEED = 19L;
 
+    /**
+     * Executor which is supplied to the {@link ContractionHierarchyPrecomputation}
+     * algorithm in this test case.
+     */
+    private static ThreadPoolExecutor executor;
+
+    @BeforeClass
+    public static void createExecutor(){
+        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+    }
+
+    @AfterClass
+    public static void shutdownExecutor(){
+        ConcurrentUtil.shutdownExecutionService(executor);
+    }
+
     @Test
     public void testEmptyGraph()
     {
         Graph<Integer, DefaultWeightedEdge> graph =
             new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
         ContractionHierarchyPrecomputation<Integer, DefaultWeightedEdge> contractor =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED));
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor);
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
             contractor.computeContractionHierarchy();
 
@@ -74,7 +91,7 @@ public class ContractionHierarchyPrecomputationTest
         Graphs.addEdgeWithVertices(graph, 2, 3, 1);
 
         ContractionHierarchyPrecomputation<Integer, DefaultWeightedEdge> contractor =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED));
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor);
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
             contractor.computeContractionHierarchy();
 
@@ -111,7 +128,7 @@ public class ContractionHierarchyPrecomputationTest
         Graphs.addEdgeWithVertices(graph, 1, 3, 1);
 
         ContractionHierarchyPrecomputation<Integer, DefaultWeightedEdge> contractor =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED));
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor);
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
             contractor.computeContractionHierarchy();
 
@@ -140,7 +157,7 @@ public class ContractionHierarchyPrecomputationTest
         Graphs.addEdgeWithVertices(graph, 3, 5, 1);
 
         ContractionHierarchyPrecomputation<Integer, DefaultWeightedEdge> contractor =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED));
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor);
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
             contractor.computeContractionHierarchy();
 
@@ -179,7 +196,7 @@ public class ContractionHierarchyPrecomputationTest
         Graphs.addEdgeWithVertices(graph, 2, 3, 1);
 
         ContractionHierarchyPrecomputation<Integer, DefaultWeightedEdge> contractor =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED));
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor);
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
             contractor.computeContractionHierarchy();
 
@@ -219,7 +236,7 @@ public class ContractionHierarchyPrecomputationTest
         Graphs.addEdgeWithVertices(graph, 3, 1, 1);
 
         ContractionHierarchyPrecomputation<Integer, DefaultWeightedEdge> contractor =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED));
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor);
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
             contractor.computeContractionHierarchy();
 
@@ -250,7 +267,7 @@ public class ContractionHierarchyPrecomputationTest
         Graphs.addEdgeWithVertices(graph, 3, 5, 1);
 
         ContractionHierarchyPrecomputation<Integer, DefaultWeightedEdge> contractor =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED));
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor);
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
             contractor.computeContractionHierarchy();
 
@@ -307,7 +324,7 @@ public class ContractionHierarchyPrecomputationTest
         Graphs.addEdgeWithVertices(graph, 8, 9, 3);
 
         ContractionHierarchyPrecomputation<Integer, DefaultWeightedEdge> contractor =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED));
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor);
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
             contractor.computeContractionHierarchy();
 
@@ -360,7 +377,7 @@ public class ContractionHierarchyPrecomputationTest
         Graphs.addEdgeWithVertices(graph, 2, 2, 2);
 
         ContractionHierarchyPrecomputation<Integer, DefaultWeightedEdge> contractor =
-            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED));
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor);
         ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
             contractor.computeContractionHierarchy();
 
@@ -411,7 +428,7 @@ public class ContractionHierarchyPrecomputationTest
             generateRandomGraph(graph, numOfVertices, probability);
 
             ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
-                new ContractionHierarchyPrecomputation<>(graph).computeContractionHierarchy();
+                new ContractionHierarchyPrecomputation<>(graph, executor).computeContractionHierarchy();
 
             assertCorrectMapping(graph, hierarchy);
             assertNoEdgesRemoved(graph, hierarchy);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputationTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputationTest.java
@@ -48,12 +48,12 @@ public class ContractionHierarchyPrecomputationTest
 
     @BeforeClass
     public static void createExecutor(){
-        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+        executor = ConcurrencyUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
     }
 
     @AfterClass
     public static void shutdownExecutor(){
-        ConcurrentUtil.shutdownExecutionService(executor);
+        ConcurrencyUtil.shutdownExecutionService(executor);
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputationTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyPrecomputationTest.java
@@ -52,7 +52,7 @@ public class ContractionHierarchyPrecomputationTest
     }
 
     @AfterClass
-    public static void shutdownExecutor(){
+    public static void shutdownExecutor() throws InterruptedException {
         ConcurrencyUtil.shutdownExecutionService(executor);
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
@@ -26,6 +26,7 @@ import org.junit.*;
 import org.junit.rules.*;
 
 import java.util.*;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -37,6 +38,18 @@ import static org.junit.Assert.assertNull;
  */
 public class DeltaSteppingShortestPathTest
 {
+    private static ThreadPoolExecutor executor;
+
+    @BeforeClass
+    public static void createExecutor(){
+        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+    }
+
+    @AfterClass
+    public static void shutdownExecutor(){
+        ConcurrentUtil.shutdownExecutionService(executor);
+    }
+
 
     private static final String S = "S";
     private static final String T = "T";
@@ -54,7 +67,7 @@ public class DeltaSteppingShortestPathTest
             new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
         graph.addVertex(S);
 
-        new DeltaSteppingShortestPath<>(graph).getPaths(S);
+        new DeltaSteppingShortestPath<>(graph, executor).getPaths(S);
     }
 
     @Test
@@ -66,7 +79,7 @@ public class DeltaSteppingShortestPathTest
         Graphs.addEdge(graph, S, T, -10.0);
 
         exception.expect(IllegalArgumentException.class);
-        new DeltaSteppingShortestPath<>(graph).getPaths(S);
+        new DeltaSteppingShortestPath<>(graph, executor).getPaths(S);
     }
 
     @Test
@@ -75,19 +88,19 @@ public class DeltaSteppingShortestPathTest
         Graph<String, DefaultWeightedEdge> graph = generateSimpleGraph();
 
         assertEquals(
-            Arrays.asList(S), new DeltaSteppingShortestPath<>(graph).getPath(S, S).getVertexList());
+            Arrays.asList(S), new DeltaSteppingShortestPath<>(graph, executor).getPath(S, S).getVertexList());
         assertEquals(
             Arrays.asList(S, Y, T),
-            new DeltaSteppingShortestPath<>(graph).getPath(S, T).getVertexList());
+            new DeltaSteppingShortestPath<>(graph, executor).getPath(S, T).getVertexList());
         assertEquals(
             Arrays.asList(S, Y, T, X),
-            new DeltaSteppingShortestPath<>(graph).getPath(S, X).getVertexList());
+            new DeltaSteppingShortestPath<>(graph, executor).getPath(S, X).getVertexList());
         assertEquals(
             Arrays.asList(S, Y),
-            new DeltaSteppingShortestPath<>(graph).getPath(S, Y).getVertexList());
+            new DeltaSteppingShortestPath<>(graph, executor).getPath(S, Y).getVertexList());
         assertEquals(
             Arrays.asList(S, Y, Z),
-            new DeltaSteppingShortestPath<>(graph).getPath(S, Z).getVertexList());
+            new DeltaSteppingShortestPath<>(graph, executor).getPath(S, Z).getVertexList());
     }
 
     @Test
@@ -96,7 +109,7 @@ public class DeltaSteppingShortestPathTest
         Graph<String, DefaultWeightedEdge> graph = generateSimpleGraph();
 
         ShortestPathAlgorithm.SingleSourcePaths<String, DefaultWeightedEdge> paths1 =
-            new DeltaSteppingShortestPath<>(graph, 0.999).getPaths(S);
+            new DeltaSteppingShortestPath<>(graph, 0.999, executor).getPaths(S);
 
         assertEquals(0d, paths1.getWeight(S), 1e-9);
         assertEquals(8d, paths1.getWeight(T), 1e-9);
@@ -105,7 +118,7 @@ public class DeltaSteppingShortestPathTest
         assertEquals(7d, paths1.getWeight(Z), 1e-9);
 
         ShortestPathAlgorithm.SingleSourcePaths<String, DefaultWeightedEdge> paths2 =
-            new DeltaSteppingShortestPath<>(graph, 5.0).getPaths(S);
+            new DeltaSteppingShortestPath<>(graph, 5.0, executor).getPaths(S);
 
         assertEquals(0d, paths2.getWeight(S), 1e-9);
         assertEquals(8d, paths2.getWeight(T), 1e-9);
@@ -114,7 +127,7 @@ public class DeltaSteppingShortestPathTest
         assertEquals(7d, paths2.getWeight(Z), 1e-9);
 
         ShortestPathAlgorithm.SingleSourcePaths<String, DefaultWeightedEdge> path3 =
-            new DeltaSteppingShortestPath<>(graph, 11.0).getPaths(S);
+            new DeltaSteppingShortestPath<>(graph, 11.0, executor).getPaths(S);
 
         assertEquals(0d, path3.getWeight(S), 1e-9);
         assertEquals(8d, path3.getWeight(T), 1e-9);
@@ -123,7 +136,7 @@ public class DeltaSteppingShortestPathTest
         assertEquals(7d, path3.getWeight(Z), 1e-9);
 
         ShortestPathAlgorithm.SingleSourcePaths<String, DefaultWeightedEdge> path4 =
-            new DeltaSteppingShortestPath<>(graph).getPaths(S);
+            new DeltaSteppingShortestPath<>(graph, executor).getPaths(S);
 
         assertEquals(0d, path4.getWeight(S), 1e-9);
         assertEquals(8d, path4.getWeight(T), 1e-9);
@@ -153,7 +166,7 @@ public class DeltaSteppingShortestPathTest
                 new DijkstraShortestPath<>(graph).getPaths(source);
         ShortestPathAlgorithm.SingleSourcePaths<Integer,
             DefaultWeightedEdge> deltaSteppingShortestPaths =
-                new DeltaSteppingShortestPath<>(graph).getPaths(source);
+                new DeltaSteppingShortestPath<>(graph, executor).getPaths(source);
         assertEqualPaths(dijkstraShortestPaths, deltaSteppingShortestPaths, graph.vertexSet());
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
@@ -49,7 +49,7 @@ public class DeltaSteppingShortestPathTest
     }
 
     @AfterClass
-    public static void shutdownExecutor(){
+    public static void shutdownExecutor() throws InterruptedException {
         ConcurrencyUtil.shutdownExecutionService(executor);
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
@@ -38,6 +38,9 @@ import static org.junit.Assert.assertNull;
  */
 public class DeltaSteppingShortestPathTest
 {
+    /**
+     * Executor which is supplied to {@link DeltaSteppingShortestPath} in this test case.
+     */
     private static ThreadPoolExecutor executor;
 
     @BeforeClass

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
@@ -45,12 +45,12 @@ public class DeltaSteppingShortestPathTest
 
     @BeforeClass
     public static void createExecutor(){
-        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+        executor = ConcurrencyUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
     }
 
     @AfterClass
     public static void shutdownExecutor(){
-        ConcurrentUtil.shutdownExecutionService(executor);
+        ConcurrencyUtil.shutdownExecutionService(executor);
     }
 
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputationTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputationTest.java
@@ -26,7 +26,10 @@ import org.jgrapht.generate.GraphGenerator;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.DirectedWeightedPseudograph;
 import org.jgrapht.graph.GraphWalk;
+import org.jgrapht.util.ConcurrentUtil;
 import org.jgrapht.util.SupplierUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -36,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.stream.Collectors;
 
 import static org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.ContractionHierarchy;
@@ -60,6 +64,21 @@ public class TransitNodeRoutingPrecomputationTest {
     private static final long SEED = 19L;
 
     /**
+     * Executor which is supplied to {@link TransitNodeRoutingPrecomputation} in this test case.
+     */
+    private static ThreadPoolExecutor executor;
+
+    @BeforeClass
+    public static void createExecutor(){
+        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+    }
+
+    @AfterClass
+    public static void shutdownExecutor(){
+        ConcurrentUtil.shutdownExecutionService(executor);
+    }
+
+    /**
      * Tests the algorithm on an empty graph to ensure no exception is thrown.
      */
     @Test
@@ -67,9 +86,9 @@ public class TransitNodeRoutingPrecomputationTest {
         Graph<Integer, DefaultWeightedEdge> graph = new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
 
         ContractionHierarchy<Integer, DefaultWeightedEdge> contractionHierarchy
-                = new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED)).computeContractionHierarchy();
+                = new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor).computeContractionHierarchy();
         TransitNodeRoutingPrecomputation<Integer, DefaultWeightedEdge> routing
-                = new TransitNodeRoutingPrecomputation<>(contractionHierarchy, 0);
+                = new TransitNodeRoutingPrecomputation<>(contractionHierarchy, 0, executor);
         routing.computeTransitNodeRouting();
     }
 
@@ -81,11 +100,12 @@ public class TransitNodeRoutingPrecomputationTest {
         graph.addVertex(vertex);
 
         ContractionHierarchy<Integer, DefaultWeightedEdge> contractionHierarchy
-                = new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED)).computeContractionHierarchy();
+                = new ContractionHierarchyPrecomputation<>(
+                        graph, () -> new Random(SEED), executor).computeContractionHierarchy();
 
         // computation
         TransitNodeRoutingPrecomputation<Integer, DefaultWeightedEdge> precomputation =
-                new TransitNodeRoutingPrecomputation<>(contractionHierarchy, 1);
+                new TransitNodeRoutingPrecomputation<>(contractionHierarchy, 1, executor);
         TransitNodeRouting<Integer, DefaultWeightedEdge> routing = precomputation.computeTransitNodeRouting();
 
         Map<Integer, ContractionVertex<Integer>> contractionMapping = contractionHierarchy.getContractionMapping();
@@ -131,11 +151,12 @@ public class TransitNodeRoutingPrecomputationTest {
         DefaultWeightedEdge edge4 = Graphs.addEdgeWithVertices(graph, v3, v2, 2.0);
 
         ContractionHierarchy<Integer, DefaultWeightedEdge> contractionHierarchy
-                = new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED)).computeContractionHierarchy();
+                = new ContractionHierarchyPrecomputation<>(
+                        graph, () -> new Random(SEED), executor).computeContractionHierarchy();
 
         // computation
         TransitNodeRoutingPrecomputation<Integer, DefaultWeightedEdge> precomputation =
-                new TransitNodeRoutingPrecomputation<>(contractionHierarchy, 1);
+                new TransitNodeRoutingPrecomputation<>(contractionHierarchy, 1, executor);
         TransitNodeRouting<Integer, DefaultWeightedEdge> routing = precomputation.computeTransitNodeRouting();
 
         Map<Integer, ContractionVertex<Integer>> contractionMapping = routing.getContractionHierarchy().getContractionMapping();
@@ -203,7 +224,8 @@ public class TransitNodeRoutingPrecomputationTest {
         for (int i = 0; i < numOfIterations; ++i) {
             Graph<Integer, DefaultWeightedEdge> graph = generateRandomGraph(numOfVertices,
                     vertexDegree * numOfVertices, random);
-            TransitNodeRoutingPrecomputation<Integer, DefaultWeightedEdge> routing = new TransitNodeRoutingPrecomputation<>(graph);
+            TransitNodeRoutingPrecomputation<Integer, DefaultWeightedEdge> routing =
+                    new TransitNodeRoutingPrecomputation<>(graph, executor);
             assertCorrectTNR(graph, routing.computeTransitNodeRouting());
         }
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputationTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputationTest.java
@@ -75,7 +75,7 @@ public class TransitNodeRoutingPrecomputationTest {
     }
 
     @AfterClass
-    public static void shutdownExecutor(){
+    public static void shutdownExecutor() throws InterruptedException {
         ConcurrencyUtil.shutdownExecutionService(executor);
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputationTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputationTest.java
@@ -64,7 +64,8 @@ public class TransitNodeRoutingPrecomputationTest {
     private static final long SEED = 19L;
 
     /**
-     * Executor which is supplied to {@link TransitNodeRoutingPrecomputation} in this test case.
+     * Executor which is supplied to {@link ContractionHierarchyPrecomputation}
+     * and {@link TransitNodeRoutingPrecomputation} in this test case.
      */
     private static ThreadPoolExecutor executor;
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputationTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingPrecomputationTest.java
@@ -26,7 +26,7 @@ import org.jgrapht.generate.GraphGenerator;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.DirectedWeightedPseudograph;
 import org.jgrapht.graph.GraphWalk;
-import org.jgrapht.util.ConcurrentUtil;
+import org.jgrapht.util.ConcurrencyUtil;
 import org.jgrapht.util.SupplierUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -71,12 +71,12 @@ public class TransitNodeRoutingPrecomputationTest {
 
     @BeforeClass
     public static void createExecutor(){
-        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+        executor = ConcurrencyUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
     }
 
     @AfterClass
     public static void shutdownExecutor(){
-        ConcurrentUtil.shutdownExecutionService(executor);
+        ConcurrencyUtil.shutdownExecutionService(executor);
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPathTest.java
@@ -26,7 +26,7 @@ import org.jgrapht.generate.GraphGenerator;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.DirectedWeightedPseudograph;
 import org.jgrapht.graph.GraphWalk;
-import org.jgrapht.util.ConcurrentUtil;
+import org.jgrapht.util.ConcurrencyUtil;
 import org.jgrapht.util.SupplierUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -62,12 +62,12 @@ public class TransitNodeRoutingShortestPathTest {
 
     @BeforeClass
     public static void createExecutor(){
-        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+        executor = ConcurrencyUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
     }
 
     @AfterClass
     public static void shutdownExecutor(){
-        ConcurrentUtil.shutdownExecutionService(executor);
+        ConcurrencyUtil.shutdownExecutionService(executor);
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPathTest.java
@@ -55,7 +55,8 @@ public class TransitNodeRoutingShortestPathTest {
     private static final long SEED = 19L;
 
     /**
-     * Executor which is supplied to {@link TransitNodeRoutingPrecomputation} in this test case.
+     * Executor which is supplied to {@link TransitNodeRoutingShortestPath},
+     * {@link TransitNodeRoutingPrecomputation} and {@link ContractionHierarchyPrecomputation} in this test case.
      */
     private static ThreadPoolExecutor executor;
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPathTest.java
@@ -66,7 +66,7 @@ public class TransitNodeRoutingShortestPathTest {
     }
 
     @AfterClass
-    public static void shutdownExecutor(){
+    public static void shutdownExecutor() throws InterruptedException {
         ConcurrencyUtil.shutdownExecutionService(executor);
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPathTest.java
@@ -26,13 +26,17 @@ import org.jgrapht.generate.GraphGenerator;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.DirectedWeightedPseudograph;
 import org.jgrapht.graph.GraphWalk;
+import org.jgrapht.util.ConcurrentUtil;
 import org.jgrapht.util.SupplierUtil;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Random;
 import java.util.Set;
+import java.util.concurrent.ThreadPoolExecutor;
 
 import static org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.ContractionHierarchy;
 import static org.jgrapht.alg.shortestpath.TransitNodeRoutingPrecomputation.TransitNodeRouting;
@@ -50,13 +54,29 @@ public class TransitNodeRoutingShortestPathTest {
      */
     private static final long SEED = 19L;
 
+    /**
+     * Executor which is supplied to {@link TransitNodeRoutingPrecomputation} in this test case.
+     */
+    private static ThreadPoolExecutor executor;
+
+    @BeforeClass
+    public static void createExecutor(){
+        executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+    }
+
+    @AfterClass
+    public static void shutdownExecutor(){
+        ConcurrentUtil.shutdownExecutionService(executor);
+    }
+
     @Test
     public void testOneVertex() {
         Integer vertex = 1;
         Graph<Integer, DefaultWeightedEdge> graph = new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
         graph.addVertex(vertex);
 
-        TransitNodeRoutingShortestPath<Integer, DefaultWeightedEdge> shortestPath = new TransitNodeRoutingShortestPath<>(graph);
+        TransitNodeRoutingShortestPath<Integer, DefaultWeightedEdge> shortestPath
+                = new TransitNodeRoutingShortestPath<>(graph, executor);
 
         GraphPath<Integer, DefaultWeightedEdge> path = shortestPath.getPath(vertex, vertex);
         GraphWalk<Integer, DefaultWeightedEdge> expectedPath = new GraphWalk<>(graph, vertex, vertex,
@@ -75,10 +95,11 @@ public class TransitNodeRoutingShortestPathTest {
         DefaultWeightedEdge edge3 = Graphs.addEdgeWithVertices(graph, v2, v1, 1.0);
 
         ContractionHierarchy<Integer, DefaultWeightedEdge> contractionHierarchy =
-                new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED)).computeContractionHierarchy();
+                new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor).computeContractionHierarchy();
 
         TransitNodeRouting<Integer, DefaultWeightedEdge> routing
-                = new TransitNodeRoutingPrecomputation<>(contractionHierarchy, 1).computeTransitNodeRouting();
+                = new TransitNodeRoutingPrecomputation<>(
+                        contractionHierarchy, 1, executor).computeTransitNodeRouting();
         TransitNodeRoutingShortestPath<Integer, DefaultWeightedEdge> shortestPath
                 = new TransitNodeRoutingShortestPath<>(routing);
 
@@ -103,10 +124,12 @@ public class TransitNodeRoutingShortestPathTest {
         DefaultWeightedEdge edge3 = Graphs.addEdgeWithVertices(graph, v3, v2, 1.0);
 
         ContractionHierarchy<Integer, DefaultWeightedEdge> contractionHierarchy =
-                new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED)).computeContractionHierarchy();
+                new ContractionHierarchyPrecomputation<>(
+                        graph, () -> new Random(SEED), executor).computeContractionHierarchy();
 
         TransitNodeRouting<Integer, DefaultWeightedEdge> routing
-                = new TransitNodeRoutingPrecomputation<>(contractionHierarchy, 1).computeTransitNodeRouting();
+                = new TransitNodeRoutingPrecomputation<>(
+                        contractionHierarchy, 1, executor).computeTransitNodeRouting();
         TransitNodeRoutingShortestPath<Integer, DefaultWeightedEdge> shortestPath
                 = new TransitNodeRoutingShortestPath<>(routing);
 
@@ -152,10 +175,11 @@ public class TransitNodeRoutingShortestPathTest {
                 new DijkstraShortestPath<>(graph).getPaths(source);
 
         ContractionHierarchy<Integer, DefaultWeightedEdge> contractionHierarchy
-                = new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED)).computeContractionHierarchy();
+                = new ContractionHierarchyPrecomputation<>(
+                        graph, () -> new Random(SEED), executor).computeContractionHierarchy();
 
         TransitNodeRouting<Integer, DefaultWeightedEdge> routing =
-                new TransitNodeRoutingPrecomputation<>(contractionHierarchy).computeTransitNodeRouting();
+                new TransitNodeRoutingPrecomputation<>(contractionHierarchy, executor).computeTransitNodeRouting();
 
         TransitNodeRoutingShortestPath<Integer, DefaultWeightedEdge> transitNodeRoutingShortestPath
                 = new TransitNodeRoutingShortestPath<>(routing);

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/DeltaSteppingShortestPathPerformance.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/DeltaSteppingShortestPathPerformance.java
@@ -23,8 +23,6 @@ import org.jgrapht.alg.shortestpath.*;
 import org.jgrapht.generate.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
 import org.openjdk.jmh.annotations.*;
 
 import java.util.concurrent.*;
@@ -159,12 +157,12 @@ public class DeltaSteppingShortestPathPerformance
 
         @Setup
         public void createExecutor(){
-            executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+            executor = ConcurrencyUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
         }
 
         @TearDown
         public void shutdownExecutor(){
-            ConcurrentUtil.shutdownExecutionService(executor);
+            ConcurrencyUtil.shutdownExecutionService(executor);
         }
 
         public abstract void generateGraph();

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/DeltaSteppingShortestPathPerformance.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/DeltaSteppingShortestPathPerformance.java
@@ -161,7 +161,7 @@ public class DeltaSteppingShortestPathPerformance
         }
 
         @TearDown
-        public void shutdownExecutor(){
+        public void shutdownExecutor() throws InterruptedException {
             ConcurrencyUtil.shutdownExecutionService(executor);
         }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/DeltaSteppingShortestPathPerformance.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/DeltaSteppingShortestPathPerformance.java
@@ -23,6 +23,8 @@ import org.jgrapht.alg.shortestpath.*;
 import org.jgrapht.generate.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.openjdk.jmh.annotations.*;
 
 import java.util.concurrent.*;
@@ -47,7 +49,7 @@ public class DeltaSteppingShortestPathPerformance
     public ShortestPathAlgorithm.SingleSourcePaths<Integer,
         DefaultWeightedEdge> testDeltaSteppingGnm(GnmState data)
     {
-        return new DeltaSteppingShortestPath<>(data.graph, 1.0 / data.edgeDegree).getPaths(0);
+        return new DeltaSteppingShortestPath<>(data.graph, 1.0 / data.edgeDegree, data.executor).getPaths(0);
     }
 
     @Benchmark
@@ -69,7 +71,7 @@ public class DeltaSteppingShortestPathPerformance
         DefaultWeightedEdge> testDeltaSteppingGnp(GnpState data)
     {
         return new DeltaSteppingShortestPath<>(
-            data.graph, 1.0 / (1 + (data.p * data.numOfVertices))).getPaths(0);
+            data.graph, 1.0 / (1 + (data.p * data.numOfVertices)), data.executor).getPaths(0);
     }
 
     @Benchmark
@@ -90,7 +92,7 @@ public class DeltaSteppingShortestPathPerformance
     public ShortestPathAlgorithm.SingleSourcePaths<Integer,
         DefaultWeightedEdge> testDeltaSteppingBarabasiAlbert(BarabasiAlbertState data)
     {
-        return new DeltaSteppingShortestPath<>(data.graph, 1.0 / data.m0).getPaths(0);
+        return new DeltaSteppingShortestPath<>(data.graph, 1.0 / data.m0, data.executor).getPaths(0);
     }
 
     @Benchmark
@@ -111,7 +113,7 @@ public class DeltaSteppingShortestPathPerformance
     public ShortestPathAlgorithm.SingleSourcePaths<Integer,
         DefaultWeightedEdge> testDeltaSteppingWattsStogatz(WattsStogatzState data)
     {
-        return new DeltaSteppingShortestPath<>(data.graph, 1.0 / data.k).getPaths(0);
+        return new DeltaSteppingShortestPath<>(data.graph, 1.0 / data.k, data.executor).getPaths(0);
     }
 
     @Benchmark
@@ -132,7 +134,7 @@ public class DeltaSteppingShortestPathPerformance
     public ShortestPathAlgorithm.SingleSourcePaths<Integer,
         DefaultWeightedEdge> testDeltaSteppingComplete(CompleteGraphState data)
     {
-        return new DeltaSteppingShortestPath<>(data.graph, 1.0 / data.numOfVertices).getPaths(0);
+        return new DeltaSteppingShortestPath<>(data.graph, 1.0 / data.numOfVertices, data.executor).getPaths(0);
     }
 
     @Benchmark
@@ -153,6 +155,17 @@ public class DeltaSteppingShortestPathPerformance
     public abstract static class BaseState
     {
         DefaultUndirectedWeightedGraph<Integer, DefaultWeightedEdge> graph;
+        public ThreadPoolExecutor executor;
+
+        @Setup
+        public void createExecutor(){
+            executor = ConcurrentUtil.createThreadPoolExecutor(Runtime.getRuntime().availableProcessors());
+        }
+
+        @TearDown
+        public void shutdownExecutor(){
+            ConcurrentUtil.shutdownExecutionService(executor);
+        }
 
         public abstract void generateGraph();
 


### PR DESCRIPTION
This PR is based on the discussion in #956.

Changes summary:

- `ThreadPoolExecutor` is now a parameter for algorithms which use parallelism.
- Created `ConcurrentUtil` for managing the lifecycke of `ThreadPoolExecutor`.
- Updated documentation. 



- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
