### PR TITLE
[Util] replace comparators with lambda and deprecate them for removal

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/FloydWarshallShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/FloydWarshallShortestPaths.java
@@ -18,6 +18,7 @@
 package org.jgrapht.alg.shortestpath;
 
 import org.jgrapht.*;
+import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
 
@@ -71,8 +72,7 @@ public class FloydWarshallShortestPaths<V, E>
          * vertex which has degree at least one and at least two.
          */
         this.vertices = new ArrayList<>(graph.vertexSet());
-        Collections
-            .sort(vertices, (v1, v2) -> Integer.compare(graph.degreeOf(v1), graph.degreeOf(v2)));
+        Collections.sort(vertices, VertexDegreeComparator.of(graph));
         this.degrees = new ArrayList<>();
         this.vertexIndices = CollectionUtil.newHashMapWithExpectedSize(this.vertices.size());
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/FloydWarshallShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/FloydWarshallShortestPaths.java
@@ -18,7 +18,6 @@
 package org.jgrapht.alg.shortestpath;
 
 import org.jgrapht.*;
-import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
 
@@ -73,9 +72,7 @@ public class FloydWarshallShortestPaths<V, E>
          */
         this.vertices = new ArrayList<>(graph.vertexSet());
         Collections
-            .sort(
-                vertices,
-                new VertexDegreeComparator<>(graph, VertexDegreeComparator.Order.ASCENDING));
+            .sort(vertices, (v1, v2) -> Integer.compare(graph.degreeOf(v1), graph.degreeOf(v2)));
         this.degrees = new ArrayList<>();
         this.vertexIndices = CollectionUtil.newHashMapWithExpectedSize(this.vertices.size());
 
@@ -333,8 +330,9 @@ public class FloydWarshallShortestPaths<V, E>
     {
         lazyCalculateMatrix();
 
-        if (lastHopMatrix != null)
+        if (lastHopMatrix != null) {
             return;
+        }
 
         // Initialize matrix
         int n = vertices.size();
@@ -343,8 +341,9 @@ public class FloydWarshallShortestPaths<V, E>
         // Populate matrix
         for (int i = 0; i < n; i++) {
             for (int j = 0; j < n; j++) {
-                if (i == j || lastHopMatrix[i][j] != null || backtrace[i][j] == null)
+                if (i == j || lastHopMatrix[i][j] != null || backtrace[i][j] == null) {
                     continue;
+                }
 
                 // Reconstruct the path from i to j
                 V u = vertices.get(i);
@@ -364,7 +363,7 @@ public class FloydWarshallShortestPaths<V, E>
         implements
         SingleSourcePaths<V, E>
     {
-        private V source;
+        private final V source;
 
         public FloydWarshallSingleSourcePaths(V source)
         {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/AlwaysEqualComparator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/AlwaysEqualComparator.java
@@ -21,10 +21,11 @@ import java.util.*;
 
 /**
  * A default implementation for a check on equality (that always holds)
- * 
+ *
  * @param <T> type of elements to be compared
- * 
+ * @deprecated use a lambda like {@code (t1,t2) -> 0} instead
  */
+@Deprecated(forRemoval = true, since = "1.5.1")
 public class AlwaysEqualComparator<T>
     implements
     Comparator<T>

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
@@ -33,7 +33,13 @@ import java.util.*;
  * @param <E> the graph edge type
  *
  * @author Linda Buisman
+ * @deprecated use a lambda like
+ *             {@code (v1,v2) -> Integer.compare(graph.degreeOf(v1), graph.degreeOf(v2))} for
+ *             ascending order or like
+ *             {@code (v1,v2) -> -Integer.compare(graph.degreeOf(v1), graph.degreeOf(v2))} for
+ *             descending order
  */
+@Deprecated(forRemoval = true, since = "1.5.1")
 public class VertexDegreeComparator<V, E>
     implements
     Comparator<V>
@@ -46,7 +52,7 @@ public class VertexDegreeComparator<V, E>
     {
         ASCENDING,
         DESCENDING
-    };
+    }
 
     /**
      * The graph that contains the vertices to be compared.
@@ -96,9 +102,10 @@ public class VertexDegreeComparator<V, E>
     {
         int comparison = Integer.compare(graph.degreeOf(v1), graph.degreeOf(v2));
 
-        if (order == Order.ASCENDING)
+        if (order == Order.ASCENDING) {
             return comparison;
-        else
+        } else {
             return -1 * comparison;
+        }
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
@@ -33,21 +33,31 @@ import java.util.*;
  * @param <E> the graph edge type
  *
  * @author Linda Buisman
- * @deprecated use a lambda like
- *             {@code (v1,v2) -> Integer.compare(graph.degreeOf(v1), graph.degreeOf(v2))} for
- *             ascending order or like
- *             {@code (v1,v2) -> -Integer.compare(graph.degreeOf(v1), graph.degreeOf(v2))} for
- *             descending order
+ *
  */
-@Deprecated(forRemoval = true, since = "1.5.1")
 public class VertexDegreeComparator<V, E>
     implements
     Comparator<V>
 {
+    /**
+     * Returns a {@link Comparator} that compares vertices by their degrees in the specified graph.
+     * <p>
+     * The comparator compares in ascending order of degrees (lower degree first). To obtain a
+     * comparator that compares in descending order call {@link Comparator#reversed()} on the
+     * returned comparator.
+     * </p>
+     *
+     * @param g graph with respect to which the degree is calculated.
+     */
+    public static <V> Comparator<V> of(Graph<V, ?> g)
+    {
+        return Comparator.comparingInt(g::degreeOf);
+    }
 
     /**
      * Order in which we sort the vertices: ascending vertex degree or descending vertex degree
      */
+    @Deprecated(forRemoval = true, since = "1.5.1")
     public enum Order
     {
         ASCENDING,
@@ -57,11 +67,13 @@ public class VertexDegreeComparator<V, E>
     /**
      * The graph that contains the vertices to be compared.
      */
+    @Deprecated(forRemoval = true, since = "1.5.1")
     private Graph<V, E> graph;
 
     /**
      * Order in which the vertices are sorted: ascending or descending
      */
+    @Deprecated(forRemoval = true, since = "1.5.1")
     private Order order;
 
     /**
@@ -69,7 +81,9 @@ public class VertexDegreeComparator<V, E>
      * comparator compares in ascending order of degrees (lowest first).
      *
      * @param g graph with respect to which the degree is calculated.
+     * @deprecated use {@link VertexDegreeComparator#forGraph(Graph)}
      */
+    @Deprecated(forRemoval = true, since = "1.5.1")
     public VertexDegreeComparator(Graph<V, E> g)
     {
         this(g, Order.ASCENDING);
@@ -80,7 +94,10 @@ public class VertexDegreeComparator<V, E>
      *
      * @param g graph with respect to which the degree is calculated.
      * @param order order in which the vertices are sorted (ascending or descending)
+     * @deprecated use {@link VertexDegreeComparator#forGraph(Graph)} for ascending order or
+     *             {@link Comparator#reversed() reverse the comparator } for descending order.
      */
+    @Deprecated(forRemoval = true, since = "1.5.1")
     public VertexDegreeComparator(Graph<V, E> g, Order order)
     {
         graph = g;
@@ -98,6 +115,7 @@ public class VertexDegreeComparator<V, E>
      * v1</code> comes after <code>v2</code>, 0 if equal.
      */
     @Override
+    @Deprecated(forRemoval = true, since = "1.5.1")
     public int compare(V v1, V v2)
     {
         int comparison = Integer.compare(graph.degreeOf(v1), graph.degreeOf(v2));

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
@@ -46,16 +46,23 @@ public class VertexDegreeComparator<V, E>
      * comparator that compares in descending order call {@link Comparator#reversed()} on the
      * returned comparator.
      * </p>
-     *
+     * 
+     * @param <V> the graph vertex type
      * @param g graph with respect to which the degree is calculated.
+     * @return a {@code Comparator} to compare vertices by their degree in ascending order
      */
     public static <V> Comparator<V> of(Graph<V, ?> g)
     {
         return Comparator.comparingInt(g::degreeOf);
     }
 
+    // TODO: after next release remove everything below this line and remove implementation of
+    // comparator (and the type parameters)
+
     /**
      * Order in which we sort the vertices: ascending vertex degree or descending vertex degree
+     * 
+     * @deprecated use {@link VertexDegreeComparator#of(Graph)}
      */
     @Deprecated(forRemoval = true, since = "1.5.1")
     public enum Order
@@ -67,13 +74,11 @@ public class VertexDegreeComparator<V, E>
     /**
      * The graph that contains the vertices to be compared.
      */
-    @Deprecated(forRemoval = true, since = "1.5.1")
     private Graph<V, E> graph;
 
     /**
      * Order in which the vertices are sorted: ascending or descending
      */
-    @Deprecated(forRemoval = true, since = "1.5.1")
     private Order order;
 
     /**
@@ -81,7 +86,7 @@ public class VertexDegreeComparator<V, E>
      * comparator compares in ascending order of degrees (lowest first).
      *
      * @param g graph with respect to which the degree is calculated.
-     * @deprecated use {@link VertexDegreeComparator#forGraph(Graph)}
+     * @deprecated use {@link VertexDegreeComparator#of(Graph)}
      */
     @Deprecated(forRemoval = true, since = "1.5.1")
     public VertexDegreeComparator(Graph<V, E> g)
@@ -94,7 +99,7 @@ public class VertexDegreeComparator<V, E>
      *
      * @param g graph with respect to which the degree is calculated.
      * @param order order in which the vertices are sorted (ascending or descending)
-     * @deprecated use {@link VertexDegreeComparator#forGraph(Graph)} for ascending order or
+     * @deprecated use {@link VertexDegreeComparator#of(Graph)} for ascending order or
      *             {@link Comparator#reversed() reverse the comparator } for descending order.
      */
     @Deprecated(forRemoval = true, since = "1.5.1")
@@ -113,6 +118,7 @@ public class VertexDegreeComparator<V, E>
      *
      * @return -1 if <code>v1</code> comes before <code>v2</code>, +1 if <code>
      * v1</code> comes after <code>v2</code>, 0 if equal.
+     * @deprecated use {@link VertexDegreeComparator#of(Graph)}
      */
     @Override
     @Deprecated(forRemoval = true, since = "1.5.1")

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismInspectorTest.java
@@ -18,13 +18,12 @@
 package org.jgrapht.alg.isomorphism;
 
 import org.jgrapht.*;
-import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.*;
 import org.junit.*;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class VF2SubgraphIsomorphismInspectorTest
 {
@@ -334,8 +333,9 @@ public class VF2SubgraphIsomorphismInspectorTest
                     "[0=~~ 1=0 2=2 3=1]", "[0=1 1=2 2=0 3=~~]", "[0=1 1=2 2=~~ 3=0]",
                     "[0=1 1=~~ 2=2 3=0]", "[0=~~ 1=1 2=2 3=0]", "[0=2 1=0 2=1 3=~~]",
                     "[0=2 1=0 2=~~ 3=1]", "[0=2 1=~~ 2=0 3=1]", "[0=~~ 1=2 2=0 3=1]"));
-        for (int i = 0; i < 24; i++)
+        for (int i = 0; i < 24; i++) {
             assertEquals(true, mappings10.remove(iter10.next().toString()));
+        }
         assertEquals(false, iter10.hasNext());
 
         /* ECS-11: isomorphic graphs */
@@ -394,8 +394,9 @@ public class VF2SubgraphIsomorphismInspectorTest
                     "[0=~~ 1=10 2=8 3=9 4=7 5=6]", "[0=~~ 1=8 2=9 3=10 4=7 5=6]",
                     "[0=~~ 1=9 2=10 3=8 4=7 5=6]", "[0=~~ 1=10 2=8 3=9 4=6 5=7]",
                     "[0=~~ 1=8 2=9 3=10 4=6 5=7]", "[0=~~ 1=9 2=10 3=8 4=6 5=7]"));
-        for (int i = 0; i < 12; i++)
+        for (int i = 0; i < 12; i++) {
             assertEquals(true, mappings12.remove(iter12.next().toString()));
+        }
         assertEquals(false, iter12.hasNext());
     }
 
@@ -862,8 +863,7 @@ public class VF2SubgraphIsomorphismInspectorTest
          */
 
         VF2SubgraphIsomorphismInspector<String, Integer> vf3 =
-            new VF2SubgraphIsomorphismInspector<>(
-                g1, g2, new VertexComp(), new AlwaysEqualComparator<>());
+            new VF2SubgraphIsomorphismInspector<>(g1, g2, new VertexComp(), (t1, t2) -> 0);
 
         Iterator<GraphMapping<String, Integer>> iter2 = vf3.getMappings();
 
@@ -878,8 +878,7 @@ public class VF2SubgraphIsomorphismInspectorTest
          */
 
         VF2SubgraphIsomorphismInspector<String, Integer> vf4 =
-            new VF2SubgraphIsomorphismInspector<>(
-                g1, g2, new AlwaysEqualComparator<>(), new EdgeComp());
+            new VF2SubgraphIsomorphismInspector<>(g1, g2, (t1, t2) -> 0, new EdgeComp());
 
         Iterator<GraphMapping<String, Integer>> iter3 = vf4.getMappings();
 
@@ -897,10 +896,11 @@ public class VF2SubgraphIsomorphismInspectorTest
         @Override
         public int compare(String o1, String o2)
         {
-            if (o1.toLowerCase().equals(o2.toLowerCase()))
+            if (o1.toLowerCase().equals(o2.toLowerCase())) {
                 return 0;
-            else
+            } else {
                 return 1;
+            }
         }
     }
 


### PR DESCRIPTION
The comparators of the `util` package are used rarely and can be replaced by lambdas that are shorter than calling the constructor of the corresponding comparator.

In order to avoid unnecessary code, I suggest to remove these comparators after the next release.
With this PR the comparators are replaced where they were used and marked as deprecated for removal.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
