### PR TITLE
Replace Map<Integer, E> with ArrayList<E> where possible

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/color/ColorRefinementAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/color/ColorRefinementAlgorithm.java
@@ -236,8 +236,8 @@ public class ColorRefinementAlgorithm<V, E>
 
         // Update colors classes if some color has changed
         for (V v : positiveDegreeColorClasses) {
-            Integer value = newMapping[rep.colorDegree.get(v)];
-            if (!value.equals(color)) {
+            int value = newMapping[rep.colorDegree.get(v)];
+            if (value != color.intValue()) {
                 rep.colorClasses.get(color).remove(v);
                 rep.colorClasses.get(value).add(v);
                 rep.coloring.replace(v, value);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/color/ColorRefinementAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/color/ColorRefinementAlgorithm.java
@@ -174,7 +174,7 @@ public class ColorRefinementAlgorithm<V, E>
                 rep.colorDegree.put(v, 0);
             }
             rep.maxColorDegree[c] = 0;
-            rep.positiveDegreeColorClasses.put(c, new ArrayList<>());
+            rep.positiveDegreeColorClasses.set(c, new ArrayList<>());
         }
     }
 
@@ -189,60 +189,58 @@ public class ColorRefinementAlgorithm<V, E>
     {
         // Initialize and calculate numColorDegree (mapping from the color degree to the number of
         // vertices with that color degree).
-        Map<Integer, Integer> numColorDegree = new HashMap<>();
-        for (int i = 1; i <= rep.maxColorDegree[color]; ++i) {
-            numColorDegree.put(i, 0);
-        }
-        numColorDegree
-            .put(
-                0, rep.colorClasses.get(color).size()
-                    - rep.positiveDegreeColorClasses.get(color).size());
-        for (V v : rep.positiveDegreeColorClasses.get(color)) {
-            numColorDegree
-                .put(rep.colorDegree.get(v), numColorDegree.get(rep.colorDegree.get(v)) + 1);
+        List<V> positiveDegreeColorClasses = rep.positiveDegreeColorClasses.get(color);
+        int maxColorDegree = rep.maxColorDegree[color];
+
+        int[] numColorDegree = new int[maxColorDegree + 1];
+        numColorDegree[0] = rep.colorClasses.get(color).size() - positiveDegreeColorClasses.size();
+
+        for (V v : positiveDegreeColorClasses) {
+            int degree = rep.colorDegree.get(v);
+            numColorDegree[degree] += 1;
         }
 
         // Helper variable storing the index with the maximum number of vertices with the
         // corresponding color degree
         int maxColorDegreeIndex = 0;
-        for (int i = 1; i <= rep.maxColorDegree[color]; ++i) {
-            if (numColorDegree.get(i) > numColorDegree.get(maxColorDegreeIndex)) {
+        for (int i = 1; i <= maxColorDegree; ++i) {
+            if (numColorDegree[i] > numColorDegree[maxColorDegreeIndex]) {
                 maxColorDegreeIndex = i;
             }
         }
 
         // Go through all indices (color degrees) of numColorDegree
-        Map<Integer, Integer> newMapping = new HashMap<>();
+        int[] newMapping = new int[maxColorDegree + 1];
         boolean isCurrentColorInStack = refineStack.contains(color);
-        int currentMaxColorDegree = rep.maxColorDegree[color];
-        for (int i = 0; i <= currentMaxColorDegree; ++i) {
-            if (numColorDegree.get(i) >= 1) {
+        for (int i = 0; i <= maxColorDegree; ++i) {
+            if (numColorDegree[i] >= 1) {
                 if (i == rep.minColorDegree[color]) {
-                    newMapping.put(i, color); // keep current color
+                    newMapping[i] = color; // keep current color
 
                     // Push current color on the stack if it is not in the stack and i is not the
                     // index with the maximum number of vertices with the corresponding color degree
                     if (!isCurrentColorInStack && maxColorDegreeIndex != i) {
-                        refineStack.push(newMapping.get(i));
+                        refineStack.push(newMapping[i]);
                     }
                 } else {
-                    newMapping.put(i, ++rep.lastUsedColor); // new color
+                    newMapping[i] = ++rep.lastUsedColor; // new color
 
                     // Push current color on the stack if it is in the stack and i is not the index
                     // with the maximum number of vertices with the corresponding color degree
                     if (isCurrentColorInStack || i != maxColorDegreeIndex) {
-                        refineStack.push(newMapping.get(i));
+                        refineStack.push(newMapping[i]);
                     }
                 }
             }
         }
 
         // Update colors classes if some color has changed
-        for (V v : rep.positiveDegreeColorClasses.get(color)) {
-            if (!newMapping.get(rep.colorDegree.get(v)).equals(color)) {
+        for (V v : positiveDegreeColorClasses) {
+            Integer value = newMapping[rep.colorDegree.get(v)];
+            if (!value.equals(color)) {
                 rep.colorClasses.get(color).remove(v);
-                rep.colorClasses.get(newMapping.get(rep.colorDegree.get(v))).add(v);
-                rep.coloring.replace(v, newMapping.get(rep.colorDegree.get(v)));
+                rep.colorClasses.get(value).add(v);
+                rep.coloring.replace(v, value);
             }
         }
     }
@@ -323,12 +321,12 @@ public class ColorRefinementAlgorithm<V, E>
         /**
          * mapping from all colors to their classes
          */
-        HashMap<Integer, List<V>> colorClasses;
+        List<List<V>> colorClasses;
         /**
          * mapping from color to their classes, whereby every vertex in the classes has
          * colorDegree(v) >= 1
          */
-        HashMap<Integer, List<V>> positiveDegreeColorClasses;
+        List<List<V>> positiveDegreeColorClasses;
         /**
          * mapping from color to its maximum color degree
          */
@@ -354,16 +352,16 @@ public class ColorRefinementAlgorithm<V, E>
         public ColoringRepresentation(Graph<V, E> graph, Coloring<V> alpha)
         {
             int n = graph.vertexSet().size();
-            this.colorClasses = CollectionUtil.newHashMapWithExpectedSize(n);
-            this.positiveDegreeColorClasses = CollectionUtil.newHashMapWithExpectedSize(n);
+            this.colorClasses = new ArrayList<>(n);
+            this.positiveDegreeColorClasses = new ArrayList<>(n);
             this.maxColorDegree = new int[n];
             this.minColorDegree = new int[n];
             this.colorDegree = new HashMap<>();
             this.coloring = new HashMap<>();
 
             for (int c = 0; c < n; ++c) {
-                colorClasses.put(c, new ArrayList<>());
-                positiveDegreeColorClasses.put(c, new ArrayList<>());
+                colorClasses.add(new ArrayList<>());
+                positiveDegreeColorClasses.add(new ArrayList<>());
             }
             for (V v : graph.vertexSet()) {
                 colorClasses.get(alpha.getColors().get(v)).add(v);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChinesePostman.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChinesePostman.java
@@ -83,17 +83,15 @@ public class ChinesePostman<V, E>
         GraphTests.requireDirectedOrUndirected(graph);
 
         // If graph has no vertices, or no edges, instantly return.
-        if (graph.vertexSet().isEmpty() || graph.edgeSet().isEmpty()) {
+        if (graph.vertexSet().isEmpty() || graph.edgeSet().isEmpty())
             return new HierholzerEulerianCycle<V, E>().getEulerianCycle(graph);
-        }
 
         assert GraphTests.isStronglyConnected(graph);
 
-        if (graph.getType().isUndirected()) {
+        if (graph.getType().isUndirected())
             return solveCPPUndirected(graph);
-        } else {
+        else
             return solveCPPDirected(graph);
-        }
 
     }
 
@@ -130,9 +128,8 @@ public class ChinesePostman<V, E>
 
         for (V u : oddDegreeVertices) {
             for (V v : oddDegreeVertices) {
-                if (u == v) {
+                if (u == v)
                     continue;
-                }
                 Graphs
                     .addEdge(
                         auxGraph, u, v, shortestPaths.get(new UnorderedPair<>(u, v)).getWeight());
@@ -177,16 +174,14 @@ public class ChinesePostman<V, E>
         for (V v : graph.vertexSet()) {
             int imbalance = graph.outDegreeOf(v) - graph.inDegreeOf(v);
 
-            if (imbalance == 0) {
+            if (imbalance == 0)
                 continue;
-            }
             imbalancedVertices.put(v, Math.abs(imbalance));
 
-            if (imbalance < 0) {
+            if (imbalance < 0)
                 negImbalancedVertices.add(v);
-            } else {
+            else
                 postImbalancedVertices.add(v);
-            }
         }
 
         // 2. Compute all pairwise shortest paths from the negative imbalanced vertices to the

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChinesePostman.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChinesePostman.java
@@ -83,15 +83,17 @@ public class ChinesePostman<V, E>
         GraphTests.requireDirectedOrUndirected(graph);
 
         // If graph has no vertices, or no edges, instantly return.
-        if (graph.vertexSet().isEmpty() || graph.edgeSet().isEmpty())
+        if (graph.vertexSet().isEmpty() || graph.edgeSet().isEmpty()) {
             return new HierholzerEulerianCycle<V, E>().getEulerianCycle(graph);
+        }
 
         assert GraphTests.isStronglyConnected(graph);
 
-        if (graph.getType().isUndirected())
+        if (graph.getType().isUndirected()) {
             return solveCPPUndirected(graph);
-        else
+        } else {
             return solveCPPDirected(graph);
+        }
 
     }
 
@@ -128,8 +130,9 @@ public class ChinesePostman<V, E>
 
         for (V u : oddDegreeVertices) {
             for (V v : oddDegreeVertices) {
-                if (u == v)
+                if (u == v) {
                     continue;
+                }
                 Graphs
                     .addEdge(
                         auxGraph, u, v, shortestPaths.get(new UnorderedPair<>(u, v)).getWeight());
@@ -174,14 +177,16 @@ public class ChinesePostman<V, E>
         for (V v : graph.vertexSet()) {
             int imbalance = graph.outDegreeOf(v) - graph.inDegreeOf(v);
 
-            if (imbalance == 0)
+            if (imbalance == 0) {
                 continue;
+            }
             imbalancedVertices.put(v, Math.abs(imbalance));
 
-            if (imbalance < 0)
+            if (imbalance < 0) {
                 negImbalancedVertices.add(v);
-            else
+            } else {
                 postImbalancedVertices.add(v);
+            }
         }
 
         // 2. Compute all pairwise shortest paths from the negative imbalanced vertices to the
@@ -202,15 +207,15 @@ public class ChinesePostman<V, E>
         // node equals its imbalance.
         Graph<Integer, DefaultWeightedEdge> auxGraph =
             new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
-        Map<Integer, V> duplicateMap = new HashMap<>();
+        List<V> duplicateMap = new ArrayList<>();
         Set<Integer> negImbalancedPartition = new HashSet<>();
         Set<Integer> postImbalancedPartition = new HashSet<>();
-        int vertex = 0;
+        Integer vertex = 0;
 
         for (V v : negImbalancedVertices) {
             for (int i = 0; i < imbalancedVertices.get(v); i++) {
                 auxGraph.addVertex(vertex);
-                duplicateMap.put(vertex, v);
+                duplicateMap.add(v);
                 negImbalancedPartition.add(vertex);
                 vertex++;
             }
@@ -218,7 +223,7 @@ public class ChinesePostman<V, E>
         for (V v : postImbalancedVertices) {
             for (int i = 0; i < imbalancedVertices.get(v); i++) {
                 auxGraph.addVertex(vertex);
-                duplicateMap.put(vertex, v);
+                duplicateMap.add(v);
                 postImbalancedPartition.add(vertex);
                 vertex++;
             }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/WeakChordalityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/WeakChordalityInspector.java
@@ -91,7 +91,7 @@ public class WeakChordalityInspector<V, E>
     /**
      * Inverse of the bijective mapping of vertices onto $\left[0,n-1\right]$
      */
-    private Map<Integer, V> indices;
+    private List<V> indices;
     /**
      * Contains true if the graph is weakly chordal, otherwise false. Is null before the first call
      * to the {@link WeakChordalityInspector#isWeaklyChordal()}.
@@ -123,13 +123,9 @@ public class WeakChordalityInspector<V, E>
      */
     private void initMappings()
     {
-        vertices = CollectionUtil.newHashMapWithExpectedSize(n);
-        indices = CollectionUtil.newHashMapWithExpectedSize(n);
-        int i = 0;
-        for (V v : graph.vertexSet()) {
-            indices.put(i, v);
-            vertices.put(v, i++);
-        }
+        VertexToIntegerMapping<V> mapping = new VertexToIntegerMapping<>(graph.vertexSet());
+        vertices = mapping.getVertexMap();
+        indices = mapping.getIndexList();
     }
 
     /**
@@ -169,7 +165,7 @@ public class WeakChordalityInspector<V, E>
             List<Pair<List<Pair<Integer, Integer>>, E>> globalSeparatorList =
                 computeGlobalSeparatorList();
 
-            if (globalSeparatorList.size() > 0) {
+            if (!globalSeparatorList.isEmpty()) {
                 Pair<Integer, Integer> pair;
                 sortSeparatorsList(globalSeparatorList);
 
@@ -406,7 +402,7 @@ public class WeakChordalityInspector<V, E>
         bucketsByLabel.set(0, unvisited);
         int minLabel = 0;
 
-        while (unvisited.size() > 0) {
+        while (!unvisited.isEmpty()) {
             List<Integer> coConnectedComponent = new ArrayList<>();
             do {
                 // When minLabel = coConnectedComponent.size(), we've visited all vertices in some
@@ -595,13 +591,9 @@ public class WeakChordalityInspector<V, E>
     private GraphPath<V, E> findHole(
         Graph<V, E> graph, V sourceInSeparator, V source, V target, V targetInSeparator)
     {
-        Map<V, Boolean> visited =
-            CollectionUtil.newHashMapWithExpectedSize(graph.vertexSet().size());
-        for (V vertex : graph.vertexSet()) {
-            visited.put(vertex, false);
-        }
-        visited.put(target, true);
-        visited.put(source, true);
+        Set<V> visited = CollectionUtil.newHashSetWithExpectedSize(graph.vertexSet().size());
+        visited.add(target);
+        visited.add(source);
 
         // Obtaining some cycle, which can be minimized to a hole
         List<V> cycle =
@@ -626,7 +618,7 @@ public class WeakChordalityInspector<V, E>
      * @return the computed cycle, which contains a hole
      */
     private List<V> findCycle(
-        Map<V, Boolean> visited, Graph<V, E> graph, V tarInSep, V tar, V sour, V sourInSep)
+        Set<V> visited, Graph<V, E> graph, V tarInSep, V tar, V sour, V sourInSep)
     {
         List<V> cycle = new ArrayList<>(Arrays.asList(tarInSep, tar, sour));
         Deque<V> stack = new ArrayDeque<>();
@@ -634,8 +626,7 @@ public class WeakChordalityInspector<V, E>
 
         while (!stack.isEmpty()) {
             V currentVertex = stack.removeLast();
-            if (!visited.get(currentVertex)) {
-                visited.put(currentVertex, true);
+            if (visited.add(currentVertex)) {
 
                 // trying to advance cycle from current vertex
                 // removing all vertices from the head of the cycle, which aren't adjacent to the
@@ -653,7 +644,7 @@ public class WeakChordalityInspector<V, E>
                         // adjacent to the
                         // source vertex and (it isn't adjacent to the target vertex or it is
                         // targetInSeparator (the end of the cycle))
-                        if (!visited.get(neighbor) && !graph.containsEdge(sour, neighbor)
+                        if (!visited.contains(neighbor) && !graph.containsEdge(sour, neighbor)
                             && (!graph.containsEdge(tar, neighbor) || neighbor.equals(tarInSep)))
                         {
                             stack.add(neighbor);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/WeakChordalityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/WeakChordalityInspector.java
@@ -165,7 +165,7 @@ public class WeakChordalityInspector<V, E>
             List<Pair<List<Pair<Integer, Integer>>, E>> globalSeparatorList =
                 computeGlobalSeparatorList();
 
-            if (!globalSeparatorList.isEmpty()) {
+            if (globalSeparatorList.size() > 0) {
                 Pair<Integer, Integer> pair;
                 sortSeparatorsList(globalSeparatorList);
 
@@ -402,7 +402,7 @@ public class WeakChordalityInspector<V, E>
         bucketsByLabel.set(0, unvisited);
         int minLabel = 0;
 
-        while (!unvisited.isEmpty()) {
+        while (unvisited.size() > 0) {
             List<Integer> coConnectedComponent = new ArrayList<>();
             do {
                 // When minLabel = coConnectedComponent.size(), we've visited all vertices in some

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
@@ -19,6 +19,7 @@ package org.jgrapht.alg.tour;
 
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
+import org.jgrapht.util.*;
 
 import java.util.*;
 
@@ -67,7 +68,7 @@ public class TwoOptHeuristicTSP<V, E>
     private int n;
     private double[][] dist;
     private Map<V, Integer> index;
-    private Map<Integer, V> revIndex;
+    private List<V> revIndex;
 
     /**
      * Constructor. By default one initial random tour is used.
@@ -217,20 +218,17 @@ public class TwoOptHeuristicTSP<V, E>
         this.graph = graph;
         this.n = graph.vertexSet().size();
         this.dist = new double[n][n];
-        this.index = new HashMap<>();
-        this.revIndex = new HashMap<>();
-        int i = 0;
-        for (V v : graph.vertexSet()) {
-            index.put(v, i);
-            revIndex.put(i, v);
-            i++;
-        }
+        VertexToIntegerMapping<V> vertex2index = new VertexToIntegerMapping<>(graph.vertexSet());
+        this.index = vertex2index.getVertexMap();
+        this.revIndex = vertex2index.getIndexList();
 
         for (E e : graph.edgeSet()) {
+
             V s = graph.getEdgeSource(e);
             int si = index.get(s);
             V t = graph.getEdgeTarget(e);
             int ti = index.get(t);
+
             double weight = graph.getEdgeWeight(e);
             dist[si][ti] = weight;
             dist[ti][si] = weight;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoOptHeuristicTSP.java
@@ -223,7 +223,6 @@ public class TwoOptHeuristicTSP<V, E>
         this.revIndex = vertex2index.getIndexList();
 
         for (E e : graph.edgeSet()) {
-
             V s = graph.getEdgeSource(e);
             int si = index.get(s);
             V t = graph.getEdgeTarget(e);

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GnmRandomBipartiteGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GnmRandomBipartiteGraphGenerator.java
@@ -18,7 +18,6 @@
 package org.jgrapht.generate;
 
 import org.jgrapht.*;
-import org.jgrapht.util.*;
 
 import java.util.*;
 
@@ -50,8 +49,8 @@ public class GnmRandomBipartiteGraphGenerator<V, E>
     private final int n2;
     private final int m;
 
-    private Map<Integer, V> partitionA;
-    private Map<Integer, V> partitionB;
+    private List<V> partitionA;
+    private List<V> partitionB;
 
     /**
      * Create a new random bipartite graph generator. The generator uses the $G(n, m)$ model when $n
@@ -128,14 +127,14 @@ public class GnmRandomBipartiteGraphGenerator<V, E>
         // create vertices
         int previousVertexSetSize = target.vertexSet().size();
 
-        partitionA = CollectionUtil.newLinkedHashMapWithExpectedSize(n1);
+        partitionA = new ArrayList<>(n1);
         for (int i = 0; i < n1; i++) {
-            partitionA.put(i, target.addVertex());
+            partitionA.add(target.addVertex());
         }
 
-        partitionB = CollectionUtil.newLinkedHashMapWithExpectedSize(n2);
+        partitionB = new ArrayList<>(n2);
         for (int i = 0; i < n2; i++) {
-            partitionB.put(i, target.addVertex());
+            partitionB.add(target.addVertex());
         }
 
         if (target.vertexSet().size() != previousVertexSetSize + n1 + n2) {
@@ -201,10 +200,11 @@ public class GnmRandomBipartiteGraphGenerator<V, E>
      */
     public Set<V> getFirstPartition()
     {
-        if (partitionA.size() <= partitionB.size())
-            return new LinkedHashSet<>(partitionA.values());
-        else
-            return new LinkedHashSet<>(partitionB.values());
+        if (partitionA.size() <= partitionB.size()) {
+            return new LinkedHashSet<>(partitionA);
+        } else {
+            return new LinkedHashSet<>(partitionB);
+        }
     }
 
     /**
@@ -215,10 +215,11 @@ public class GnmRandomBipartiteGraphGenerator<V, E>
      */
     public Set<V> getSecondPartition()
     {
-        if (partitionB.size() >= partitionA.size())
-            return new LinkedHashSet<>(partitionB.values());
-        else
-            return new LinkedHashSet<>(partitionA.values());
+        if (partitionB.size() >= partitionA.size()) {
+            return new LinkedHashSet<>(partitionB);
+        } else {
+            return new LinkedHashSet<>(partitionA);
+        }
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GnmRandomBipartiteGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GnmRandomBipartiteGraphGenerator.java
@@ -200,11 +200,10 @@ public class GnmRandomBipartiteGraphGenerator<V, E>
      */
     public Set<V> getFirstPartition()
     {
-        if (partitionA.size() <= partitionB.size()) {
+        if (partitionA.size() <= partitionB.size())
             return new LinkedHashSet<>(partitionA);
-        } else {
+        else
             return new LinkedHashSet<>(partitionB);
-        }
     }
 
     /**
@@ -215,11 +214,10 @@ public class GnmRandomBipartiteGraphGenerator<V, E>
      */
     public Set<V> getSecondPartition()
     {
-        if (partitionB.size() >= partitionA.size()) {
+        if (partitionB.size() >= partitionA.size())
             return new LinkedHashSet<>(partitionB);
-        } else {
+        else
             return new LinkedHashSet<>(partitionA);
-        }
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GnmRandomGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GnmRandomGraphGenerator.java
@@ -273,8 +273,10 @@ public class GnmRandomGraphGenerator<V, E>
                     }
                 }
             } else {
-                if (createMultipleEdges && n > 1) {
-                    return Integer.MAX_VALUE;
+                if (createMultipleEdges) {
+                    if (n > 1) {
+                        return Integer.MAX_VALUE;
+                    }
                 }
             }
         } catch (ArithmeticException e) {

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GnmRandomGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GnmRandomGraphGenerator.java
@@ -18,7 +18,6 @@
 package org.jgrapht.generate;
 
 import org.jgrapht.*;
-import org.jgrapht.util.*;
 
 import java.util.*;
 
@@ -176,10 +175,10 @@ public class GnmRandomGraphGenerator<V, E>
         }
 
         // create vertices
-        Map<Integer, V> vertices = CollectionUtil.newHashMapWithExpectedSize(n);
+        List<V> vertices = new ArrayList<>(n);
         int previousVertexSetSize = target.vertexSet().size();
         for (int i = 0; i < n; i++) {
-            vertices.put(i, target.addVertex());
+            vertices.add(target.addVertex());
         }
 
         if (target.vertexSet().size() != previousVertexSetSize + n) {
@@ -242,7 +241,7 @@ public class GnmRandomGraphGenerator<V, E>
      * @param createMultipleEdges if multiple (parallel) edges are allowed
      * @return the number of maximum edges
      */
-    static <V, E> int computeMaximumAllowedEdges(
+    static int computeMaximumAllowedEdges(
         int n, boolean isDirected, boolean createLoops, boolean createMultipleEdges)
     {
         if (n == 0) {
@@ -274,10 +273,8 @@ public class GnmRandomGraphGenerator<V, E>
                     }
                 }
             } else {
-                if (createMultipleEdges) {
-                    if (n > 1) {
-                        return Integer.MAX_VALUE;
-                    }
+                if (createMultipleEdges && n > 1) {
+                    return Integer.MAX_VALUE;
                 }
             }
         } catch (ArithmeticException e) {

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GnpRandomBipartiteGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GnpRandomBipartiteGraphGenerator.java
@@ -18,7 +18,6 @@
 package org.jgrapht.generate;
 
 import org.jgrapht.*;
-import org.jgrapht.util.*;
 
 import java.util.*;
 
@@ -48,8 +47,8 @@ public class GnpRandomBipartiteGraphGenerator<V, E>
     private final int n2;
     private final double p;
 
-    private Map<Integer, V> partitionA;
-    private Map<Integer, V> partitionB;
+    private List<V> partitionA;
+    private List<V> partitionB;
 
     /**
      * Create a new random bipartite graph generator. The generator uses the $G(n, p)$ model when $n
@@ -126,14 +125,14 @@ public class GnpRandomBipartiteGraphGenerator<V, E>
         // create vertices
         int previousVertexSetSize = target.vertexSet().size();
 
-        partitionA = CollectionUtil.newLinkedHashMapWithExpectedSize(n1);
+        partitionA = new ArrayList<>(n1);
         for (int i = 0; i < n1; i++) {
-            partitionA.put(i, target.addVertex());
+            partitionA.add(target.addVertex());
         }
 
-        partitionB = CollectionUtil.newLinkedHashMapWithExpectedSize(n2);
+        partitionB = new ArrayList<>(n2);
         for (int i = 0; i < n2; i++) {
-            partitionB.put(i, target.addVertex());
+            partitionB.add(target.addVertex());
         }
 
         if (target.vertexSet().size() != previousVertexSetSize + n1 + n2) {
@@ -155,11 +154,9 @@ public class GnpRandomBipartiteGraphGenerator<V, E>
                     target.addEdge(s, t);
                 }
 
-                if (isDirected) {
-                    // t->s
-                    if (rng.nextDouble() < p) {
-                        target.addEdge(t, s);
-                    }
+                // t->s
+                if (isDirected && rng.nextDouble() < p) {
+                    target.addEdge(t, s);
                 }
             }
         }
@@ -174,10 +171,11 @@ public class GnpRandomBipartiteGraphGenerator<V, E>
      */
     public Set<V> getFirstPartition()
     {
-        if (partitionA.size() <= partitionB.size())
-            return new LinkedHashSet<>(partitionA.values());
-        else
-            return new LinkedHashSet<>(partitionB.values());
+        if (partitionA.size() <= partitionB.size()) {
+            return new LinkedHashSet<>(partitionA);
+        } else {
+            return new LinkedHashSet<>(partitionB);
+        }
     }
 
     /**
@@ -188,10 +186,11 @@ public class GnpRandomBipartiteGraphGenerator<V, E>
      */
     public Set<V> getSecondPartition()
     {
-        if (partitionB.size() >= partitionA.size())
-            return new LinkedHashSet<>(partitionB.values());
-        else
-            return new LinkedHashSet<>(partitionA.values());
+        if (partitionB.size() >= partitionA.size()) {
+            return new LinkedHashSet<>(partitionB);
+        } else {
+            return new LinkedHashSet<>(partitionA);
+        }
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GnpRandomBipartiteGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GnpRandomBipartiteGraphGenerator.java
@@ -154,9 +154,11 @@ public class GnpRandomBipartiteGraphGenerator<V, E>
                     target.addEdge(s, t);
                 }
 
-                // t->s
-                if (isDirected && rng.nextDouble() < p) {
-                    target.addEdge(t, s);
+                if (isDirected) {
+                    // t->s
+                    if (rng.nextDouble() < p) {
+                        target.addEdge(t, s);
+                    }
                 }
             }
         }
@@ -171,11 +173,10 @@ public class GnpRandomBipartiteGraphGenerator<V, E>
      */
     public Set<V> getFirstPartition()
     {
-        if (partitionA.size() <= partitionB.size()) {
+        if (partitionA.size() <= partitionB.size())
             return new LinkedHashSet<>(partitionA);
-        } else {
+        else
             return new LinkedHashSet<>(partitionB);
-        }
     }
 
     /**
@@ -186,11 +187,10 @@ public class GnpRandomBipartiteGraphGenerator<V, E>
      */
     public Set<V> getSecondPartition()
     {
-        if (partitionB.size() >= partitionA.size()) {
+        if (partitionB.size() >= partitionA.size())
             return new LinkedHashSet<>(partitionB);
-        } else {
+        else
             return new LinkedHashSet<>(partitionA);
-        }
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GnpRandomGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GnpRandomGraphGenerator.java
@@ -18,7 +18,6 @@
 package org.jgrapht.generate;
 
 import org.jgrapht.*;
-import org.jgrapht.util.*;
 
 import java.util.*;
 
@@ -134,9 +133,10 @@ public class GnpRandomGraphGenerator<V, E>
 
         // create vertices
         int previousVertexSetSize = target.vertexSet().size();
-        Map<Integer, V> vertices = CollectionUtil.newHashMapWithExpectedSize(n);
+        List<V> vertices = new ArrayList<>(n);
+
         for (int i = 0; i < n; i++) {
-            vertices.put(i, target.addVertex());
+            vertices.add(target.addVertex());
         }
 
         if (target.vertexSet().size() != previousVertexSetSize + n) {
@@ -151,11 +151,9 @@ public class GnpRandomGraphGenerator<V, E>
         for (int i = 0; i < n; i++) {
             for (int j = i; j < n; j++) {
 
-                if (i == j) {
-                    if (!createLoops) {
-                        // no self-loops
-                        continue;
-                    }
+                if (i == j && !createLoops) {
+                    // no self-loops
+                    continue;
                 }
 
                 V s = null;
@@ -167,16 +165,13 @@ public class GnpRandomGraphGenerator<V, E>
                     t = vertices.get(j);
                     target.addEdge(s, t);
                 }
-
-                if (isDirected) {
-                    // t->s
-                    if (rng.nextDouble() < p) {
-                        if (s == null) {
-                            s = vertices.get(i);
-                            t = vertices.get(j);
-                        }
-                        target.addEdge(t, s);
+                // t->s
+                if (isDirected && rng.nextDouble() < p) {
+                    if (s == null) {
+                        s = vertices.get(i);
+                        t = vertices.get(j);
                     }
+                    target.addEdge(t, s);
                 }
             }
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GnpRandomGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GnpRandomGraphGenerator.java
@@ -151,9 +151,11 @@ public class GnpRandomGraphGenerator<V, E>
         for (int i = 0; i < n; i++) {
             for (int j = i; j < n; j++) {
 
-                if (i == j && !createLoops) {
-                    // no self-loops
-                    continue;
+                if (i == j) {
+                    if (!createLoops) {
+                        // no self-loops
+                        continue;
+                    }
                 }
 
                 V s = null;
@@ -165,13 +167,16 @@ public class GnpRandomGraphGenerator<V, E>
                     t = vertices.get(j);
                     target.addEdge(s, t);
                 }
-                // t->s
-                if (isDirected && rng.nextDouble() < p) {
-                    if (s == null) {
-                        s = vertices.get(i);
-                        t = vertices.get(j);
+
+                if (isDirected) {
+                    // t->s
+                    if (rng.nextDouble() < p) {
+                        if (s == null) {
+                            s = vertices.get(i);
+                            t = vertices.get(j);
+                        }
+                        target.addEdge(t, s);
                     }
-                    target.addEdge(t, s);
                 }
             }
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GridGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GridGraphGenerator.java
@@ -71,13 +71,14 @@ public class GridGraphGenerator<V, E>
     @Override
     public void generateGraph(Graph<V, E> target, Map<String, V> resultMap)
     {
-        Map<Integer, V> map = new TreeMap<>();
+        List<V> list = new ArrayList<>();
+        list.add(null); // add zero'th element to enable one based indices
 
         // Adding all vertices to the set
         int cornerCtr = 0;
         for (int i = 0; i < rows * cols; i++) {
             V vertex = target.addVertex();
-            map.put(i + 1, vertex);
+            list.add(vertex);
 
             boolean isCorner = (i == 0) || (i == (cols - 1)) || (i == (cols * (rows - 1)))
                 || (i == ((rows * cols) - 1));
@@ -91,11 +92,11 @@ public class GridGraphGenerator<V, E>
         // second addEdge call will return nothing; it will not add a the edge
         // at the opposite direction. For directed graph, edges in opposite
         // direction are also added.
-        for (int i : map.keySet()) {
-            for (int j : map.keySet()) {
+        for (int i = 1; i <= list.size(); i++) {
+            for (int j = 1; j <= list.size(); j++) {
                 if ((((i % cols) > 0) && ((i + 1) == j)) || ((i + cols) == j)) {
-                    target.addEdge(map.get(i), map.get(j));
-                    target.addEdge(map.get(j), map.get(i));
+                    target.addEdge(list.get(i), list.get(j));
+                    target.addEdge(list.get(j), list.get(i));
                 }
             }
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GridGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GridGraphGenerator.java
@@ -71,13 +71,13 @@ public class GridGraphGenerator<V, E>
     @Override
     public void generateGraph(Graph<V, E> target, Map<String, V> resultMap)
     {
-        List<V> list = new ArrayList<>();
+        List<V> vertices = new ArrayList<>(rows * cols);
 
         // Adding all vertices to the set
         int cornerCtr = 0;
         for (int i = 0; i < rows * cols; i++) {
             V vertex = target.addVertex();
-            list.add(vertex);
+            vertices.add(vertex);
 
             boolean isCorner = (i == 0) || (i == (cols - 1)) || (i == (cols * (rows - 1)))
                 || (i == ((rows * cols) - 1));
@@ -91,11 +91,11 @@ public class GridGraphGenerator<V, E>
         // second addEdge call will return nothing; it will not add a the edge
         // at the opposite direction. For directed graph, edges in opposite
         // direction are also added.
-        for (int i = 1; i <= list.size(); i++) {
-            for (int j = 1; j <= list.size(); j++) {
+        for (int i = 1; i <= vertices.size(); i++) {
+            for (int j = 1; j <= vertices.size(); j++) {
                 if ((((i % cols) > 0) && ((i + 1) == j)) || ((i + cols) == j)) {
-                    target.addEdge(list.get(i - 1), list.get(j - 1));
-                    target.addEdge(list.get(j - 1), list.get(i - 1));
+                    target.addEdge(vertices.get(i - 1), vertices.get(j - 1));
+                    target.addEdge(vertices.get(j - 1), vertices.get(i - 1));
                 }
             }
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GridGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GridGraphGenerator.java
@@ -72,7 +72,6 @@ public class GridGraphGenerator<V, E>
     public void generateGraph(Graph<V, E> target, Map<String, V> resultMap)
     {
         List<V> list = new ArrayList<>();
-        list.add(null); // add zero'th element to enable one based indices
 
         // Adding all vertices to the set
         int cornerCtr = 0;
@@ -95,8 +94,8 @@ public class GridGraphGenerator<V, E>
         for (int i = 1; i <= list.size(); i++) {
             for (int j = 1; j <= list.size(); j++) {
                 if ((((i % cols) > 0) && ((i + 1) == j)) || ((i + cols) == j)) {
-                    target.addEdge(list.get(i), list.get(j));
-                    target.addEdge(list.get(j), list.get(i));
+                    target.addEdge(list.get(i - 1), list.get(j - 1));
+                    target.addEdge(list.get(j - 1), list.get(i - 1));
                 }
             }
         }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/DIMACSImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/DIMACSImporter.java
@@ -90,6 +90,7 @@ public class DIMACSImporter<V, E>
      */
     public DIMACSImporter(double defaultWeight)
     {
+        super();
         this.defaultWeight = defaultWeight;
     }
 
@@ -214,5 +215,4 @@ public class DIMACSImporter<V, E>
     {
         return index < list.size() ? list.get(index) : null;
     }
-
 }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/DIMACSImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/DIMACSImporter.java
@@ -188,13 +188,13 @@ public class DIMACSImporter<V, E>
 
         public final Consumer<Triple<Integer, Integer, Double>> edgeConsumer = t -> {
             int source = t.getFirst();
-            V from = list.get(source - 1);
+            V from = getElement(list, source - 1);
             if (from == null) {
                 throw new ImportException("Node " + source + " does not exist");
             }
 
             int target = t.getSecond();
-            V to = list.get(target - 1);
+            V to = getElement(list, target - 1);
             if (to == null) {
                 throw new ImportException("Node " + target + " does not exist");
             }
@@ -208,6 +208,11 @@ public class DIMACSImporter<V, E>
             notifyEdge(e);
         };
 
+    }
+
+    private static <E> E getElement(List<E> list, int index)
+    {
+        return index < list.size() ? list.get(index) : null;
     }
 
 }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/DIMACSImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/DIMACSImporter.java
@@ -159,11 +159,12 @@ public class DIMACSImporter<V, E>
     private class Consumers
     {
         private Graph<V, E> graph;
-        private final List<V> list = new ArrayList<>();
+        private List<V> list;
 
         public Consumers(Graph<V, E> graph)
         {
             this.graph = graph;
+            this.list = new ArrayList<>();
         }
 
         public final Consumer<Integer> nodeCountConsumer = n -> {

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/DIMACSImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/DIMACSImporter.java
@@ -90,7 +90,6 @@ public class DIMACSImporter<V, E>
      */
     public DIMACSImporter(double defaultWeight)
     {
-        super();
         this.defaultWeight = defaultWeight;
     }
 
@@ -159,19 +158,15 @@ public class DIMACSImporter<V, E>
     private class Consumers
     {
         private Graph<V, E> graph;
-        private Integer nodeCount;
-        private Map<Integer, V> map;
+        private final List<V> list = new ArrayList<>();
 
         public Consumers(Graph<V, E> graph)
         {
             this.graph = graph;
-            this.nodeCount = null;
-            this.map = new HashMap<Integer, V>();
         }
 
-        public final Consumer<Integer> nodeCountConsumer = (n) -> {
-            this.nodeCount = n;
-            for (int i = 1; i <= nodeCount; i++) {
+        public final Consumer<Integer> nodeCountConsumer = n -> {
+            for (int i = 1; i <= n; i++) {
                 V v;
                 if (vertexFactory != null) {
                     v = vertexFactory.apply(i);
@@ -180,7 +175,7 @@ public class DIMACSImporter<V, E>
                     v = graph.addVertex();
                 }
 
-                map.put(i, v);
+                list.add(v);
 
                 /*
                  * Notify the first time we create the node.
@@ -191,15 +186,15 @@ public class DIMACSImporter<V, E>
             }
         };
 
-        public final Consumer<Triple<Integer, Integer, Double>> edgeConsumer = (t) -> {
+        public final Consumer<Triple<Integer, Integer, Double>> edgeConsumer = t -> {
             int source = t.getFirst();
-            V from = map.get(t.getFirst());
+            V from = list.get(source - 1);
             if (from == null) {
                 throw new ImportException("Node " + source + " does not exist");
             }
 
             int target = t.getSecond();
-            V to = map.get(target);
+            V to = list.get(target - 1);
             if (to == null) {
                 throw new ImportException("Node " + target + " does not exist");
             }


### PR DESCRIPTION
While looking into the `GnpRandomGraphGenerator` I noticed that it is using a Map<Integer, E> where the keys are consecutive int values. In this case a ArrayList is the better data structure to choose in terms of runtime and memory demand.

Getting an element at a certain index of a `ArrayList` is much faster than getting the value of a key from a `HashMap` plus autoboxing from int to integer objects is avoided. Additionally the memory demand of a ArrayList with the same number of elements/entrys is clearly smaller because the backing array is smaller and entry-Objects are avoided.
Furthermore Map<Integer,Integer> is replaced by an int-array, if possible.

Using a Integer-key in maps is only useful if the keys are not consecutive values.

There are many more places in JGraphT where Maps with Integer-keys are used but from a first look at the classes I cannot say if the integer-keys are consecutive. If you know more classes where this change is applicable, I can include them.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
