### PR TITLE
Dot importer edge attributes

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/BaseEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/BaseEventDrivenImporter.java
@@ -59,7 +59,6 @@ public abstract class BaseEventDrivenImporter<V, E>
         this.graphAttributeConsumers = new ArrayList<>();
         this.vertexAttributeConsumers = new ArrayList<>();
         this.edgeAttributeConsumers = new ArrayList<>();
-        this.edgeWithAttributesConsumers = new ArrayList<>();
         this.importEventConsumers = new ArrayList<>();
     }
 

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/BaseEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/BaseEventDrivenImporter.java
@@ -37,7 +37,9 @@ public abstract class BaseEventDrivenImporter<V, E>
     private List<Consumer<Integer>> vertexCountConsumers;
     private List<Consumer<Integer>> edgeCountConsumers;
     private List<Consumer<V>> vertexConsumers;
+    private List<BiConsumer<V, Map<String, Attribute>>> vertexWithAttributesConsumers;
     private List<Consumer<E>> edgeConsumers;
+    private List<BiConsumer<E, Map<String, Attribute>>> edgeWithAttributesConsumers;
     private List<BiConsumer<String, Attribute>> graphAttributeConsumers;
     private List<BiConsumer<Pair<V, String>, Attribute>> vertexAttributeConsumers;
     private List<BiConsumer<Pair<E, String>, Attribute>> edgeAttributeConsumers;
@@ -51,10 +53,13 @@ public abstract class BaseEventDrivenImporter<V, E>
         this.vertexCountConsumers = new ArrayList<>();
         this.edgeCountConsumers = new ArrayList<>();
         this.vertexConsumers = new ArrayList<>();
+        this.vertexWithAttributesConsumers = new ArrayList<>();
         this.edgeConsumers = new ArrayList<>();
+        this.edgeWithAttributesConsumers = new ArrayList<>();
         this.graphAttributeConsumers = new ArrayList<>();
         this.vertexAttributeConsumers = new ArrayList<>();
         this.edgeAttributeConsumers = new ArrayList<>();
+        this.edgeWithAttributesConsumers = new ArrayList<>();
         this.importEventConsumers = new ArrayList<>();
     }
 
@@ -199,6 +204,24 @@ public abstract class BaseEventDrivenImporter<V, E>
     }
 
     /**
+     * Add a vertex with attributes consumer.
+     * 
+     * @param consumer the consumer
+     */
+    public void addVertexWithAttributesConsumer(BiConsumer<V, Map<String, Attribute>> consumer) { 
+        vertexWithAttributesConsumers.add(consumer);
+    }
+    
+    /**
+     * Remove a vertex with attributes consumer
+     * 
+     * @param consumer the consumer
+     */
+    public void removeVertexWithAttributesConsumer(BiConsumer<V, Map<String, Attribute>> consumer) { 
+        vertexWithAttributesConsumers.remove(consumer);
+    }
+    
+    /**
      * Add an edge attribute consumer.
      * 
      * @param consumer the consumer
@@ -218,6 +241,24 @@ public abstract class BaseEventDrivenImporter<V, E>
         edgeAttributeConsumers.remove(consumer);
     }
 
+    /**
+     * Add an edge with attributes consumer.
+     * 
+     * @param consumer the consumer
+     */
+    public void addEdgeWithAttributesConsumer(BiConsumer<E, Map<String, Attribute>> consumer) { 
+        edgeWithAttributesConsumers.add(consumer);
+    }
+    
+    /**
+     * Remove an edge with attributes consumer
+     * 
+     * @param consumer the consumer
+     */
+    public void removeEdgeWithAttributesConsumer(BiConsumer<E, Map<String, Attribute>> consumer) { 
+        edgeWithAttributesConsumers.remove(consumer);
+    }
+    
     /**
      * Notify for the vertex count.
      * 
@@ -247,6 +288,17 @@ public abstract class BaseEventDrivenImporter<V, E>
     {
         vertexConsumers.forEach(c -> c.accept(v));
     }
+    
+    /**
+     * Notify for a vertex with attributes.
+     * 
+     * @param v the vertex
+     * @param attrs the attributes
+     */
+    protected void notifyVertexWithAttributes(V v, Map<String, Attribute> attrs)
+    {
+        vertexWithAttributesConsumers.forEach(c -> c.accept(v, attrs));
+    }
 
     /**
      * Notify for an edge.
@@ -258,6 +310,17 @@ public abstract class BaseEventDrivenImporter<V, E>
         edgeConsumers.forEach(c -> c.accept(e));
     }
 
+    /**
+     * Notify for an edge with attributes.
+     * 
+     * @param e the edge
+     * @param attrs the attributes
+     */
+    protected void notifyEdgeWithAttributes(E e, Map<String, Attribute> attrs)
+    {
+        edgeWithAttributesConsumers.forEach(c -> c.accept(e, attrs));
+    }
+    
     /**
      * Notify for a graph attribute
      * 

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/EventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/EventDrivenImporter.java
@@ -21,6 +21,7 @@ import org.jgrapht.alg.util.*;
 
 import java.io.*;
 import java.nio.charset.*;
+import java.util.Map;
 import java.util.function.*;
 
 /**
@@ -88,6 +89,20 @@ public interface EventDrivenImporter<V, E>
     void removeVertexConsumer(Consumer<V> consumer);
 
     /**
+     * Add a vertex with attributes consumer.
+     * 
+     * @param consumer the consumer
+     */
+    void addVertexWithAttributesConsumer(BiConsumer<V, Map<String, Attribute>> consumer);
+    
+    /**
+     * Remove a vertex with attributes consumer
+     * 
+     * @param consumer the consumer
+     */
+    void removeVertexWithAttributesConsumer(BiConsumer<V, Map<String, Attribute>> consumer);
+ 
+    /**
      * Add an edge consumer.
      * 
      * @param consumer the consumer
@@ -101,6 +116,20 @@ public interface EventDrivenImporter<V, E>
      */
     void removeEdgeConsumer(Consumer<E> consumer);
 
+    /**
+     * Add an edge with attributes consumer.
+     * 
+     * @param consumer the consumer
+     */
+    void addEdgeWithAttributesConsumer(BiConsumer<E, Map<String, Attribute>> consumer);
+    
+    /**
+     * Remove an edge with attributes consumer
+     * 
+     * @param consumer the consumer
+     */
+    void removeEdgeWithAttributesConsumer(BiConsumer<E, Map<String, Attribute>> consumer);
+    
     /**
      * Add a graph attribute consumer.
      * 

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTEventDrivenImporter.java
@@ -26,6 +26,7 @@ import org.jgrapht.nio.*;
 
 import java.io.*;
 import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * Import a graph from a DOT file.
@@ -54,11 +55,26 @@ public class DOTEventDrivenImporter
 
     // identifier unescape rule
     private final CharSequenceTranslator UNESCAPE_ID;
-
+    
+    private boolean notifyVertexAttributesOutOfOrder;
+    private boolean notifyEdgeAttributesOutOfOrder;
+    
     /**
      * Constructs a new importer.
      */
-    public DOTEventDrivenImporter()
+    public DOTEventDrivenImporter() { 
+        this(true, true);
+    }
+    
+    /**
+     * Constructs a new importer.
+     * 
+     * @param notifyVertexAttributesOutOfOrder whether to notify for vertex attributes out-of-order even if 
+     *        they appear together in the input
+     * @param notifyEdgeAttributesOutOfOrder whether to notify for edge attributes out-of-order even if 
+     *        they appear together in the input        
+     */
+    public DOTEventDrivenImporter(boolean notifyVertexAttributesOutOfOrder, boolean notifyEdgeAttributesOutOfOrder)
     {
         super();
         Map<CharSequence, CharSequence> lookupMap = new HashMap<>();
@@ -67,6 +83,9 @@ public class DOTEventDrivenImporter
         lookupMap.put("\\'", "'");
         lookupMap.put("\\", "");
         UNESCAPE_ID = new AggregateTranslator(new LookupTranslator(lookupMap));
+        
+        this.notifyVertexAttributesOutOfOrder = notifyVertexAttributesOutOfOrder;
+        this.notifyEdgeAttributesOutOfOrder = notifyEdgeAttributesOutOfOrder;
     }
 
     @Override
@@ -342,9 +361,16 @@ public class DOTEventDrivenImporter
                             }
 
                             Pair<String, String> pe = Pair.of(sourceVertex, targetVertex);
-                            notifyEdge(pe);
-                            for (String key : edgeAttrs.keySet()) {
-                                notifyEdgeAttribute(pe, key, edgeAttrs.get(key));
+
+                            if (notifyEdgeAttributesOutOfOrder) { 
+                                // notify individually
+                                notifyEdge(pe);
+                                for(Entry<String, Attribute> entry: edgeAttrs.entrySet()) { 
+                                    notifyEdgeAttribute(pe, entry.getKey(), entry.getValue());
+                                }
+                            } else { 
+                                // notify with all attributes
+                                notifyEdgeWithAttributes(pe, edgeAttrs);
                             }
                         }
                     }
@@ -425,11 +451,15 @@ public class DOTEventDrivenImporter
                 // append extra attributes
                 defaultAttrs.putAll(attrs);
 
-                notifyVertex(nodeId);
-                for (String key : defaultAttrs.keySet()) {
-                    notifyVertexAttribute(nodeId, key, defaultAttrs.get(key));
+                if (notifyVertexAttributesOutOfOrder) { 
+                    notifyVertex(nodeId);
+                    for(Entry<String, Attribute> entry: defaultAttrs.entrySet()) { 
+                        notifyVertexAttribute(nodeId, entry.getKey(), entry.getValue());
+                    }
+                } else { 
+                    notifyVertexWithAttributes(nodeId, defaultAttrs);
                 }
-
+                
                 vertices.add(nodeId);
                 scope.addVertex(nodeId);
             } else {
@@ -474,10 +504,16 @@ public class DOTEventDrivenImporter
                 SubgraphScope scope = subgraphScopes.element();
                 // find default attributes
                 Map<String, Attribute> defaultAttrs = new HashMap<>(scope.nodeAttrs);
-                notifyVertex(nodeId);
-                for (String key : defaultAttrs.keySet()) {
-                    notifyVertexAttribute(nodeId, key, defaultAttrs.get(key));
+                
+                if (notifyVertexAttributesOutOfOrder) { 
+                    notifyVertex(nodeId);
+                    for(Entry<String, Attribute> entry: defaultAttrs.entrySet()) { 
+                        notifyVertexAttribute(nodeId, entry.getKey(), entry.getValue());
+                    }
+                } else { 
+                    notifyVertexWithAttributes(nodeId, defaultAttrs);
                 }
+                
                 vertices.add(nodeId);
                 scope.addVertex(nodeId);
             }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTImporter.java
@@ -50,7 +50,18 @@ import java.util.function.*;
  * The default behavior of the importer is to use the graph vertex supplier in order to create
  * vertices. The user can also bypass vertex creation by providing a custom vertex factory method
  * using {@link #setVertexFactory(Function)}. The factory method is responsible to create a new
- * graph vertex given the vertex identifier read from file.
+ * graph vertex given the vertex identifier read from file. Additionally this importer also supports
+ * creating vertices with {@link #setVertexWithAttributesFactory(BiFunction)}. This factory method is 
+ * responsible for creating a new graph vertex given the vertex identifier read from file together
+ * with all available attributes of the vertex at the location of the file where the vertex is first
+ * defined.
+ *
+ * <p>
+ * The default behavior of the importer is to use the graph edge supplier in order to create
+ * edges. The user can also bypass edge creation by providing a custom edge factory method
+ * using {@link #setEdgeWithAttributesFactory(Function)}. The factory method is responsible to create
+ * a new graph edge given all available attributes of the edge at the location of the file where the
+ * edge is first defined.
  *
  * @author Dimitrios Michail
  *
@@ -69,6 +80,8 @@ public class DOTImporter<V, E>
     public static final String DEFAULT_VERTEX_ID_KEY = "ID";
 
     private Function<String, V> vertexFactory;
+    private BiFunction<String, Map<String, Attribute>, V> vertexWithAttributesFactory;
+    private Function<Map<String, Attribute>, E> edgeWithAttributesFactory;
 
     /**
      * Constructs a new importer.
@@ -81,12 +94,26 @@ public class DOTImporter<V, E>
     @Override
     public void importGraph(Graph<V, E> graph, Reader input)
     {
-        DOTEventDrivenImporter genericImporter = new DOTEventDrivenImporter();
+        final boolean verticesOutOfOrder = vertexWithAttributesFactory == null;
+        final boolean edgesOutOfOrder = edgeWithAttributesFactory == null;
+        DOTEventDrivenImporter genericImporter = new DOTEventDrivenImporter(verticesOutOfOrder, edgesOutOfOrder);
+        
         Consumers consumers = new Consumers(graph);
-        genericImporter.addVertexConsumer(consumers.vertexConsumer);
+
+        if (vertexWithAttributesFactory != null) { 
+            genericImporter.addVertexWithAttributesConsumer(consumers.vertexWithAttributesConsumer);
+        } else { 
+            genericImporter.addVertexConsumer(consumers.vertexConsumer);
+        }
         genericImporter.addVertexAttributeConsumer(consumers.vertexAttributeConsumer);
-        genericImporter.addEdgeConsumer(consumers.edgeConsumer);
+        
+        if (edgeWithAttributesFactory != null) { 
+            genericImporter.addEdgeWithAttributesConsumer(consumers.edgeWithAttributesConsumer);
+        } else { 
+            genericImporter.addEdgeConsumer(consumers.edgeConsumer);
+        }
         genericImporter.addEdgeAttributeConsumer(consumers.edgeAttributeConsumer);
+        
         genericImporter.addGraphAttributeConsumer(consumers.graphAttributeConsumer);
         genericImporter.importInput(input);
     }
@@ -106,8 +133,8 @@ public class DOTImporter<V, E>
      * Set the user custom vertex factory. The default behavior is being null in which case the
      * graph vertex supplier is used.
      * 
-     * If supplied the vertex factory is called every time a new vertex is encountered in the file.
-     * The method is called with parameter the vertex identifier from the file and should return the
+     * If supplied the vertex factory is called every time a new vertex is encountered in the input.
+     * The method is called with parameter the vertex identifier from the input and should return the
      * actual graph vertex to add to the graph.
      * 
      * @param vertexFactory a vertex factory
@@ -115,6 +142,62 @@ public class DOTImporter<V, E>
     public void setVertexFactory(Function<String, V> vertexFactory)
     {
         this.vertexFactory = vertexFactory;
+    }
+    
+    /**
+     * Get the user custom vertex factory with attributes. This is null by default and the graph supplier is used
+     * instead.
+     *  
+     * @return the user custom vertex factory with attributes. 
+     */
+    public BiFunction<String, Map<String, Attribute>, V> getVertexWithAttributesFactory()
+    {
+        return vertexWithAttributesFactory;
+    }
+
+    /**
+     * Set the user custom vertex factory with attributes. The default behavior is being null in which case the
+     * graph vertex supplier is used.
+     * 
+     * If supplied the vertex factory is called every time a new vertex is encountered in the input.
+     * The method is called with parameter the vertex identifier from the input and a set of attributes  
+     * and should return the actual graph vertex to add to the graph. Note that the set of attributes might 
+     * not be complete, as only attributes available at the first vertex definition are collected.
+     * 
+     * @param vertexWithAttributesFactory a vertex factory with attributes
+     */
+    public void setVertexWithAttributesFactory(
+        BiFunction<String, Map<String, Attribute>, V> vertexWithAttributesFactory)
+    {
+        this.vertexWithAttributesFactory = vertexWithAttributesFactory;
+    }
+    
+    /**
+     * Get the user custom edges factory with attributes. This is null by default and the graph supplier is used
+     * instead.
+     *  
+     * @return the user custom edge factory with attributes. 
+     */
+    public Function<Map<String, Attribute>, E> getEdgeWithAttributesFactory()
+    {
+        return edgeWithAttributesFactory;
+    }
+
+    /**
+     * Set the user custom edge factory with attributes. The default behavior is being null in which case the
+     * graph edge supplier is used.
+     * 
+     * If supplied the edge factory is called every time a new edge is encountered in the input.
+     * The method is called with parameter the set of attributes and should return the actual graph edge to add
+     * to the graph. Note that the set of attributes might not be complete, as only attributes available at the
+     * first edge definition are collected.
+     * 
+     * @param edgeWithAttributesFactory an edge factory with attributes
+     */
+    public void setEdgeWithAttributesFactory(
+        Function<Map<String, Attribute>, E> edgeWithAttributesFactory)
+    {
+        this.edgeWithAttributesFactory = edgeWithAttributesFactory;
     }
 
     private class Consumers
@@ -146,9 +229,30 @@ public class DOTImporter<V, E>
                 v = graph.addVertex();
             }
             map.put(t, v);
+
+            // notify individually
             notifyVertex(v);
             notifyVertexAttribute(v, DEFAULT_VERTEX_ID_KEY, DefaultAttribute.createAttribute(t));
         };
+
+        public final BiConsumer<String, Map<String, Attribute>> vertexWithAttributesConsumer =
+            (t, attrs) -> {
+                if (map.containsKey(t)) {
+                    throw new ImportException("Node " + t + " already exists");
+                }            
+                V v;
+                if (vertexWithAttributesFactory != null) {
+                    v = vertexWithAttributesFactory.apply(t, attrs);
+                    graph.addVertex(v);
+                } else {
+                    v = graph.addVertex();
+                }
+                map.put(t, v);
+
+                // notify with all collected attributes
+                attrs.put(DEFAULT_VERTEX_ID_KEY, DefaultAttribute.createAttribute(t));
+                notifyVertexWithAttributes(v, attrs);
+            };
 
         public final BiConsumer<Pair<String, String>, Attribute> vertexAttributeConsumer =
             (p, a) -> {
@@ -174,10 +278,35 @@ public class DOTImporter<V, E>
 
             E e = graph.addEdge(from, to);
             notifyEdge(e);
-
+            
             lastPair = p;
             lastEdge = e;
         };
+
+        public final BiConsumer<Pair<String, String>,
+            Map<String, Attribute>> edgeWithAttributesConsumer = (p, attrs) -> {
+                String source = p.getFirst();
+                V from = map.get(p.getFirst());
+                if (from == null) {
+                    throw new ImportException("Node " + source + " does not exist");
+                }
+
+                String target = p.getSecond();
+                V to = map.get(target);
+                if (to == null) {
+                    throw new ImportException("Node " + target + " does not exist");
+                }
+
+                E e;
+                if (edgeWithAttributesFactory != null) { 
+                    e = edgeWithAttributesFactory.apply(attrs);
+                    graph.addEdge(from, to, e);
+                } else { 
+                    e = graph.addEdge(from, to);
+                }
+                
+                notifyEdgeWithAttributes(e, attrs);
+            };
 
         public final BiConsumer<Pair<Pair<String, String>, String>,
             Attribute> edgeAttributeConsumer = (p, a) -> {

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTImporter.java
@@ -306,6 +306,9 @@ public class DOTImporter<V, E>
                 }
                 
                 notifyEdgeWithAttributes(e, attrs);
+                
+                lastPair = p;
+                lastEdge = e;
             };
 
         public final BiConsumer<Pair<Pair<String, String>, String>,

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/dot/DOTImporter2Test.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/dot/DOTImporter2Test.java
@@ -27,6 +27,7 @@ import java.io.*;
 import java.util.*;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 /**
@@ -949,4 +950,64 @@ public class DOTImporter2Test
 
     }
 
+    @Test
+    public void testCreateVerticesWithAttributes()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "digraph G {" + NL +
+                       "  a0 [color=gray];" + NL +
+                       "  a1 [color=green];" + NL +                       
+                       "  a0 -> a1;" + NL +
+                       "  a2 [color=white];" + NL +                       
+                       "}";
+        // @formatter:on
+
+        DOTImporter<String, DefaultEdge> importer = new DOTImporter<>();
+        
+        importer.setVertexWithAttributesFactory((id, attrs)->{
+            return id + "-" + attrs.get("color").getValue();
+        });
+
+        DirectedPseudograph<String, DefaultEdge> graph = new DirectedPseudograph<>(
+            SupplierUtil.createStringSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        importer.importGraph(graph, new StringReader(input));
+
+        assertTrue(graph.containsVertex("a0-gray"));
+        assertTrue(graph.containsVertex("a1-green"));
+        assertTrue(graph.containsVertex("a2-white"));
+    }
+    
+    @Test
+    public void testCreateEdgesWithAttributes()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "digraph G {" + NL +
+                       "  a0 [color=gray];" + NL +
+                       "  a1 [color=green];" + NL +                       
+                       "  a2 [color=white];" + NL +                       
+                       "  a0 -> a1 [label=\"e1\"];" + NL +
+                       "  a1 -> a2 [label=\"e2\"];" + NL +                       
+                       "}";
+        // @formatter:on
+
+        DOTImporter<String, String> importer = new DOTImporter<>();
+        
+        importer.setVertexWithAttributesFactory((id, attrs)->{
+            return id + "-" + attrs.get("color").getValue();
+        });
+        
+        importer.setEdgeWithAttributesFactory((attrs)->{
+            return attrs.get("label").getValue();
+        });
+
+        DirectedPseudograph<String, String> graph = new DirectedPseudograph<>(
+            SupplierUtil.createStringSupplier(), null, false);
+        importer.importGraph(graph, new StringReader(input));
+
+        assertTrue(graph.containsEdge("e1"));
+        assertTrue(graph.containsEdge("e2"));
+    }
+    
 }


### PR DESCRIPTION
Enhanced the `BaseEventDrivenImporter` to also support notifications for a vertex/edge together bundled with a set of attributes. 
Enhanced the `DOTImporter` by adding support for custom user vertex factory with attributes and custom user edge factory with attributes. 

This is related to #997 and #987. 

It seems this use case is pretty common, so worth supporting our old functionality. Given the first change, other importers can also be adjusted if someone requests such functionality.

----
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
