### PR TITLE
Fixed triangle count when multiple edges are present

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/GraphMetrics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphMetrics.java
@@ -225,17 +225,43 @@ public abstract class GraphMetrics
     {
         long total = 0;
 
-        for (int i = 0; i < vertexSubset.size(); i++) {
-            for (int j = i + 1; j < vertexSubset.size(); j++) {
-                for (int k = j + 1; k < vertexSubset.size(); k++) {
-                    V u = vertexSubset.get(i);
-                    V v = vertexSubset.get(j);
-                    V w = vertexSubset.get(k);
+        if (graph.getType().isAllowingMultipleEdges()) {
+            for (int i = 0; i < vertexSubset.size(); i++) {
+                for (int j = i + 1; j < vertexSubset.size(); j++) {
+                    for (int k = j + 1; k < vertexSubset.size(); k++) {
+                        V u = vertexSubset.get(i);
+                        V v = vertexSubset.get(j);
+                        V w = vertexSubset.get(k);
 
-                    if (graph.containsEdge(u, v) && graph.containsEdge(v, w)
-                        && graph.containsEdge(w, u))
-                    {
-                        total++;
+                        int uvEdgeCount = graph.getAllEdges(u, v).size();
+                        if (uvEdgeCount == 0) {
+                            continue;
+                        }
+                        int vwEdgeCount = graph.getAllEdges(v, w).size();
+                        if (vwEdgeCount == 0) {
+                            continue;
+                        }
+                        int wuEdgeCount = graph.getAllEdges(w, u).size();
+                        if (wuEdgeCount == 0) {
+                            continue;
+                        }
+                        total += uvEdgeCount * vwEdgeCount * wuEdgeCount;
+                    }
+                }
+            }
+        } else {
+            for (int i = 0; i < vertexSubset.size(); i++) {
+                for (int j = i + 1; j < vertexSubset.size(); j++) {
+                    for (int k = j + 1; k < vertexSubset.size(); k++) {
+                        V u = vertexSubset.get(i);
+                        V v = vertexSubset.get(j);
+                        V w = vertexSubset.get(k);
+
+                        if (graph.containsEdge(u, v) && graph.containsEdge(v, w)
+                            && graph.containsEdge(w, u))
+                        {
+                            total++;
+                        }
                     }
                 }
             }

--- a/jgrapht-core/src/test/java/org/jgrapht/GraphMetricsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/GraphMetricsTest.java
@@ -17,15 +17,36 @@
  */
 package org.jgrapht;
 
-import org.jgrapht.alg.cycle.*;
-import org.jgrapht.generate.*;
-import org.jgrapht.graph.*;
-import org.jgrapht.util.*;
-import org.junit.*;
-
-import java.util.*;
-
 import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+
+import org.jgrapht.alg.cycle.TarjanSimpleCycles;
+import org.jgrapht.generate.BarabasiAlbertGraphGenerator;
+import org.jgrapht.generate.CompleteGraphGenerator;
+import org.jgrapht.generate.GnpRandomGraphGenerator;
+import org.jgrapht.generate.GraphGenerator;
+import org.jgrapht.generate.GridGraphGenerator;
+import org.jgrapht.generate.NamedGraphGenerator;
+import org.jgrapht.generate.RingGraphGenerator;
+import org.jgrapht.generate.WheelGraphGenerator;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedMultigraph;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.Multigraph;
+import org.jgrapht.graph.Pseudograph;
+import org.jgrapht.graph.SimpleDirectedGraph;
+import org.jgrapht.graph.SimpleDirectedWeightedGraph;
+import org.jgrapht.graph.SimpleGraph;
+import org.jgrapht.graph.builder.GraphTypeBuilder;
+import org.jgrapht.util.SupplierUtil;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Tests for GraphMetrics
@@ -337,4 +358,68 @@ public class GraphMetricsTest
         Assert.assertEquals(56, GraphMetrics.getNumberOfTriangles(graph));
         Assert.assertEquals(56, naiveCountTriangles(graph));
     }
+
+    @Test
+    public void testCountTriangles4()
+    {
+        Graph<Integer,
+            DefaultEdge> g = GraphTypeBuilder
+                .undirected().allowingMultipleEdges(true).allowingSelfLoops(true).weighted(false)
+                .edgeSupplier(SupplierUtil.DEFAULT_EDGE_SUPPLIER)
+                .vertexSupplier(SupplierUtil.createIntegerSupplier()).buildGraph();
+
+        for (int i = 0; i < 25; i++) {
+            g.addVertex(i);
+        }
+
+        int[][] edges = { { 0, 1 }, { 1, 2 }, { 0, 3 }, { 1, 3 }, { 2, 5 }, { 3, 5 }, { 4, 5 },
+            { 1, 6 }, { 2, 6 }, { 1, 7 }, { 2, 7 }, { 3, 7 }, { 4, 7 }, { 1, 8 }, { 2, 8 },
+            { 2, 9 }, { 1, 10 }, { 7, 10 }, { 1, 11 }, { 2, 11 }, { 2, 12 }, { 3, 13 }, { 4, 13 },
+            { 1, 15 }, { 6, 15 }, { 9, 15 }, { 1, 16 }, { 4, 16 }, { 11, 16 }, { 1, 18 }, { 2, 18 },
+            { 1, 19 }, { 3, 19 }, { 6, 19 }, { 1, 20 }, { 2, 20 }, { 2, 21 }, { 3, 21 }, { 3, 22 },
+            { 5, 22 }, { 10, 22 }, { 3, 23 }, { 19, 23 }, { 1, 24 }, { 2, 24 } };
+
+        for (int[] e : edges) {
+            g.addEdge(e[0], e[1]);
+        }
+
+        long t1 = GraphMetrics.getNumberOfTriangles(g);
+        List<Integer> allVertices = new ArrayList<>(g.vertexSet());
+        long t2 = GraphMetrics.naiveCountTriangles(g, allVertices);
+
+        assertEquals(t1, t2);
+    }
+
+    @Test
+    public void testMultipleEdges()
+    {
+        Graph<Integer,
+            DefaultEdge> g = GraphTypeBuilder
+                .undirected().allowingMultipleEdges(true).allowingSelfLoops(true).weighted(false)
+                .edgeSupplier(SupplierUtil.DEFAULT_EDGE_SUPPLIER)
+                .vertexSupplier(SupplierUtil.createIntegerSupplier()).buildGraph();
+
+        int[][] edges = { { 0, 1 }, { 1, 2 }, { 2, 0 }, { 1, 3 }, { 2, 3 }, { 2, 1 } };
+        for (int[] e : edges) {
+            Graphs.addEdgeWithVertices(g, e[0], e[1]);
+        }
+        assertEquals(4, GraphMetrics.getNumberOfTriangles(g));
+    }
+    
+    @Test
+    public void testMultipleEdges2()
+    {
+        Graph<Integer,
+            DefaultEdge> g = GraphTypeBuilder
+                .undirected().allowingMultipleEdges(true).allowingSelfLoops(true).weighted(false)
+                .edgeSupplier(SupplierUtil.DEFAULT_EDGE_SUPPLIER)
+                .vertexSupplier(SupplierUtil.createIntegerSupplier()).buildGraph();
+
+        int[][] edges = { { 0, 1 }, { 1, 2 }, { 2, 0 }, { 1, 3 }, { 2, 3 }, { 2, 1 }, {0, 2}, {0, 2} };
+        for (int[] e : edges) {
+            Graphs.addEdgeWithVertices(g, e[0], e[1]);
+        }
+        assertEquals(8, GraphMetrics.getNumberOfTriangles(g));
+    }
+
 }


### PR DESCRIPTION
Our triangle count method has a bug when the graph contains multiple edges. It computes correctly only for the vertices which have small degrees (non heavy hitters) but not for the vertices with large degrees. This PR fixes this. See discussion at #981 .

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
