### PR TITLE
Reduce number of Map lookups in Graph-Specifics

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -317,11 +317,8 @@ public abstract class AbstractBaseGraph<V, E>
     {
         if (v == null) {
             throw new NullPointerException();
-        } else if (containsVertex(v)) {
-            return false;
         } else {
-            specifics.addVertex(v);
-            return true;
+            return specifics.addVertex(v);
         }
     }
 
@@ -580,8 +577,7 @@ public abstract class AbstractBaseGraph<V, E>
     {
         // override interface to avoid instantiating frequently
         if (graphIterables == null) {
-            graphIterables =
-                new DefaultGraphIterables<>(this);
+            graphIterables = new DefaultGraphIterables<>(this);
         }
         return graphIterables;
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/DirectedSpecifics.java
@@ -31,7 +31,7 @@ import java.util.function.*;
  * getEdge(V u, V v), containsEdge(V u, V v), addEdge(V u, V v), etc may be relatively slow when the
  * average degree of a vertex is high (dense graphs). For a fast implementation, use
  * {@link FastLookupDirectedSpecifics}.
- * 
+ *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
  *
@@ -51,7 +51,7 @@ public class DirectedSpecifics<V, E>
 
     /**
      * Construct a new directed specifics.
-     * 
+     *
      * @param graph the graph for which these specifics are for
      * @param vertexMap map for the storage of vertex edge sets. Needs to have a predictable
      *        iteration order.
@@ -70,14 +70,11 @@ public class DirectedSpecifics<V, E>
      * {@inheritDoc}
      */
     @Override
-    public boolean addVertex(V v)
+    public boolean addVertex(V vertex)
     {
-        DirectedEdgeContainer<V, E> ec = vertexMap.get(v);
-        if (ec == null) {
-            vertexMap.put(v, new DirectedEdgeContainer<>(edgeSetFactory, v));
-            return true;
-        }
-        return false;
+        int previousSize = vertexMap.size();
+        vertexMap.computeIfAbsent(vertex, v -> new DirectedEdgeContainer<>(edgeSetFactory, v));
+        return previousSize < vertexMap.size();
     }
 
     /**
@@ -195,18 +192,19 @@ public class DirectedSpecifics<V, E>
     @Override
     public Set<E> edgesOf(V vertex)
     {
-        ArrayUnenforcedSet<E> inAndOut =
-            new ArrayUnenforcedSet<>(getEdgeContainer(vertex).incoming);
+        DirectedEdgeContainer<V, E> ec = getEdgeContainer(vertex);
+        Set<E> inAndOut = new ArrayUnenforcedSet<>(ec.incoming.size() + ec.outgoing.size());
+        inAndOut.addAll(ec.incoming);
 
         if (graph.getType().isAllowingSelfLoops()) {
-            for (E e : getEdgeContainer(vertex).outgoing) {
+            for (E e : ec.outgoing) {
                 V target = graph.getEdgeTarget(e);
                 if (!vertex.equals(target)) {
                     inAndOut.add(e);
                 }
             }
         } else {
-            inAndOut.addAll(getEdgeContainer(vertex).outgoing);
+            inAndOut.addAll(ec.outgoing);
         }
 
         return Collections.unmodifiableSet(inAndOut);
@@ -270,6 +268,7 @@ public class DirectedSpecifics<V, E>
         DirectedEdgeContainer<V, E> ec = vertexMap.get(vertex);
 
         if (ec == null) {
+            // It is very unlikely that ec==null, so we save the lambda for Map.computeIfAbsent()
             ec = new DirectedEdgeContainer<>(edgeSetFactory, vertex);
             vertexMap.put(vertex, ec);
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupDirectedSpecifics.java
@@ -49,7 +49,7 @@ public class FastLookupDirectedSpecifics<V, E>
 
     /**
      * Construct a new fast lookup directed specifics.
-     * 
+     *
      * @param graph the graph for which these specifics are for
      * @param vertexMap map for the storage of vertex edge sets. Needs to have a predictable
      *        iteration order.
@@ -86,9 +86,9 @@ public class FastLookupDirectedSpecifics<V, E>
     public E getEdge(V sourceVertex, V targetVertex)
     {
         Set<E> edges = touchingVerticesToEdgeMap.get(new Pair<>(sourceVertex, targetVertex));
-        if (edges == null || edges.isEmpty())
+        if (edges == null || edges.isEmpty()) {
             return null;
-        else {
+        } else {
             return edges.iterator().next();
         }
     }
@@ -140,7 +140,7 @@ public class FastLookupDirectedSpecifics<V, E>
 
     /**
      * Add an edge to the index.
-     * 
+     *
      * @param sourceVertex the source vertex
      * @param targetVertex the target vertex
      * @param e the edge
@@ -148,19 +148,14 @@ public class FastLookupDirectedSpecifics<V, E>
     protected void addToIndex(V sourceVertex, V targetVertex, E e)
     {
         Pair<V, V> vertexPair = new Pair<>(sourceVertex, targetVertex);
-        Set<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);
-        if (edgeSet != null)
-            edgeSet.add(e);
-        else {
-            edgeSet = edgeSetFactory.createEdgeSet(sourceVertex);
-            edgeSet.add(e);
-            touchingVerticesToEdgeMap.put(vertexPair, edgeSet);
-        }
+        Set<E> edgeSet = touchingVerticesToEdgeMap
+            .computeIfAbsent(vertexPair, p -> edgeSetFactory.createEdgeSet(sourceVertex));
+        edgeSet.add(e);
     }
 
     /**
      * Remove an edge from the index.
-     * 
+     *
      * @param sourceVertex the source vertex
      * @param targetVertex the target vertex
      * @param e the edge
@@ -168,13 +163,10 @@ public class FastLookupDirectedSpecifics<V, E>
     protected void removeFromIndex(V sourceVertex, V targetVertex, E e)
     {
         Pair<V, V> vertexPair = new Pair<>(sourceVertex, targetVertex);
-        Set<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);
-        if (edgeSet != null) {
+        touchingVerticesToEdgeMap.computeIfPresent(vertexPair, (p, edgeSet) -> {
             edgeSet.remove(e);
-            if (edgeSet.isEmpty()) {
-                touchingVerticesToEdgeMap.remove(vertexPair);
-            }
-        }
+            return !edgeSet.isEmpty() ? edgeSet : null; // remove if empty
+        });
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/FastLookupUndirectedSpecifics.java
@@ -49,7 +49,7 @@ public class FastLookupUndirectedSpecifics<V, E>
 
     /**
      * Construct a new fast lookup undirected specifics.
-     * 
+     *
      * @param graph the graph for which these specifics are for
      * @param vertexMap map for the storage of vertex edge sets. Needs to have a predictable
      *        iteration order.
@@ -88,10 +88,11 @@ public class FastLookupUndirectedSpecifics<V, E>
     {
         Set<E> edges =
             touchingVerticesToEdgeMap.get(new UnorderedPair<>(sourceVertex, targetVertex));
-        if (edges == null || edges.isEmpty())
+        if (edges == null || edges.isEmpty()) {
             return null;
-        else
+        } else {
             return edges.iterator().next();
+        }
     }
 
     @Override
@@ -141,7 +142,7 @@ public class FastLookupUndirectedSpecifics<V, E>
 
     /**
      * Add an edge to the index.
-     * 
+     *
      * @param sourceVertex the source vertex
      * @param targetVertex the target vertex
      * @param e the edge
@@ -149,19 +150,14 @@ public class FastLookupUndirectedSpecifics<V, E>
     protected void addToIndex(V sourceVertex, V targetVertex, E e)
     {
         Pair<V, V> vertexPair = new UnorderedPair<>(sourceVertex, targetVertex);
-        Set<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);
-        if (edgeSet != null)
-            edgeSet.add(e);
-        else {
-            edgeSet = edgeSetFactory.createEdgeSet(sourceVertex);
-            edgeSet.add(e);
-            touchingVerticesToEdgeMap.put(vertexPair, edgeSet);
-        }
+        Set<E> edgeSet = touchingVerticesToEdgeMap
+            .computeIfAbsent(vertexPair, p -> edgeSetFactory.createEdgeSet(sourceVertex));
+        edgeSet.add(e);
     }
 
     /**
      * Remove an edge from the index.
-     * 
+     *
      * @param sourceVertex the source vertex
      * @param targetVertex the target vertex
      * @param e the edge
@@ -169,12 +165,10 @@ public class FastLookupUndirectedSpecifics<V, E>
     protected void removeFromIndex(V sourceVertex, V targetVertex, E e)
     {
         Pair<V, V> vertexPair = new UnorderedPair<>(sourceVertex, targetVertex);
-        Set<E> edgeSet = touchingVerticesToEdgeMap.get(vertexPair);
-        if (edgeSet != null) {
+        touchingVerticesToEdgeMap.computeIfPresent(vertexPair, (p, edgeSet) -> {
             edgeSet.remove(e);
-            if (edgeSet.isEmpty())
-                touchingVerticesToEdgeMap.remove(vertexPair);
-        }
+            return !edgeSet.isEmpty() ? edgeSet : null; // remove if empty
+        });
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/UndirectedSpecifics.java
@@ -51,7 +51,7 @@ public class UndirectedSpecifics<V, E>
 
     /**
      * Construct a new undirected specifics.
-     * 
+     *
      * @param graph the graph for which these specifics are for
      * @param vertexMap map for the storage of vertex edge sets. Needs to have a predictable
      *        iteration order.
@@ -70,14 +70,11 @@ public class UndirectedSpecifics<V, E>
      * {@inheritDoc}
      */
     @Override
-    public boolean addVertex(V v)
+    public boolean addVertex(V vertex)
     {
-        UndirectedEdgeContainer<V, E> ec = vertexMap.get(v);
-        if (ec == null) {
-            vertexMap.put(v, new UndirectedEdgeContainer<>(edgeSetFactory, v));
-            return true;
-        }
-        return false;
+        int previousSize = vertexMap.size();
+        vertexMap.computeIfAbsent(vertex, v -> new UndirectedEdgeContainer<>(edgeSetFactory, v));
+        return previousSize < vertexMap.size();
     }
 
     /**
@@ -134,12 +131,10 @@ public class UndirectedSpecifics<V, E>
 
     private boolean isEqualsStraightOrInverted(Object sourceVertex, Object targetVertex, E e)
     {
-        boolean equalStraight = sourceVertex.equals(graph.getEdgeSource(e))
-            && targetVertex.equals(graph.getEdgeTarget(e));
-
-        boolean equalInverted = sourceVertex.equals(graph.getEdgeTarget(e))
-            && targetVertex.equals(graph.getEdgeSource(e));
-        return equalStraight || equalInverted;
+        V s = graph.getEdgeSource(e);
+        V t = graph.getEdgeTarget(e);
+        return (sourceVertex.equals(s) && targetVertex.equals(t)) // equals straight
+            || (sourceVertex.equals(t) && targetVertex.equals(s)); // equals inverted
     }
 
     @Override
@@ -287,6 +282,7 @@ public class UndirectedSpecifics<V, E>
         UndirectedEdgeContainer<V, E> ec = vertexMap.get(vertex);
 
         if (ec == null) {
+            // It is very unlikely that ec==null, so we save the lambda for Map.computeIfAbsent()
             ec = new UndirectedEdgeContainer<>(edgeSetFactory, vertex);
             vertexMap.put(vertex, ec);
         }


### PR DESCRIPTION
While looking into the implementations of the graph-specifics I noticed some Map lookups that can be avoided. Reducing Map lookups improves the performance, which is why I would like to contribute these changes with this PR.

Map lookups are reduced by using Map's `computeIfAbsent()` or `computeIfPresent()` methods where applicable.
Furthermore I restructured some methods to avoid unnecessary method calls and take advantage of short-circuit logical operators (like in "UndirectedSpecifics.isEqualsStraightOrInverted()"), which in the end again avoids lookups.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
