### PR TITLE
Improvements of StrongConnectivityInspector algorithms

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/AbstractStrongConnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/AbstractStrongConnectivityInspector.java
@@ -42,7 +42,7 @@ abstract class AbstractStrongConnectivityInspector<V, E>
     protected List<Set<V>> stronglyConnectedSets;
     protected List<Graph<V, E>> stronglyConnectedSubgraphs;
 
-    public AbstractStrongConnectivityInspector(Graph<V, E> graph)
+    protected AbstractStrongConnectivityInspector(Graph<V, E> graph)
     {
         this.graph = GraphTests.requireDirected(graph);
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/AbstractStrongConnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/AbstractStrongConnectivityInspector.java
@@ -78,8 +78,7 @@ abstract class AbstractStrongConnectivityInspector<V, E>
     {
         List<Set<V>> sets = stronglyConnectedSets();
 
-        Graph<Graph<V, E>, DefaultEdge> condensation =
-            new SimpleDirectedGraph<>(null, DefaultEdge::new, false);
+        Graph<Graph<V, E>, DefaultEdge> condensation = new SimpleDirectedGraph<>(DefaultEdge.class);
         Map<V, Graph<V, E>> vertexToComponent =
             CollectionUtil.newHashMapWithExpectedSize(graph.vertexSet().size());
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/AbstractStrongConnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/AbstractStrongConnectivityInspector.java
@@ -20,6 +20,7 @@ package org.jgrapht.alg.connectivity;
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
 import org.jgrapht.graph.*;
+import org.jgrapht.util.*;
 
 import java.util.*;
 
@@ -77,8 +78,10 @@ abstract class AbstractStrongConnectivityInspector<V, E>
     {
         List<Set<V>> sets = stronglyConnectedSets();
 
-        Graph<Graph<V, E>, DefaultEdge> condensation = new SimpleDirectedGraph<>(DefaultEdge.class);
-        Map<V, Graph<V, E>> vertexToComponent = new HashMap<>();
+        Graph<Graph<V, E>, DefaultEdge> condensation =
+            new SimpleDirectedGraph<>(null, DefaultEdge::new, false);
+        Map<V, Graph<V, E>> vertexToComponent =
+            CollectionUtil.newHashMapWithExpectedSize(graph.vertexSet().size());
 
         for (Set<V> set : sets) {
             Graph<V, E> component = new AsSubgraph<>(graph, set, null);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/ConnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/ConnectivityInspector.java
@@ -21,6 +21,7 @@ import org.jgrapht.*;
 import org.jgrapht.event.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.traverse.*;
+import org.jgrapht.util.*;
 
 import java.util.*;
 
@@ -142,7 +143,8 @@ public class ConnectivityInspector<V, E>
 
         // If source and target are in the same set, do nothing, otherwise, merge sets
         if (sourceSet != targetSet) {
-            Set<V> merge = new HashSet<>();
+            Set<V> merge =
+                CollectionUtil.newHashSetWithExpectedSize(sourceSet.size() + targetSet.size());
             merge.addAll(sourceSet);
             merge.addAll(targetSet);
             connectedSets.remove(sourceSet);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/GabowStrongConnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/GabowStrongConnectivityInspector.java
@@ -38,9 +38,9 @@ public class GabowStrongConnectivityInspector<V, E>
     AbstractStrongConnectivityInspector<V, E>
 {
     // the sequence of (original) vertices encountered but not yet assigned to a component
-    private Deque<VertexNumber<V>> S = new ArrayDeque<>();
+    private Deque<VertexNumber<V>> stackS = new ArrayDeque<>();
     // the boundaries between contracted vertices on the current path of the dfs-tree
-    private Deque<VertexNumber<V>> B = new ArrayDeque<>();
+    private Deque<VertexNumber<V>> stackB = new ArrayDeque<>();
 
     // maps vertices to their VertexNumber object
     private Map<V, VertexNumber<V>> vertexToVertexNumber;
@@ -76,8 +76,8 @@ public class GabowStrongConnectivityInspector<V, E>
             }
 
             vertexToVertexNumber = null;
-            S = null;
-            B = null;
+            stackS = null;
+            stackB = null;
         }
 
         return stronglyConnectedSets;
@@ -95,8 +95,8 @@ public class GabowStrongConnectivityInspector<V, E>
             vertexToVertexNumber.put(vertex, new VertexNumber<>(vertex));
         }
 
-        S = new ArrayDeque<>(c);
-        B = new ArrayDeque<>(c);
+        stackS = new ArrayDeque<>(c);
+        stackB = new ArrayDeque<>(c);
     }
 
     /*
@@ -104,9 +104,9 @@ public class GabowStrongConnectivityInspector<V, E>
      */
     private void dfsVisit(VertexNumber<V> v)
     {
-        S.push(v);
-        v.number = S.size();
-        B.push(v);
+        stackS.push(v);
+        v.number = stackS.size();
+        stackB.push(v);
 
         // follow all edges
 
@@ -116,14 +116,14 @@ public class GabowStrongConnectivityInspector<V, E>
             if (w.number == 0) {
                 dfsVisit(w);
             } else { /* contract if necessary */
-                while (w.number < B.peek().number) {
-                    B.pop();
+                while (w.number < stackB.peek().number) {
+                    stackB.pop();
                 }
             }
         }
-        if (v == B.peek()) {
+        if (v == stackB.peek()) {
             // number vertices of the next strong component
-            B.pop();
+            stackB.pop();
             c++;
             Set<V> sccVertices = createSCCVertexSetAndNumberVertices(v);
             stronglyConnectedSets.add(sccVertices);
@@ -132,19 +132,19 @@ public class GabowStrongConnectivityInspector<V, E>
 
     private Set<V> createSCCVertexSetAndNumberVertices(VertexNumber<V> v)
     {
-        int sccSize = S.size() - v.number + 1;
+        int sccSize = stackS.size() - v.number + 1;
         // All VertexNumber objects on S above and including v form the current SCC.
         // To collect them from S, elements have to be popped while the size of S is greater or
         // equal to v.number. This results in <sccSize> removals(pops) from S.
         Set<V> scc;
         if (sccSize == 1) {
-            VertexNumber<V> r = S.pop();
+            VertexNumber<V> r = stackS.pop();
             scc = Collections.singleton(r.vertex);
             r.number = c;
         } else {
             scc = CollectionUtil.newHashSetWithExpectedSize(sccSize);
             for (int i = 0; i < sccSize; i++) {
-                VertexNumber<V> r = S.pop();
+                VertexNumber<V> r = stackS.pop();
                 scc.add(r.vertex);
                 r.number = c;
             }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/GabowStrongConnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/GabowStrongConnectivityInspector.java
@@ -31,15 +31,16 @@ import java.util.*;
  * @param <E> the graph edge type
  *
  * @author Sarah Komla-Ebri
+ * @author Hannes Wellmann
  */
 public class GabowStrongConnectivityInspector<V, E>
     extends
     AbstractStrongConnectivityInspector<V, E>
 {
-    // stores the vertices
+    // the sequence of (original) vertices encountered but not yet assigned to a component
     private Deque<VertexNumber<V>> S = new ArrayDeque<>();
-    // store the numbers
-    private Deque<Integer> B = new ArrayDeque<>();
+    // the boundaries between contracted vertices on the current path of the dfs-tree
+    private Deque<VertexNumber<V>> B = new ArrayDeque<>();
 
     // maps vertices to their VertexNumber object
     private Map<V, VertexNumber<V>> vertexToVertexNumber;
@@ -104,8 +105,8 @@ public class GabowStrongConnectivityInspector<V, E>
     private void dfsVisit(VertexNumber<V> v)
     {
         S.push(v);
-        v.number = S.size() - 1;
-        B.push(v.number);
+        v.number = S.size();
+        B.push(v);
 
         // follow all edges
 
@@ -115,12 +116,12 @@ public class GabowStrongConnectivityInspector<V, E>
             if (w.number == 0) {
                 dfsVisit(w);
             } else { /* contract if necessary */
-                while (w.number < B.peek()) {
+                while (w.number < B.peek().number) {
                     B.pop();
                 }
             }
         }
-        if (v.number == B.peek()) {
+        if (v == B.peek()) {
             // number vertices of the next strong component
             B.pop();
             c++;
@@ -131,7 +132,7 @@ public class GabowStrongConnectivityInspector<V, E>
 
     private Set<V> createSCCVertexSetAndNumberVertices(VertexNumber<V> v)
     {
-        int sccSize = S.size() - v.number;
+        int sccSize = S.size() - v.number + 1;
         // All VertexNumber objects on S above and including v form the current SCC.
         // To collect them from S, elements have to be popped while the size of S is greater or
         // equal to v.number. This results in <sccSize> removals(pops) from S.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/KosarajuStrongConnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/KosarajuStrongConnectivityInspector.java
@@ -64,8 +64,8 @@ public class KosarajuStrongConnectivityInspector<V, E>
     public List<Set<V>> stronglyConnectedSets()
     {
         if (stronglyConnectedSets == null) {
-            orderedVertices = new LinkedList<VertexData<V>>();
-            stronglyConnectedSets = new Vector<Set<V>>();
+            orderedVertices = new LinkedList<>();
+            stronglyConnectedSets = new ArrayList<>();
 
             // create VertexData objects for all vertices, store them
             createVertexData();
@@ -79,7 +79,7 @@ public class KosarajuStrongConnectivityInspector<V, E>
             }
 
             // 'create' inverse graph (i.e. every edge is reversed)
-            Graph<V, E> inverseGraph = new EdgeReversedGraph<V, E>(graph);
+            Graph<V, E> inverseGraph = new EdgeReversedGraph<>(graph);
 
             // get ready for next dfs round
             resetVertexData();
@@ -90,7 +90,7 @@ public class KosarajuStrongConnectivityInspector<V, E>
             for (VertexData<V> data : orderedVertices) {
                 if (!data.isDiscovered()) {
                     // new strongly connected set
-                    Set<V> set = new HashSet<V>();
+                    Set<V> set = new HashSet<>();
                     stronglyConnectedSets.add(set);
                     dfsVisit(inverseGraph, data, set);
                 }
@@ -112,7 +112,7 @@ public class KosarajuStrongConnectivityInspector<V, E>
         vertexToVertexData = CollectionUtil.newHashMapWithExpectedSize(graph.vertexSet().size());
 
         for (V vertex : graph.vertexSet()) {
-            vertexToVertexData.put(vertex, new VertexData2<V>(vertex, false, false));
+            vertexToVertexData.put(vertex, new VertexData2<>(vertex, false, false));
         }
     }
 
@@ -123,7 +123,7 @@ public class KosarajuStrongConnectivityInspector<V, E>
      */
     private void dfsVisit(Graph<V, E> visitedGraph, VertexData<V> vertexData, Set<V> vertices)
     {
-        Deque<VertexData<V>> stack = new ArrayDeque<VertexData<V>>();
+        Deque<VertexData<V>> stack = new ArrayDeque<>();
         stack.add(vertexData);
 
         while (!stack.isEmpty()) {
@@ -136,7 +136,7 @@ public class KosarajuStrongConnectivityInspector<V, E>
                     vertices.add(data.getVertex());
                 }
 
-                stack.add(new VertexData1<V>(data, true, true));
+                stack.add(new VertexData1<>(data, true, true));
 
                 // follow all edges
                 for (E edge : visitedGraph.outgoingEdgesOf(data.getVertex())) {
@@ -148,10 +148,8 @@ public class KosarajuStrongConnectivityInspector<V, E>
                         stack.add(targetData);
                     }
                 }
-            } else if (data.isFinished()) {
-                if (vertices == null) {
-                    orderedVertices.addFirst(data.getFinishedData());
-                }
+            } else if (data.isFinished() && vertices == null) {
+                orderedVertices.addFirst(data.getFinishedData());
             }
         }
     }
@@ -170,7 +168,7 @@ public class KosarajuStrongConnectivityInspector<V, E>
     /*
      * Lightweight class storing some data for every vertex.
      */
-    private static abstract class VertexData<V>
+    private abstract static class VertexData<V>
     {
         private byte bitfield;
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/connectivity/StrongConnectivityAlgorithmTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/connectivity/StrongConnectivityAlgorithmTest.java
@@ -21,13 +21,20 @@ import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
 import org.jgrapht.generate.*;
 import org.jgrapht.graph.*;
+import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 import org.junit.*;
+import org.junit.runner.*;
+import org.junit.runners.*;
+import org.junit.runners.Parameterized.*;
 
 import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.*;
 
 /**
  * Test cases for the GabowStrongConnectivityInspector. Tests are identical to the tests for the
@@ -35,7 +42,9 @@ import static org.junit.Assert.assertTrue;
  *
  * @author Sarah Komla-Ebri
  * @author Joris Kinable
+ * @author Hannes Wellmann
  */
+@RunWith(Parameterized.class)
 public class StrongConnectivityAlgorithmTest
 {
     // ~ Static fields/initializers ---------------------------------------------
@@ -45,85 +54,54 @@ public class StrongConnectivityAlgorithmTest
     private static final String V3 = "v3";
     private static final String V4 = "v4";
     private static final String V5 = "v5";
+    private static final String V6 = "v6";
+    private static final String V7 = "v7";
+    private static final String V8 = "v8";
+    private static final String V9 = "v9";
+    private static final String V10 = "v10";
+    private static final String V11 = "v11";
+
+    private static final List<String> VERTICES =
+        List.of(V1, V2, V3, V4, V5, V6, V7, V8, V9, V10, V11);
 
     // ~ Instance fields --------------------------------------------------------
 
-    //
-    @Test
-    public void testStrongConnectivityClasses()
+    @Parameter()
+    public String name;
+
+    @Parameter(1)
+    public Function<Graph<?, ?>, StrongConnectivityAlgorithm<?, ?>> algorithmFactory;
+
+    @Parameters(name = "{0}")
+    @SuppressWarnings("unchecked")
+    public static List<Object[]> getAlgorithmFactory()
     {
-        Class<?>[] strongConnectivityAlgorithmClasses =
-            { GabowStrongConnectivityInspector.class, KosarajuStrongConnectivityInspector.class };
-        for (Class<?> strongConnectivityAlgorithm : strongConnectivityAlgorithmClasses) {
-            this.testStronglyConnected1(strongConnectivityAlgorithm);
-            this.testStronglyConnected2(strongConnectivityAlgorithm);
-            this.testStronglyConnected3(strongConnectivityAlgorithm);
-            this.testStronglyConnected4(strongConnectivityAlgorithm);
-        }
+        return List
+            .of(
+                new Object[] { GabowStrongConnectivityInspector.class.getSimpleName(),
+                    (Function<Graph<?, ?>, ?>) GabowStrongConnectivityInspector::new },
+
+                new Object[] { KosarajuStrongConnectivityInspector.class.getSimpleName(),
+                    (Function<Graph<?, ?>, ?>) KosarajuStrongConnectivityInspector::new });
     }
 
-    /**
-     * .
-     */
-    public void testStronglyConnected1(Class<?> strongConnectivityAlgorithm)
+    @Test
+    public void testStronglyConnected1()
     {
-        Graph<String, DefaultEdge> g = new DefaultDirectedGraph<>(DefaultEdge.class);
-        g.addVertex(V1);
-        g.addVertex(V2);
-        g.addVertex(V3);
-        g.addVertex(V4);
+        Graph<String, DefaultEdge> g = createDirectedGraphWithVertices(4);
 
         g.addEdge(V1, V2);
         g.addEdge(V2, V1); // strongly connected
 
         g.addEdge(V3, V4); // only weakly connected
 
-        StrongConnectivityAlgorithm<String, DefaultEdge> inspector =
-            this.getStrongConnectivityInspector(g, strongConnectivityAlgorithm);
-
-        // convert from List to Set because we need to ignore order
-        // during comparison
-        Set<Set<String>> actualSets = new HashSet<>(inspector.stronglyConnectedSets());
-
-        // construct the expected answer
-        Set<Set<String>> expectedSets = new HashSet<>();
-        Set<String> set = new HashSet<>();
-        set.add(V1);
-        set.add(V2);
-        expectedSets.add(set);
-        set = new HashSet<>();
-        set.add(V3);
-        expectedSets.add(set);
-        set = new HashSet<>();
-        set.add(V4);
-        expectedSets.add(set);
-
-        assertEquals(expectedSets, actualSets);
-
-        actualSets.clear();
-
-        List<Graph<String, DefaultEdge>> subgraphs = inspector.getStronglyConnectedComponents();
-        for (Graph<String, DefaultEdge> sg : subgraphs) {
-            actualSets.add(sg.vertexSet());
-
-            StrongConnectivityAlgorithm<String, DefaultEdge> ci =
-                this.getStrongConnectivityInspector(sg, strongConnectivityAlgorithm);
-            assertTrue(ci.isStronglyConnected());
-        }
-
-        assertEquals(expectedSets, actualSets);
+        assertStronglyConnectedSets(g, Set.of(V1, V2), Set.of(V3), Set.of(V4));
     }
 
-    /**
-     * .
-     */
-    public void testStronglyConnected2(Class<?> strongConnectivityAlgorithm)
+    @Test
+    public void testStronglyConnected2()
     {
-        Graph<String, DefaultEdge> g = new DefaultDirectedGraph<>(DefaultEdge.class);
-        g.addVertex(V1);
-        g.addVertex(V2);
-        g.addVertex(V3);
-        g.addVertex(V4);
+        Graph<String, DefaultEdge> g = createDirectedGraphWithVertices(4);
 
         g.addEdge(V1, V2);
         g.addEdge(V2, V1); // strongly connected
@@ -131,52 +109,13 @@ public class StrongConnectivityAlgorithmTest
         g.addEdge(V4, V3); // only weakly connected
         g.addEdge(V3, V2); // only weakly connected
 
-        StrongConnectivityAlgorithm<String, DefaultEdge> inspector =
-            this.getStrongConnectivityInspector(g, strongConnectivityAlgorithm);
-
-        // convert from List to Set because we need to ignore order
-        // during comparison
-        Set<Set<String>> actualSets = new HashSet<>(inspector.stronglyConnectedSets());
-
-        // construct the expected answer
-        Set<Set<String>> expectedSets = new HashSet<>();
-        Set<String> set = new HashSet<>();
-        set.add(V1);
-        set.add(V2);
-        expectedSets.add(set);
-        set = new HashSet<>();
-        set.add(V3);
-        expectedSets.add(set);
-        set = new HashSet<>();
-        set.add(V4);
-        expectedSets.add(set);
-
-        assertEquals(expectedSets, actualSets);
-
-        actualSets.clear();
-
-        List<Graph<String, DefaultEdge>> subgraphs = inspector.getStronglyConnectedComponents();
-        for (Graph<String, DefaultEdge> sg : subgraphs) {
-            actualSets.add(sg.vertexSet());
-
-            StrongConnectivityAlgorithm<String, DefaultEdge> ci =
-                this.getStrongConnectivityInspector(sg, strongConnectivityAlgorithm);
-            assertTrue(ci.isStronglyConnected());
-        }
-
-        assertEquals(expectedSets, actualSets);
+        assertStronglyConnectedSets(g, Set.of(V1, V2), Set.of(V3), Set.of(V4));
     }
 
-    /**
-     * .
-     */
-    public void testStronglyConnected3(Class<?> strongConnectivityAlgorithm)
+    @Test
+    public void testStronglyConnected3()
     {
-        Graph<String, DefaultEdge> g = new DefaultDirectedGraph<>(DefaultEdge.class);
-        g.addVertex(V1);
-        g.addVertex(V2);
-        g.addVertex(V3);
-        g.addVertex(V4);
+        Graph<String, DefaultEdge> g = createDirectedGraphWithVertices(4);
 
         g.addEdge(V1, V2);
         g.addEdge(V2, V3);
@@ -186,64 +125,121 @@ public class StrongConnectivityAlgorithmTest
         g.addEdge(V2, V4);
         g.addEdge(V3, V4); // weakly connected
 
-        StrongConnectivityAlgorithm<String, DefaultEdge> inspector =
-            this.getStrongConnectivityInspector(g, strongConnectivityAlgorithm);
-
-        // convert from List to Set because we need to ignore order
-        // during comparison
-        Set<Set<String>> actualSets = new HashSet<>(inspector.stronglyConnectedSets());
-
-        // construct the expected answer
-        Set<Set<String>> expectedSets = new HashSet<>();
-        Set<String> set = new HashSet<>();
-        set.add(V1);
-        set.add(V2);
-        set.add(V3);
-        expectedSets.add(set);
-        set = new HashSet<>();
-        set.add(V4);
-        expectedSets.add(set);
-
-        assertEquals(expectedSets, actualSets);
-
-        actualSets.clear();
-
-        List<Graph<String, DefaultEdge>> subgraphs = inspector.getStronglyConnectedComponents();
-
-        for (Graph<String, DefaultEdge> sg : subgraphs) {
-            actualSets.add(sg.vertexSet());
-
-            StrongConnectivityAlgorithm<String, DefaultEdge> ci =
-                this.getStrongConnectivityInspector(sg, strongConnectivityAlgorithm);
-            assertTrue(ci.isStronglyConnected());
-        }
-
-        assertEquals(expectedSets, actualSets);
+        assertStronglyConnectedSets(g, Set.of(V1, V2, V3), Set.of(V4));
     }
 
-    public void testStronglyConnected4(Class<?> strongConnectivityAlgorithm)
+    @Test
+    public void testStronglyConnected4()
     {
-        DefaultDirectedGraph<Integer, String> graph = new DefaultDirectedGraph<>(
+        Graph<Integer, String> graph = new DefaultDirectedGraph<>(
             SupplierUtil.createIntegerSupplier(), SupplierUtil.createStringSupplier(), false);
 
         new RingGraphGenerator<Integer, String>(3).generateGraph(graph);
 
-        StrongConnectivityAlgorithm<Integer, String> sc =
-            this.getStrongConnectivityInspector(graph, strongConnectivityAlgorithm);
-        List<Set<Integer>> expected = new ArrayList<>();
-        expected.add(graph.vertexSet());
-        assertEquals(expected, sc.stronglyConnectedSets());
+        assertStronglyConnectedSets(graph, Set.of(0, 1, 2));
     }
 
     @Test
+    public void testStronglyConnected5()
+    {
+
+        // example from paper "Path-based depth-first search for strong and biconnected components"
+        // of Harold N. Gabow (2000)
+
+        Graph<String, DefaultEdge> graph = createDirectedGraphWithVertices(6);
+
+        graph.addEdge(V1, V2);
+        graph.addEdge(V1, V3);
+
+        graph.addEdge(V2, V3);
+        graph.addEdge(V2, V4);
+
+        graph.addEdge(V4, V3);
+        graph.addEdge(V4, V5);
+
+        graph.addEdge(V5, V2);
+        graph.addEdge(V5, V6);
+
+        graph.addEdge(V6, V3);
+        graph.addEdge(V6, V4);
+
+        assertStronglyConnectedSets(graph, Set.of(V1), Set.of(V2, V4, V5, V6), Set.of(V3));
+    }
+
+    @Test
+    public void testStronglyConnected6()
+    {
+        // example from
+        // https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+
+        Graph<String, DefaultEdge> graph = createDirectedGraphWithVertices(8);
+
+        graph.addEdge(V1, V5);
+        graph.addEdge(V2, V1);
+        graph.addEdge(V3, V2);
+        graph.addEdge(V3, V4);
+        graph.addEdge(V4, V3);
+        graph.addEdge(V5, V2);
+        graph.addEdge(V6, V2);
+        graph.addEdge(V6, V5);
+        graph.addEdge(V6, V7);
+        graph.addEdge(V7, V3);
+        graph.addEdge(V7, V6);
+        graph.addEdge(V8, V4);
+        graph.addEdge(V8, V7);
+
+        assertStronglyConnectedSets(
+            graph, Set.of(V1, V2, V5), Set.of(V3, V4), Set.of(V6, V7), Set.of(V8));
+    }
+
+    @Test
+    public void testStronglyConnected7()
+    {
+        Graph<String, DefaultEdge> graph = createDirectedGraphWithVertices(5);
+
+        graph.addEdge(V1, V2);
+        graph.addEdge(V2, V3);
+        graph.addEdge(V3, V4);
+        graph.addEdge(V3, V5);
+        graph.addEdge(V4, V1);
+        graph.addEdge(V5, V3);
+
+        assertStronglyConnectedSets(graph, Set.of(V1, V2, V3, V4, V5));
+    }
+
+    @Test
+    public void testStronglyConnected8()
+    {
+        Graph<String, DefaultEdge> graph = createDirectedGraphWithVertices(11);
+
+        graph.addEdge(V1, V2);
+        graph.addEdge(V1, V4);
+        graph.addEdge(V2, V3);
+        graph.addEdge(V2, V5);
+        graph.addEdge(V3, V1);
+        graph.addEdge(V3, V7);
+        graph.addEdge(V4, V3);
+        graph.addEdge(V5, V6);
+        graph.addEdge(V5, V7);
+        graph.addEdge(V6, V7);
+        graph.addEdge(V6, V8);
+        graph.addEdge(V6, V9);
+        graph.addEdge(V6, V10);
+        graph.addEdge(V7, V5);
+        graph.addEdge(V8, V10);
+        graph.addEdge(V9, V10);
+        graph.addEdge(V10, V9);
+
+        assertStronglyConnectedSets(
+            graph, Set.of(V1, V2, V3, V4), Set.of(V5, V6, V7), Set.of(V8), Set.of(V9, V10),
+            Set.of(V11));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
     public void testCondensation()
     {
-        Graph<String, DefaultEdge> g = new DefaultDirectedGraph<>(DefaultEdge.class);
-        g.addVertex(V1);
-        g.addVertex(V2);
-        g.addVertex(V3);
-        g.addVertex(V4);
-        g.addVertex(V5);
+        Graph<String, DefaultEdge> g = createDirectedGraphWithVertices(5);
 
         g.addEdge(V1, V2);
         g.addEdge(V2, V1); // strongly connected
@@ -252,22 +248,38 @@ public class StrongConnectivityAlgorithmTest
         g.addEdge(V5, V4); // only weakly connected
 
         StrongConnectivityAlgorithm<String, DefaultEdge> inspector =
-            new GabowStrongConnectivityInspector<>(g);
+            getStrongConnectivityInspector(g);
 
         Graph<Graph<String, DefaultEdge>, DefaultEdge> condensation = inspector.getCondensation();
-        assertEquals(
-            "([([v1, v2], [(v1,v2), (v2,v1)]), ([v4], []), ([v3], []), ([v5], [])], [(([v3], []),([v4], [])), (([v5], []),([v4], []))])",
-            condensation.toString());
+
+        // assert that the condensation is as expected
+
+        assertThat(
+            condensation.vertexSet().stream().map(Graph::vertexSet).collect(Collectors.toList()),
+            containsInAnyOrder(Set.of(V1, V2), Set.of(V3), Set.of(V4), Set.of(V5)));
+
+        Graph<String, DefaultEdge> g1 = getOnlyGraphWithVertices(condensation, Set.of(V1, V2));
+        Graph<String, DefaultEdge> g2 = getOnlyGraphWithVertices(condensation, Set.of(V3));
+        Graph<String, DefaultEdge> g3 = getOnlyGraphWithVertices(condensation, Set.of(V4));
+        Graph<String, DefaultEdge> g4 = getOnlyGraphWithVertices(condensation, Set.of(V5));
+
+        // Check edges inside condensed graphs
+        assertThat(g1.edgeSet(), is(equalTo(Set.of(g.getEdge(V1, V2), g.getEdge(V2, V1)))));
+        assertThat(g2.edgeSet(), empty());
+        assertThat(g3.edgeSet(), empty());
+        assertThat(g4.edgeSet(), empty());
+
+        // check edges between SCCs
+        Set<DefaultEdge> interSCCEdges =
+            Set.of(condensation.getEdge(g2, g3), condensation.getEdge(g4, g3));
+        assertThat(condensation.edgeSet(), is(equalTo(interSCCEdges)));
     }
 
     @Test
+    @SuppressWarnings("unchecked")
     public void testCondensation2()
     {
-        Graph<String, DefaultEdge> g = new DefaultDirectedGraph<>(DefaultEdge.class);
-        g.addVertex(V1);
-        g.addVertex(V2);
-        g.addVertex(V3);
-        g.addVertex(V4);
+        Graph<String, DefaultEdge> g = createDirectedGraphWithVertices(4);
 
         g.addEdge(V1, V2);
         g.addEdge(V2, V1);
@@ -278,22 +290,133 @@ public class StrongConnectivityAlgorithmTest
         g.addEdge(V2, V4);
 
         StrongConnectivityAlgorithm<String, DefaultEdge> inspector =
-            new GabowStrongConnectivityInspector<>(g);
+            getStrongConnectivityInspector(g);
 
         Graph<Graph<String, DefaultEdge>, DefaultEdge> condensation = inspector.getCondensation();
-        assertEquals(
-            "([([v3, v4], [(v3,v4), (v4,v3)]), ([v1, v2], [(v1,v2), (v2,v1)])], [(([v1, v2], [(v1,v2), (v2,v1)]),([v3, v4], [(v3,v4), (v4,v3)]))])",
-            condensation.toString());
+
+        // assert that the condensation is as expected
+
+        assertThat(
+            condensation.vertexSet().stream().map(Graph::vertexSet).collect(Collectors.toList()),
+            containsInAnyOrder(Set.of(V1, V2), Set.of(V3, V4)));
+
+        Graph<String, DefaultEdge> g1 = getOnlyGraphWithVertices(condensation, Set.of(V1, V2));
+        Graph<String, DefaultEdge> g2 = getOnlyGraphWithVertices(condensation, Set.of(V3, V4));
+
+        // Check edges inside condensed graphs
+        assertThat(g1.edgeSet(), is(equalTo(Set.of(g.getEdge(V1, V2), g.getEdge(V2, V1)))));
+        assertThat(g2.edgeSet(), is(equalTo(Set.of(g.getEdge(V3, V4), g.getEdge(V4, V3)))));
+
+        // check edges between SCCs
+        assertThat(condensation.edgeSet(), is(equalTo(Set.of(condensation.getEdge(g1, g2)))));
+
     }
 
-    private <V, E> StrongConnectivityAlgorithm<V, E> getStrongConnectivityInspector(
-        Graph<V, E> graph, Class<?> strongConnectivityAlgorithm)
+    // --- utility methods ---
+
+    private static Graph<String, DefaultEdge> createDirectedGraphWithVertices(int vertexCount)
     {
-        if (strongConnectivityAlgorithm == GabowStrongConnectivityInspector.class)
-            return new GabowStrongConnectivityInspector<>(graph);
-        else if (strongConnectivityAlgorithm == KosarajuStrongConnectivityInspector.class)
-            return new KosarajuStrongConnectivityInspector<>(graph);
-        else
-            throw new IllegalArgumentException("Unknown strongConnectivityInspectorClass");
+        Graph<String, DefaultEdge> g = new DefaultDirectedGraph<>(DefaultEdge.class);
+        VERTICES.subList(0, vertexCount).forEach(g::addVertex);
+        return g;
+    }
+
+    @SafeVarargs
+    private <V, E> void assertStronglyConnectedSets(Graph<V, E> graph, Set<V>... expectedSets)
+    {
+        // Test the SCC algorithm for each vertex of the graph as start vertex
+        int vertices = graph.vertexSet().size();
+
+        for (int i = 0; i < vertices; i++) {
+            Graph<V, E> g = createRotatedGraphCopy(graph, i);
+            Set<V>[] expectedVertices = createdRotatedSets(expectedSets, i, graph);
+
+            StrongConnectivityAlgorithm<V, E> inspector = getStrongConnectivityInspector(g);
+
+            assertThat(inspector.stronglyConnectedSets(), containsInAnyOrder(expectedVertices));
+
+            Set<Set<V>> actualSets = new HashSet<>();
+            for (Graph<V, E> sg : inspector.getStronglyConnectedComponents()) {
+                actualSets.add(sg.vertexSet());
+
+                StrongConnectivityAlgorithm<V, E> ci = getStrongConnectivityInspector(sg);
+                assertTrue(ci.isStronglyConnected());
+            }
+
+            assertThat(actualSets, containsInAnyOrder(expectedVertices));
+        }
+    }
+
+    private static <V, E> Graph<V, E> createRotatedGraphCopy(Graph<V, E> graph, int shift)
+    {
+        // Because the algorithm implementations don't use linked Maps it is not sufficient to just
+        // add vertices in a different order to achieve different start vertices. Instead the
+        // vertices are added to a graph-copy in the same order every-time but they are logically
+        // shifted by the given shift-length.
+        // This logical shift is achieved by shifting the touching vertices of each edges.
+        // So if the shift is 1 a edge from v1 to v2 is now going from v2 to v3 and so on.
+        List<V> vertexList = new ArrayList<>(graph.vertexSet());
+        Graph<V, E> g = GraphTypeBuilder.forGraph(graph).buildGraph();
+        vertexList.forEach(g::addVertex); // add all vertices
+
+        for (E edge : graph.edgeSet()) {
+            // Apply shift to edges
+            V source = graph.getEdgeSource(edge);
+            source = getShiftedCounterpart(source, shift, vertexList);
+
+            V target = graph.getEdgeTarget(edge);
+            target = getShiftedCounterpart(target, shift, vertexList);
+
+            g.addEdge(source, target);
+        }
+        return g;
+    }
+
+    private static <V> V getShiftedCounterpart(V v, int shift, List<V> vertexList)
+    {
+        int index = vertexList.indexOf(v);
+        int shiftedIndex = (index + shift) % vertexList.size();
+        return vertexList.get(shiftedIndex);
+    }
+
+    private static <V, E> Set<V>[] createdRotatedSets(Set<V>[] sets, int shift, Graph<V, E> graph)
+    {
+        List<V> vertexList = new ArrayList<>(graph.vertexSet());
+        List<Set<V>> rotatedSets = new ArrayList<>();
+        for (Set<V> set : sets) {
+            Set<V> newSet = CollectionUtil.newHashSetWithExpectedSize(set.size());
+            for (V v : set) {
+                v = getShiftedCounterpart(v, shift, vertexList);
+                newSet.add(v);
+            }
+            rotatedSets.add(newSet);
+        }
+
+        @SuppressWarnings("unchecked") Set<V>[] rotatedSet =
+            (Set<V>[]) rotatedSets.toArray(i -> new Set<?>[i]);
+        return rotatedSet;
+    }
+
+    private static <T> Graph<T, DefaultEdge> getOnlyGraphWithVertices(
+        Graph<Graph<T, DefaultEdge>, DefaultEdge> graph, Set<T> vertices)
+    {
+        return getOnlyMatch(graph.vertexSet(), g -> g.vertexSet().equals(vertices));
+    }
+
+    private static <T> T getOnlyMatch(Collection<T> c, Predicate<T> p)
+    {
+        List<T> matches = c.stream().filter(p).collect(Collectors.toList());
+        if (matches.size() == 1) {
+            return matches.get(0);
+        } else {
+            fail("Not exactly one match: " + matches);
+            return null; // never executed, fail() throws
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private <V, E> StrongConnectivityAlgorithm<V, E> getStrongConnectivityInspector(Graph<V, E> g)
+    {
+        return (StrongConnectivityAlgorithm<V, E>) algorithmFactory.apply(g);
     }
 }


### PR DESCRIPTION
While going through the algorithms regarding strongly connected components (SCC) I found some improvements, mainly in the field of memory consumption and comprehensibility, that I want to contribute with this PR.

- The majority of changes affect the `GabowStrongConnectivityInspector`.
First I replaced `Vector` by `ArrayList` and create the `HashSet`-objects holding the SCCs with the expected (and actual) size of the SCC. Additionally the algorithm now uses `Collections.singleton()`-set to store single vertex SCCs. By default a `HashSet` has a initial capacity of 16, so the memory demand to store single-vertex SCCs is reduced significantly.
Besides that I refactored the code to improve comprehensibility. This includes removing of unnecessary method parameters, inlining (and avoiding) of all methods of `VertexNumber` and renaming field `stack` to `S` and using stack-methods (push()/pop()/peek()) instead of Dequeue methods in order to comply more with Gabow's paper.
_
In the second commit I changed the number of the first vertex on a path respectively the first vertex passed to `dfsVisit` from zero to one. Using zero-based numbers for unassigned vertices had the effect that, if the initial vertex of a DFS was part of a SCC, the SCC was detected not until a successor of the initial vertex was explored again. This becomes clear when you think of a graph of three vertices forming a directed ring. This had the effect that in the mentioned case the initial vertex was visited twice, therefore two times on the stack and the first occurrence was left behind on the stack when `dfsVisit` finally returned. However it looks like that the algorithm still worked correctly (at least I couldn't find a case where wrong a SCC was computed). Nevertheless I think this a miss-understanding of the original algorithm described by Gabow and therefore a (uncritical) bug.
_
In his paper "Path-based depth-first search for strong and biconnected components" from the year 2000 Gabow writes that the index of a vertex should be the index of the top of stack S where the vertex was just pushed (see beginning of **procedure DFS** called by **procedure STRONG** in the lower right on the third page). It looks like Gabow assumes one-based stack indices (and not zero-based like it was in `GabowStrongConnectivityInspector`). This is not explicitly stated by Gabow, but I conclude this from `equation` (2) and also the preceding paragraphs. Especially (2) states that the index of a vertex is zero "if v has never been in P". So the reverse conclusion has to be that the first vertex of a path must have index one and not zero.
_
The previous change also allows to use the VertexNumber objects in stack `B`. This is possible because each vertex is on the stack S (which is a super-set of stack B) at most once and has a unique number while on the stacks. Therefore the `VertexNumber` object is equivalent for an Integer object. This avoids auto-boxing and creation of Integer-objects (which are only cached up to 127 by default. See Integer$IntegerCache).
_
Correct me, if my statements are wrong.

- The second class with many changes is `StrongConnectivityAlgorithmTest`.
I simplified and unified it by using JUnit Parameterized runner and adding methods to create the test-graph and to check the result. Additionally I added more test cases and repeat each case for all possible initial vertices of the test-graph.

- In class `KosarajuStrongConnectivityInspector` I just replaced the `Vector` by an `ArrayList` and (my Eclipse) applied the diamond operator where possible.

- In `AbstractStrongConnectivityInspector.getCondensation()` I use the faster constructor-based edge-supplier lambda instead of the class based supplier and create the `vertexToComponent` Map with the expected size.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
