### PR TITLE
Eigenvector centrality

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/EigenvectorCentrality.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/EigenvectorCentrality.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2020, by Sebastiano Vigna.
+ * (C) Copyright 2020-2020, by Sebastiano Vigna and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/EigenvectorCentrality.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/EigenvectorCentrality.java
@@ -1,0 +1,203 @@
+/*
+ * (C) Copyright 2020, by Sebastiano Vigna.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.scoring;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphIterables;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.interfaces.VertexScoringAlgorithm;
+
+/**
+ * Eigenvector-centrality implementation.
+ *
+ * <p>
+ * Eigenvector centrality, introduced in 1895 by Edmund Landau for chess tournaments, associates
+ * with a (weighted) graph the left dominant eigenvector of its adjacency matrix. More information
+ * can be found on <a href="https://en.wikipedia.org/wiki/Eigenvector_centrality">wikipedia</a>.
+ * </p>
+ *
+ * <p>
+ * This is a simple iterative implementation of the
+ * <a href="https://en.wikipedia.org/wiki/Power_iteration">power method</a> which stops after a
+ * given number of iterations or if centrality values between two iterations do not change more than
+ * a predefined value (technically, we stop when the &#x2113;<sub>2</sub> norm of the difference
+ * between the current estimate and the next one drops below a given threshold). Correspondingly,
+ * the result will be &#x2113;<sub>2</sub>-normalized.
+ * </p>
+ *
+ * <p>
+ * Each iteration of the algorithm runs in linear time O(n+m) when n is the number of nodes and m
+ * the number of edges of the graph. The maximum number of iterations can be adjusted by the caller.
+ * The default value is {@link EigenvectorCentrality#MAX_ITERATIONS_DEFAULT}. Also in case of
+ * weighted graphs, negative weights are not expected.
+ * </p>
+ *
+ * @param <V> the graph vertex type
+ * @param <E> the graph edge type
+ *
+ * @author Sebastiano Vigna
+ */
+public final class EigenvectorCentrality<V, E>
+    implements
+    VertexScoringAlgorithm<V, Double>
+{
+    /**
+     * Default number of maximum iterations.
+     */
+    public static final int MAX_ITERATIONS_DEFAULT = 100;
+
+    /**
+     * Default value for the tolerance. The calculation will stop if the &#x2113;<sub>2</sub> norm
+     * of the difference of centrality values between iterations changes less than this value.
+     */
+    public static final double TOLERANCE_DEFAULT = 0.0001;
+
+    private final Graph<V, E> g;
+    private Map<V, Double> scores;
+
+    /**
+     * Create and execute an instance of EigenvectorCentrality
+     *
+     * @param g the input graph
+     */
+    public EigenvectorCentrality(final Graph<V, E> g)
+    {
+        this(g, MAX_ITERATIONS_DEFAULT, TOLERANCE_DEFAULT);
+    }
+
+    /**
+     * Create and execute an instance of EigenvectorCentrality
+     *
+     * @param g the input graph
+     * @param maxIterations the maximum number of iterations to perform
+     */
+    public EigenvectorCentrality(final Graph<V, E> g, final int maxIterations)
+    {
+        this(g, maxIterations, TOLERANCE_DEFAULT);
+    }
+
+    /**
+     * Create and execute an instance of EigenvectorCentrality.
+     *
+     * @param g the input graph
+     * @param maxIterations the maximum number of iterations to perform
+     * @param tolerance calculation will stop if the &#x2113;<sub>2</sub> norm of the difference of
+     *        centrality values between iterations changes less than this value
+     */
+    public EigenvectorCentrality(
+        final Graph<V, E> g, final int maxIterations, final double tolerance)
+    {
+        this.g = g;
+        this.scores = new HashMap<>();
+
+        validate(maxIterations, tolerance);
+        run(maxIterations, tolerance);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Map<V, Double> getScores()
+    {
+        return Collections.unmodifiableMap(scores);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Double getVertexScore(final V v)
+    {
+        if (!g.containsVertex(v)) {
+            throw new IllegalArgumentException("Cannot return score of unknown vertex");
+        }
+        return scores.get(v);
+    }
+
+    /* Checks for the valid values of the parameters */
+    private void validate(final int maxIterations, final double tolerance)
+    {
+        if (maxIterations <= 0) {
+            throw new IllegalArgumentException("Maximum iterations must be positive");
+        }
+
+        if (tolerance <= 0.0) {
+            throw new IllegalArgumentException("Tolerance not valid, must be positive");
+        }
+    }
+
+    private void run(int maxIterations, final double tolerance)
+    {
+        // initialization
+        final int totalVertices = g.vertexSet().size();
+        final GraphIterables<V, E> iterables = g.iterables();
+
+        final double initScore = Math.sqrt(1.0d / totalVertices);
+        for (final V v : iterables.vertices()) {
+            scores.put(v, initScore);
+        }
+
+        // run the power method
+        Map<V, Double> nextScores = new HashMap<>();
+        double l2Norm = tolerance;
+
+        while (maxIterations > 0 && l2Norm >= tolerance) {
+            // compute next iteration scores
+            double sumOfSquares = 0d;
+            for (final V v : iterables.vertices()) {
+                double vNewValue = 0d;
+
+                for (final E e : iterables.incomingEdgesOf(v)) {
+                    final V w = Graphs.getOppositeVertex(g, e, v);
+                    vNewValue += scores.get(w) * g.getEdgeWeight(e);
+                }
+
+                sumOfSquares += vNewValue * vNewValue;
+                nextScores.put(v, vNewValue);
+            }
+
+            final double l2NormFactor = 1 / Math.sqrt(sumOfSquares);
+
+            double sumOfDiffs2 = 0;
+            // Normalize and evaluate norm
+            for (final V v : iterables.vertices()) {
+                final double score = nextScores.get(v) * l2NormFactor;
+                nextScores.put(v, score);
+                final double d = scores.get(v) - score;
+                sumOfDiffs2 += d * d;
+            }
+
+            // swap scores
+            final Map<V, Double> tmp = scores;
+            scores = nextScores;
+            nextScores = tmp;
+
+            l2Norm = Math.sqrt(sumOfDiffs2);
+
+            // progress
+            maxIterations--;
+        }
+
+    }
+
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/EigenvectorCentralityTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/EigenvectorCentralityTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2020, by Sebastiano Vigna.
+ * (C) Copyright 2020-2020, by Sebastiano Vigna and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/EigenvectorCentralityTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/EigenvectorCentralityTest.java
@@ -1,0 +1,175 @@
+/*
+ * (C) Copyright 2020, by Sebastiano Vigna.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.scoring;
+
+import static org.junit.Assert.assertEquals;
+
+import org.jgrapht.alg.interfaces.VertexScoringAlgorithm;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.junit.Test;
+
+/**
+ * Unit tests for eigenvector centrality
+ *
+ * @author Sebastiano Vigna
+ */
+public class EigenvectorCentralityTest
+{
+    @Test
+    public void testGraph2Nodes()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addEdge("1", "2");
+        g.addEdge("2", "1");
+
+        final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
+
+        assertEquals(pr.getVertexScore("1"), 1 / Math.sqrt(2), 0.0001);
+        assertEquals(pr.getVertexScore("2"), 1 / Math.sqrt(2), 0.0001);
+    }
+
+    @Test
+    public void testGraph3Nodes()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addEdge("1", "2");
+        g.addEdge("2", "3");
+        g.addEdge("3", "1");
+
+        final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
+
+        assertEquals(pr.getVertexScore("1"), 1 / Math.sqrt(3), 0.0001);
+        assertEquals(pr.getVertexScore("2"), 1 / Math.sqrt(3), 0.0001);
+        assertEquals(pr.getVertexScore("3"), 1 / Math.sqrt(3), 0.0001);
+    }
+
+    @Test
+    public void testGraph1()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("0");
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addVertex("4");
+
+        g.addEdge("0", "1");
+        g.addEdge("0", "2");
+        g.addEdge("1", "3");
+        g.addEdge("1", "2");
+        g.addEdge("2", "1");
+        g.addEdge("2", "4");
+        g.addEdge("2", "3");
+        g.addEdge("3", "1");
+        g.addEdge("3", "2");
+        g.addEdge("3", "3");
+        g.addEdge("4", "2");
+        g.addEdge("4", "0");
+
+        final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
+
+        assertEquals(pr.getVertexScore("0"), 0.08032022089204849, 0.001);
+        assertEquals(pr.getVertexScore("1"), 0.48765632797141506, 0.001);
+        assertEquals(pr.getVertexScore("2"), 0.5453987490787013, 0.001);
+        assertEquals(pr.getVertexScore("3"), 0.6437087676602127, 0.001);
+        assertEquals(pr.getVertexScore("4"), 0.20956906939251885, 0.001);
+    }
+
+    @Test
+    public void testWeightedGraph1()
+    {
+        final DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =
+            new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+
+        g.addVertex("a");
+        g.addVertex("b");
+        g.addVertex("c");
+        g.addVertex("d");
+
+        g.setEdgeWeight(g.addEdge("a", "b"), 1. / 2);
+        g.setEdgeWeight(g.addEdge("a", "c"), 1. / 3);
+        g.setEdgeWeight(g.addEdge("b", "a"), 1);
+        g.setEdgeWeight(g.addEdge("b", "b"), 2);
+        g.setEdgeWeight(g.addEdge("b", "d"), 1. / 4);
+        g.setEdgeWeight(g.addEdge("c", "a"), 1);
+        g.setEdgeWeight(g.addEdge("c", "d"), 3);
+        g.setEdgeWeight(g.addEdge("d", "b"), 1. / 5);
+        g.setEdgeWeight(g.addEdge("d", "d"), 1);
+
+        final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
+
+        assertEquals(pr.getVertexScore("a"), 0.400610775759173, 0.0001);
+        assertEquals(pr.getVertexScore("b"), 0.863882834704165, 0.0001);
+        assertEquals(pr.getVertexScore("c"), 0.0580276877361552, 0.0001);
+        assertEquals(pr.getVertexScore("d"), 0.299750298600000, 0.0001);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNonExistantVertex()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("center");
+        g.addVertex("a");
+        g.addVertex("b");
+        g.addVertex("c");
+        g.addVertex("d");
+
+        g.addEdge("center", "a");
+        g.addEdge("center", "b");
+        g.addEdge("center", "c");
+
+        final VertexScoringAlgorithm<String, Double> pr = new EigenvectorCentrality<>(g);
+
+        pr.getVertexScore("unknown");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadParameters1()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
+
+        new EigenvectorCentrality<>(g, -1);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadParameters2()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
+
+        new EigenvectorCentrality<>(g, 1, 0);
+    }
+
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/KatzCentralityTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/KatzCentralityTest.java
@@ -1,0 +1,382 @@
+/*
+ * (C) Copyright 2016-2020, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.scoring;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.ToDoubleFunction;
+
+import org.jgrapht.alg.interfaces.VertexScoringAlgorithm;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.DirectedWeightedPseudograph;
+import org.junit.Test;
+
+/**
+ * Unit tests for KatzCentrality
+ *
+ * @author Dimitrios Michail
+ * @author Pratik Tibrewal
+ */
+public class KatzCentralityTest
+{
+    @Test
+    public void testGraph2Nodes()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addEdge("1", "2");
+        g.addEdge("2", "1");
+
+        final VertexScoringAlgorithm<String, Double> pr = new KatzCentrality<>(g);
+
+        assertEquals(pr.getVertexScore("1"), pr.getVertexScore("2"), 0.0001);
+    }
+
+    @Test
+    public void testExogenousFactor()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addEdge("1", "2");
+        g.addEdge("2", "1");
+
+        final VertexScoringAlgorithm<String, Double> pr =
+            new KatzCentrality<>(g, 0.5, x -> x.equals("1") ? .5 : 1);
+
+        assertEquals(4. / 3, pr.getVertexScore("1"), 0.0001);
+        assertEquals(5. / 3, pr.getVertexScore("2"), 0.0001);
+    }
+
+    @Test
+    public void testGraph3Nodes()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addEdge("1", "2");
+        g.addEdge("2", "3");
+        g.addEdge("3", "1");
+
+        final VertexScoringAlgorithm<String, Double> pr = new KatzCentrality<>(g);
+
+        assertEquals(pr.getVertexScore("1"), pr.getVertexScore("2"), 0.0001);
+        assertEquals(pr.getVertexScore("1"), pr.getVertexScore("3"), 0.0001);
+    }
+
+    @Test
+    public void testGraph1()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("A");
+        g.addVertex("B");
+        g.addVertex("C");
+        g.addVertex("D");
+        g.addVertex("E");
+        g.addVertex("F");
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addVertex("4");
+        g.addVertex("5");
+
+        g.addEdge("A", "E");
+        g.addEdge("A", "F");
+        g.addEdge("B", "E");
+        g.addEdge("B", "F");
+        g.addEdge("C", "E");
+        g.addEdge("D", "E");
+        g.addEdge("1", "E");
+        g.addEdge("1", "F");
+        g.addEdge("E", "1");
+        g.addEdge("2", "E");
+        g.addEdge("2", "F");
+        g.addEdge("3", "F");
+        g.addEdge("F", "3");
+        g.addEdge("4", "F");
+        g.addEdge("E", "4");
+        g.addEdge("4", "5");
+        g.addEdge("E", "F");
+
+        final VertexScoringAlgorithm<String, Double> pr = new KatzCentrality<>(g, 0.85);
+
+        assertEquals(pr.getVertexScore("A"), 1.0000, 0.5);
+        assertEquals(pr.getVertexScore("B"), 1.0000, 0.5);
+        assertEquals(pr.getVertexScore("C"), 1.0000, 0.5);
+        assertEquals(pr.getVertexScore("D"), 1.0000, 0.5);
+        assertEquals(pr.getVertexScore("E"), 22.000, 0.5);
+        assertEquals(pr.getVertexScore("F"), 204.00, 0.5);
+        assertEquals(pr.getVertexScore("1"), 20.000, 0.5);
+        assertEquals(pr.getVertexScore("2"), 1.0000, 0.5);
+        assertEquals(pr.getVertexScore("3"), 174.00, 0.5);
+        assertEquals(pr.getVertexScore("4"), 20.000, 0.5);
+        assertEquals(pr.getVertexScore("5"), 18.000, 0.5);
+    }
+
+    @Test
+    public void testGraph2()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("A");
+        g.addVertex("B");
+        g.addVertex("C");
+        g.addVertex("D");
+        g.addVertex("E");
+        g.addVertex("F");
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addVertex("4");
+        g.addVertex("5");
+
+        g.addEdge("A", "E");
+        g.addEdge("A", "F");
+        g.addEdge("B", "E");
+        g.addEdge("B", "F");
+        g.addEdge("C", "E");
+        g.addEdge("D", "E");
+        g.addEdge("1", "E");
+        g.addEdge("1", "F");
+        g.addEdge("E", "1");
+        g.addEdge("2", "E");
+        g.addEdge("2", "F");
+        g.addEdge("3", "F");
+        g.addEdge("F", "3");
+        g.addEdge("4", "F");
+        g.addEdge("E", "4");
+        g.addEdge("4", "5");
+        g.addEdge("E", "F");
+
+        final VertexScoringAlgorithm<String, Double> pr = new KatzCentrality<>(g, 0.15);
+
+        assertEquals(pr.getVertexScore("A"), 1.0000, 0.05);
+        assertEquals(pr.getVertexScore("B"), 1.0000, 0.05);
+        assertEquals(pr.getVertexScore("C"), 1.0000, 0.05);
+        assertEquals(pr.getVertexScore("D"), 1.0000, 0.05);
+        assertEquals(pr.getVertexScore("E"), 1.9400, 0.05);
+        assertEquals(pr.getVertexScore("F"), 2.3300, 0.05);
+        assertEquals(pr.getVertexScore("1"), 1.2900, 0.05);
+        assertEquals(pr.getVertexScore("2"), 1.0000, 0.05);
+        assertEquals(pr.getVertexScore("3"), 1.3500, 0.05);
+        assertEquals(pr.getVertexScore("4"), 1.2900, 0.05);
+        assertEquals(pr.getVertexScore("5"), 1.1900, 0.05);
+    }
+
+    @Test
+    public void testGraph3()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("A");
+        g.addVertex("B");
+        g.addVertex("C");
+        g.addVertex("D");
+        g.addVertex("E");
+        g.addVertex("F");
+        g.addVertex("1");
+        g.addVertex("2");
+        g.addVertex("3");
+        g.addVertex("4");
+        g.addVertex("5");
+
+        g.addEdge("A", "E");
+        g.addEdge("A", "F");
+        g.addEdge("B", "E");
+        g.addEdge("B", "F");
+        g.addEdge("C", "E");
+        g.addEdge("D", "E");
+        g.addEdge("1", "E");
+        g.addEdge("1", "F");
+        g.addEdge("E", "1");
+        g.addEdge("2", "E");
+        g.addEdge("2", "F");
+        g.addEdge("3", "F");
+        g.addEdge("F", "3");
+        g.addEdge("4", "F");
+        g.addEdge("E", "4");
+        g.addEdge("4", "5");
+        g.addEdge("E", "F");
+
+        final Map<String, Double> exogenousfactormap = new HashMap<>();
+        for (final String v : g.vertexSet()) {
+            exogenousfactormap.put(v, 1.0);
+        }
+        exogenousfactormap.put("4", 2.0);
+
+        final ToDoubleFunction<String> exogenousFactorFunction = (v) -> exogenousfactormap.get(v);
+
+        final VertexScoringAlgorithm<String, Double> pr =
+            new KatzCentrality<>(g, 0.15, exogenousFactorFunction);
+
+        assertEquals(pr.getVertexScore("A"), 1.0000, 0.005);
+        assertEquals(pr.getVertexScore("B"), 1.0000, 0.005);
+        assertEquals(pr.getVertexScore("C"), 1.0000, 0.005);
+        assertEquals(pr.getVertexScore("D"), 1.0000, 0.005);
+        assertEquals(pr.getVertexScore("E"), 1.9400, 0.005);
+        assertEquals(pr.getVertexScore("F"), 2.4800, 0.005);
+        assertEquals(pr.getVertexScore("1"), 1.2900, 0.005);
+        assertEquals(pr.getVertexScore("2"), 1.0000, 0.005);
+        assertEquals(pr.getVertexScore("3"), 1.3700, 0.005);
+        assertEquals(pr.getVertexScore("4"), 2.2900, 0.005);
+        assertEquals(pr.getVertexScore("5"), 1.3400, 0.005);
+    }
+
+    @Test
+    public void testWeightedGraph1()
+    {
+        final DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =
+            new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+
+        g.addVertex("center");
+        g.addVertex("a");
+        g.addVertex("b");
+        g.addVertex("c");
+
+        g.setEdgeWeight(g.addEdge("center", "a"), 75.0);
+        g.setEdgeWeight(g.addEdge("center", "b"), 20.0);
+        g.setEdgeWeight(g.addEdge("center", "c"), 5.0);
+
+        final VertexScoringAlgorithm<String, Double> pr =
+            new KatzCentrality<>(g, 0.85, 100, 0.0001);
+
+        assertEquals(pr.getVertexScore("center"), 1.0000, 0.0001);
+        assertEquals(pr.getVertexScore("a"), 64.7500, 0.0001);
+        assertEquals(pr.getVertexScore("b"), 18.0000, 0.0001);
+        assertEquals(pr.getVertexScore("c"), 5.2500, 0.0001);
+    }
+
+    @Test
+    public void testweightedGraph2()
+    {
+        final DirectedWeightedPseudograph<String, DefaultWeightedEdge> g =
+            new DirectedWeightedPseudograph<>(DefaultWeightedEdge.class);
+
+        g.addVertex("center");
+        g.addVertex("a");
+        g.addVertex("b");
+        g.addVertex("c");
+
+        g.setEdgeWeight(g.addEdge("center", "a"), 1.0);
+        g.setEdgeWeight(g.addEdge("center", "b"), 1.0);
+        g.setEdgeWeight(g.addEdge("center", "c"), 1.0);
+
+        final VertexScoringAlgorithm<String, Double> pr =
+            new KatzCentrality<>(g, 0.85, 100, 0.0001);
+
+        assertEquals(pr.getVertexScore("center"), 1.0000, 0.0001);
+        assertEquals(pr.getVertexScore("a"), 1.8500, 0.0001);
+        assertEquals(pr.getVertexScore("b"), 1.8500, 0.0001);
+        assertEquals(pr.getVertexScore("c"), 1.8500, 0.0001);
+    }
+
+    @Test
+    public void testUnweightedGraph2()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("center");
+        g.addVertex("a");
+        g.addVertex("b");
+        g.addVertex("c");
+        g.addVertex("d");
+
+        g.addEdge("center", "a");
+        g.addEdge("center", "b");
+        g.addEdge("center", "c");
+
+        final VertexScoringAlgorithm<String, Double> pr =
+            new KatzCentrality<>(g, 0.85, 100, 0.0001);
+
+        assertEquals(pr.getVertexScore("center"), 1.0000, 0.0001);
+        assertEquals(pr.getVertexScore("a"), 1.8500, 0.0001);
+        assertEquals(pr.getVertexScore("b"), 1.8500, 0.0001);
+        assertEquals(pr.getVertexScore("c"), 1.8500, 0.0001);
+        assertEquals(pr.getVertexScore("d"), 1.0000, 0.0001);
+    }
+
+    @Test
+    public void testEmptyGraph()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        final VertexScoringAlgorithm<String, Double> pr =
+            new KatzCentrality<>(g, 0.85, 100, 0.0001);
+
+        assertTrue(pr.getScores().isEmpty());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testNonExistantVertex()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex("center");
+        g.addVertex("a");
+        g.addVertex("b");
+        g.addVertex("c");
+        g.addVertex("d");
+
+        g.addEdge("center", "a");
+        g.addEdge("center", "b");
+        g.addEdge("center", "c");
+
+        final VertexScoringAlgorithm<String, Double> pr =
+            new KatzCentrality<>(g, 0.85, 100, 0.0001);
+
+        pr.getVertexScore("unknown");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadParameters1()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        new KatzCentrality<>(g, -1, 100, 0.0001);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadParameters2()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        new KatzCentrality<>(g, 0.85, 0, 0.0001);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadParameters3()
+    {
+        final DirectedPseudograph<String, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        new KatzCentrality<>(g, 0.85, 100, 0.0);
+    }
+}


### PR DESCRIPTION
This pull request implements eigenvector centrality. As discussed in https://github.com/jgrapht/jgrapht/issues/1013, AlphaCentrality is not really computing eigenvector centrality. This class implements the power method with 𝓁₂ normalization (the most commonly used normalization).

Tests have been created using the Maple mathematical software package to compute eigenvector centrality on sample matrices.

I think that it would be a good idea to have a KatzCentrality class doing essentially what AlphaCentrality does, but pointing at the right papers and dispensing with the exogenous factor as a scalar. In Katz centrality, any constant vector will give the same centrality, just scaled by the constant contained in the vector. Having a scalar exogenous factor will make the user believe that by changing it the centrality computed will somehow change, but all that will happen is a rescaling. 

I refrained from touching the documentation in AlphaCentrality, but probably it would also be a good idea to eliminate the part related to eigenvector centrality, as the results would be completely different from those returned by this class.
