### PR TITLE
Leverage Java-11's Set.of()

### DIFF
--- a/jgrapht-core/src/test/java/org/jgrapht/GraphsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/GraphsTest.java
@@ -443,7 +443,7 @@ public class GraphsTest
         graph.addEdge(3, 4);
         graph.addEdge(1, 4);
         Set<Integer> neighborSet = Graphs.neighborSetOf(graph, 1);
-        Assert.assertEquals(new HashSet<>(Arrays.asList(2, 4)), neighborSet);
+        Assert.assertEquals(Set.of(2, 4), neighborSet);
     }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/clique/CliqueMinimalSeparatorDecompositionTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/clique/CliqueMinimalSeparatorDecompositionTest.java
@@ -69,9 +69,9 @@ public class CliqueMinimalSeparatorDecompositionTest
         // check atoms
         boolean atom1found = false, atom2found = false;
         for (Set<Integer> atom : cmsd.getAtoms()) {
-            if (atom.equals(new HashSet<>(Arrays.asList(1, 2, 3)))) {
+            if (atom.equals(Set.of(1, 2, 3))) {
                 atom1found = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList(2, 3, 4)))) {
+            } else if (atom.equals(Set.of(2, 3, 4))) {
                 atom2found = true;
             }
         }
@@ -82,7 +82,7 @@ public class CliqueMinimalSeparatorDecompositionTest
         // check seprators
         boolean separator1found = false;
         for (Set<Integer> separator : cmsd.getSeparators()) {
-            if (separator.equals(new HashSet<>(Arrays.asList(2, 3)))) {
+            if (separator.equals(Set.of(2, 3))) {
                 separator1found = true;
             }
         }
@@ -127,9 +127,9 @@ public class CliqueMinimalSeparatorDecompositionTest
         // check atoms
         boolean atom1found = false, atom2found = false;
         for (Set<Integer> atom : cmsd.getAtoms()) {
-            if (atom.equals(new HashSet<>(Arrays.asList(1, 2, 3)))) {
+            if (atom.equals(Set.of(1, 2, 3))) {
                 atom1found = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList(2, 3, 4)))) {
+            } else if (atom.equals(Set.of(2, 3, 4))) {
                 atom2found = true;
             }
         }
@@ -140,7 +140,7 @@ public class CliqueMinimalSeparatorDecompositionTest
         // check seprators
         boolean separator1found = false;
         for (Set<Integer> separator : cmsd.getSeparators()) {
-            if (separator.equals(new HashSet<>(Arrays.asList(2, 3)))) {
+            if (separator.equals(Set.of(2, 3))) {
                 separator1found = true;
             }
         }
@@ -179,7 +179,7 @@ public class CliqueMinimalSeparatorDecompositionTest
         // check atoms
         boolean atom1found = false;
         for (Set<Integer> atom : cmsd.getAtoms()) {
-            if (atom.equals(new HashSet<>(Arrays.asList(1, 2, 3, 4)))) {
+            if (atom.equals(Set.of(1, 2, 3, 4))) {
                 atom1found = true;
             }
         }
@@ -243,13 +243,13 @@ public class CliqueMinimalSeparatorDecompositionTest
         // check atoms
         boolean atom1found = false, atom2found = false, atom3found = false, atom4found = false;
         for (Set<String> atom : cmsd.getAtoms()) {
-            if (atom.equals(new HashSet<>(Arrays.asList("a", "b", "c", "k")))) {
+            if (atom.equals(Set.of("a", "b", "c", "k"))) {
                 atom1found = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("c", "d", "j", "k")))) {
+            } else if (atom.equals(Set.of("c", "d", "j", "k"))) {
                 atom2found = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("h", "i", "j", "k")))) {
+            } else if (atom.equals(Set.of("h", "i", "j", "k"))) {
                 atom3found = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("d", "e", "f", "g", "j", "k")))) {
+            } else if (atom.equals(Set.of("d", "e", "f", "g", "j", "k"))) {
                 atom4found = true;
             }
         }
@@ -262,11 +262,11 @@ public class CliqueMinimalSeparatorDecompositionTest
         // check seprators
         boolean separator1found = false, separator2found = false, separator3found = false;
         for (Set<String> separator : cmsd.getSeparators()) {
-            if (separator.equals(new HashSet<>(Arrays.asList("c", "k")))) {
+            if (separator.equals(Set.of("c", "k"))) {
                 separator1found = true;
-            } else if (separator.equals(new HashSet<>(Arrays.asList("j", "k")))) {
+            } else if (separator.equals(Set.of("j", "k"))) {
                 separator2found = true;
-            } else if (separator.equals(new HashSet<>(Arrays.asList("d", "j", "k")))) {
+            } else if (separator.equals(Set.of("d", "j", "k"))) {
                 separator3found = true;
             }
         }
@@ -331,13 +331,13 @@ public class CliqueMinimalSeparatorDecompositionTest
         // check atoms
         boolean atom1found = false, atom2found = false, atom3found = false, atom4found = false;
         for (Set<String> atom : cmsd.getAtoms()) {
-            if (atom.equals(new HashSet<>(Arrays.asList("a", "c", "d", "f")))) {
+            if (atom.equals(Set.of("a", "c", "d", "f"))) {
                 atom1found = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("b", "c", "g", "h")))) {
+            } else if (atom.equals(Set.of("b", "c", "g", "h"))) {
                 atom2found = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("d", "e", "i", "j")))) {
+            } else if (atom.equals(Set.of("d", "e", "i", "j"))) {
                 atom3found = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("c", "d", "f", "h", "i", "k")))) {
+            } else if (atom.equals(Set.of("c", "d", "f", "h", "i", "k"))) {
                 atom4found = true;
             }
         }
@@ -350,11 +350,11 @@ public class CliqueMinimalSeparatorDecompositionTest
         // check seprators
         boolean separator1found = false, separator2found = false, separator3found = false;
         for (Set<String> separator : cmsd.getSeparators()) {
-            if (separator.equals(new HashSet<>(Arrays.asList("c", "d", "f")))) {
+            if (separator.equals(Set.of("c", "d", "f"))) {
                 separator1found = true;
-            } else if (separator.equals(new HashSet<>(Arrays.asList("c", "h")))) {
+            } else if (separator.equals(Set.of("c", "h"))) {
                 separator2found = true;
-            } else if (separator.equals(new HashSet<>(Arrays.asList("d", "i")))) {
+            } else if (separator.equals(Set.of("d", "i"))) {
                 separator3found = true;
             }
         }
@@ -421,23 +421,23 @@ public class CliqueMinimalSeparatorDecompositionTest
         assertEquals(9, cmsd.getAtoms().size());
         boolean[] atomsFound = new boolean[cmsd.getAtoms().size()];
         for (Set<String> atom : cmsd.getAtoms()) {
-            if (atom.equals(new HashSet<>(Arrays.asList("a", "b", "d", "e")))) {
+            if (atom.equals(Set.of("a", "b", "d", "e"))) {
                 atomsFound[0] = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("c", "e")))) {
+            } else if (atom.equals(Set.of("c", "e"))) {
                 atomsFound[1] = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("d", "g", "i")))) {
+            } else if (atom.equals(Set.of("d", "g", "i"))) {
                 atomsFound[2] = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("d", "h", "i")))) {
+            } else if (atom.equals(Set.of("d", "h", "i"))) {
                 atomsFound[3] = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("d", "e", "i", "j")))) {
+            } else if (atom.equals(Set.of("d", "e", "i", "j"))) {
                 atomsFound[4] = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("e", "f", "j", "k")))) {
+            } else if (atom.equals(Set.of("e", "f", "j", "k"))) {
                 atomsFound[5] = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("i", "l")))) {
+            } else if (atom.equals(Set.of("i", "l"))) {
                 atomsFound[6] = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("i", "j", "m")))) {
+            } else if (atom.equals(Set.of("i", "j", "m"))) {
                 atomsFound[7] = true;
-            } else if (atom.equals(new HashSet<>(Arrays.asList("i", "j", "n")))) {
+            } else if (atom.equals(Set.of("i", "j", "n"))) {
                 atomsFound[8] = true;
             }
         }
@@ -448,17 +448,17 @@ public class CliqueMinimalSeparatorDecompositionTest
         assertEquals(6, cmsd.getSeparators().size());
         boolean[] separatorsFound = new boolean[cmsd.getSeparators().size()];
         for (Set<String> separator : cmsd.getSeparators()) {
-            if (separator.equals(new HashSet<>(Arrays.asList("d", "e")))) {
+            if (separator.equals(Set.of("d", "e"))) {
                 separatorsFound[0] = true;
-            } else if (separator.equals(new HashSet<>(Collections.singletonList("e")))) {
+            } else if (separator.equals(Set.of("e"))) {
                 separatorsFound[1] = true;
-            } else if (separator.equals(new HashSet<>(Arrays.asList("d", "i")))) {
+            } else if (separator.equals(Set.of("d", "i"))) {
                 separatorsFound[2] = true;
-            } else if (separator.equals(new HashSet<>(Collections.singletonList("i")))) {
+            } else if (separator.equals(Set.of("i"))) {
                 separatorsFound[3] = true;
-            } else if (separator.equals(new HashSet<>(Arrays.asList("e", "j")))) {
+            } else if (separator.equals(Set.of("e", "j"))) {
                 separatorsFound[4] = true;
-            } else if (separator.equals(new HashSet<>(Arrays.asList("i", "j")))) {
+            } else if (separator.equals(Set.of("i", "j"))) {
                 separatorsFound[5] = true;
             }
         }
@@ -468,29 +468,17 @@ public class CliqueMinimalSeparatorDecompositionTest
         // check component counts
         assertEquals(6, cmsd.getFullComponentCount().size());
 
-        assertEquals(
-            2, cmsd.getFullComponentCount().get(new HashSet<>(Arrays.asList("d", "e"))).intValue());
+        assertEquals(2, cmsd.getFullComponentCount().get(Set.of("d", "e")).intValue());
 
-        assertEquals(
-            2,
-            cmsd
-                .getFullComponentCount().get(new HashSet<>(Collections.singletonList("e")))
-                .intValue());
+        assertEquals(2, cmsd.getFullComponentCount().get(Set.of("e")).intValue());
 
-        assertEquals(
-            3, cmsd.getFullComponentCount().get(new HashSet<>(Arrays.asList("d", "i"))).intValue());
+        assertEquals(3, cmsd.getFullComponentCount().get(Set.of("d", "i")).intValue());
 
-        assertEquals(
-            2,
-            cmsd
-                .getFullComponentCount().get(new HashSet<>(Collections.singletonList("i")))
-                .intValue());
+        assertEquals(2, cmsd.getFullComponentCount().get(Set.of("i")).intValue());
 
-        assertEquals(
-            2, cmsd.getFullComponentCount().get(new HashSet<>(Arrays.asList("e", "j"))).intValue());
+        assertEquals(2, cmsd.getFullComponentCount().get(Set.of("e", "j")).intValue());
 
-        assertEquals(
-            3, cmsd.getFullComponentCount().get(new HashSet<>(Arrays.asList("i", "j"))).intValue());
+        assertEquals(3, cmsd.getFullComponentCount().get(Set.of("i", "j")).intValue());
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/clustering/KSpanningTreeClusteringTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/clustering/KSpanningTreeClusteringTest.java
@@ -67,9 +67,9 @@ public class KSpanningTreeClusteringTest
         assertEquals(clustering.getNumberClusters(), k);
         List<Set<Integer>> clusters = clustering.getClusters();
 
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 2, 3, 4, 5, 6)), clusters.get(0));
-        assertEquals(new HashSet<>(Arrays.asList(7)), clusters.get(1));
-        assertEquals(new HashSet<>(Arrays.asList(8)), clusters.get(2));
+        assertEquals(Set.of(0, 1, 2, 3, 4, 5, 6), clusters.get(0));
+        assertEquals(Set.of(7), clusters.get(1));
+        assertEquals(Set.of(8), clusters.get(2));
     }
 
     @Test
@@ -104,10 +104,10 @@ public class KSpanningTreeClusteringTest
         assertEquals(clustering.getNumberClusters(), k);
         List<Set<Integer>> clusters = clustering.getClusters();
 
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 5)), clusters.get(0));
-        assertEquals(new HashSet<>(Arrays.asList(2, 3, 4)), clusters.get(1));
-        assertEquals(new HashSet<>(Arrays.asList(6)), clusters.get(2));
-        assertEquals(new HashSet<>(Arrays.asList(7, 8)), clusters.get(3));
+        assertEquals(Set.of(0, 1, 5), clusters.get(0));
+        assertEquals(Set.of(2, 3, 4), clusters.get(1));
+        assertEquals(Set.of(6), clusters.get(2));
+        assertEquals(Set.of(7, 8), clusters.get(3));
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/clustering/LabelPropagationClusteringTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/clustering/LabelPropagationClusteringTest.java
@@ -67,7 +67,7 @@ public class LabelPropagationClusteringTest
         assertEquals(1, clustering.getNumberClusters());
         List<Set<Integer>> clusters = clustering.getClusters();
 
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 2, 3, 4, 5, 6, 7, 8)), clusters.get(0));
+        assertEquals(Set.of(0, 1, 2, 3, 4, 5, 6, 7, 8), clusters.get(0));
     }
 
     @Test
@@ -108,8 +108,8 @@ public class LabelPropagationClusteringTest
         assertEquals(2, clustering.getNumberClusters());
         List<Set<Integer>> clusters = clustering.getClusters();
 
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 2, 3)), clusters.get(0));
-        assertEquals(new HashSet<>(Arrays.asList(4, 5, 6, 7)), clusters.get(1));
+        assertEquals(Set.of(0, 1, 2, 3), clusters.get(0));
+        assertEquals(Set.of(4, 5, 6, 7), clusters.get(1));
     }
 
     @Test
@@ -160,9 +160,9 @@ public class LabelPropagationClusteringTest
         assertEquals(3, clustering.getNumberClusters());
         List<Set<Integer>> clusters = clustering.getClusters();
 
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 2, 3)), clusters.get(0));
-        assertEquals(new HashSet<>(Arrays.asList(4, 5, 6, 7)), clusters.get(1));
-        assertEquals(new HashSet<>(Arrays.asList(8, 9, 10, 11)), clusters.get(2));
+        assertEquals(Set.of(0, 1, 2, 3), clusters.get(0));
+        assertEquals(Set.of(4, 5, 6, 7), clusters.get(1));
+        assertEquals(Set.of(8, 9, 10, 11), clusters.get(2));
     }
 
     @Test
@@ -189,8 +189,8 @@ public class LabelPropagationClusteringTest
         assertEquals(2, clustering.getNumberClusters());
         List<Set<Integer>> clusters = clustering.getClusters();
 
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 2)), clusters.get(0));
-        assertEquals(new HashSet<>(Arrays.asList(3)), clusters.get(1));
+        assertEquals(Set.of(0, 1, 2), clusters.get(0));
+        assertEquals(Set.of(3), clusters.get(1));
     }
     
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/connectivity/BiconnectivityInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/connectivity/BiconnectivityInspectorTest.java
@@ -100,8 +100,8 @@ public class BiconnectivityInspectorTest
         assertEquals(2, inspector.getConnectedComponents().size());
         assertFalse(inspector.isConnected());
 
-        Graph<Integer, DefaultEdge> g1 = new AsSubgraph<>(g, new HashSet<>(Arrays.asList(1, 2, 3)));
-        Graph<Integer, DefaultEdge> g2 = new AsSubgraph<>(g, new HashSet<>(Arrays.asList(4, 5)));
+        Graph<Integer, DefaultEdge> g1 = new AsSubgraph<>(g, Set.of(1, 2, 3));
+        Graph<Integer, DefaultEdge> g2 = new AsSubgraph<>(g, Set.of(4, 5));
 
         for (Integer v : g1.vertexSet())
             assertEquals(g1, inspector.getConnectedComponent(v));
@@ -124,7 +124,7 @@ public class BiconnectivityInspectorTest
 
         assertTrue(inspector.isConnected());
 
-        Set<Integer> expectedCutpoints = new HashSet<>(Arrays.asList(4, 5, 6, 7, 9));
+        Set<Integer> expectedCutpoints = Set.of(4, 5, 6, 7, 9);
         assertEquals(expectedCutpoints, inspector.getCutpoints());
 
         Set<DefaultEdge> expectedBridges = new HashSet<>();
@@ -137,13 +137,13 @@ public class BiconnectivityInspectorTest
 
         // Check vertex to block mapping
         List<Graph<Integer, DefaultEdge>> blocks = new ArrayList<>();
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(1, 2, 3, 4)))); // 0
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(4, 5)))); // 1
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(5, 6)))); // 2
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(6, 7)))); // 3
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(7, 8)))); // 4
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(9, 10)))); // 5
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(7, 9, 11, 12, 13, 14)))); // 6
+        blocks.add(new AsSubgraph<>(g, Set.of(1, 2, 3, 4))); // 0
+        blocks.add(new AsSubgraph<>(g, Set.of(4, 5))); // 1
+        blocks.add(new AsSubgraph<>(g, Set.of(5, 6))); // 2
+        blocks.add(new AsSubgraph<>(g, Set.of(6, 7))); // 3
+        blocks.add(new AsSubgraph<>(g, Set.of(7, 8))); // 4
+        blocks.add(new AsSubgraph<>(g, Set.of(9, 10))); // 5
+        blocks.add(new AsSubgraph<>(g, Set.of(7, 9, 11, 12, 13, 14))); // 6
 
         for (int v : Arrays.asList(1, 2, 3))
             assertEquals(Collections.singleton(blocks.get(0)), inspector.getBlocks(v));
@@ -153,17 +153,11 @@ public class BiconnectivityInspectorTest
         }
 
         // cutpoints reside in multiple blocks
-        assertEquals(
-            new HashSet<>(Arrays.asList(blocks.get(0), blocks.get(1))), inspector.getBlocks(4));
-        assertEquals(
-            new HashSet<>(Arrays.asList(blocks.get(1), blocks.get(2))), inspector.getBlocks(5));
-        assertEquals(
-            new HashSet<>(Arrays.asList(blocks.get(2), blocks.get(3))), inspector.getBlocks(6));
-        assertEquals(
-            new HashSet<>(Arrays.asList(blocks.get(3), blocks.get(4), blocks.get(6))),
-            inspector.getBlocks(7));
-        assertEquals(
-            new HashSet<>(Arrays.asList(blocks.get(5), blocks.get(6))), inspector.getBlocks(9));
+        assertEquals(Set.of(blocks.get(0), blocks.get(1)), inspector.getBlocks(4));
+        assertEquals(Set.of(blocks.get(1), blocks.get(2)), inspector.getBlocks(5));
+        assertEquals(Set.of(blocks.get(2), blocks.get(3)), inspector.getBlocks(6));
+        assertEquals(Set.of(blocks.get(3), blocks.get(4), blocks.get(6)), inspector.getBlocks(7));
+        assertEquals(Set.of(blocks.get(5), blocks.get(6)), inspector.getBlocks(9));
 
     }
 
@@ -183,8 +177,8 @@ public class BiconnectivityInspectorTest
         assertEquals(Collections.singleton(bridge), inspector.getBridges());
 
         List<Graph<Integer, DefaultEdge>> blocks = new ArrayList<>();
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(0, 1)))); // 0
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(1, 2)))); // 1
+        blocks.add(new AsSubgraph<>(g, Set.of(0, 1))); // 0
+        blocks.add(new AsSubgraph<>(g, Set.of(1, 2))); // 1
 
         assertEquals(new HashSet<>(blocks), inspector.getBlocks());
     }
@@ -206,20 +200,20 @@ public class BiconnectivityInspectorTest
 
         assertTrue(inspector.isConnected());
 
-        Set<Integer> expectedCutpoints = new HashSet<>(Arrays.asList(4, 5, 6, 7, 9));
+        Set<Integer> expectedCutpoints = Set.of(4, 5, 6, 7, 9);
         assertEquals(expectedCutpoints, inspector.getCutpoints());
 
         assertEquals(Collections.emptySet(), inspector.getBridges());
 
         // Check vertex to block mapping
         List<Graph<Integer, DefaultEdge>> blocks = new ArrayList<>();
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(1, 2, 3, 4)))); // 0
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(4, 5)))); // 1
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(5, 6)))); // 2
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(6, 7)))); // 3
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(7, 8)))); // 4
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(9, 10)))); // 5
-        blocks.add(new AsSubgraph<>(g, new HashSet<>(Arrays.asList(7, 9, 11, 12, 13, 14)))); // 6
+        blocks.add(new AsSubgraph<>(g, Set.of(1, 2, 3, 4))); // 0
+        blocks.add(new AsSubgraph<>(g, Set.of(4, 5))); // 1
+        blocks.add(new AsSubgraph<>(g, Set.of(5, 6))); // 2
+        blocks.add(new AsSubgraph<>(g, Set.of(6, 7))); // 3
+        blocks.add(new AsSubgraph<>(g, Set.of(7, 8))); // 4
+        blocks.add(new AsSubgraph<>(g, Set.of(9, 10))); // 5
+        blocks.add(new AsSubgraph<>(g, Set.of(7, 9, 11, 12, 13, 14))); // 6
 
         for (int v : Arrays.asList(1, 2, 3))
             assertEquals(Collections.singleton(blocks.get(0)), inspector.getBlocks(v));
@@ -229,17 +223,11 @@ public class BiconnectivityInspectorTest
         }
 
         // cutpoints reside in multiple blocks
-        assertEquals(
-            new HashSet<>(Arrays.asList(blocks.get(0), blocks.get(1))), inspector.getBlocks(4));
-        assertEquals(
-            new HashSet<>(Arrays.asList(blocks.get(1), blocks.get(2))), inspector.getBlocks(5));
-        assertEquals(
-            new HashSet<>(Arrays.asList(blocks.get(2), blocks.get(3))), inspector.getBlocks(6));
-        assertEquals(
-            new HashSet<>(Arrays.asList(blocks.get(3), blocks.get(4), blocks.get(6))),
-            inspector.getBlocks(7));
-        assertEquals(
-            new HashSet<>(Arrays.asList(blocks.get(5), blocks.get(6))), inspector.getBlocks(9));
+        assertEquals(Set.of(blocks.get(0), blocks.get(1)), inspector.getBlocks(4));
+        assertEquals(Set.of(blocks.get(1), blocks.get(2)), inspector.getBlocks(5));
+        assertEquals(Set.of(blocks.get(2), blocks.get(3)), inspector.getBlocks(6));
+        assertEquals(Set.of(blocks.get(3), blocks.get(4), blocks.get(6)), inspector.getBlocks(7));
+        assertEquals(Set.of(blocks.get(5), blocks.get(6)), inspector.getBlocks(9));
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinderTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/ChordalGraphMinimalVertexSeparatorFinderTest.java
@@ -65,7 +65,7 @@ public class ChordalGraphMinimalVertexSeparatorFinderTest
         Map<Set<Integer>, Integer> separatorsAndMultiplicities =
             finder.getMinimalSeparatorsWithMultiplicities();
         Map<Set<Integer>, Integer> expected = new HashMap<>();
-        expected.put(new HashSet<>(Arrays.asList(2, 3)), 1);
+        expected.put(Set.of(2, 3), 1);
         assertEquals(expected.keySet(), separators);
         assertEquals(expected, separatorsAndMultiplicities);
     }
@@ -88,10 +88,10 @@ public class ChordalGraphMinimalVertexSeparatorFinderTest
         Map<Set<Integer>, Integer> separatorsAndMultiplicities =
             finder.getMinimalSeparatorsWithMultiplicities();
         Map<Set<Integer>, Integer> expected = new HashMap<>();
-        expected.put(new HashSet<>(Collections.singletonList(3)), 1);
-        expected.put(new HashSet<>(Arrays.asList(3, 6)), 2);
-        expected.put(new HashSet<>(Arrays.asList(8, 10)), 1);
-        expected.put(new HashSet<>(Arrays.asList(6, 8, 10)), 1);
+        expected.put(Set.of(3), 1);
+        expected.put(Set.of(3, 6), 2);
+        expected.put(Set.of(8, 10), 1);
+        expected.put(Set.of(6, 8, 10), 1);
         assertEquals(expected.keySet(), separators);
         assertEquals(expected, separatorsAndMultiplicities);
     }
@@ -114,10 +114,10 @@ public class ChordalGraphMinimalVertexSeparatorFinderTest
         Map<Set<Integer>, Integer> separatorsAndMultiplicities =
             finder.getMinimalSeparatorsWithMultiplicities();
         Map<Set<Integer>, Integer> expected = new HashMap<>();
-        expected.put(new HashSet<>(Collections.singletonList(2)), 1);
-        expected.put(new HashSet<>(Arrays.asList(6, 8)), 2);
-        expected.put(new HashSet<>(Arrays.asList(8, 9)), 3);
-        expected.put(new HashSet<>(Arrays.asList(8, 9, 11)), 1);
+        expected.put(Set.of(2), 1);
+        expected.put(Set.of(6, 8), 2);
+        expected.put(Set.of(8, 9), 3);
+        expected.put(Set.of(8, 9, 11), 1);
         assertEquals(expected.keySet(), separators);
         assertEquals(expected, separatorsAndMultiplicities);
     }
@@ -156,8 +156,8 @@ public class ChordalGraphMinimalVertexSeparatorFinderTest
         Map<Set<Integer>, Integer> separatorsAndMultiplicities =
             finder.getMinimalSeparatorsWithMultiplicities();
         Map<Set<Integer>, Integer> expected = new HashMap<>();
-        expected.put(new HashSet<>(Collections.singletonList(2)), 1);
-        expected.put(new HashSet<>(Arrays.asList(3, 5)), 1);
+        expected.put(Set.of(2), 1);
+        expected.put(Set.of(3, 5), 1);
         assertEquals(expected.keySet(), separators);
         assertEquals(expected, separatorsAndMultiplicities);
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PadbergRaoOddMinimumCutsetTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/flow/PadbergRaoOddMinimumCutsetTest.java
@@ -103,9 +103,9 @@ public class PadbergRaoOddMinimumCutsetTest
     @Test
     public void testIsOddSetMethod()
     {
-        Set<Integer> vertices = new HashSet<>(Arrays.asList(1, 2, 3, 4, 5, 6));
-        Set<Integer> oddVertices1 = new HashSet<>(Arrays.asList(1, 2, 3, 7));
-        Set<Integer> oddVertices2 = new HashSet<>(Arrays.asList(1, 2, 3, 4));
+        Set<Integer> vertices = Set.of(1, 2, 3, 4, 5, 6);
+        Set<Integer> oddVertices1 = Set.of(1, 2, 3, 7);
+        Set<Integer> oddVertices2 = Set.of(1, 2, 3, 4);
         assertTrue(PadbergRaoOddMinimumCutset.isOddVertexSet(vertices, oddVertices1));
         assertFalse(PadbergRaoOddMinimumCutset.isOddVertexSet(vertices, oddVertices2));
     }
@@ -131,7 +131,7 @@ public class PadbergRaoOddMinimumCutsetTest
         Graphs.addEdge(network, 5, 4, 7);
         Graphs.addEdge(network, 3, 4, 5);
 
-        Set<Integer> oddVertices = new HashSet<>(Arrays.asList(2, 3, 5, 6));
+        Set<Integer> oddVertices = Set.of(2, 3, 5, 6);
         this.runTest(network, oddVertices, true);
         this.runTest(network, oddVertices, false);
 
@@ -150,7 +150,7 @@ public class PadbergRaoOddMinimumCutsetTest
         Graphs.addEdge(network, 1, 2, 4);
         Graphs.addEdge(network, 0, 2, 7);
         Graphs.addEdge(network, 3, 4, 9);
-        Set<Integer> oddVertices = new HashSet<>(Arrays.asList(0, 1, 2, 4));
+        Set<Integer> oddVertices = Set.of(0, 1, 2, 4);
         this.runTest(network, oddVertices, true);
         this.runTest(network, oddVertices, false);
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHUForestIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHUForestIsomorphismInspectorTest.java
@@ -47,10 +47,8 @@ public class AHUForestIsomorphismInspectorTest
         tree1.addEdge("1", "2");
         tree1.addVertex("3");
 
-        AHUForestIsomorphismInspector<String,
-            DefaultEdge> forestIsomorphism = new AHUForestIsomorphismInspector<>(
-                tree1, new HashSet<>(Arrays.asList("1", "2")), tree1,
-                new HashSet<>(Arrays.asList("1", "2")));
+        AHUForestIsomorphismInspector<String, DefaultEdge> forestIsomorphism =
+            new AHUForestIsomorphismInspector<>(tree1, Set.of("1", "2"), tree1, Set.of("1", "2"));
 
         forestIsomorphism.isomorphismExists();
     }
@@ -136,10 +134,8 @@ public class AHUForestIsomorphismInspectorTest
 
         tree2.addVertex("D");
 
-        AHUForestIsomorphismInspector<String,
-            DefaultEdge> forestIsomorphism = new AHUForestIsomorphismInspector<>(
-                tree1, new HashSet<>(Arrays.asList("b", "d")), tree2,
-                new HashSet<>(Arrays.asList("A", "D")));
+        AHUForestIsomorphismInspector<String, DefaultEdge> forestIsomorphism =
+            new AHUForestIsomorphismInspector<>(tree1, Set.of("b", "d"), tree2, Set.of("A", "D"));
 
         Assert.assertFalse(forestIsomorphism.isomorphismExists());
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHURootedTreeIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHURootedTreeIsomorphismInspectorTest.java
@@ -289,10 +289,8 @@ public class AHURootedTreeIsomorphismInspectorTest
 
         // Test as forest
 
-        AHUForestIsomorphismInspector<Integer,
-            DefaultEdge> forestIsomorphism = new AHUForestIsomorphismInspector<>(
-                tree1, new HashSet<>(Arrays.asList(1, 3)), tree2,
-                new HashSet<>(Arrays.asList(11, 31)));
+        AHUForestIsomorphismInspector<Integer, DefaultEdge> forestIsomorphism =
+            new AHUForestIsomorphismInspector<>(tree1, Set.of(1, 3), tree2, Set.of(11, 31));
 
         Assert.assertTrue(forestIsomorphism.isomorphismExists());
         IsomorphicGraphMapping<Integer, DefaultEdge> treeMapping = forestIsomorphism.getMapping();

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHUUnrootedTreeIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHUUnrootedTreeIsomorphismInspectorTest.java
@@ -333,10 +333,8 @@ public class AHUUnrootedTreeIsomorphismInspectorTest
 
         // Test as forest
 
-        AHUForestIsomorphismInspector<Integer,
-            DefaultEdge> forestIsomorphism = new AHUForestIsomorphismInspector<>(
-                tree1, new HashSet<>(Arrays.asList(1, 3)), tree2,
-                new HashSet<>(Arrays.asList(11, 31)));
+        AHUForestIsomorphismInspector<Integer, DefaultEdge> forestIsomorphism =
+            new AHUForestIsomorphismInspector<>(tree1, Set.of(1, 3), tree2, Set.of(11, 31));
 
         Assert.assertTrue(forestIsomorphism.isomorphismExists());
         IsomorphicGraphMapping<Integer, DefaultEdge> treeMapping = forestIsomorphism.getMapping();

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/VF2GraphIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/VF2GraphIsomorphismInspectorTest.java
@@ -23,7 +23,7 @@ import org.junit.*;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * This test class is fairly small compared with the tests for the VF2SubgraphIsomorphismInspector
@@ -87,9 +87,9 @@ public class VF2GraphIsomorphismInspectorTest
         Iterator<GraphMapping<Integer, DefaultEdge>> iter2 = vf3.getMappings();
 
         Set<String> mappings2 = Set.of("[1=1 2=2 3=3]", "[1=3 2=2 3=1]");
-        assertEquals(true, mappings2.remove(iter2.next().toString()));
-        assertEquals(true, mappings2.remove(iter2.next().toString()));
-        assertEquals(false, iter2.hasNext());
+        assertTrue(mappings2.contains(iter2.next().toString()));
+        assertTrue(mappings2.contains(iter2.next().toString()));
+        assertFalse(iter2.hasNext());
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/VF2GraphIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/VF2GraphIsomorphismInspectorTest.java
@@ -86,7 +86,7 @@ public class VF2GraphIsomorphismInspectorTest
 
         Iterator<GraphMapping<Integer, DefaultEdge>> iter2 = vf3.getMappings();
 
-        Set<String> mappings2 = new HashSet<>(Arrays.asList("[1=1 2=2 3=3]", "[1=3 2=2 3=1]"));
+        Set<String> mappings2 = Set.of("[1=1 2=2 3=3]", "[1=3 2=2 3=1]");
         assertEquals(true, mappings2.remove(iter2.next().toString()));
         assertEquals(true, mappings2.remove(iter2.next().toString()));
         assertEquals(false, iter2.hasNext());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismInspectorTest.java
@@ -322,19 +322,18 @@ public class VF2SubgraphIsomorphismInspectorTest
             new VF2SubgraphIsomorphismInspector<>(sg4k, sg3k);
         Iterator<GraphMapping<Integer, DefaultEdge>> iter10 = vfs10.getMappings();
 
-        Set<String> mappings10 = new HashSet<>(
-            Arrays
-                .asList(
-                    "[0=0 1=1 2=2 3=~~]", "[0=0 1=1 2=~~ 3=2]", "[0=0 1=~~ 2=1 3=2]",
-                    "[0=~~ 1=0 2=1 3=2]", "[0=1 1=0 2=2 3=~~]", "[0=1 1=0 2=~~ 3=2]",
-                    "[0=1 1=~~ 2=0 3=2]", "[0=~~ 1=1 2=0 3=2]", "[0=2 1=1 2=0 3=~~]",
-                    "[0=2 1=1 2=~~ 3=0]", "[0=2 1=~~ 2=1 3=0]", "[0=~~ 1=2 2=1 3=0]",
-                    "[0=0 1=2 2=1 3=~~]", "[0=0 1=2 2=~~ 3=1]", "[0=0 1=~~ 2=2 3=1]",
-                    "[0=~~ 1=0 2=2 3=1]", "[0=1 1=2 2=0 3=~~]", "[0=1 1=2 2=~~ 3=0]",
-                    "[0=1 1=~~ 2=2 3=0]", "[0=~~ 1=1 2=2 3=0]", "[0=2 1=0 2=1 3=~~]",
-                    "[0=2 1=0 2=~~ 3=1]", "[0=2 1=~~ 2=0 3=1]", "[0=~~ 1=2 2=0 3=1]"));
+        Set<String> mappings10 = Set
+            .of(
+                "[0=0 1=1 2=2 3=~~]", "[0=0 1=1 2=~~ 3=2]", "[0=0 1=~~ 2=1 3=2]",
+                "[0=~~ 1=0 2=1 3=2]", "[0=1 1=0 2=2 3=~~]", "[0=1 1=0 2=~~ 3=2]",
+                "[0=1 1=~~ 2=0 3=2]", "[0=~~ 1=1 2=0 3=2]", "[0=2 1=1 2=0 3=~~]",
+                "[0=2 1=1 2=~~ 3=0]", "[0=2 1=~~ 2=1 3=0]", "[0=~~ 1=2 2=1 3=0]",
+                "[0=0 1=2 2=1 3=~~]", "[0=0 1=2 2=~~ 3=1]", "[0=0 1=~~ 2=2 3=1]",
+                "[0=~~ 1=0 2=2 3=1]", "[0=1 1=2 2=0 3=~~]", "[0=1 1=2 2=~~ 3=0]",
+                "[0=1 1=~~ 2=2 3=0]", "[0=~~ 1=1 2=2 3=0]", "[0=2 1=0 2=1 3=~~]",
+                "[0=2 1=0 2=~~ 3=1]", "[0=2 1=~~ 2=0 3=1]", "[0=~~ 1=2 2=0 3=1]");
         for (int i = 0; i < 24; i++) {
-            assertEquals(true, mappings10.remove(iter10.next().toString()));
+            assertTrue(mappings10.contains(iter10.next().toString()));
         }
         assertEquals(false, iter10.hasNext());
 
@@ -346,9 +345,9 @@ public class VF2SubgraphIsomorphismInspectorTest
         Iterator<GraphMapping<Integer, DefaultEdge>> iter11 = vfs11.getMappings();
 
         Set<String> mappings11 = Set.of("[1=1 2=2 3=3 4=4]", "[1=4 2=3 3=2 4=1]");
-        assertEquals(true, mappings11.remove(iter11.next().toString()));
-        assertEquals(true, mappings11.remove(iter11.next().toString()));
-        assertEquals(false, iter11.hasNext());
+        assertTrue(mappings11.contains(iter11.next().toString()));
+        assertTrue(mappings11.contains(iter11.next().toString()));
+        assertFalse(iter11.hasNext());
 
         /* ECS-12: not connected graphs of different size */
 
@@ -867,9 +866,9 @@ public class VF2SubgraphIsomorphismInspectorTest
         Iterator<GraphMapping<String, Integer>> iter2 = vf3.getMappings();
 
         Set<String> mappings = Set.of("[A=A B=b a=~~ b=B]", "[A=~~ B=B a=A b=b]");
-        assertEquals(true, mappings.remove(iter2.next().toString()));
-        assertEquals(true, mappings.remove(iter2.next().toString()));
-        assertEquals(false, iter2.hasNext());
+        assertTrue(mappings.contains(iter2.next().toString()));
+        assertTrue(mappings.contains(iter2.next().toString()));
+        assertFalse(iter2.hasNext());
 
         /*
          * SEM-3 test edge comparator
@@ -881,9 +880,9 @@ public class VF2SubgraphIsomorphismInspectorTest
         Iterator<GraphMapping<String, Integer>> iter3 = vf4.getMappings();
 
         Set<String> mappings2 = Set.of("[A=A B=b a=~~ b=B]", "[A=A B=~~ a=b b=B]");
-        assertEquals(true, mappings2.remove(iter3.next().toString()));
-        assertEquals(true, mappings2.remove(iter3.next().toString()));
-        assertEquals(false, iter3.hasNext());
+        assertTrue(mappings2.contains(iter3.next().toString()));
+        assertTrue(mappings2.contains(iter3.next().toString()));
+        assertFalse(iter3.hasNext());
     }
 
     private class VertexComp

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/VF2SubgraphIsomorphismInspectorTest.java
@@ -345,8 +345,7 @@ public class VF2SubgraphIsomorphismInspectorTest
 
         Iterator<GraphMapping<Integer, DefaultEdge>> iter11 = vfs11.getMappings();
 
-        Set<String> mappings11 =
-            new HashSet<>(Arrays.asList("[1=1 2=2 3=3 4=4]", "[1=4 2=3 3=2 4=1]"));
+        Set<String> mappings11 = Set.of("[1=1 2=2 3=3 4=4]", "[1=4 2=3 3=2 4=1]");
         assertEquals(true, mappings11.remove(iter11.next().toString()));
         assertEquals(true, mappings11.remove(iter11.next().toString()));
         assertEquals(false, iter11.hasNext());
@@ -867,8 +866,7 @@ public class VF2SubgraphIsomorphismInspectorTest
 
         Iterator<GraphMapping<String, Integer>> iter2 = vf3.getMappings();
 
-        Set<String> mappings =
-            new HashSet<>(Arrays.asList("[A=A B=b a=~~ b=B]", "[A=~~ B=B a=A b=b]"));
+        Set<String> mappings = Set.of("[A=A B=b a=~~ b=B]", "[A=~~ B=B a=A b=b]");
         assertEquals(true, mappings.remove(iter2.next().toString()));
         assertEquals(true, mappings.remove(iter2.next().toString()));
         assertEquals(false, iter2.hasNext());
@@ -882,8 +880,7 @@ public class VF2SubgraphIsomorphismInspectorTest
 
         Iterator<GraphMapping<String, Integer>> iter3 = vf4.getMappings();
 
-        Set<String> mappings2 =
-            new HashSet<>(Arrays.asList("[A=A B=b a=~~ b=B]", "[A=A B=~~ a=b b=B]"));
+        Set<String> mappings2 = Set.of("[A=A B=b a=~~ b=B]", "[A=A B=~~ a=b b=B]");
         assertEquals(true, mappings2.remove(iter3.next().toString()));
         assertEquals(true, mappings2.remove(iter3.next().toString()));
         assertEquals(false, iter3.hasNext());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/DenseEdmondsMaximumCardinalityMatchingTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/DenseEdmondsMaximumCardinalityMatchingTest.java
@@ -176,7 +176,7 @@ public final class DenseEdmondsMaximumCardinalityMatchingTest
 
         // Perfect matching
         Matching<Integer, DefaultEdge> m1 =
-            new MatchingAlgorithm.MatchingImpl<>(g, new HashSet<>(Arrays.asList(e12, e34)), 2);
+            new MatchingAlgorithm.MatchingImpl<>(g, Set.of(e12, e34), 2);
         assertTrue(matcher.isMaximumMatching(m1));
 
         // Maximum matching in graph with odd number of vertices
@@ -185,8 +185,8 @@ public final class DenseEdmondsMaximumCardinalityMatchingTest
         assertTrue(matcher.isMaximumMatching(m1));
 
         // Not a maximum matching: augmenting path exists
-        Matching<Integer, DefaultEdge> m2 = new MatchingAlgorithm.MatchingImpl<>(
-            g, new HashSet<>(Collections.singletonList(e12)), 2);
+        Matching<Integer, DefaultEdge> m2 =
+            new MatchingAlgorithm.MatchingImpl<>(g, Set.of(e12), 2);
         assertFalse(matcher.isMaximumMatching(m2));
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/MaximumCardinalityBipartiteMatchingTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/MaximumCardinalityBipartiteMatchingTest.java
@@ -114,8 +114,8 @@ public abstract class MaximumCardinalityBipartiteMatchingTest
     public void testGraph1()
     {
         Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
-        Set<Integer> partition1 = new HashSet<>(Arrays.asList(0, 1, 2, 3, 4, 5, 6));
-        Set<Integer> partition2 = new HashSet<>(Arrays.asList(7, 8, 9));
+        Set<Integer> partition1 = Set.of(0, 1, 2, 3, 4, 5, 6);
+        Set<Integer> partition2 = Set.of(7, 8, 9);
         Graphs.addAllVertices(graph, partition1);
         Graphs.addAllVertices(graph, partition2);
         int[][] edges = { { 5, 8 }, { 4, 9 }, { 2, 7 }, { 6, 9 }, { 1, 9 } };
@@ -132,8 +132,8 @@ public abstract class MaximumCardinalityBipartiteMatchingTest
     public void testGraph2()
     {
         Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
-        Set<Integer> partition1 = new HashSet<>(Arrays.asList(0, 1, 2, 3, 4, 5, 6));
-        Set<Integer> partition2 = new HashSet<>(Arrays.asList(7, 8, 9));
+        Set<Integer> partition1 = Set.of(0, 1, 2, 3, 4, 5, 6);
+        Set<Integer> partition2 = Set.of(7, 8, 9);
         Graphs.addAllVertices(graph, partition1);
         Graphs.addAllVertices(graph, partition2);
         int[][] edges =
@@ -157,8 +157,8 @@ public abstract class MaximumCardinalityBipartiteMatchingTest
 
         Graphs.addAllVertices(g, IntStream.rangeClosed(0, 3).boxed().collect(Collectors.toList()));
 
-        Set<Integer> left = new HashSet<>(Arrays.asList(0, 1));
-        Set<Integer> right = new HashSet<>(Arrays.asList(2, 3));
+        Set<Integer> left = Set.of(0, 1);
+        Set<Integer> right = Set.of(2, 3);
 
         g.addEdge(0, 2);
         g.addEdge(0, 3);
@@ -175,8 +175,8 @@ public abstract class MaximumCardinalityBipartiteMatchingTest
     public void testPseudoGraph()
     {
         Graph<Integer, DefaultEdge> graph = new Pseudograph<>(DefaultEdge.class);
-        Set<Integer> partition1 = new HashSet<>(Arrays.asList(0, 1, 2));
-        Set<Integer> partition2 = new HashSet<>(Arrays.asList(3, 4, 5));
+        Set<Integer> partition1 = Set.of(0, 1, 2);
+        Set<Integer> partition2 = Set.of(3, 4, 5);
         Graphs.addAllVertices(graph, partition1);
         Graphs.addAllVertices(graph, partition2);
         int[][] edges = { { 0, 3 }, { 1, 4 }, { 2, 5 }, { 0, 3 }, { 0, 0 } };

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVInitializerTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVInitializerTest.java
@@ -76,11 +76,9 @@ public class BlossomVInitializerTest
         assertEquals(2, state.edgeNum);
         assertEquals(0, state.treeNum);
 
-        assertEquals(Collections.emptySet(), BlossomVDebugger.getTreeRoots(state));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(edge12)), BlossomVDebugger.getEdgesOf(node1));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(edge12)), BlossomVDebugger.getEdgesOf(node2));
+        assertEquals(Set.of(), BlossomVDebugger.getTreeRoots(state));
+        assertEquals(Set.of(edge12), BlossomVDebugger.getEdgesOf(node1));
+        assertEquals(Set.of(edge12), BlossomVDebugger.getEdgesOf(node2));
 
         assertEquals(edge12, node1.matched);
         assertEquals(edge12, node2.matched);
@@ -170,21 +168,13 @@ public class BlossomVInitializerTest
         assertEquals(expectedRoots.size(), actualRoots.size());
         assertTrue(actualRoots.containsAll(expectedRoots));
 
-        assertEquals(
-            new HashSet<>(Collections.singletonList(edge12)), BlossomVDebugger.getEdgesOf(node1));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge12, edge23, edge25)),
-            BlossomVDebugger.getEdgesOf(node2));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(edge23)), BlossomVDebugger.getEdgesOf(node3));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(edge45)), BlossomVDebugger.getEdgesOf(node4));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge25, edge45, edge56)),
-            BlossomVDebugger.getEdgesOf(node5));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(edge56)), BlossomVDebugger.getEdgesOf(node6));
-        assertEquals(new HashSet<>(), BlossomVDebugger.getEdgesOf(node7));
+        assertEquals(Set.of(edge12), BlossomVDebugger.getEdgesOf(node1));
+        assertEquals(Set.of(edge12, edge23, edge25), BlossomVDebugger.getEdgesOf(node2));
+        assertEquals(Set.of(edge23), BlossomVDebugger.getEdgesOf(node3));
+        assertEquals(Set.of(edge45), BlossomVDebugger.getEdgesOf(node4));
+        assertEquals(Set.of(edge25, edge45, edge56), BlossomVDebugger.getEdgesOf(node5));
+        assertEquals(Set.of(edge56), BlossomVDebugger.getEdgesOf(node6));
+        assertEquals(Set.of(), BlossomVDebugger.getEdgesOf(node7));
 
         assertEquals(1, BlossomVDebugger.getTreeEdgesOf(tree1).size());
         assertEquals(3, BlossomVDebugger.getTreeEdgesOf(tree2).size());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVNodeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVNodeTest.java
@@ -196,10 +196,10 @@ public class BlossomVNodeTest
         BlossomVEdge edge24 = edgeMap.get(e24);
         BlossomVEdge edge34 = edgeMap.get(e34);
 
-        testIncidentEdgeIteratorOf(node1, new HashSet<>(Arrays.asList(edge12, edge14)));
-        testIncidentEdgeIteratorOf(node2, new HashSet<>(Arrays.asList(edge12, edge23, edge24)));
-        testIncidentEdgeIteratorOf(node3, new HashSet<>(Arrays.asList(edge23, edge34)));
-        testIncidentEdgeIteratorOf(node4, new HashSet<>(Arrays.asList(edge14, edge24, edge34)));
+        testIncidentEdgeIteratorOf(node1, Set.of(edge12, edge14));
+        testIncidentEdgeIteratorOf(node2, Set.of(edge12, edge23, edge24));
+        testIncidentEdgeIteratorOf(node3, Set.of(edge23, edge34));
+        testIncidentEdgeIteratorOf(node4, Set.of(edge14, edge24, edge34));
     }
 
     /**
@@ -265,29 +265,23 @@ public class BlossomVNodeTest
 
         Set<BlossomVNode> empty = new HashSet<>();
 
-        assertEquals(
-            new HashSet<>(Collections.singletonList(node3)), BlossomVDebugger.getChildrenOf(node2));
+        assertEquals(Set.of(node3), BlossomVDebugger.getChildrenOf(node2));
         node3.removeFromChildList();
         assertEquals(empty, BlossomVDebugger.getChildrenOf(node2));
 
-        assertEquals(
-            new HashSet<>(Collections.singletonList(node5)), BlossomVDebugger.getChildrenOf(node4));
+        assertEquals(Set.of(node5), BlossomVDebugger.getChildrenOf(node4));
         node5.removeFromChildList();
         assertEquals(empty, BlossomVDebugger.getChildrenOf(node4));
 
-        assertEquals(
-            new HashSet<>(Arrays.asList(node2, node4)), BlossomVDebugger.getChildrenOf(node1));
+        assertEquals(Set.of(node2, node4), BlossomVDebugger.getChildrenOf(node1));
         node4.removeFromChildList();
-        assertEquals(
-            new HashSet<>(Collections.singletonList(node2)), BlossomVDebugger.getChildrenOf(node1));
+        assertEquals(Set.of(node2), BlossomVDebugger.getChildrenOf(node1));
         node2.removeFromChildList();
         assertEquals(empty, BlossomVDebugger.getChildrenOf(node1));
 
-        assertEquals(
-            new HashSet<>(Arrays.asList(node1, node6)), BlossomVDebugger.getTreeRoots(state));
+        assertEquals(Set.of(node1, node6), BlossomVDebugger.getTreeRoots(state));
         node1.removeFromChildList();
-        assertEquals(
-            new HashSet<>(Collections.singletonList(node6)), BlossomVDebugger.getTreeRoots(state));
+        assertEquals(Set.of(node6), BlossomVDebugger.getTreeRoots(state));
         node6.removeFromChildList();
         assertEquals(empty, BlossomVDebugger.getTreeRoots(state));
     }
@@ -345,23 +339,19 @@ public class BlossomVNodeTest
 
         // node5 and node4 have no children
         node5.moveChildrenTo(node3);
-        assertEquals(new HashSet<>(), BlossomVDebugger.getChildrenOf(node3));
+        assertEquals(Set.of(), BlossomVDebugger.getChildrenOf(node3));
 
         // moving child list of size 1 to empty list
         node2.moveChildrenTo(node4);
 
-        assertEquals(
-            new HashSet<>(Arrays.asList(node3, node5)), BlossomVDebugger.getChildrenOf(node4));
+        assertEquals(Set.of(node3, node5), BlossomVDebugger.getChildrenOf(node4));
         // moving child list of size 2 to empty list
         node4.moveChildrenTo(node2);
-        assertEquals(
-            new HashSet<>(Arrays.asList(node3, node5)), BlossomVDebugger.getChildrenOf(node2));
+        assertEquals(Set.of(node3, node5), BlossomVDebugger.getChildrenOf(node2));
 
         // moving child list to non-empty child list
         node1.moveChildrenTo(node6);
-        assertEquals(
-            new HashSet<>(Arrays.asList(node2, node4, node7)),
-            BlossomVDebugger.getChildrenOf(node6));
+        assertEquals(Set.of(node2, node4, node7), BlossomVDebugger.getChildrenOf(node6));
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVPrimalUpdaterTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVPrimalUpdaterTest.java
@@ -1152,7 +1152,7 @@ public class BlossomVPrimalUpdaterTest
         assertEquals(blossom, node5.blossomGrandparent);
 
         Set<BlossomVNode> expectedBlossomNodes = Set.of(node1, node2, node3, node4, node5);
-        Set<BlossomVNode> actualBlossomNodes = Set.of(node1);
+        Set<BlossomVNode> actualBlossomNodes = new HashSet<>(Collections.singletonList(node1));
         for (BlossomVNode current = node1.blossomSibling.getOpposite(node1); current != node1;
             current = current.blossomSibling.getOpposite(current))
         {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVPrimalUpdaterTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVPrimalUpdaterTest.java
@@ -751,12 +751,8 @@ public class BlossomVPrimalUpdaterTest
 
         primalUpdater.augment(edge12);
 
-        assertEquals(
-            new HashSet<>(Collections.singletonList(treeEdge34)),
-            BlossomVDebugger.getTreeEdgesOf(tree3));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(treeEdge34)),
-            BlossomVDebugger.getTreeEdgesOf(tree4));
+        assertEquals(Set.of(treeEdge34), BlossomVDebugger.getTreeEdgesOf(tree3));
+        assertEquals(Set.of(treeEdge34), BlossomVDebugger.getTreeEdgesOf(tree4));
     }
 
     /**
@@ -803,12 +799,9 @@ public class BlossomVPrimalUpdaterTest
 
         assertFalse(node1.isTreeRoot);
 
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge12, edge13)), BlossomVDebugger.getEdgesOf(node1));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge12, edge23)), BlossomVDebugger.getEdgesOf(node2));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge14, edge24)), BlossomVDebugger.getEdgesOf(blossom));
+        assertEquals(Set.of(edge12, edge13), BlossomVDebugger.getEdgesOf(node1));
+        assertEquals(Set.of(edge12, edge23), BlossomVDebugger.getEdgesOf(node2));
+        assertEquals(Set.of(edge14, edge24), BlossomVDebugger.getEdgesOf(blossom));
 
         assertEquals(blossom, node1.blossomParent);
         assertEquals(blossom, node2.blossomParent);
@@ -1085,20 +1078,13 @@ public class BlossomVPrimalUpdaterTest
         BlossomVNode blossom = primalUpdater.shrink(edge34, false);
         blossom.tree.clearCurrentEdges();
 
+        assertEquals(Set.of(edge12, edge13, edge51), BlossomVDebugger.getEdgesOf(node1));
+        assertEquals(Set.of(edge12, edge23), BlossomVDebugger.getEdgesOf(node2));
+        assertEquals(Set.of(edge13, edge23, edge34), BlossomVDebugger.getEdgesOf(node3));
+        assertEquals(Set.of(edge34, edge45), BlossomVDebugger.getEdgesOf(node4));
+        assertEquals(Set.of(edge45, edge51), BlossomVDebugger.getEdgesOf(node5));
         assertEquals(
-            new HashSet<>(Arrays.asList(edge12, edge13, edge51)),
-            BlossomVDebugger.getEdgesOf(node1));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge12, edge23)), BlossomVDebugger.getEdgesOf(node2));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge13, edge23, edge34)),
-            BlossomVDebugger.getEdgesOf(node3));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge34, edge45)), BlossomVDebugger.getEdgesOf(node4));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge45, edge51)), BlossomVDebugger.getEdgesOf(node5));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge29, edge56, edge57, edge58, edge47, edge48)),
+            Set.of(edge29, edge56, edge57, edge58, edge47, edge48),
             BlossomVDebugger.getEdgesOf(blossom));
 
         BlossomVTreeEdge treeEdge = BlossomVDebugger.getTreeEdge(node1.tree, node6.tree);
@@ -1165,9 +1151,8 @@ public class BlossomVPrimalUpdaterTest
         assertEquals(blossom, node4.blossomGrandparent);
         assertEquals(blossom, node5.blossomGrandparent);
 
-        Set<BlossomVNode> expectedBlossomNodes =
-            new HashSet<>(Arrays.asList(node1, node2, node3, node4, node5));
-        Set<BlossomVNode> actualBlossomNodes = new HashSet<>(Collections.singletonList(node1));
+        Set<BlossomVNode> expectedBlossomNodes = Set.of(node1, node2, node3, node4, node5);
+        Set<BlossomVNode> actualBlossomNodes = Set.of(node1);
         for (BlossomVNode current = node1.blossomSibling.getOpposite(node1); current != node1;
             current = current.blossomSibling.getOpposite(current))
         {
@@ -1255,8 +1240,7 @@ public class BlossomVPrimalUpdaterTest
         // validating the tree structure
         assertEquals(blossom, node4.getTreeParent());
         assertEquals(blossom, node6.getTreeParent());
-        assertEquals(
-            new HashSet<>(Arrays.asList(node4, node6)), BlossomVDebugger.getChildrenOf(blossom));
+        assertEquals(Set.of(node4, node6), BlossomVDebugger.getChildrenOf(blossom));
 
         // validating the edges endpoints
         assertEquals(blossom, edge18.getOpposite(node8));
@@ -1476,13 +1460,9 @@ public class BlossomVPrimalUpdaterTest
         assertEquals(node4.tree, node3.tree);
         assertEquals(node4, node3.getTreeParent());
         assertEquals(node3, node5.getTreeParent());
-        assertEquals(
-            new HashSet<>(Collections.singletonList(node3)), BlossomVDebugger.getChildrenOf(node4));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(node5)), BlossomVDebugger.getChildrenOf(node3));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge34, edge35, edge23, edge13)),
-            BlossomVDebugger.getEdgesOf(node3));
+        assertEquals(Set.of(node3), BlossomVDebugger.getChildrenOf(node4));
+        assertEquals(Set.of(node5), BlossomVDebugger.getChildrenOf(node3));
+        assertEquals(Set.of(edge34, edge35, edge23, edge13), BlossomVDebugger.getEdgesOf(node3));
 
         // checking edges new endpoints
         assertEquals(node3, edge34.getOpposite(node4));
@@ -1646,20 +1626,14 @@ public class BlossomVPrimalUpdaterTest
         assertEquals(node4, node3.getTreeParent());
         assertEquals(node3, node7.getTreeParent());
 
+        assertEquals(Set.of(node2), BlossomVDebugger.getChildrenOf(node6));
+        assertEquals(Set.of(node1), BlossomVDebugger.getChildrenOf(node2));
+        assertEquals(Set.of(node5), BlossomVDebugger.getChildrenOf(node1));
+        assertEquals(Set.of(node4), BlossomVDebugger.getChildrenOf(node5));
+        assertEquals(Set.of(node3), BlossomVDebugger.getChildrenOf(node4));
+        assertEquals(Set.of(node7), BlossomVDebugger.getChildrenOf(node3));
         assertEquals(
-            new HashSet<>(Collections.singletonList(node2)), BlossomVDebugger.getChildrenOf(node6));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(node1)), BlossomVDebugger.getChildrenOf(node2));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(node5)), BlossomVDebugger.getChildrenOf(node1));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(node4)), BlossomVDebugger.getChildrenOf(node5));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(node3)), BlossomVDebugger.getChildrenOf(node4));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(node7)), BlossomVDebugger.getChildrenOf(node3));
-        assertEquals(
-            new HashSet<>(Arrays.asList(node6, node2, node1, node5, node4, node3, node7)),
+            Set.of(node6, node2, node1, node5, node4, node3, node7),
             BlossomVDebugger.getTreeNodes(node6.tree));
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVStateTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVStateTest.java
@@ -72,23 +72,15 @@ public class BlossomVStateTest
 
         edge12.moveEdgeTail(node2, node3);
         assertEquals(node3, edge12.getOpposite(node1));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge12, edge13)), BlossomVDebugger.getEdgesOf(node1));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(edge23)), BlossomVDebugger.getEdgesOf(node2));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge12, edge13, edge23)),
-            BlossomVDebugger.getEdgesOf(node3));
+        assertEquals(Set.of(edge12, edge13), BlossomVDebugger.getEdgesOf(node1));
+        assertEquals(Set.of(edge23), BlossomVDebugger.getEdgesOf(node2));
+        assertEquals(Set.of(edge12, edge13, edge23), BlossomVDebugger.getEdgesOf(node3));
 
         edge23.moveEdgeTail(node2, node1);
         assertEquals(node1, edge13.getOpposite(node3));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge12, edge13, edge23)),
-            BlossomVDebugger.getEdgesOf(node1));
-        assertEquals(new HashSet<>(), BlossomVDebugger.getEdgesOf(node2));
-        assertEquals(
-            new HashSet<>(Arrays.asList(edge12, edge13, edge23)),
-            BlossomVDebugger.getEdgesOf(node3));
+        assertEquals(Set.of(edge12, edge13, edge23), BlossomVDebugger.getEdgesOf(node1));
+        assertEquals(Set.of(), BlossomVDebugger.getEdgesOf(node2));
+        assertEquals(Set.of(edge12, edge13, edge23), BlossomVDebugger.getEdgesOf(node3));
     }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVTreeEdgeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVTreeEdgeTest.java
@@ -91,22 +91,14 @@ public class BlossomVTreeEdgeTest
 
         treeEdge12.removeFromTreeEdgeList();
 
-        assertEquals(
-            new HashSet<>(Collections.singletonList(treeEdge13)),
-            BlossomVDebugger.getTreeEdgesOf(tree1));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(treeEdge23)),
-            BlossomVDebugger.getTreeEdgesOf(tree2));
+        assertEquals(Set.of(treeEdge13), BlossomVDebugger.getTreeEdgesOf(tree1));
+        assertEquals(Set.of(treeEdge23), BlossomVDebugger.getTreeEdgesOf(tree2));
 
         treeEdge13.removeFromTreeEdgeList();
 
         assertTrue(BlossomVDebugger.getTreeEdgesOf(tree1).isEmpty());
-        assertEquals(
-            new HashSet<>(Collections.singletonList(treeEdge23)),
-            BlossomVDebugger.getTreeEdgesOf(tree2));
-        assertEquals(
-            new HashSet<>(Collections.singletonList(treeEdge23)),
-            BlossomVDebugger.getTreeEdgesOf(tree3));
+        assertEquals(Set.of(treeEdge23), BlossomVDebugger.getTreeEdgesOf(tree2));
+        assertEquals(Set.of(treeEdge23), BlossomVDebugger.getTreeEdgesOf(tree3));
 
         treeEdge23.removeFromTreeEdgeList();
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVTreeTest.java
@@ -87,9 +87,7 @@ public class BlossomVTreeTest
             actualNodes.add(iterator.next());
         }
         assertEquals(7, i);
-        assertEquals(
-            new HashSet<>(Arrays.asList(node1, node2, node3, node4, node5, node6, node7)),
-            actualNodes);
+        assertEquals(Set.of(node1, node2, node3, node4, node5, node6, node7), actualNodes);
     }
 
     @Test
@@ -109,8 +107,8 @@ public class BlossomVTreeTest
         BlossomVTreeEdge treeEdge2 = BlossomVTree.addTreeEdge(tree1, tree3);
         BlossomVTreeEdge treeEdge3 = BlossomVTree.addTreeEdge(tree4, tree1);
         BlossomVTreeEdge treeEdge4 = BlossomVTree.addTreeEdge(tree5, tree1);
-        Set<BlossomVTreeEdge> expectedOutEdges = new HashSet<>(Arrays.asList(treeEdge1, treeEdge2));
-        Set<BlossomVTreeEdge> expectedInEdges = new HashSet<>(Arrays.asList(treeEdge3, treeEdge4));
+        Set<BlossomVTreeEdge> expectedOutEdges = Set.of(treeEdge1, treeEdge2);
+        Set<BlossomVTreeEdge> expectedInEdges = Set.of(treeEdge3, treeEdge4);
         Set<BlossomVTreeEdge> actualOutEdges = new HashSet<>();
         Set<BlossomVTreeEdge> actualInEdges = new HashSet<>();
         for (BlossomVTree.TreeEdgeIterator iterator = tree1.treeEdgeIterator();

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/partition/BipartitePartitioningTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/partition/BipartitePartitioningTest.java
@@ -122,8 +122,8 @@ public class BipartitePartitioningTest
 
         for (Graph<Integer, DefaultEdge> g : gList) {
             Graphs.addAllVertices(g, Arrays.asList(1, 2, 3, 4));
-            Set<Integer> a = new HashSet<>(Arrays.asList(1, 2));
-            Set<Integer> b = new HashSet<>(Arrays.asList(3, 4));
+            Set<Integer> a = Set.of(1, 2);
+            Set<Integer> b = Set.of(3, 4);
             assertTrue(GraphTests.isBipartitePartition(g, a, b));
             g.addEdge(1, 3);
             g.addEdge(1, 4);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/partition/BipartitePartitioningTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/partition/BipartitePartitioningTest.java
@@ -122,7 +122,7 @@ public class BipartitePartitioningTest
 
         for (Graph<Integer, DefaultEdge> g : gList) {
             Graphs.addAllVertices(g, Arrays.asList(1, 2, 3, 4));
-            Set<Integer> a = Set.of(1, 2);
+            Set<Integer> a = new HashSet<>(Arrays.asList(1, 2));
             Set<Integer> b = Set.of(3, 4);
             assertTrue(GraphTests.isBipartitePartition(g, a, b));
             g.addEdge(1, 3);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseManyToManyShortestPathsTest.java
@@ -101,10 +101,8 @@ public abstract class BaseManyToManyShortestPathsTest
         graph.addVertex(2);
 
         ManyToManyShortestPathsAlgorithm.ManyToManyShortestPaths<Integer,
-            DefaultWeightedEdge> shortestPaths = getAlgorithm(graph)
-                .getManyToManyPaths(
-                    new HashSet<>(Collections.singletonList(1)),
-                    new HashSet<>(Collections.singletonList(2)));
+            DefaultWeightedEdge> shortestPaths =
+                getAlgorithm(graph).getManyToManyPaths(Set.of(1), Set.of(2));
 
         assertEquals(Double.POSITIVE_INFINITY, shortestPaths.getWeight(1, 2), 1e-9);
         assertNull(shortestPaths.getPath(1, 2));
@@ -120,9 +118,8 @@ public abstract class BaseManyToManyShortestPathsTest
             getAlgorithm(getSimpleGraph());
 
         ManyToManyShortestPathsAlgorithm.ManyToManyShortestPaths<Integer,
-            DefaultWeightedEdge> shortestPaths = algorithm
-                .getManyToManyPaths(
-                    new HashSet<>(Arrays.asList(4, 1, 2)), new HashSet<>(Arrays.asList(8, 9, 6)));
+            DefaultWeightedEdge> shortestPaths =
+                algorithm.getManyToManyPaths(Set.of(4, 1, 2), Set.of(8, 9, 6));
 
         assertEquals(2.0, shortestPaths.getWeight(4, 8), 1e-9);
         assertEquals(Arrays.asList(4, 5, 8), shortestPaths.getPath(4, 8).getVertexList());
@@ -162,9 +159,8 @@ public abstract class BaseManyToManyShortestPathsTest
             getAlgorithm(getMultigraph());
 
         ManyToManyShortestPathsAlgorithm.ManyToManyShortestPaths<Integer,
-            DefaultWeightedEdge> shortestPaths = algorithm
-                .getManyToManyPaths(
-                    new HashSet<>(Arrays.asList(1, 4)), new HashSet<>(Arrays.asList(2, 5)));
+            DefaultWeightedEdge> shortestPaths =
+                algorithm.getManyToManyPaths(Set.of(1, 4), Set.of(2, 5));
 
         assertEquals(1.0, shortestPaths.getWeight(1, 2), 1e-9);
         assertEquals(Arrays.asList(1, 2), shortestPaths.getPath(1, 2).getVertexList());
@@ -190,9 +186,8 @@ public abstract class BaseManyToManyShortestPathsTest
             getAlgorithm(getSimpleGraph());
 
         ManyToManyShortestPathsAlgorithm.ManyToManyShortestPaths<Integer,
-            DefaultWeightedEdge> shortestPaths = algorithm
-                .getManyToManyPaths(
-                    new HashSet<>(Arrays.asList(1, 5, 9)), new HashSet<>(Arrays.asList(1, 5, 9)));
+            DefaultWeightedEdge> shortestPaths =
+                algorithm.getManyToManyPaths(Set.of(1, 5, 9), Set.of(1, 5, 9));
 
         assertEquals(0.0, shortestPaths.getWeight(1, 1), 1e-9);
         assertEquals(Collections.singletonList(1), shortestPaths.getPath(1, 1).getVertexList());
@@ -229,9 +224,8 @@ public abstract class BaseManyToManyShortestPathsTest
             getAlgorithm(getMultigraph());
 
         ManyToManyShortestPathsAlgorithm.ManyToManyShortestPaths<Integer,
-            DefaultWeightedEdge> shortestPaths = algorithm
-                .getManyToManyPaths(
-                    new HashSet<>(Arrays.asList(2, 4, 6)), new HashSet<>(Arrays.asList(2, 4, 6)));
+            DefaultWeightedEdge> shortestPaths =
+                algorithm.getManyToManyPaths(Set.of(2, 4, 6), Set.of(2, 4, 6));
 
         assertEquals(0.0, shortestPaths.getWeight(2, 2), 1e-9);
         assertEquals(Collections.singletonList(2), shortestPaths.getPath(2, 2).getVertexList());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
@@ -112,9 +112,7 @@ public class CHManyToManyShortestPathsTest
 
         ManyToManyShortestPathsAlgorithm.ManyToManyShortestPaths<Integer,
             DefaultWeightedEdge> shortestPaths = new CHManyToManyShortestPaths<>(hierarchy)
-                .getManyToManyPaths(
-                    new HashSet<>(Arrays.asList(1, 3, 7, 9)),
-                    new HashSet<>(Collections.singletonList(5)));
+                .getManyToManyPaths(Set.of(1, 3, 7, 9), Set.of(5));
 
         assertEquals(2.0, shortestPaths.getWeight(1, 5), 1e-9);
         assertEquals(Arrays.asList(1, 4, 5), shortestPaths.getPath(1, 5).getVertexList());
@@ -140,9 +138,7 @@ public class CHManyToManyShortestPathsTest
 
         ManyToManyShortestPathsAlgorithm.ManyToManyShortestPaths<Integer,
             DefaultWeightedEdge> shortestPaths = new CHManyToManyShortestPaths<>(hierarchy)
-                .getManyToManyPaths(
-                    new HashSet<>(Arrays.asList(2, 3, 4, 5, 6)),
-                    new HashSet<>(Collections.singletonList(1)));
+                .getManyToManyPaths(Set.of(2, 3, 4, 5, 6), Set.of(1));
 
         assertEquals(3.0, shortestPaths.getWeight(2, 1), 1e-9);
         assertEquals(Arrays.asList(2, 1), shortestPaths.getPath(2, 1).getVertexList());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/GraphMeasurerTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/GraphMeasurerTest.java
@@ -205,7 +205,7 @@ public class GraphMeasurerTest
         Graph<Integer, DefaultEdge> g1 = getGraph1();
         GraphMeasurer<Integer, DefaultEdge> gdm = new GraphMeasurer<>(g1);
         Set<Integer> graphCenter1 = gdm.getGraphCenter();
-        assertEquals(new HashSet<>(Collections.singletonList(1)), graphCenter1);
+        assertEquals(Set.of(1), graphCenter1);
     }
 
     @Test
@@ -214,7 +214,7 @@ public class GraphMeasurerTest
         Graph<Integer, DefaultEdge> g2 = getGraph2();
         GraphMeasurer<Integer, DefaultEdge> gdm = new GraphMeasurer<>(g2);
         Set<Integer> graphCenter2 = gdm.getGraphCenter();
-        assertEquals(new HashSet<>(Arrays.asList(1, 5)), graphCenter2);
+        assertEquals(Set.of(1, 5), graphCenter2);
     }
 
     @Test
@@ -223,7 +223,7 @@ public class GraphMeasurerTest
         Graph<Integer, DefaultEdge> g1 = getGraph1();
         GraphMeasurer<Integer, DefaultEdge> gdm = new GraphMeasurer<>(g1);
         Set<Integer> graphPeriphery1 = gdm.getGraphPeriphery();
-        assertEquals(new HashSet<>(Arrays.asList(4, 6)), graphPeriphery1);
+        assertEquals(Set.of(4, 6), graphPeriphery1);
     }
 
     @Test
@@ -232,7 +232,7 @@ public class GraphMeasurerTest
         Graph<Integer, DefaultEdge> g2 = getGraph2();
         GraphMeasurer<Integer, DefaultEdge> gdm = new GraphMeasurer<>(g2);
         Set<Integer> graphPeriphery2 = gdm.getGraphPeriphery();
-        assertEquals(new HashSet<>(Arrays.asList(0, 2, 3, 4, 6)), graphPeriphery2);
+        assertEquals(Set.of(0, 2, 3, 4, 6), graphPeriphery2);
     }
 
     @Test
@@ -241,7 +241,7 @@ public class GraphMeasurerTest
         Graph<Integer, DefaultEdge> g1 = getGraph1();
         GraphMeasurer<Integer, DefaultEdge> gdm = new GraphMeasurer<>(g1);
         Set<Integer> graphPseudoPeriphery1 = gdm.getGraphPseudoPeriphery();
-        assertEquals(new HashSet<>(Arrays.asList(4, 6)), graphPseudoPeriphery1);
+        assertEquals(Set.of(4, 6), graphPseudoPeriphery1);
     }
 
     @Test
@@ -250,7 +250,7 @@ public class GraphMeasurerTest
         Graph<Integer, DefaultEdge> g2 = getGraph2();
         GraphMeasurer<Integer, DefaultEdge> gdm = new GraphMeasurer<>(g2);
         Set<Integer> graphPseudoPeriphery2 = gdm.getGraphPseudoPeriphery();
-        assertEquals(new HashSet<>(Arrays.asList(0, 2, 3, 4, 6)), graphPseudoPeriphery2);
+        assertEquals(Set.of(0, 2, 3, 4, 6), graphPseudoPeriphery2);
     }
 
     @Test
@@ -260,11 +260,10 @@ public class GraphMeasurerTest
         GraphMeasurer<Integer, DefaultEdge> gdm = new GraphMeasurer<>(g3);
         Set<Integer> graphPseudoPeriphery3 = gdm.getGraphPseudoPeriphery();
         assertEquals(
-            new HashSet<>(
-                Arrays
-                    .asList(
-                        6, 7, 13, 17, 19, 20, 21, 24, 32, 36, 37, 39, 41, 42, 46, 48, 51, 53, 60,
-                        61, 63, 64, 66, 67, 69, 70, 71, 83, 89, 90, 95, 98)),
+            Set
+                .of(
+                    6, 7, 13, 17, 19, 20, 21, 24, 32, 36, 37, 39, 41, 42, 46, 48, 51, 53, 60, 61,
+                    63, 64, 66, 67, 69, 70, 71, 83, 89, 90, 95, 98),
             graphPseudoPeriphery3);
     }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TreeMeasurerTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TreeMeasurerTest.java
@@ -59,7 +59,7 @@ public class TreeMeasurerTest
 
         TreeMeasurer<Integer, DefaultEdge> treeMeasurer = new TreeMeasurer<>(tree);
 
-        assertEquals(new HashSet<>(Arrays.asList(2, 3)), treeMeasurer.getGraphCenter());
+        assertEquals(Set.of(2, 3), treeMeasurer.getGraphCenter());
     }
 
     @Test
@@ -80,6 +80,6 @@ public class TreeMeasurerTest
 
         TreeMeasurer<Integer, DefaultEdge> treeMeasurer = new TreeMeasurer<>(tree);
 
-        assertEquals(new HashSet<>(Collections.singletonList(3)), treeMeasurer.getGraphCenter());
+        assertEquals(Set.of(3), treeMeasurer.getGraphCenter());
     }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest.java
@@ -68,9 +68,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         labels.put(6, 2);
 
         Map<Integer, Pair<Set<Integer>, Double>> partition = new HashMap<>();
-        partition.put(0, Pair.of(new HashSet<>(Arrays.asList(1, 4)), 2.0));
-        partition.put(1, Pair.of(new HashSet<>(Arrays.asList(2, 5)), 2.0));
-        partition.put(2, Pair.of(new HashSet<>(Arrays.asList(3, 6)), 2.0));
+        partition.put(0, Pair.of(Set.of(1, 4), 2.0));
+        partition.put(1, Pair.of(Set.of(2, 5), 2.0));
+        partition.put(2, Pair.of(Set.of(3, 6), 2.0));
 
         Set<DefaultWeightedEdge> edges = new HashSet<>();
         edges.add(graph.getEdge(0, 1));
@@ -94,15 +94,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         assertTrue(cmst.isCapacitatedSpanningTree(graph, 0, 2.0, weights));
         assertEquals(6.0, cmst.getWeight(), 0.0000001);
 
-        assertEquals(
-            Pair.of(new HashSet<>(Arrays.asList(1, 5)), 2.0),
-            cmst.getPartition().get(cmst.getLabels().get(1)));
-        assertEquals(
-            Pair.of(new HashSet<>(Arrays.asList(2, 4)), 2.0),
-            cmst.getPartition().get(cmst.getLabels().get(2)));
-        assertEquals(
-            Pair.of(new HashSet<>(Arrays.asList(3, 6)), 2.0),
-            cmst.getPartition().get(cmst.getLabels().get(3)));
+        assertEquals(Pair.of(Set.of(1, 5), 2.0), cmst.getPartition().get(cmst.getLabels().get(1)));
+        assertEquals(Pair.of(Set.of(2, 4), 2.0), cmst.getPartition().get(cmst.getLabels().get(2)));
+        assertEquals(Pair.of(Set.of(3, 6), 2.0), cmst.getPartition().get(cmst.getLabels().get(3)));
 
         assertEquals(cmst.getLabels().get(1), cmst.getLabels().get(5), 0);
         assertEquals(cmst.getLabels().get(2), cmst.getLabels().get(4), 0);
@@ -168,15 +162,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         assertTrue(cmst.isCapacitatedSpanningTree(graph, 0, 4.0, weights));
         assertEquals(14.0, cmst.getWeight(), 0.0000001);
 
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(1)),
-            Pair.of(new HashSet<>(Arrays.asList(1, 5)), 4.0));
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(2)),
-            Pair.of(new HashSet<>(Arrays.asList(2, 3)), 3.0));
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(4)),
-            Pair.of(new HashSet<>(Collections.singletonList(4)), 3.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(1)), Pair.of(Set.of(1, 5), 4.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(2)), Pair.of(Set.of(2, 3), 3.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(4)), Pair.of(Set.of(4), 3.0));
 
         assertEquals(cmst.getLabels().get(1), cmst.getLabels().get(5), 0);
         assertEquals(cmst.getLabels().get(2), cmst.getLabels().get(3), 0);
@@ -228,10 +216,10 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         labels.put(5, 1);
 
         Map<Integer, Pair<Set<Integer>, Double>> partition = new HashMap<>();
-        partition.put(0, Pair.of(new HashSet<>(Collections.singletonList(1)), 1.0));
-        partition.put(1, Pair.of(new HashSet<>(Arrays.asList(2, 5)), 2.0));
-        partition.put(2, Pair.of(new HashSet<>(Collections.singletonList(3)), 1.0));
-        partition.put(3, Pair.of(new HashSet<>(Collections.singletonList(4)), 2.0));
+        partition.put(0, Pair.of(Set.of(1), 1.0));
+        partition.put(1, Pair.of(Set.of(2, 5), 2.0));
+        partition.put(2, Pair.of(Set.of(3), 1.0));
+        partition.put(3, Pair.of(Set.of(4), 2.0));
 
         Set<DefaultWeightedEdge> edges = new HashSet<>();
         edges.add(graph.getEdge(0, 1));
@@ -254,18 +242,10 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         assertTrue(cmst.isCapacitatedSpanningTree(graph, 0, 2.0, weights));
         assertEquals(5.0, cmst.getWeight(), 0.0000001);
 
-        assertEquals(
-            Pair.of(new HashSet<>(Arrays.asList(1, 5)), 2.0),
-            cmst.getPartition().get(cmst.getLabels().get(1)));
-        assertEquals(
-            Pair.of(new HashSet<>(Collections.singletonList(2)), 1.0),
-            cmst.getPartition().get(cmst.getLabels().get(2)));
-        assertEquals(
-            Pair.of(new HashSet<>(Collections.singletonList(3)), 1.0),
-            cmst.getPartition().get(cmst.getLabels().get(3)));
-        assertEquals(
-            Pair.of(new HashSet<>(Collections.singletonList(4)), 2.0),
-            cmst.getPartition().get(cmst.getLabels().get(4)));
+        assertEquals(Pair.of(Set.of(1, 5), 2.0), cmst.getPartition().get(cmst.getLabels().get(1)));
+        assertEquals(Pair.of(Set.of(2), 1.0), cmst.getPartition().get(cmst.getLabels().get(2)));
+        assertEquals(Pair.of(Set.of(3), 1.0), cmst.getPartition().get(cmst.getLabels().get(3)));
+        assertEquals(Pair.of(Set.of(4), 2.0), cmst.getPartition().get(cmst.getLabels().get(4)));
 
         assertEquals(cmst.getLabels().get(1), cmst.getLabels().get(5), 0);
         assertNotEquals(cmst.getLabels().get(1), cmst.getLabels().get(2));
@@ -320,9 +300,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         labels.put(7, 1);
 
         Map<Integer, Pair<Set<Integer>, Double>> partition = new HashMap<>();
-        partition.put(0, Pair.of(new HashSet<>(Arrays.asList(1, 4)), 2.0));
-        partition.put(1, Pair.of(new HashSet<>(Arrays.asList(2, 5, 7)), 3.0));
-        partition.put(2, Pair.of(new HashSet<>(Arrays.asList(3, 6)), 2.0));
+        partition.put(0, Pair.of(Set.of(1, 4), 2.0));
+        partition.put(1, Pair.of(Set.of(2, 5, 7), 3.0));
+        partition.put(2, Pair.of(Set.of(3, 6), 2.0));
 
         Set<DefaultWeightedEdge> edges = new HashSet<>();
         edges.add(graph.getEdge(0, 1));
@@ -348,14 +328,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         assertEquals(7.0, cmst.getWeight(), 0.0000001);
 
         assertEquals(
-            Pair.of(new HashSet<>(Arrays.asList(1, 4, 7)), 3.0),
-            cmst.getPartition().get(cmst.getLabels().get(1)));
-        assertEquals(
-            Pair.of(new HashSet<>(Arrays.asList(2, 5)), 2.0),
-            cmst.getPartition().get(cmst.getLabels().get(2)));
-        assertEquals(
-            Pair.of(new HashSet<>(Arrays.asList(3, 6)), 2.0),
-            cmst.getPartition().get(cmst.getLabels().get(3)));
+            Pair.of(Set.of(1, 4, 7), 3.0), cmst.getPartition().get(cmst.getLabels().get(1)));
+        assertEquals(Pair.of(Set.of(2, 5), 2.0), cmst.getPartition().get(cmst.getLabels().get(2)));
+        assertEquals(Pair.of(Set.of(3, 6), 2.0), cmst.getPartition().get(cmst.getLabels().get(3)));
 
         assertEquals(cmst.getLabels().get(1), cmst.getLabels().get(4), 0);
         assertEquals(cmst.getLabels().get(1), cmst.getLabels().get(7), 0);
@@ -421,9 +396,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         labels.put(8, 1);
 
         Map<Integer, Pair<Set<Integer>, Double>> partition = new HashMap<>();
-        partition.put(0, Pair.of(new HashSet<>(Arrays.asList(1, 4)), 2.0));
-        partition.put(1, Pair.of(new HashSet<>(Arrays.asList(2, 5, 7, 8)), 4.0));
-        partition.put(2, Pair.of(new HashSet<>(Arrays.asList(3, 6)), 2.0));
+        partition.put(0, Pair.of(Set.of(1, 4), 2.0));
+        partition.put(1, Pair.of(Set.of(2, 5, 7, 8), 4.0));
+        partition.put(2, Pair.of(Set.of(3, 6), 2.0));
 
         Set<DefaultWeightedEdge> edges = new HashSet<>();
         edges.add(graph.getEdge(0, 1));
@@ -450,14 +425,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         assertEquals(8.0, cmst.getWeight(), 0.0000001);
 
         assertEquals(
-            Pair.of(new HashSet<>(Arrays.asList(1, 4, 7, 8)), 4.0),
-            cmst.getPartition().get(cmst.getLabels().get(1)));
-        assertEquals(
-            Pair.of(new HashSet<>(Arrays.asList(2, 5)), 2.0),
-            cmst.getPartition().get(cmst.getLabels().get(2)));
-        assertEquals(
-            Pair.of(new HashSet<>(Arrays.asList(3, 6)), 2.0),
-            cmst.getPartition().get(cmst.getLabels().get(3)));
+            Pair.of(Set.of(1, 4, 7, 8), 4.0), cmst.getPartition().get(cmst.getLabels().get(1)));
+        assertEquals(Pair.of(Set.of(2, 5), 2.0), cmst.getPartition().get(cmst.getLabels().get(2)));
+        assertEquals(Pair.of(Set.of(3, 6), 2.0), cmst.getPartition().get(cmst.getLabels().get(3)));
 
         assertEquals(cmst.getLabels().get(1), cmst.getLabels().get(4), 0);
         assertEquals(cmst.getLabels().get(1), cmst.getLabels().get(7), 0);
@@ -536,11 +506,11 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         labels.put(5, 4);
 
         Map<Integer, Pair<Set<Integer>, Double>> partition = new HashMap<>();
-        partition.put(0, Pair.of(new HashSet<>(Collections.singletonList(1)), 2.0));
-        partition.put(1, Pair.of(new HashSet<>(Collections.singletonList(2)), 1.0));
-        partition.put(2, Pair.of(new HashSet<>(Collections.singletonList(3)), 2.0));
-        partition.put(3, Pair.of(new HashSet<>(Collections.singletonList(4)), 3.0));
-        partition.put(4, Pair.of(new HashSet<>(Collections.singletonList(5)), 2.0));
+        partition.put(0, Pair.of(Set.of(1), 2.0));
+        partition.put(1, Pair.of(Set.of(2), 1.0));
+        partition.put(2, Pair.of(Set.of(3), 2.0));
+        partition.put(3, Pair.of(Set.of(4), 3.0));
+        partition.put(4, Pair.of(Set.of(5), 2.0));
 
         Set<DefaultWeightedEdge> edges = new HashSet<>();
         edges.add(graph.getEdge(0, 1));
@@ -563,15 +533,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         assertTrue(cmst.isCapacitatedSpanningTree(graph, 0, 4.0, weights));
         assertEquals(14.0, cmst.getWeight(), 0.0000001);
 
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(1)),
-            Pair.of(new HashSet<>(Arrays.asList(1, 5)), 4.0));
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(2)),
-            Pair.of(new HashSet<>(Arrays.asList(2, 3)), 3.0));
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(4)),
-            Pair.of(new HashSet<>(Collections.singletonList(4)), 3.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(1)), Pair.of(Set.of(1, 5), 4.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(2)), Pair.of(Set.of(2, 3), 3.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(4)), Pair.of(Set.of(4), 3.0));
 
         assertEquals(cmst.getLabels().get(1), cmst.getLabels().get(5), 0);
         assertEquals(cmst.getLabels().get(2), cmst.getLabels().get(3), 0);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest.java
@@ -68,9 +68,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         labels.put(6, 2);
 
         Map<Integer, Pair<Set<Integer>, Double>> partition = new HashMap<>();
-        partition.put(0, Pair.of(Set.of(1, 4), 2.0));
-        partition.put(1, Pair.of(Set.of(2, 5), 2.0));
-        partition.put(2, Pair.of(Set.of(3, 6), 2.0));
+        partition.put(0, Pair.of(new HashSet<>(Arrays.asList(1, 4)), 2.0));
+        partition.put(1, Pair.of(new HashSet<>(Arrays.asList(2, 5)), 2.0));
+        partition.put(2, Pair.of(new HashSet<>(Arrays.asList(3, 6)), 2.0));
 
         Set<DefaultWeightedEdge> edges = new HashSet<>();
         edges.add(graph.getEdge(0, 1));
@@ -216,10 +216,10 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         labels.put(5, 1);
 
         Map<Integer, Pair<Set<Integer>, Double>> partition = new HashMap<>();
-        partition.put(0, Pair.of(Set.of(1), 1.0));
-        partition.put(1, Pair.of(Set.of(2, 5), 2.0));
-        partition.put(2, Pair.of(Set.of(3), 1.0));
-        partition.put(3, Pair.of(Set.of(4), 2.0));
+        partition.put(0, Pair.of(new HashSet<>(Arrays.asList(1)), 1.0));
+        partition.put(1, Pair.of(new HashSet<>(Arrays.asList(2, 5)), 2.0));
+        partition.put(2, Pair.of(new HashSet<>(Arrays.asList(3)), 1.0));
+        partition.put(3, Pair.of(new HashSet<>(Arrays.asList(4)), 2.0));
 
         Set<DefaultWeightedEdge> edges = new HashSet<>();
         edges.add(graph.getEdge(0, 1));
@@ -300,9 +300,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         labels.put(7, 1);
 
         Map<Integer, Pair<Set<Integer>, Double>> partition = new HashMap<>();
-        partition.put(0, Pair.of(Set.of(1, 4), 2.0));
-        partition.put(1, Pair.of(Set.of(2, 5, 7), 3.0));
-        partition.put(2, Pair.of(Set.of(3, 6), 2.0));
+        partition.put(0, Pair.of(new HashSet<>(Arrays.asList(1, 4)), 2.0));
+        partition.put(1, Pair.of(new HashSet<>(Arrays.asList(2, 5, 7)), 3.0));
+        partition.put(2, Pair.of(new HashSet<>(Arrays.asList(3, 6)), 2.0));
 
         Set<DefaultWeightedEdge> edges = new HashSet<>();
         edges.add(graph.getEdge(0, 1));
@@ -396,9 +396,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         labels.put(8, 1);
 
         Map<Integer, Pair<Set<Integer>, Double>> partition = new HashMap<>();
-        partition.put(0, Pair.of(Set.of(1, 4), 2.0));
-        partition.put(1, Pair.of(Set.of(2, 5, 7, 8), 4.0));
-        partition.put(2, Pair.of(Set.of(3, 6), 2.0));
+        partition.put(0, Pair.of(new HashSet<>(Arrays.asList(1, 4)), 2.0));
+        partition.put(1, Pair.of(new HashSet<>(Arrays.asList(2, 5, 7, 8)), 4.0));
+        partition.put(2, Pair.of(new HashSet<>(Arrays.asList(3, 6)), 2.0));
 
         Set<DefaultWeightedEdge> edges = new HashSet<>();
         edges.add(graph.getEdge(0, 1));
@@ -506,11 +506,11 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         labels.put(5, 4);
 
         Map<Integer, Pair<Set<Integer>, Double>> partition = new HashMap<>();
-        partition.put(0, Pair.of(Set.of(1), 2.0));
-        partition.put(1, Pair.of(Set.of(2), 1.0));
-        partition.put(2, Pair.of(Set.of(3), 2.0));
-        partition.put(3, Pair.of(Set.of(4), 3.0));
-        partition.put(4, Pair.of(Set.of(5), 2.0));
+        partition.put(0, Pair.of(new HashSet<>(Arrays.asList(1)), 2.0));
+        partition.put(1, Pair.of(new HashSet<>(Arrays.asList(2)), 1.0));
+        partition.put(2, Pair.of(new HashSet<>(Arrays.asList(3)), 2.0));
+        partition.put(3, Pair.of(new HashSet<>(Arrays.asList(4)), 3.0));
+        partition.put(4, Pair.of(new HashSet<>(Arrays.asList(5)), 2.0));
 
         Set<DefaultWeightedEdge> edges = new HashSet<>();
         edges.add(graph.getEdge(0, 1));

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/EsauWilliamsCapacitatedMinimumSpanningTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/EsauWilliamsCapacitatedMinimumSpanningTreeTest.java
@@ -86,15 +86,10 @@ public class EsauWilliamsCapacitatedMinimumSpanningTreeTest
         assertNotNull(cmst);
         assertEquals(42.0, cmst.getWeight(), 0.0000001);
 
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(1)), Pair.of(Set.of(1, 4), 2.0));
         assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(1)),
-            Pair.of(new HashSet<>(Arrays.asList(1, 4)), 2.0));
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(2)),
-            Pair.of(new HashSet<>(Arrays.asList(2, 5, 6)), 3.0));
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(3)),
-            Pair.of(new HashSet<>(Collections.singletonList(3)), 2.0));
+            cmst.getPartition().get(cmst.getLabels().get(2)), Pair.of(Set.of(2, 5, 6), 3.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(3)), Pair.of(Set.of(3), 2.0));
 
         assertEquals(cmst.getLabels().get(1), cmst.getLabels().get(4), 0);
         assertEquals(cmst.getLabels().get(2), cmst.getLabels().get(5), 0);
@@ -161,15 +156,9 @@ public class EsauWilliamsCapacitatedMinimumSpanningTreeTest
         assertNotNull(cmst);
         assertEquals(14.0, cmst.getWeight(), 0.0000001);
 
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(1)),
-            Pair.of(new HashSet<>(Arrays.asList(1, 5)), 4.0));
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(2)),
-            Pair.of(new HashSet<>(Arrays.asList(2, 3)), 3.0));
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(4)),
-            Pair.of(new HashSet<>(Collections.singletonList(4)), 3.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(1)), Pair.of(Set.of(1, 5), 4.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(2)), Pair.of(Set.of(2, 3), 3.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(4)), Pair.of(Set.of(4), 3.0));
 
         assertEquals(cmst.getLabels().get(1), cmst.getLabels().get(5), 0);
         assertEquals(cmst.getLabels().get(2), cmst.getLabels().get(3), 0);
@@ -235,15 +224,9 @@ public class EsauWilliamsCapacitatedMinimumSpanningTreeTest
         assertNotNull(cmst);
         assertEquals(14.0, cmst.getWeight(), 0.0000001);
 
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(1)),
-            Pair.of(new HashSet<>(Arrays.asList(1, 5)), 4.0));
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(2)),
-            Pair.of(new HashSet<>(Arrays.asList(2, 3)), 3.0));
-        assertEquals(
-            cmst.getPartition().get(cmst.getLabels().get(4)),
-            Pair.of(new HashSet<>(Collections.singletonList(4)), 3.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(1)), Pair.of(Set.of(1, 5), 4.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(2)), Pair.of(Set.of(2, 3), 3.0));
+        assertEquals(cmst.getPartition().get(cmst.getLabels().get(4)), Pair.of(Set.of(4), 3.0));
 
         assertEquals(cmst.getLabels().get(1), cmst.getLabels().get(5), 0);
         assertEquals(cmst.getLabels().get(2), cmst.getLabels().get(3), 0);

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/ComplementGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/ComplementGraphGeneratorTest.java
@@ -70,7 +70,7 @@ public class ComplementGraphGeneratorTest
         Graph<Integer, DefaultEdge> target = new SimpleWeightedGraph<>(DefaultEdge.class);
         cgg.generateGraph(target);
 
-        assertTrue(target.vertexSet().equals(new HashSet<>(Arrays.asList(0, 1, 2, 3))));
+        assertTrue(target.vertexSet().equals(Set.of(0, 1, 2, 3)));
         assertEquals(3, target.edgeSet().size());
         assertTrue(target.containsEdge(0, 3));
         assertTrue(target.containsEdge(2, 3));
@@ -90,7 +90,7 @@ public class ComplementGraphGeneratorTest
         Graph<Integer, DefaultEdge> target = new SimpleWeightedGraph<>(DefaultEdge.class);
         cgg.generateGraph(target);
 
-        assertTrue(target.vertexSet().equals(new HashSet<>(Arrays.asList(0, 1, 2))));
+        assertTrue(target.vertexSet().equals(Set.of(0, 1, 2)));
         assertEquals(3, target.edgeSet().size());
         assertTrue(target.containsEdge(1, 0));
         assertTrue(target.containsEdge(2, 1));
@@ -110,7 +110,7 @@ public class ComplementGraphGeneratorTest
             new ComplementGraphGenerator<>(g, true);
         Graph<Integer, DefaultEdge> target = new Pseudograph<>(DefaultEdge.class);
         cgg.generateGraph(target);
-        assertTrue(target.vertexSet().equals(new HashSet<>(Arrays.asList(0, 1, 2))));
+        assertTrue(target.vertexSet().equals(Set.of(0, 1, 2)));
         assertEquals(3, target.edgeSet().size());
         for (Integer v : target.vertexSet())
             assertTrue(target.containsEdge(v, v));

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/AsGraphUnionTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/AsGraphUnionTest.java
@@ -105,15 +105,14 @@ public class AsGraphUnionTest
         assertTrue(graphUnion.getType().isWeighted());
         assertFalse(graphUnion.getType().isModifiable());
 
-        assertEquals(new HashSet<>(Arrays.asList(v0, v1, v2, v3, v4)), graphUnion.vertexSet());
-        assertEquals(
-            new HashSet<>(Arrays.asList(e1, e2, e3, e4, e5, e6, e7, e8)), graphUnion.edgeSet());
+        assertEquals(Set.of(v0, v1, v2, v3, v4), graphUnion.vertexSet());
+        assertEquals(Set.of(e1, e2, e3, e4, e5, e6, e7, e8), graphUnion.edgeSet());
 
-        assertEquals(new HashSet<>(Arrays.asList(e1, e3)), graphUnion.edgesOf(v0));
-        assertEquals(new HashSet<>(Arrays.asList(e1, e2, e4, e7)), graphUnion.edgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e4, e5)), graphUnion.edgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e5, e6)), graphUnion.edgesOf(v3));
-        assertEquals(new HashSet<>(Arrays.asList(e2, e3, e6, e7, e8)), graphUnion.edgesOf(v4));
+        assertEquals(Set.of(e1, e3), graphUnion.edgesOf(v0));
+        assertEquals(Set.of(e1, e2, e4, e7), graphUnion.edgesOf(v1));
+        assertEquals(Set.of(e4, e5), graphUnion.edgesOf(v2));
+        assertEquals(Set.of(e5, e6), graphUnion.edgesOf(v3));
+        assertEquals(Set.of(e2, e3, e6, e7, e8), graphUnion.edgesOf(v4));
 
         assertEquals(2, graphUnion.degreeOf(v0));
         assertEquals(4, graphUnion.degreeOf(v1));
@@ -121,12 +120,11 @@ public class AsGraphUnionTest
         assertEquals(2, graphUnion.degreeOf(v3));
         assertEquals(6, graphUnion.degreeOf(v4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e1, e3)), graphUnion.incomingEdgesOf(v0));
-        assertEquals(new HashSet<>(Arrays.asList(e1, e2, e4, e7)), graphUnion.incomingEdgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e4, e5)), graphUnion.incomingEdgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e5, e6)), graphUnion.incomingEdgesOf(v3));
-        assertEquals(
-            new HashSet<>(Arrays.asList(e2, e3, e6, e7, e8)), graphUnion.incomingEdgesOf(v4));
+        assertEquals(Set.of(e1, e3), graphUnion.incomingEdgesOf(v0));
+        assertEquals(Set.of(e1, e2, e4, e7), graphUnion.incomingEdgesOf(v1));
+        assertEquals(Set.of(e4, e5), graphUnion.incomingEdgesOf(v2));
+        assertEquals(Set.of(e5, e6), graphUnion.incomingEdgesOf(v3));
+        assertEquals(Set.of(e2, e3, e6, e7, e8), graphUnion.incomingEdgesOf(v4));
 
         assertEquals(2, graphUnion.inDegreeOf(v0));
         assertEquals(4, graphUnion.inDegreeOf(v1));
@@ -134,12 +132,11 @@ public class AsGraphUnionTest
         assertEquals(2, graphUnion.inDegreeOf(v3));
         assertEquals(6, graphUnion.inDegreeOf(v4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e1, e3)), graphUnion.outgoingEdgesOf(v0));
-        assertEquals(new HashSet<>(Arrays.asList(e1, e2, e4, e7)), graphUnion.outgoingEdgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e4, e5)), graphUnion.outgoingEdgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e5, e6)), graphUnion.outgoingEdgesOf(v3));
-        assertEquals(
-            new HashSet<>(Arrays.asList(e2, e3, e6, e7, e8)), graphUnion.outgoingEdgesOf(v4));
+        assertEquals(Set.of(e1, e3), graphUnion.outgoingEdgesOf(v0));
+        assertEquals(Set.of(e1, e2, e4, e7), graphUnion.outgoingEdgesOf(v1));
+        assertEquals(Set.of(e4, e5), graphUnion.outgoingEdgesOf(v2));
+        assertEquals(Set.of(e5, e6), graphUnion.outgoingEdgesOf(v3));
+        assertEquals(Set.of(e2, e3, e6, e7, e8), graphUnion.outgoingEdgesOf(v4));
 
         assertEquals(2, graphUnion.outDegreeOf(v0));
         assertEquals(4, graphUnion.outDegreeOf(v1));
@@ -164,15 +161,14 @@ public class AsGraphUnionTest
         assertTrue(graphUnion.getType().isWeighted());
         assertFalse(graphUnion.getType().isModifiable());
 
-        assertEquals(new HashSet<>(Arrays.asList(v0, v1, v2, v3, v4)), graphUnion.vertexSet());
-        assertEquals(
-            new HashSet<>(Arrays.asList(e1, e2, e3, e4, e5, e6, e7, e8)), graphUnion.edgeSet());
+        assertEquals(Set.of(v0, v1, v2, v3, v4), graphUnion.vertexSet());
+        assertEquals(Set.of(e1, e2, e3, e4, e5, e6, e7, e8), graphUnion.edgeSet());
 
-        assertEquals(new HashSet<>(Arrays.asList(e1, e3)), graphUnion.edgesOf(v0));
-        assertEquals(new HashSet<>(Arrays.asList(e1, e2, e4, e7)), graphUnion.edgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e4, e5)), graphUnion.edgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e5, e6)), graphUnion.edgesOf(v3));
-        assertEquals(new HashSet<>(Arrays.asList(e2, e3, e6, e7, e8)), graphUnion.edgesOf(v4));
+        assertEquals(Set.of(e1, e3), graphUnion.edgesOf(v0));
+        assertEquals(Set.of(e1, e2, e4, e7), graphUnion.edgesOf(v1));
+        assertEquals(Set.of(e4, e5), graphUnion.edgesOf(v2));
+        assertEquals(Set.of(e5, e6), graphUnion.edgesOf(v3));
+        assertEquals(Set.of(e2, e3, e6, e7, e8), graphUnion.edgesOf(v4));
 
         assertEquals(2, graphUnion.degreeOf(v0));
         assertEquals(4, graphUnion.degreeOf(v1));
@@ -180,11 +176,11 @@ public class AsGraphUnionTest
         assertEquals(2, graphUnion.degreeOf(v3));
         assertEquals(6, graphUnion.degreeOf(v4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e3)), graphUnion.incomingEdgesOf(v0));
-        assertEquals(new HashSet<>(Arrays.asList(e1, e7)), graphUnion.incomingEdgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e4)), graphUnion.incomingEdgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e5)), graphUnion.incomingEdgesOf(v3));
-        assertEquals(new HashSet<>(Arrays.asList(e2, e6, e8)), graphUnion.incomingEdgesOf(v4));
+        assertEquals(Set.of(e3), graphUnion.incomingEdgesOf(v0));
+        assertEquals(Set.of(e1, e7), graphUnion.incomingEdgesOf(v1));
+        assertEquals(Set.of(e4), graphUnion.incomingEdgesOf(v2));
+        assertEquals(Set.of(e5), graphUnion.incomingEdgesOf(v3));
+        assertEquals(Set.of(e2, e6, e8), graphUnion.incomingEdgesOf(v4));
 
         assertEquals(1, graphUnion.inDegreeOf(v0));
         assertEquals(2, graphUnion.inDegreeOf(v1));
@@ -192,11 +188,11 @@ public class AsGraphUnionTest
         assertEquals(1, graphUnion.inDegreeOf(v3));
         assertEquals(3, graphUnion.inDegreeOf(v4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e1)), graphUnion.outgoingEdgesOf(v0));
-        assertEquals(new HashSet<>(Arrays.asList(e2, e4)), graphUnion.outgoingEdgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e5)), graphUnion.outgoingEdgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e6)), graphUnion.outgoingEdgesOf(v3));
-        assertEquals(new HashSet<>(Arrays.asList(e3, e7, e8)), graphUnion.outgoingEdgesOf(v4));
+        assertEquals(Set.of(e1), graphUnion.outgoingEdgesOf(v0));
+        assertEquals(Set.of(e2, e4), graphUnion.outgoingEdgesOf(v1));
+        assertEquals(Set.of(e5), graphUnion.outgoingEdgesOf(v2));
+        assertEquals(Set.of(e6), graphUnion.outgoingEdgesOf(v3));
+        assertEquals(Set.of(e3, e7, e8), graphUnion.outgoingEdgesOf(v4));
 
         assertEquals(1, graphUnion.outDegreeOf(v0));
         assertEquals(2, graphUnion.outDegreeOf(v1));
@@ -224,15 +220,14 @@ public class AsGraphUnionTest
         assertTrue(graphUnion.getType().isWeighted());
         assertFalse(graphUnion.getType().isModifiable());
 
-        assertEquals(new HashSet<>(Arrays.asList(v0, v1, v2, v3, v4)), graphUnion.vertexSet());
-        assertEquals(
-            new HashSet<>(Arrays.asList(e1, e2, e3, e4, e5, e6, e7, e8)), graphUnion.edgeSet());
+        assertEquals(Set.of(v0, v1, v2, v3, v4), graphUnion.vertexSet());
+        assertEquals(Set.of(e1, e2, e3, e4, e5, e6, e7, e8), graphUnion.edgeSet());
 
-        assertEquals(new HashSet<>(Arrays.asList(e1, e3)), graphUnion.edgesOf(v0));
-        assertEquals(new HashSet<>(Arrays.asList(e1, e2, e4, e7)), graphUnion.edgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e4, e5)), graphUnion.edgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e5, e6)), graphUnion.edgesOf(v3));
-        assertEquals(new HashSet<>(Arrays.asList(e2, e3, e6, e7, e8)), graphUnion.edgesOf(v4));
+        assertEquals(Set.of(e1, e3), graphUnion.edgesOf(v0));
+        assertEquals(Set.of(e1, e2, e4, e7), graphUnion.edgesOf(v1));
+        assertEquals(Set.of(e4, e5), graphUnion.edgesOf(v2));
+        assertEquals(Set.of(e5, e6), graphUnion.edgesOf(v3));
+        assertEquals(Set.of(e2, e3, e6, e7, e8), graphUnion.edgesOf(v4));
 
         assertEquals(2, graphUnion.degreeOf(v0));
         assertEquals(4, graphUnion.degreeOf(v1));
@@ -240,11 +235,11 @@ public class AsGraphUnionTest
         assertEquals(2, graphUnion.degreeOf(v3));
         assertEquals(6, graphUnion.degreeOf(v4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e1, e3)), graphUnion.incomingEdgesOf(v0));
-        assertEquals(new HashSet<>(Arrays.asList(e1, e2, e7)), graphUnion.incomingEdgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e4)), graphUnion.incomingEdgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e5)), graphUnion.incomingEdgesOf(v3));
-        assertEquals(new HashSet<>(Arrays.asList(e2, e3, e6, e8)), graphUnion.incomingEdgesOf(v4));
+        assertEquals(Set.of(e1, e3), graphUnion.incomingEdgesOf(v0));
+        assertEquals(Set.of(e1, e2, e7), graphUnion.incomingEdgesOf(v1));
+        assertEquals(Set.of(e4), graphUnion.incomingEdgesOf(v2));
+        assertEquals(Set.of(e5), graphUnion.incomingEdgesOf(v3));
+        assertEquals(Set.of(e2, e3, e6, e8), graphUnion.incomingEdgesOf(v4));
 
         assertEquals(2, graphUnion.inDegreeOf(v0));
         assertEquals(3, graphUnion.inDegreeOf(v1));
@@ -252,11 +247,11 @@ public class AsGraphUnionTest
         assertEquals(1, graphUnion.inDegreeOf(v3));
         assertEquals(5, graphUnion.inDegreeOf(v4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e1, e3)), graphUnion.outgoingEdgesOf(v0));
-        assertEquals(new HashSet<>(Arrays.asList(e1, e2, e4)), graphUnion.outgoingEdgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e5)), graphUnion.outgoingEdgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e6)), graphUnion.outgoingEdgesOf(v3));
-        assertEquals(new HashSet<>(Arrays.asList(e2, e3, e7, e8)), graphUnion.outgoingEdgesOf(v4));
+        assertEquals(Set.of(e1, e3), graphUnion.outgoingEdgesOf(v0));
+        assertEquals(Set.of(e1, e2, e4), graphUnion.outgoingEdgesOf(v1));
+        assertEquals(Set.of(e5), graphUnion.outgoingEdgesOf(v2));
+        assertEquals(Set.of(e6), graphUnion.outgoingEdgesOf(v3));
+        assertEquals(Set.of(e2, e3, e7, e8), graphUnion.outgoingEdgesOf(v4));
 
         assertEquals(2, graphUnion.outDegreeOf(v0));
         assertEquals(3, graphUnion.outDegreeOf(v1));

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/AsSubgraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/AsSubgraphTest.java
@@ -199,7 +199,7 @@ public class AsSubgraphTest
         g.addEdge(5, 2);
 
         Graph<Integer, DefaultEdge> sg =
-            new AsSubgraph<>(g, new HashSet<>(Arrays.asList(1, 3, 100, 200, 300, 500, 800, 1000)));
+            new AsSubgraph<>(g, Set.of(1, 3, 100, 200, 300, 500, 800, 1000));
         assertEquals(2, sg.edgeSet().size());
         assertEquals(2, sg.vertexSet().size());
     }
@@ -225,8 +225,8 @@ public class AsSubgraphTest
         DefaultEdge nonValid2 = g.addEdge(5, 1);
         g.removeEdge(nonValid2);
 
-        Graph<Integer, DefaultEdge> sg = new AsSubgraph<>(
-            g, null, new HashSet<>(Arrays.asList(e1, e2, e3, e4, e5, nonValid1, nonValid2)));
+        Graph<Integer, DefaultEdge> sg =
+            new AsSubgraph<>(g, null, Set.of(e1, e2, e3, e4, e5, nonValid1, nonValid2));
         assertEquals(5, sg.edgeSet().size());
         assertEquals(5, sg.vertexSet().size());
     }
@@ -246,37 +246,35 @@ public class AsSubgraphTest
         DefaultEdge e44 = g.addEdge(4, 4);
         g.addEdge(4, 5);
 
-        Graph<Integer,
-            DefaultEdge> sg = new AsSubgraph<>(
-                g, new HashSet<>(Arrays.asList(1, 2, 3, 4)),
-                new HashSet<>(Arrays.asList(e12, e13, e23, e24_1, e24_2, e44)));
+        Graph<Integer, DefaultEdge> sg =
+            new AsSubgraph<>(g, Set.of(1, 2, 3, 4), Set.of(e12, e13, e23, e24_1, e24_2, e44));
 
         assertEquals(6, sg.edgeSet().size());
 
-        assertEquals(new HashSet<>(Arrays.asList(e12, e13)), sg.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e24_1, e24_2, e23)), sg.edgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e13, e23)), sg.edgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e44)), sg.edgesOf(4));
+        assertEquals(Set.of(e12, e13), sg.edgesOf(1));
+        assertEquals(Set.of(e12, e24_1, e24_2, e23), sg.edgesOf(2));
+        assertEquals(Set.of(e13, e23), sg.edgesOf(3));
+        assertEquals(Set.of(e24_1, e24_2, e44), sg.edgesOf(4));
 
         assertEquals(2, sg.degreeOf(1));
         assertEquals(4, sg.degreeOf(2));
         assertEquals(2, sg.degreeOf(3));
         assertEquals(4, sg.degreeOf(4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12, e13)), sg.incomingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e24_1, e24_2, e23)), sg.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e13, e23)), sg.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e44)), sg.incomingEdgesOf(4));
+        assertEquals(Set.of(e12, e13), sg.incomingEdgesOf(1));
+        assertEquals(Set.of(e12, e24_1, e24_2, e23), sg.incomingEdgesOf(2));
+        assertEquals(Set.of(e13, e23), sg.incomingEdgesOf(3));
+        assertEquals(Set.of(e24_1, e24_2, e44), sg.incomingEdgesOf(4));
 
         assertEquals(2, sg.inDegreeOf(1));
         assertEquals(4, sg.inDegreeOf(2));
         assertEquals(2, sg.inDegreeOf(3));
         assertEquals(4, sg.inDegreeOf(4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12, e13)), sg.outgoingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e24_1, e24_2, e23)), sg.outgoingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e13, e23)), sg.outgoingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e44)), sg.outgoingEdgesOf(4));
+        assertEquals(Set.of(e12, e13), sg.outgoingEdgesOf(1));
+        assertEquals(Set.of(e12, e24_1, e24_2, e23), sg.outgoingEdgesOf(2));
+        assertEquals(Set.of(e13, e23), sg.outgoingEdgesOf(3));
+        assertEquals(Set.of(e24_1, e24_2, e44), sg.outgoingEdgesOf(4));
 
         assertEquals(2, sg.outDegreeOf(1));
         assertEquals(4, sg.outDegreeOf(2));
@@ -299,37 +297,35 @@ public class AsSubgraphTest
         DefaultEdge e44 = g.addEdge(4, 4);
         g.addEdge(4, 5);
 
-        Graph<Integer,
-            DefaultEdge> sg = new AsSubgraph<>(
-                g, new HashSet<>(Arrays.asList(1, 2, 3, 4)),
-                new HashSet<>(Arrays.asList(e12, e13, e23, e24_1, e24_2, e44)));
+        Graph<Integer, DefaultEdge> sg =
+            new AsSubgraph<>(g, Set.of(1, 2, 3, 4), Set.of(e12, e13, e23, e24_1, e24_2, e44));
 
         assertEquals(6, sg.edgeSet().size());
 
-        assertEquals(new HashSet<>(Arrays.asList(e12, e13)), sg.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e24_1, e24_2, e23)), sg.edgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e13, e23)), sg.edgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e44)), sg.edgesOf(4));
+        assertEquals(Set.of(e12, e13), sg.edgesOf(1));
+        assertEquals(Set.of(e12, e24_1, e24_2, e23), sg.edgesOf(2));
+        assertEquals(Set.of(e13, e23), sg.edgesOf(3));
+        assertEquals(Set.of(e24_1, e24_2, e44), sg.edgesOf(4));
 
         assertEquals(2, sg.degreeOf(1));
         assertEquals(4, sg.degreeOf(2));
         assertEquals(2, sg.degreeOf(3));
         assertEquals(4, sg.degreeOf(4));
 
-        assertEquals(new HashSet<>(), sg.incomingEdgesOf(1));
-        assertEquals(new HashSet<>(Collections.singletonList(e12)), sg.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e13, e23)), sg.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e44)), sg.incomingEdgesOf(4));
+        assertEquals(Set.of(), sg.incomingEdgesOf(1));
+        assertEquals(Set.of(e12), sg.incomingEdgesOf(2));
+        assertEquals(Set.of(e13, e23), sg.incomingEdgesOf(3));
+        assertEquals(Set.of(e24_1, e24_2, e44), sg.incomingEdgesOf(4));
 
         assertEquals(0, sg.inDegreeOf(1));
         assertEquals(1, sg.inDegreeOf(2));
         assertEquals(2, sg.inDegreeOf(3));
         assertEquals(3, sg.inDegreeOf(4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12, e13)), sg.outgoingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e23)), sg.outgoingEdgesOf(2));
-        assertEquals(new HashSet<>(), sg.outgoingEdgesOf(3));
-        assertEquals(new HashSet<>(Collections.singletonList(e44)), sg.outgoingEdgesOf(4));
+        assertEquals(Set.of(e12, e13), sg.outgoingEdgesOf(1));
+        assertEquals(Set.of(e24_1, e24_2, e23), sg.outgoingEdgesOf(2));
+        assertEquals(Set.of(), sg.outgoingEdgesOf(3));
+        assertEquals(Set.of(e44), sg.outgoingEdgesOf(4));
 
         assertEquals(2, sg.outDegreeOf(1));
         assertEquals(3, sg.outDegreeOf(2));

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/AsUndirectedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/AsUndirectedGraphTest.java
@@ -91,10 +91,10 @@ public class AsUndirectedGraphTest
     @Test
     public void testEdgesOf()
     {
-        assertEquals(new HashSet<>(Arrays.asList(e12)), undirected.edgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24)), undirected.edgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), undirected.edgesOf(v3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, loop)), undirected.edgesOf(v4));
+        assertEquals(Set.of(e12), undirected.edgesOf(v1));
+        assertEquals(Set.of(e12, e23, e24), undirected.edgesOf(v2));
+        assertEquals(Set.of(e23), undirected.edgesOf(v3));
+        assertEquals(Set.of(e24, loop), undirected.edgesOf(v4));
     }
 
     /**
@@ -115,10 +115,10 @@ public class AsUndirectedGraphTest
     @Test
     public void testIncomingEdgesOf()
     {
-        assertEquals(new HashSet<>(Arrays.asList(e12)), undirected.incomingEdgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24)), undirected.incomingEdgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), undirected.incomingEdgesOf(v3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, loop)), undirected.incomingEdgesOf(v4));
+        assertEquals(Set.of(e12), undirected.incomingEdgesOf(v1));
+        assertEquals(Set.of(e12, e23, e24), undirected.incomingEdgesOf(v2));
+        assertEquals(Set.of(e23), undirected.incomingEdgesOf(v3));
+        assertEquals(Set.of(e24, loop), undirected.incomingEdgesOf(v4));
     }
 
     /**
@@ -139,10 +139,10 @@ public class AsUndirectedGraphTest
     @Test
     public void testOutgoingEdgesOf()
     {
-        assertEquals(new HashSet<>(Arrays.asList(e12)), undirected.outgoingEdgesOf(v1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24)), undirected.outgoingEdgesOf(v2));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), undirected.outgoingEdgesOf(v3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, loop)), undirected.outgoingEdgesOf(v4));
+        assertEquals(Set.of(e12), undirected.outgoingEdgesOf(v1));
+        assertEquals(Set.of(e12, e23, e24), undirected.outgoingEdgesOf(v2));
+        assertEquals(Set.of(e23), undirected.outgoingEdgesOf(v3));
+        assertEquals(Set.of(e24, loop), undirected.outgoingEdgesOf(v4));
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/IncomingOutgoingEdgesTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/IncomingOutgoingEdgesTest.java
@@ -49,9 +49,9 @@ public class IncomingOutgoingEdgesTest
         assertTrue(g.edgeSet().size() == 1);
         assertEquals(Collections.emptySet(), g.incomingEdgesOf(1));
         assertEquals(0, g.inDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(e), g.outgoingEdgesOf(1));
         assertEquals(1, g.outDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.incomingEdgesOf(2));
+        assertEquals(Set.of(e), g.incomingEdgesOf(2));
         assertEquals(1, g.inDegreeOf(2));
         assertEquals(Collections.emptySet(), g.outgoingEdgesOf(2));
         assertEquals(0, g.outDegreeOf(2));
@@ -64,9 +64,9 @@ public class IncomingOutgoingEdgesTest
         assertTrue(g.edgeSet().size() == 1);
         assertEquals(Collections.emptySet(), g.incomingEdgesOf(1));
         assertEquals(0, g.inDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(e), g.outgoingEdgesOf(1));
         assertEquals(1, g.outDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.incomingEdgesOf(2));
+        assertEquals(Set.of(e), g.incomingEdgesOf(2));
         assertEquals(1, g.inDegreeOf(2));
         assertEquals(Collections.emptySet(), g.outgoingEdgesOf(2));
         assertEquals(0, g.outDegreeOf(2));
@@ -107,11 +107,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(3, g.degreeOf(4));
         assertEquals(5, g.degreeOf(5));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.edgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.edgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.edgesOf(5));
+        assertEquals(Set.of(e12), g.edgesOf(1));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.edgesOf(2));
+        assertEquals(Set.of(e23_1, e23_2), g.edgesOf(3));
+        assertEquals(Set.of(e24, e44), g.edgesOf(4));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.edgesOf(5));
 
         assertEquals(0, g.inDegreeOf(1));
         assertEquals(2, g.inDegreeOf(2));
@@ -119,11 +119,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(2, g.inDegreeOf(4));
         assertEquals(2, g.inDegreeOf(5));
 
-        assertEquals(new HashSet<>(), g.incomingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e52)), g.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e55_1, e55_2)), g.incomingEdgesOf(5));
+        assertEquals(Set.of(), g.incomingEdgesOf(1));
+        assertEquals(Set.of(e12, e52), g.incomingEdgesOf(2));
+        assertEquals(Set.of(e23_1, e23_2), g.incomingEdgesOf(3));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf(4));
+        assertEquals(Set.of(e55_1, e55_2), g.incomingEdgesOf(5));
 
         assertEquals(1, g.outDegreeOf(1));
         assertEquals(3, g.outDegreeOf(2));
@@ -131,11 +131,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(1, g.outDegreeOf(4));
         assertEquals(3, g.outDegreeOf(5));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2, e24)), g.outgoingEdgesOf(2));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e44)), g.outgoingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.outgoingEdgesOf(5));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(e23_1, e23_2, e24), g.outgoingEdgesOf(2));
+        assertEquals(Set.of(), g.outgoingEdgesOf(3));
+        assertEquals(Set.of(e44), g.outgoingEdgesOf(4));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.outgoingEdgesOf(5));
     }
 
     /**
@@ -180,18 +180,18 @@ public class IncomingOutgoingEdgesTest
         DefaultEdge e = new DefaultEdge();
         g.addEdge(1, 2, e);
         assertTrue(g.edgeSet().size() == 1);
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.edgesOf(1));
+        assertEquals(Set.of(e), g.edgesOf(1));
         assertEquals(1, g.degreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.edgesOf(2));
+        assertEquals(Set.of(e), g.edgesOf(2));
         assertEquals(1, g.degreeOf(2));
         assertEquals(Collections.emptySet(), g.edgesOf(3));
         assertEquals(0, g.degreeOf(3));
 
         assertFalse(g.addEdge(1, 3, e));
         assertTrue(g.edgeSet().size() == 1);
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.edgesOf(1));
+        assertEquals(Set.of(e), g.edgesOf(1));
         assertEquals(1, g.degreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.edgesOf(2));
+        assertEquals(Set.of(e), g.edgesOf(2));
         assertEquals(1, g.degreeOf(2));
         assertEquals(Collections.emptySet(), g.edgesOf(3));
         assertEquals(0, g.degreeOf(3));
@@ -231,11 +231,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(3, g.degreeOf(4));
         assertEquals(5, g.degreeOf(5));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.edgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.edgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.edgesOf(5));
+        assertEquals(Set.of(e12), g.edgesOf(1));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.edgesOf(2));
+        assertEquals(Set.of(e23_1, e23_2), g.edgesOf(3));
+        assertEquals(Set.of(e24, e44), g.edgesOf(4));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.edgesOf(5));
 
         assertEquals(1, g.inDegreeOf(1));
         assertEquals(5, g.inDegreeOf(2));
@@ -243,12 +243,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(3, g.inDegreeOf(4));
         assertEquals(5, g.inDegreeOf(5));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.incomingEdgesOf(1));
-        assertEquals(
-            new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.incomingEdgesOf(5));
+        assertEquals(Set.of(e12), g.incomingEdgesOf(1));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.incomingEdgesOf(2));
+        assertEquals(Set.of(e23_1, e23_2), g.incomingEdgesOf(3));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf(4));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.incomingEdgesOf(5));
 
         assertEquals(1, g.outDegreeOf(1));
         assertEquals(5, g.outDegreeOf(2));
@@ -256,12 +255,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(3, g.outDegreeOf(4));
         assertEquals(5, g.outDegreeOf(5));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf(1));
-        assertEquals(
-            new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.outgoingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.outgoingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.outgoingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.outgoingEdgesOf(5));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.outgoingEdgesOf(2));
+        assertEquals(Set.of(e23_1, e23_2), g.outgoingEdgesOf(3));
+        assertEquals(Set.of(e24, e44), g.outgoingEdgesOf(4));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.outgoingEdgesOf(5));
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/MaskSubgraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/MaskSubgraphTest.java
@@ -60,30 +60,30 @@ public class MaskSubgraphTest
 
         assertEquals(6, sg.edgeSet().size());
 
-        assertEquals(new HashSet<>(Arrays.asList(e12, e13)), sg.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e24_1, e24_2, e23)), sg.edgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e13, e23)), sg.edgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e44)), sg.edgesOf(4));
+        assertEquals(Set.of(e12, e13), sg.edgesOf(1));
+        assertEquals(Set.of(e12, e24_1, e24_2, e23), sg.edgesOf(2));
+        assertEquals(Set.of(e13, e23), sg.edgesOf(3));
+        assertEquals(Set.of(e24_1, e24_2, e44), sg.edgesOf(4));
 
         assertEquals(2, sg.degreeOf(1));
         assertEquals(4, sg.degreeOf(2));
         assertEquals(2, sg.degreeOf(3));
         assertEquals(4, sg.degreeOf(4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12, e13)), sg.incomingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e24_1, e24_2, e23)), sg.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e13, e23)), sg.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e44)), sg.incomingEdgesOf(4));
+        assertEquals(Set.of(e12, e13), sg.incomingEdgesOf(1));
+        assertEquals(Set.of(e12, e24_1, e24_2, e23), sg.incomingEdgesOf(2));
+        assertEquals(Set.of(e13, e23), sg.incomingEdgesOf(3));
+        assertEquals(Set.of(e24_1, e24_2, e44), sg.incomingEdgesOf(4));
 
         assertEquals(2, sg.inDegreeOf(1));
         assertEquals(4, sg.inDegreeOf(2));
         assertEquals(2, sg.inDegreeOf(3));
         assertEquals(4, sg.inDegreeOf(4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12, e13)), sg.outgoingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e24_1, e24_2, e23)), sg.outgoingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e13, e23)), sg.outgoingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e44)), sg.outgoingEdgesOf(4));
+        assertEquals(Set.of(e12, e13), sg.outgoingEdgesOf(1));
+        assertEquals(Set.of(e12, e24_1, e24_2, e23), sg.outgoingEdgesOf(2));
+        assertEquals(Set.of(e13, e23), sg.outgoingEdgesOf(3));
+        assertEquals(Set.of(e24_1, e24_2, e44), sg.outgoingEdgesOf(4));
 
         assertEquals(2, sg.outDegreeOf(1));
         assertEquals(4, sg.outDegreeOf(2));
@@ -111,10 +111,10 @@ public class MaskSubgraphTest
 
         assertEquals(6, sg.edgeSet().size());
 
-        assertEquals(new HashSet<>(Arrays.asList(e12, e13)), sg.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e24_1, e24_2, e23)), sg.edgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e13, e23)), sg.edgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e44)), sg.edgesOf(4));
+        assertEquals(Set.of(e12, e13), sg.edgesOf(1));
+        assertEquals(Set.of(e12, e24_1, e24_2, e23), sg.edgesOf(2));
+        assertEquals(Set.of(e13, e23), sg.edgesOf(3));
+        assertEquals(Set.of(e24_1, e24_2, e44), sg.edgesOf(4));
 
         assertEquals(2, sg.degreeOf(1));
         assertEquals(4, sg.degreeOf(2));
@@ -122,19 +122,19 @@ public class MaskSubgraphTest
         assertEquals(4, sg.degreeOf(4));
 
         assertEquals(new HashSet<>(), sg.incomingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12)), sg.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e13, e23)), sg.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e44)), sg.incomingEdgesOf(4));
+        assertEquals(Set.of(e12), sg.incomingEdgesOf(2));
+        assertEquals(Set.of(e13, e23), sg.incomingEdgesOf(3));
+        assertEquals(Set.of(e24_1, e24_2, e44), sg.incomingEdgesOf(4));
 
         assertEquals(0, sg.inDegreeOf(1));
         assertEquals(1, sg.inDegreeOf(2));
         assertEquals(2, sg.inDegreeOf(3));
         assertEquals(3, sg.inDegreeOf(4));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12, e13)), sg.outgoingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e24_1, e24_2, e23)), sg.outgoingEdgesOf(2));
-        assertEquals(new HashSet<>(), sg.outgoingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e44)), sg.outgoingEdgesOf(4));
+        assertEquals(Set.of(e12, e13), sg.outgoingEdgesOf(1));
+        assertEquals(Set.of(e24_1, e24_2, e23), sg.outgoingEdgesOf(2));
+        assertEquals(Set.of(), sg.outgoingEdgesOf(3));
+        assertEquals(Set.of(e44), sg.outgoingEdgesOf(4));
 
         assertEquals(2, sg.outDegreeOf(1));
         assertEquals(3, sg.outDegreeOf(2));

--- a/jgrapht-core/src/test/java/org/jgrapht/util/UnmodifiableUnionSetTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/UnmodifiableUnionSetTest.java
@@ -35,9 +35,8 @@ public class UnmodifiableUnionSetTest
     @Test
     public void test1()
     {
-        UnmodifiableUnionSet<Integer> union = new UnmodifiableUnionSet<>(
-            new HashSet<>(Arrays.asList(1, 2, 3, 4, 5)),
-            new HashSet<>(Arrays.asList(1, 2, 3, 4, 5)));
+        UnmodifiableUnionSet<Integer> union =
+            new UnmodifiableUnionSet<>(Set.of(1, 2, 3, 4, 5), Set.of(1, 2, 3, 4, 5));
         assertEquals(5, union.size());
         IntStream.rangeClosed(1, 5).forEach(x -> assertTrue(union.contains(x)));
         IntStream.rangeClosed(6, 15).forEach(x -> assertFalse(union.contains(x)));
@@ -47,8 +46,7 @@ public class UnmodifiableUnionSetTest
     public void test2()
     {
         UnmodifiableUnionSet<Integer> union = new UnmodifiableUnionSet<>(
-            new HashSet<>(Arrays.asList(1, 2, 3, 4, 5)),
-            new HashSet<>(Arrays.asList(6, 7, 8, 9, 10, 11, 12, 13, 14, 15)));
+            Set.of(1, 2, 3, 4, 5), Set.of(6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
         assertEquals(15, union.size());
         IntStream.rangeClosed(1, 15).forEach(x -> assertTrue(union.contains(x)));
         IntStream.rangeClosed(16, 20).forEach(x -> assertFalse(union.contains(x)));
@@ -57,9 +55,8 @@ public class UnmodifiableUnionSetTest
     @Test
     public void test3()
     {
-        UnmodifiableUnionSet<Integer> union = new UnmodifiableUnionSet<>(
-            new HashSet<>(Arrays.asList(1, 2, 3, 4, 5)),
-            new HashSet<>(Arrays.asList(3, 4, 5, 6, 7, 8, 9, 10, 20)));
+        UnmodifiableUnionSet<Integer> union =
+            new UnmodifiableUnionSet<>(Set.of(1, 2, 3, 4, 5), Set.of(3, 4, 5, 6, 7, 8, 9, 10, 20));
         assertEquals(11, union.size());
         IntStream.rangeClosed(1, 10).forEach(x -> assertTrue(union.contains(x)));
         IntStream.rangeClosed(11, 19).forEach(x -> assertFalse(union.contains(x)));
@@ -69,8 +66,8 @@ public class UnmodifiableUnionSetTest
     @Test
     public void test4()
     {
-        UnmodifiableUnionSet<Integer> union = new UnmodifiableUnionSet<>(
-            new HashSet<>(), new HashSet<>(Arrays.asList(1, 2, 3, 4, 5)));
+        UnmodifiableUnionSet<Integer> union =
+            new UnmodifiableUnionSet<>(new HashSet<>(), Set.of(1, 2, 3, 4, 5));
         assertEquals(5, union.size());
         IntStream.rangeClosed(1, 5).forEach(x -> assertTrue(union.contains(x)));
         IntStream.of(6).forEach(x -> assertFalse(union.contains(x)));
@@ -89,8 +86,7 @@ public class UnmodifiableUnionSetTest
     public void testIteratorDisjoint()
     {
         UnmodifiableUnionSet<Integer> union = new UnmodifiableUnionSet<>(
-            new HashSet<>(Arrays.asList(1, 2, 3, 4, 5)),
-            new HashSet<>(Arrays.asList(6, 7, 8, 9, 10, 11, 12, 13, 14, 15)));
+            Set.of(1, 2, 3, 4, 5), Set.of(6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
         assertEquals(15, union.size());
 
         List<Integer> collectedElementsAsList = StreamSupport
@@ -108,9 +104,8 @@ public class UnmodifiableUnionSetTest
     @Test
     public void testIteratorCommonElements()
     {
-        UnmodifiableUnionSet<Integer> union = new UnmodifiableUnionSet<>(
-            new HashSet<>(Arrays.asList(1, 2, 3, 4, 5)),
-            new HashSet<>(Arrays.asList(3, 4, 5, 6, 7, 8, 9, 10)));
+        UnmodifiableUnionSet<Integer> union =
+            new UnmodifiableUnionSet<>(Set.of(1, 2, 3, 4, 5), Set.of(3, 4, 5, 6, 7, 8, 9, 10));
         assertEquals(10, union.size());
 
         List<Integer> collectedElementsAsList = StreamSupport
@@ -133,9 +128,9 @@ public class UnmodifiableUnionSetTest
         // underlying sets, and that size/iterator calls are optimized
         // based on the relative sizes of the underlying sets
 
-        Set<Integer> smallerHash = new HashSet<>(Arrays.asList(1, 2, 3, 4, 5));
+        Set<Integer> smallerHash = Set.of(1, 2, 3, 4, 5);
         ProfilingSet<Integer> smaller = new ProfilingSet<>(smallerHash);
-        Set<Integer> biggerHash = new HashSet<>(Arrays.asList(3, 4, 5, 6, 7, 8, 9, 10));
+        Set<Integer> biggerHash = Set.of(3, 4, 5, 6, 7, 8, 9, 10);
         ProfilingSet<Integer> bigger = new ProfilingSet<>(biggerHash);
 
         UnmodifiableUnionSet<Integer> union = new UnmodifiableUnionSet<>(smaller, bigger);

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableGraphAdapterTest.java
@@ -75,11 +75,11 @@ public class ImmutableGraphAdapterTest
         EndpointPair<String> e44 = EndpointPair.ordered("v4", "v4");
         EndpointPair<String> e52 = EndpointPair.ordered("v5", "v2");
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.edgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.edgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52)), g.edgesOf("v5"));
+        assertEquals(Set.of(e12), g.edgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.edgesOf("v2"));
+        assertEquals(Set.of(e23), g.edgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.edgesOf("v4"));
+        assertEquals(Set.of(e52), g.edgesOf("v5"));
 
         assertEquals(0, g.inDegreeOf("v1"));
         assertEquals(2, g.inDegreeOf("v2"));
@@ -87,11 +87,11 @@ public class ImmutableGraphAdapterTest
         assertEquals(2, g.inDegreeOf("v4"));
         assertEquals(0, g.inDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e52)), g.incomingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.incomingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf("v4"));
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v5"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e52), g.incomingEdgesOf("v2"));
+        assertEquals(Set.of(e23), g.incomingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf("v4"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v5"));
 
         assertEquals(1, g.outDegreeOf("v1"));
         assertEquals(2, g.outDegreeOf("v2"));
@@ -99,11 +99,11 @@ public class ImmutableGraphAdapterTest
         assertEquals(1, g.outDegreeOf("v4"));
         assertEquals(1, g.outDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e23, e24)), g.outgoingEdgesOf("v2"));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e44)), g.outgoingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52)), g.outgoingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf("v1"));
+        assertEquals(Set.of(e23, e24), g.outgoingEdgesOf("v2"));
+        assertEquals(Set.of(), g.outgoingEdgesOf("v3"));
+        assertEquals(Set.of(e44), g.outgoingEdgesOf("v4"));
+        assertEquals(Set.of(e52), g.outgoingEdgesOf("v5"));
 
         // test indeed immutable
         try {
@@ -195,11 +195,11 @@ public class ImmutableGraphAdapterTest
         EndpointPair<String> e44 = EndpointPair.ordered("v4", "v4");
         EndpointPair<String> e52 = EndpointPair.ordered("v5", "v2");
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.edgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.edgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52)), g.edgesOf("v5"));
+        assertEquals(Set.of(e12), g.edgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.edgesOf("v2"));
+        assertEquals(Set.of(e23), g.edgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.edgesOf("v4"));
+        assertEquals(Set.of(e52), g.edgesOf("v5"));
 
         assertEquals(0, g.inDegreeOf("v1"));
         assertEquals(2, g.inDegreeOf("v2"));
@@ -207,11 +207,11 @@ public class ImmutableGraphAdapterTest
         assertEquals(2, g.inDegreeOf("v4"));
         assertEquals(0, g.inDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e52)), g.incomingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.incomingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf("v4"));
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v5"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e52), g.incomingEdgesOf("v2"));
+        assertEquals(Set.of(e23), g.incomingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf("v4"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v5"));
 
         assertEquals(1, g.outDegreeOf("v1"));
         assertEquals(2, g.outDegreeOf("v2"));
@@ -219,11 +219,11 @@ public class ImmutableGraphAdapterTest
         assertEquals(1, g.outDegreeOf("v4"));
         assertEquals(1, g.outDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e23, e24)), g.outgoingEdgesOf("v2"));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e44)), g.outgoingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52)), g.outgoingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf("v1"));
+        assertEquals(Set.of(e23, e24), g.outgoingEdgesOf("v2"));
+        assertEquals(Set.of(), g.outgoingEdgesOf("v3"));
+        assertEquals(Set.of(e44), g.outgoingEdgesOf("v4"));
+        assertEquals(Set.of(e52), g.outgoingEdgesOf("v5"));
 
     }
 

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableNetworkAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableNetworkAdapterTest.java
@@ -81,11 +81,11 @@ public class ImmutableNetworkAdapterTest
         assertEquals(3, g.degreeOf("v4"));
         assertEquals(5, g.degreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.edgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.edgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.edgesOf("v5"));
+        assertEquals(Set.of(e12), g.edgesOf("v1"));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.edgesOf("v2"));
+        assertEquals(Set.of(e23_1, e23_2), g.edgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.edgesOf("v4"));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.edgesOf("v5"));
 
         assertEquals(0, g.inDegreeOf("v1"));
         assertEquals(2, g.inDegreeOf("v2"));
@@ -93,11 +93,11 @@ public class ImmutableNetworkAdapterTest
         assertEquals(2, g.inDegreeOf("v4"));
         assertEquals(2, g.inDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e52)), g.incomingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.incomingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e55_1, e55_2)), g.incomingEdgesOf("v5"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e52), g.incomingEdgesOf("v2"));
+        assertEquals(Set.of(e23_1, e23_2), g.incomingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf("v4"));
+        assertEquals(Set.of(e55_1, e55_2), g.incomingEdgesOf("v5"));
 
         assertEquals(1, g.outDegreeOf("v1"));
         assertEquals(3, g.outDegreeOf("v2"));
@@ -105,11 +105,11 @@ public class ImmutableNetworkAdapterTest
         assertEquals(1, g.outDegreeOf("v4"));
         assertEquals(3, g.outDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2, e24)), g.outgoingEdgesOf("v2"));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e44)), g.outgoingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.outgoingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf("v1"));
+        assertEquals(Set.of(e23_1, e23_2, e24), g.outgoingEdgesOf("v2"));
+        assertEquals(Set.of(), g.outgoingEdgesOf("v3"));
+        assertEquals(Set.of(e44), g.outgoingEdgesOf("v4"));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.outgoingEdgesOf("v5"));
 
         // test indeed immutable
         try {

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableValueGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableValueGraphAdapterTest.java
@@ -192,11 +192,11 @@ public class ImmutableValueGraphAdapterTest
         EndpointPair<String> e44 = EndpointPair.ordered("v4", "v4");
         EndpointPair<String> e52 = EndpointPair.ordered("v5", "v2");
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.edgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.edgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52)), g.edgesOf("v5"));
+        assertEquals(Set.of(e12), g.edgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.edgesOf("v2"));
+        assertEquals(Set.of(e23), g.edgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.edgesOf("v4"));
+        assertEquals(Set.of(e52), g.edgesOf("v5"));
 
         assertEquals(0, g.inDegreeOf("v1"));
         assertEquals(2, g.inDegreeOf("v2"));
@@ -204,11 +204,11 @@ public class ImmutableValueGraphAdapterTest
         assertEquals(2, g.inDegreeOf("v4"));
         assertEquals(0, g.inDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e52)), g.incomingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.incomingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf("v4"));
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v5"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e52), g.incomingEdgesOf("v2"));
+        assertEquals(Set.of(e23), g.incomingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf("v4"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v5"));
 
         assertEquals(1, g.outDegreeOf("v1"));
         assertEquals(2, g.outDegreeOf("v2"));
@@ -216,11 +216,11 @@ public class ImmutableValueGraphAdapterTest
         assertEquals(1, g.outDegreeOf("v4"));
         assertEquals(1, g.outDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e23, e24)), g.outgoingEdgesOf("v2"));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e44)), g.outgoingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52)), g.outgoingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf("v1"));
+        assertEquals(Set.of(e23, e24), g.outgoingEdgesOf("v2"));
+        assertEquals(Set.of(), g.outgoingEdgesOf("v3"));
+        assertEquals(Set.of(e44), g.outgoingEdgesOf("v4"));
+        assertEquals(Set.of(e52), g.outgoingEdgesOf("v5"));
 
         // test indeed immutable
         try {
@@ -315,11 +315,11 @@ public class ImmutableValueGraphAdapterTest
         EndpointPair<String> e44 = EndpointPair.ordered("v4", "v4");
         EndpointPair<String> e52 = EndpointPair.ordered("v5", "v2");
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.edgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.edgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52)), g.edgesOf("v5"));
+        assertEquals(Set.of(e12), g.edgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.edgesOf("v2"));
+        assertEquals(Set.of(e23), g.edgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.edgesOf("v4"));
+        assertEquals(Set.of(e52), g.edgesOf("v5"));
 
         assertEquals(0, g.inDegreeOf("v1"));
         assertEquals(2, g.inDegreeOf("v2"));
@@ -327,11 +327,11 @@ public class ImmutableValueGraphAdapterTest
         assertEquals(2, g.inDegreeOf("v4"));
         assertEquals(0, g.inDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e52)), g.incomingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.incomingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf("v4"));
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v5"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e52), g.incomingEdgesOf("v2"));
+        assertEquals(Set.of(e23), g.incomingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf("v4"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v5"));
 
         assertEquals(1, g.outDegreeOf("v1"));
         assertEquals(2, g.outDegreeOf("v2"));
@@ -339,11 +339,11 @@ public class ImmutableValueGraphAdapterTest
         assertEquals(1, g.outDegreeOf("v4"));
         assertEquals(1, g.outDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e23, e24)), g.outgoingEdgesOf("v2"));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e44)), g.outgoingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52)), g.outgoingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf("v1"));
+        assertEquals(Set.of(e23, e24), g.outgoingEdgesOf("v2"));
+        assertEquals(Set.of(), g.outgoingEdgesOf("v3"));
+        assertEquals(Set.of(e44), g.outgoingEdgesOf("v4"));
+        assertEquals(Set.of(e52), g.outgoingEdgesOf("v5"));
 
     }
 

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableGraphAdapterTest.java
@@ -71,11 +71,11 @@ public class MutableGraphAdapterTest
         assertEquals(3, g.degreeOf("v4"));
         assertEquals(3, g.degreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.edgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.edgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55)), g.edgesOf("v5"));
+        assertEquals(Set.of(e12), g.edgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.edgesOf("v2"));
+        assertEquals(Set.of(e23), g.edgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.edgesOf("v4"));
+        assertEquals(Set.of(e52, e55), g.edgesOf("v5"));
 
         assertEquals(0, g.inDegreeOf("v1"));
         assertEquals(2, g.inDegreeOf("v2"));
@@ -83,11 +83,11 @@ public class MutableGraphAdapterTest
         assertEquals(2, g.inDegreeOf("v4"));
         assertEquals(1, g.inDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e52)), g.incomingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.incomingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e55)), g.incomingEdgesOf("v5"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e52), g.incomingEdgesOf("v2"));
+        assertEquals(Set.of(e23), g.incomingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf("v4"));
+        assertEquals(Set.of(e55), g.incomingEdgesOf("v5"));
 
         assertEquals(1, g.outDegreeOf("v1"));
         assertEquals(2, g.outDegreeOf("v2"));
@@ -95,11 +95,11 @@ public class MutableGraphAdapterTest
         assertEquals(1, g.outDegreeOf("v4"));
         assertEquals(2, g.outDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e23, e24)), g.outgoingEdgesOf("v2"));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e44)), g.outgoingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55)), g.outgoingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf("v1"));
+        assertEquals(Set.of(e23, e24), g.outgoingEdgesOf("v2"));
+        assertEquals(Set.of(), g.outgoingEdgesOf("v3"));
+        assertEquals(Set.of(e44), g.outgoingEdgesOf("v4"));
+        assertEquals(Set.of(e52, e55), g.outgoingEdgesOf("v5"));
     }
 
     /**
@@ -136,11 +136,11 @@ public class MutableGraphAdapterTest
         assertEquals(3, g.degreeOf("v4"));
         assertEquals(3, g.degreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.edgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.edgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55)), g.edgesOf("v5"));
+        assertEquals(Set.of(e12), g.edgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.edgesOf("v2"));
+        assertEquals(Set.of(e23), g.edgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.edgesOf("v4"));
+        assertEquals(Set.of(e52, e55), g.edgesOf("v5"));
 
         assertEquals(1, g.inDegreeOf("v1"));
         assertEquals(4, g.inDegreeOf("v2"));
@@ -148,11 +148,11 @@ public class MutableGraphAdapterTest
         assertEquals(3, g.inDegreeOf("v4"));
         assertEquals(3, g.inDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.incomingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.incomingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.incomingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55)), g.incomingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.incomingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.incomingEdgesOf("v2"));
+        assertEquals(Set.of(e23), g.incomingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf("v4"));
+        assertEquals(Set.of(e52, e55), g.incomingEdgesOf("v5"));
 
         assertEquals(1, g.outDegreeOf("v1"));
         assertEquals(4, g.outDegreeOf("v2"));
@@ -160,11 +160,11 @@ public class MutableGraphAdapterTest
         assertEquals(3, g.outDegreeOf("v4"));
         assertEquals(3, g.outDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.outgoingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.outgoingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.outgoingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55)), g.outgoingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.outgoingEdgesOf("v2"));
+        assertEquals(Set.of(e23), g.outgoingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.outgoingEdgesOf("v4"));
+        assertEquals(Set.of(e52, e55), g.outgoingEdgesOf("v5"));
     }
 
     @Test
@@ -202,7 +202,7 @@ public class MutableGraphAdapterTest
         // @example:findVertexCover:begin
         VertexCoverAlgorithm<String> alg = new RecursiveExactVCImpl<>(jgrapht);
         VertexCoverAlgorithm.VertexCover<String> cover = alg.getVertexCover();
-        Set<String> expectedCover = new HashSet<String>(Arrays.asList("um", "ml", "mr", "lm"));
+        Set<String> expectedCover = Set.of("um", "ml", "mr", "lm");
         assertEquals(expectedCover, cover);
         // @example:findVertexCover:end
     }

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableNetworkAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableNetworkAdapterTest.java
@@ -89,11 +89,11 @@ public class MutableNetworkAdapterTest
         assertEquals(3, g.degreeOf("v4"));
         assertEquals(5, g.degreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.edgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.edgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.edgesOf("v5"));
+        assertEquals(Set.of(e12), g.edgesOf("v1"));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.edgesOf("v2"));
+        assertEquals(Set.of(e23_1, e23_2), g.edgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.edgesOf("v4"));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.edgesOf("v5"));
 
         assertEquals(0, g.inDegreeOf("v1"));
         assertEquals(2, g.inDegreeOf("v2"));
@@ -101,11 +101,11 @@ public class MutableNetworkAdapterTest
         assertEquals(2, g.inDegreeOf("v4"));
         assertEquals(2, g.inDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e52)), g.incomingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.incomingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e55_1, e55_2)), g.incomingEdgesOf("v5"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e52), g.incomingEdgesOf("v2"));
+        assertEquals(Set.of(e23_1, e23_2), g.incomingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf("v4"));
+        assertEquals(Set.of(e55_1, e55_2), g.incomingEdgesOf("v5"));
 
         assertEquals(1, g.outDegreeOf("v1"));
         assertEquals(3, g.outDegreeOf("v2"));
@@ -113,11 +113,11 @@ public class MutableNetworkAdapterTest
         assertEquals(1, g.outDegreeOf("v4"));
         assertEquals(3, g.outDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2, e24)), g.outgoingEdgesOf("v2"));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e44)), g.outgoingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.outgoingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf("v1"));
+        assertEquals(Set.of(e23_1, e23_2, e24), g.outgoingEdgesOf("v2"));
+        assertEquals(Set.of(), g.outgoingEdgesOf("v3"));
+        assertEquals(Set.of(e44), g.outgoingEdgesOf("v4"));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.outgoingEdgesOf("v5"));
     }
 
     /**
@@ -158,11 +158,11 @@ public class MutableNetworkAdapterTest
         assertEquals(3, g.degreeOf("v4"));
         assertEquals(5, g.degreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.edgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.edgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.edgesOf("v5"));
+        assertEquals(Set.of(e12), g.edgesOf("v1"));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.edgesOf("v2"));
+        assertEquals(Set.of(e23_1, e23_2), g.edgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.edgesOf("v4"));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.edgesOf("v5"));
 
         assertEquals(1, g.inDegreeOf("v1"));
         assertEquals(5, g.inDegreeOf("v2"));
@@ -170,12 +170,11 @@ public class MutableNetworkAdapterTest
         assertEquals(3, g.inDegreeOf("v4"));
         assertEquals(5, g.inDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.incomingEdgesOf("v1"));
-        assertEquals(
-            new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.incomingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.incomingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.incomingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.incomingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.incomingEdgesOf("v2"));
+        assertEquals(Set.of(e23_1, e23_2), g.incomingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf("v4"));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.incomingEdgesOf("v5"));
 
         assertEquals(1, g.outDegreeOf("v1"));
         assertEquals(5, g.outDegreeOf("v2"));
@@ -183,12 +182,11 @@ public class MutableNetworkAdapterTest
         assertEquals(3, g.outDegreeOf("v4"));
         assertEquals(5, g.outDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf("v1"));
-        assertEquals(
-            new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.outgoingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.outgoingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.outgoingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.outgoingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.outgoingEdgesOf("v2"));
+        assertEquals(Set.of(e23_1, e23_2), g.outgoingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.outgoingEdgesOf("v4"));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.outgoingEdgesOf("v5"));
     }
 
     /**

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableValueGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableValueGraphAdapterTest.java
@@ -17,26 +17,16 @@
  */
 package org.jgrapht.graph.guava;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashSet;
-import java.util.function.ToDoubleFunction;
-
 import org.jgrapht.Graph;
-import org.jgrapht.graph.DefaultEdge;
-import org.junit.Test;
+import org.junit.*;
 
-import com.google.common.graph.EndpointPair;
-import com.google.common.graph.MutableNetwork;
-import com.google.common.graph.MutableValueGraph;
-import com.google.common.graph.NetworkBuilder;
-import com.google.common.graph.ValueGraphBuilder;
+import java.io.*;
+import java.util.*;
+import java.util.function.*;
+
+import com.google.common.graph.*;
+
+import static org.junit.Assert.*;
 
 /**
  * Check Incoming/Outgoing edges in directed and undirected graphs.
@@ -221,11 +211,11 @@ public class MutableValueGraphAdapterTest
         assertEquals(3, g.degreeOf("v4"));
         assertEquals(3, g.degreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.edgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.edgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55)), g.edgesOf("v5"));
+        assertEquals(Set.of(e12), g.edgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.edgesOf("v2"));
+        assertEquals(Set.of(e23), g.edgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.edgesOf("v4"));
+        assertEquals(Set.of(e52, e55), g.edgesOf("v5"));
 
         assertEquals(0, g.inDegreeOf("v1"));
         assertEquals(2, g.inDegreeOf("v2"));
@@ -233,11 +223,11 @@ public class MutableValueGraphAdapterTest
         assertEquals(2, g.inDegreeOf("v4"));
         assertEquals(1, g.inDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(), g.incomingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e52)), g.incomingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.incomingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e55)), g.incomingEdgesOf("v5"));
+        assertEquals(Set.of(), g.incomingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e52), g.incomingEdgesOf("v2"));
+        assertEquals(Set.of(e23), g.incomingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf("v4"));
+        assertEquals(Set.of(e55), g.incomingEdgesOf("v5"));
 
         assertEquals(1, g.outDegreeOf("v1"));
         assertEquals(2, g.outDegreeOf("v2"));
@@ -245,11 +235,11 @@ public class MutableValueGraphAdapterTest
         assertEquals(1, g.outDegreeOf("v4"));
         assertEquals(2, g.outDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e23, e24)), g.outgoingEdgesOf("v2"));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e44)), g.outgoingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55)), g.outgoingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf("v1"));
+        assertEquals(Set.of(e23, e24), g.outgoingEdgesOf("v2"));
+        assertEquals(Set.of(), g.outgoingEdgesOf("v3"));
+        assertEquals(Set.of(e44), g.outgoingEdgesOf("v4"));
+        assertEquals(Set.of(e52, e55), g.outgoingEdgesOf("v5"));
     }
 
     /**
@@ -288,11 +278,11 @@ public class MutableValueGraphAdapterTest
         assertEquals(3, g.degreeOf("v4"));
         assertEquals(3, g.degreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.edgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.edgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55)), g.edgesOf("v5"));
+        assertEquals(Set.of(e12), g.edgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.edgesOf("v2"));
+        assertEquals(Set.of(e23), g.edgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.edgesOf("v4"));
+        assertEquals(Set.of(e52, e55), g.edgesOf("v5"));
 
         assertEquals(1, g.inDegreeOf("v1"));
         assertEquals(4, g.inDegreeOf("v2"));
@@ -300,11 +290,11 @@ public class MutableValueGraphAdapterTest
         assertEquals(3, g.inDegreeOf("v4"));
         assertEquals(3, g.inDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.incomingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.incomingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.incomingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55)), g.incomingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.incomingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.incomingEdgesOf("v2"));
+        assertEquals(Set.of(e23), g.incomingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf("v4"));
+        assertEquals(Set.of(e52, e55), g.incomingEdgesOf("v5"));
 
         assertEquals(1, g.outDegreeOf("v1"));
         assertEquals(4, g.outDegreeOf("v2"));
@@ -312,11 +302,11 @@ public class MutableValueGraphAdapterTest
         assertEquals(3, g.outDegreeOf("v4"));
         assertEquals(3, g.outDegreeOf("v5"));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf("v1"));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23, e24, e52)), g.outgoingEdgesOf("v2"));
-        assertEquals(new HashSet<>(Arrays.asList(e23)), g.outgoingEdgesOf("v3"));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.outgoingEdgesOf("v4"));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55)), g.outgoingEdgesOf("v5"));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf("v1"));
+        assertEquals(Set.of(e12, e23, e24, e52), g.outgoingEdgesOf("v2"));
+        assertEquals(Set.of(e23), g.outgoingEdgesOf("v3"));
+        assertEquals(Set.of(e24, e44), g.outgoingEdgesOf("v4"));
+        assertEquals(Set.of(e52, e55), g.outgoingEdgesOf("v5"));
     }
 
     /**

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONExporter.java
@@ -198,7 +198,7 @@ public class JSONExporter<V, E>
         if (!edgeAttributeProvider.isPresent()) {
             return;
         }
-        Set<String> forbidden = new HashSet<>(Arrays.asList("id", "source", "target"));
+        Set<String> forbidden = Set.of("id", "source", "target");
         edgeAttributeProvider
             .get().apply(e).entrySet().stream().filter(entry -> !forbidden.contains(entry.getKey()))
             .forEach(entry -> {

--- a/jgrapht-opt/src/test/java/org/jgrapht/opt/graph/fastutil/IncomingOutgoingEdgesTest.java
+++ b/jgrapht-opt/src/test/java/org/jgrapht/opt/graph/fastutil/IncomingOutgoingEdgesTest.java
@@ -17,22 +17,16 @@
  */
 package org.jgrapht.opt.graph.fastutil;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import org.jgrapht.*;
+import org.jgrapht.graph.*;
+import org.jgrapht.graph.builder.*;
+import org.jgrapht.util.*;
+import org.junit.*;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.function.Supplier;
+import java.util.*;
+import java.util.function.*;
 
-import org.jgrapht.Graph;
-import org.jgrapht.graph.DefaultEdge;
-import org.jgrapht.graph.DirectedPseudograph;
-import org.jgrapht.graph.Pseudograph;
-import org.jgrapht.graph.builder.GraphTypeBuilder;
-import org.jgrapht.util.SupplierUtil;
-import org.junit.Test;
+import static org.junit.Assert.*;
 
 /**
  * Check Incoming/Outgoing edges in directed and undirected graphs.
@@ -56,9 +50,9 @@ public class IncomingOutgoingEdgesTest
         assertTrue(g.edgeSet().size() == 1);
         assertEquals(Collections.emptySet(), g.incomingEdgesOf(1));
         assertEquals(0, g.inDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(e), g.outgoingEdgesOf(1));
         assertEquals(1, g.outDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.incomingEdgesOf(2));
+        assertEquals(Set.of(e), g.incomingEdgesOf(2));
         assertEquals(1, g.inDegreeOf(2));
         assertEquals(Collections.emptySet(), g.outgoingEdgesOf(2));
         assertEquals(0, g.outDegreeOf(2));
@@ -71,9 +65,9 @@ public class IncomingOutgoingEdgesTest
         assertTrue(g.edgeSet().size() == 1);
         assertEquals(Collections.emptySet(), g.incomingEdgesOf(1));
         assertEquals(0, g.inDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(e), g.outgoingEdgesOf(1));
         assertEquals(1, g.outDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.incomingEdgesOf(2));
+        assertEquals(Set.of(e), g.incomingEdgesOf(2));
         assertEquals(1, g.inDegreeOf(2));
         assertEquals(Collections.emptySet(), g.outgoingEdgesOf(2));
         assertEquals(0, g.outDegreeOf(2));
@@ -114,11 +108,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(3, g.degreeOf(4));
         assertEquals(5, g.degreeOf(5));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.edgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.edgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.edgesOf(5));
+        assertEquals(Set.of(e12), g.edgesOf(1));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.edgesOf(2));
+        assertEquals(Set.of(e23_1, e23_2), g.edgesOf(3));
+        assertEquals(Set.of(e24, e44), g.edgesOf(4));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.edgesOf(5));
 
         assertEquals(0, g.inDegreeOf(1));
         assertEquals(2, g.inDegreeOf(2));
@@ -126,11 +120,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(2, g.inDegreeOf(4));
         assertEquals(2, g.inDegreeOf(5));
 
-        assertEquals(new HashSet<>(), g.incomingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e52)), g.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e55_1, e55_2)), g.incomingEdgesOf(5));
+        assertEquals(Set.of(), g.incomingEdgesOf(1));
+        assertEquals(Set.of(e12, e52), g.incomingEdgesOf(2));
+        assertEquals(Set.of(e23_1, e23_2), g.incomingEdgesOf(3));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf(4));
+        assertEquals(Set.of(e55_1, e55_2), g.incomingEdgesOf(5));
 
         assertEquals(1, g.outDegreeOf(1));
         assertEquals(3, g.outDegreeOf(2));
@@ -138,11 +132,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(1, g.outDegreeOf(4));
         assertEquals(3, g.outDegreeOf(5));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2, e24)), g.outgoingEdgesOf(2));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e44)), g.outgoingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.outgoingEdgesOf(5));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(e23_1, e23_2, e24), g.outgoingEdgesOf(2));
+        assertEquals(Set.of(), g.outgoingEdgesOf(3));
+        assertEquals(Set.of(e44), g.outgoingEdgesOf(4));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.outgoingEdgesOf(5));
     }
 
     /**
@@ -187,18 +181,18 @@ public class IncomingOutgoingEdgesTest
         DefaultEdge e = new DefaultEdge();
         g.addEdge(1, 2, e);
         assertTrue(g.edgeSet().size() == 1);
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.edgesOf(1));
+        assertEquals(Set.of(e), g.edgesOf(1));
         assertEquals(1, g.degreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.edgesOf(2));
+        assertEquals(Set.of(e), g.edgesOf(2));
         assertEquals(1, g.degreeOf(2));
         assertEquals(Collections.emptySet(), g.edgesOf(3));
         assertEquals(0, g.degreeOf(3));
 
         assertFalse(g.addEdge(1, 3, e));
         assertTrue(g.edgeSet().size() == 1);
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.edgesOf(1));
+        assertEquals(Set.of(e), g.edgesOf(1));
         assertEquals(1, g.degreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e)), g.edgesOf(2));
+        assertEquals(Set.of(e), g.edgesOf(2));
         assertEquals(1, g.degreeOf(2));
         assertEquals(Collections.emptySet(), g.edgesOf(3));
         assertEquals(0, g.degreeOf(3));
@@ -238,11 +232,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(3, g.degreeOf(4));
         assertEquals(5, g.degreeOf(5));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.edgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.edgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.edgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.edgesOf(5));
+        assertEquals(Set.of(e12), g.edgesOf(1));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.edgesOf(2));
+        assertEquals(Set.of(e23_1, e23_2), g.edgesOf(3));
+        assertEquals(Set.of(e24, e44), g.edgesOf(4));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.edgesOf(5));
 
         assertEquals(1, g.inDegreeOf(1));
         assertEquals(5, g.inDegreeOf(2));
@@ -250,12 +244,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(3, g.inDegreeOf(4));
         assertEquals(5, g.inDegreeOf(5));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.incomingEdgesOf(1));
-        assertEquals(
-            new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.incomingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.incomingEdgesOf(5));
+        assertEquals(Set.of(e12), g.incomingEdgesOf(1));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.incomingEdgesOf(2));
+        assertEquals(Set.of(e23_1, e23_2), g.incomingEdgesOf(3));
+        assertEquals(Set.of(e24, e44), g.incomingEdgesOf(4));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.incomingEdgesOf(5));
 
         assertEquals(1, g.outDegreeOf(1));
         assertEquals(5, g.outDegreeOf(2));
@@ -263,12 +256,11 @@ public class IncomingOutgoingEdgesTest
         assertEquals(3, g.outDegreeOf(4));
         assertEquals(5, g.outDegreeOf(5));
 
-        assertEquals(new HashSet<>(Arrays.asList(e12)), g.outgoingEdgesOf(1));
-        assertEquals(
-            new HashSet<>(Arrays.asList(e12, e23_1, e23_2, e24, e52)), g.outgoingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(e23_1, e23_2)), g.outgoingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(e24, e44)), g.outgoingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(e52, e55_1, e55_2)), g.outgoingEdgesOf(5));
+        assertEquals(Set.of(e12), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(e12, e23_1, e23_2, e24, e52), g.outgoingEdgesOf(2));
+        assertEquals(Set.of(e23_1, e23_2), g.outgoingEdgesOf(3));
+        assertEquals(Set.of(e24, e44), g.outgoingEdgesOf(4));
+        assertEquals(Set.of(e52, e55_1, e55_2), g.outgoingEdgesOf(5));
     }
 
     /**

--- a/jgrapht-opt/src/test/java/org/jgrapht/opt/graph/sparse/SparseIntGraphTest.java
+++ b/jgrapht-opt/src/test/java/org/jgrapht/opt/graph/sparse/SparseIntGraphTest.java
@@ -87,44 +87,44 @@ public class SparseIntGraphTest
         assertEquals(3, g.degreeOf(0));
         assertEquals(3, g.inDegreeOf(0));
         assertEquals(3, g.outDegreeOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 4)), g.edgesOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 4)), g.incomingEdgesOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 4)), g.outgoingEdgesOf(0));
+        assertEquals(Set.of(0, 1, 4), g.edgesOf(0));
+        assertEquals(Set.of(0, 1, 4), g.incomingEdgesOf(0));
+        assertEquals(Set.of(0, 1, 4), g.outgoingEdgesOf(0));
 
         assertEquals(3, g.degreeOf(1));
         assertEquals(3, g.inDegreeOf(1));
         assertEquals(3, g.outDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(3, 4, 5)), g.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(3, 4, 5)), g.incomingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(3, 4, 5)), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(3, 4, 5), g.edgesOf(1));
+        assertEquals(Set.of(3, 4, 5), g.incomingEdgesOf(1));
+        assertEquals(Set.of(3, 4, 5), g.outgoingEdgesOf(1));
 
         assertEquals(2, g.degreeOf(2));
         assertEquals(2, g.inDegreeOf(2));
         assertEquals(2, g.outDegreeOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(1, 6)), g.edgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(1, 6)), g.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(1, 6)), g.outgoingEdgesOf(2));
+        assertEquals(Set.of(1, 6), g.edgesOf(2));
+        assertEquals(Set.of(1, 6), g.incomingEdgesOf(2));
+        assertEquals(Set.of(1, 6), g.outgoingEdgesOf(2));
 
         assertEquals(2, g.degreeOf(3));
         assertEquals(2, g.inDegreeOf(3));
         assertEquals(2, g.outDegreeOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(2, 5)), g.edgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(2, 5)), g.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(2, 5)), g.outgoingEdgesOf(3));
+        assertEquals(Set.of(2, 5), g.edgesOf(3));
+        assertEquals(Set.of(2, 5), g.incomingEdgesOf(3));
+        assertEquals(Set.of(2, 5), g.outgoingEdgesOf(3));
 
         assertEquals(3, g.degreeOf(4));
         assertEquals(3, g.inDegreeOf(4));
         assertEquals(3, g.outDegreeOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(2, 3, 6)), g.edgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(2, 3, 6)), g.incomingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(2, 3, 6)), g.outgoingEdgesOf(4));
+        assertEquals(Set.of(2, 3, 6), g.edgesOf(4));
+        assertEquals(Set.of(2, 3, 6), g.incomingEdgesOf(4));
+        assertEquals(Set.of(2, 3, 6), g.outgoingEdgesOf(4));
 
         assertEquals(1, g.degreeOf(5));
         assertEquals(1, g.inDegreeOf(5));
         assertEquals(1, g.outDegreeOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(0)), g.edgesOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(0)), g.incomingEdgesOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(0)), g.outgoingEdgesOf(5));
+        assertEquals(Set.of(0), g.edgesOf(5));
+        assertEquals(Set.of(0), g.incomingEdgesOf(5));
+        assertEquals(Set.of(0), g.outgoingEdgesOf(5));
 
         assertEquals(Integer.valueOf(0), g.getEdgeSource(0));
         assertEquals(Integer.valueOf(5), g.getEdgeTarget(0));
@@ -193,30 +193,30 @@ public class SparseIntGraphTest
         assertEquals(7, g.degreeOf(0));
         assertEquals(7, g.inDegreeOf(0));
         assertEquals(7, g.outDegreeOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0, 3, 1, 4, 2)), g.edgesOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0, 3, 1, 4, 2)), g.incomingEdgesOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0, 3, 1, 4, 2)), g.outgoingEdgesOf(0));
+        assertEquals(Set.of(0, 3, 1, 4, 2), g.edgesOf(0));
+        assertEquals(Set.of(0, 3, 1, 4, 2), g.incomingEdgesOf(0));
+        assertEquals(Set.of(0, 3, 1, 4, 2), g.outgoingEdgesOf(0));
 
         assertEquals(5, g.degreeOf(1));
         assertEquals(5, g.inDegreeOf(1));
         assertEquals(5, g.outDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(1, 4, 5, 6)), g.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(1, 4, 5, 6)), g.incomingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(1, 4, 5, 6)), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(1, 4, 5, 6), g.edgesOf(1));
+        assertEquals(Set.of(1, 4, 5, 6), g.incomingEdgesOf(1));
+        assertEquals(Set.of(1, 4, 5, 6), g.outgoingEdgesOf(1));
 
         assertEquals(2, g.degreeOf(2));
         assertEquals(2, g.inDegreeOf(2));
         assertEquals(2, g.outDegreeOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(2, 6)), g.edgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(2, 6)), g.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(2, 6)), g.outgoingEdgesOf(2));
+        assertEquals(Set.of(2, 6), g.edgesOf(2));
+        assertEquals(Set.of(2, 6), g.incomingEdgesOf(2));
+        assertEquals(Set.of(2, 6), g.outgoingEdgesOf(2));
 
         assertEquals(0, g.degreeOf(3));
         assertEquals(0, g.inDegreeOf(3));
         assertEquals(0, g.outDegreeOf(3));
-        assertEquals(new HashSet<>(Arrays.asList()), g.edgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList()), g.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList()), g.outgoingEdgesOf(3));
+        assertEquals(Set.of(), g.edgesOf(3));
+        assertEquals(Set.of(), g.incomingEdgesOf(3));
+        assertEquals(Set.of(), g.outgoingEdgesOf(3));
 
         assertEquals(Integer.valueOf(0), g.getEdgeSource(0));
         assertEquals(Integer.valueOf(0), g.getEdgeTarget(0));
@@ -275,44 +275,44 @@ public class SparseIntGraphTest
         assertEquals(3, g.degreeOf(0));
         assertEquals(3, g.inDegreeOf(0));
         assertEquals(3, g.outDegreeOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 4)), g.edgesOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 4)), g.incomingEdgesOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 4)), g.outgoingEdgesOf(0));
+        assertEquals(Set.of(0, 1, 4), g.edgesOf(0));
+        assertEquals(Set.of(0, 1, 4), g.incomingEdgesOf(0));
+        assertEquals(Set.of(0, 1, 4), g.outgoingEdgesOf(0));
 
         assertEquals(3, g.degreeOf(1));
         assertEquals(3, g.inDegreeOf(1));
         assertEquals(3, g.outDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(3, 4, 5)), g.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(3, 4, 5)), g.incomingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(3, 4, 5)), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(3, 4, 5), g.edgesOf(1));
+        assertEquals(Set.of(3, 4, 5), g.incomingEdgesOf(1));
+        assertEquals(Set.of(3, 4, 5), g.outgoingEdgesOf(1));
 
         assertEquals(2, g.degreeOf(2));
         assertEquals(2, g.inDegreeOf(2));
         assertEquals(2, g.outDegreeOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(1, 6)), g.edgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(1, 6)), g.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(1, 6)), g.outgoingEdgesOf(2));
+        assertEquals(Set.of(1, 6), g.edgesOf(2));
+        assertEquals(Set.of(1, 6), g.incomingEdgesOf(2));
+        assertEquals(Set.of(1, 6), g.outgoingEdgesOf(2));
 
         assertEquals(2, g.degreeOf(3));
         assertEquals(2, g.inDegreeOf(3));
         assertEquals(2, g.outDegreeOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(2, 5)), g.edgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(2, 5)), g.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(2, 5)), g.outgoingEdgesOf(3));
+        assertEquals(Set.of(2, 5), g.edgesOf(3));
+        assertEquals(Set.of(2, 5), g.incomingEdgesOf(3));
+        assertEquals(Set.of(2, 5), g.outgoingEdgesOf(3));
 
         assertEquals(3, g.degreeOf(4));
         assertEquals(3, g.inDegreeOf(4));
         assertEquals(3, g.outDegreeOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(2, 3, 6)), g.edgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(2, 3, 6)), g.incomingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(2, 3, 6)), g.outgoingEdgesOf(4));
+        assertEquals(Set.of(2, 3, 6), g.edgesOf(4));
+        assertEquals(Set.of(2, 3, 6), g.incomingEdgesOf(4));
+        assertEquals(Set.of(2, 3, 6), g.outgoingEdgesOf(4));
 
         assertEquals(1, g.degreeOf(5));
         assertEquals(1, g.inDegreeOf(5));
         assertEquals(1, g.outDegreeOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(0)), g.edgesOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(0)), g.incomingEdgesOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(0)), g.outgoingEdgesOf(5));
+        assertEquals(Set.of(0), g.edgesOf(5));
+        assertEquals(Set.of(0), g.incomingEdgesOf(5));
+        assertEquals(Set.of(0), g.outgoingEdgesOf(5));
 
         assertEquals(Integer.valueOf(0), g.getEdgeSource(0));
         assertEquals(Integer.valueOf(5), g.getEdgeTarget(0));
@@ -400,58 +400,58 @@ public class SparseIntGraphTest
         assertEquals(2, g.degreeOf(0));
         assertEquals(1, g.inDegreeOf(0));
         assertEquals(1, g.outDegreeOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0, 1)), g.edgesOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(1)), g.incomingEdgesOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0)), g.outgoingEdgesOf(0));
+        assertEquals(Set.of(0, 1), g.edgesOf(0));
+        assertEquals(Set.of(1), g.incomingEdgesOf(0));
+        assertEquals(Set.of(0), g.outgoingEdgesOf(0));
 
         assertEquals(5, g.degreeOf(1));
         assertEquals(1, g.inDegreeOf(1));
         assertEquals(4, g.outDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 2, 3, 4)), g.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(0)), g.incomingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(1, 2, 3, 4)), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(0, 1, 2, 3, 4), g.edgesOf(1));
+        assertEquals(Set.of(0), g.incomingEdgesOf(1));
+        assertEquals(Set.of(1, 2, 3, 4), g.outgoingEdgesOf(1));
 
         assertEquals(3, g.degreeOf(2));
         assertEquals(0, g.inDegreeOf(2));
         assertEquals(3, g.outDegreeOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(5, 6, 7)), g.edgesOf(2));
-        assertEquals(new HashSet<>(), g.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(5, 6, 7)), g.outgoingEdgesOf(2));
+        assertEquals(Set.of(5, 6, 7), g.edgesOf(2));
+        assertEquals(Set.of(), g.incomingEdgesOf(2));
+        assertEquals(Set.of(5, 6, 7), g.outgoingEdgesOf(2));
 
         assertEquals(1, g.degreeOf(3));
         assertEquals(0, g.inDegreeOf(3));
         assertEquals(1, g.outDegreeOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(8)), g.edgesOf(3));
-        assertEquals(new HashSet<>(), g.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(8)), g.outgoingEdgesOf(3));
+        assertEquals(Set.of(8), g.edgesOf(3));
+        assertEquals(Set.of(), g.incomingEdgesOf(3));
+        assertEquals(Set.of(8), g.outgoingEdgesOf(3));
 
         assertEquals(6, g.degreeOf(4));
         assertEquals(5, g.inDegreeOf(4));
         assertEquals(1, g.outDegreeOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(2, 5, 6, 7, 8, 9)), g.edgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(2, 5, 6, 7, 8)), g.incomingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(9)), g.outgoingEdgesOf(4));
+        assertEquals(Set.of(2, 5, 6, 7, 8, 9), g.edgesOf(4));
+        assertEquals(Set.of(2, 5, 6, 7, 8), g.incomingEdgesOf(4));
+        assertEquals(Set.of(9), g.outgoingEdgesOf(4));
 
         assertEquals(3, g.degreeOf(5));
         assertEquals(2, g.inDegreeOf(5));
         assertEquals(1, g.outDegreeOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(3, 9, 10)), g.edgesOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(3, 9)), g.incomingEdgesOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(10)), g.outgoingEdgesOf(5));
+        assertEquals(Set.of(3, 9, 10), g.edgesOf(5));
+        assertEquals(Set.of(3, 9), g.incomingEdgesOf(5));
+        assertEquals(Set.of(10), g.outgoingEdgesOf(5));
 
         assertEquals(3, g.degreeOf(6));
         assertEquals(3, g.inDegreeOf(6));
         assertEquals(0, g.outDegreeOf(6));
-        assertEquals(new HashSet<>(Arrays.asList(4, 10, 11)), g.edgesOf(6));
-        assertEquals(new HashSet<>(Arrays.asList(4, 10, 11)), g.incomingEdgesOf(6));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf(6));
+        assertEquals(Set.of(4, 10, 11), g.edgesOf(6));
+        assertEquals(Set.of(4, 10, 11), g.incomingEdgesOf(6));
+        assertEquals(Set.of(), g.outgoingEdgesOf(6));
 
         assertEquals(3, g.degreeOf(7));
         assertEquals(1, g.inDegreeOf(7));
         assertEquals(2, g.outDegreeOf(7));
-        assertEquals(new HashSet<>(Arrays.asList(11, 12)), g.edgesOf(7));
-        assertEquals(new HashSet<>(Arrays.asList(12)), g.incomingEdgesOf(7));
-        assertEquals(new HashSet<>(Arrays.asList(11, 12)), g.outgoingEdgesOf(7));
+        assertEquals(Set.of(11, 12), g.edgesOf(7));
+        assertEquals(Set.of(12), g.incomingEdgesOf(7));
+        assertEquals(Set.of(11, 12), g.outgoingEdgesOf(7));
 
         assertEquals(Integer.valueOf(0), g.getEdgeSource(0));
         assertEquals(Integer.valueOf(1), g.getEdgeTarget(0));
@@ -491,27 +491,27 @@ public class SparseIntGraphTest
         assertFalse(type.isWeighted());
 
         assertEquals(Integer.valueOf(0), g.getEdge(0, 1));
-        assertEquals(Collections.singleton(Integer.valueOf(0)), g.getAllEdges(0, 1));
+        assertEquals(Set.of(0), g.getAllEdges(0, 1));
         assertEquals(Integer.valueOf(1), g.getEdge(1, 0));
-        assertEquals(Collections.singleton(Integer.valueOf(1)), g.getAllEdges(1, 0));
+        assertEquals(Set.of(1), g.getAllEdges(1, 0));
         assertEquals(Integer.valueOf(2), g.getEdge(1, 4));
-        assertEquals(Collections.singleton(Integer.valueOf(2)), g.getAllEdges(1, 4));
+        assertEquals(Set.of(2), g.getAllEdges(1, 4));
         assertEquals(Integer.valueOf(3), g.getEdge(1, 5));
-        assertEquals(Collections.singleton(Integer.valueOf(3)), g.getAllEdges(1, 5));
+        assertEquals(Set.of(3), g.getAllEdges(1, 5));
         assertEquals(Integer.valueOf(4), g.getEdge(1, 6));
-        assertEquals(Collections.singleton(Integer.valueOf(4)), g.getAllEdges(1, 6));
+        assertEquals(Set.of(4), g.getAllEdges(1, 6));
         assertEquals(Integer.valueOf(5), g.getEdge(2, 4));
-        assertEquals(new HashSet<>(Arrays.asList(5, 6, 7)), g.getAllEdges(2, 4));
+        assertEquals(Set.of(5, 6, 7), g.getAllEdges(2, 4));
         assertEquals(Integer.valueOf(8), g.getEdge(3, 4));
-        assertEquals(Collections.singleton(Integer.valueOf(8)), g.getAllEdges(3, 4));
+        assertEquals(Set.of(8), g.getAllEdges(3, 4));
         assertEquals(Integer.valueOf(9), g.getEdge(4, 5));
-        assertEquals(Collections.singleton(Integer.valueOf(9)), g.getAllEdges(4, 5));
+        assertEquals(Set.of(9), g.getAllEdges(4, 5));
         assertEquals(Integer.valueOf(10), g.getEdge(5, 6));
-        assertEquals(Collections.singleton(Integer.valueOf(10)), g.getAllEdges(5, 6));
+        assertEquals(Set.of(10), g.getAllEdges(5, 6));
         assertEquals(Integer.valueOf(11), g.getEdge(7, 6));
-        assertEquals(Collections.singleton(Integer.valueOf(11)), g.getAllEdges(7, 6));
+        assertEquals(Set.of(11), g.getAllEdges(7, 6));
         assertEquals(Integer.valueOf(12), g.getEdge(7, 7));
-        assertEquals(Collections.singleton(Integer.valueOf(12)), g.getAllEdges(7, 7));
+        assertEquals(Set.of(12), g.getAllEdges(7, 7));
 
     }
 
@@ -547,58 +547,58 @@ public class SparseIntGraphTest
         assertEquals(2, g.degreeOf(0));
         assertEquals(1, g.inDegreeOf(0));
         assertEquals(1, g.outDegreeOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0, 1)), g.edgesOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(1)), g.incomingEdgesOf(0));
-        assertEquals(new HashSet<>(Arrays.asList(0)), g.outgoingEdgesOf(0));
+        assertEquals(Set.of(0, 1), g.edgesOf(0));
+        assertEquals(Set.of(1), g.incomingEdgesOf(0));
+        assertEquals(Set.of(0), g.outgoingEdgesOf(0));
 
         assertEquals(5, g.degreeOf(1));
         assertEquals(1, g.inDegreeOf(1));
         assertEquals(4, g.outDegreeOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(0, 1, 2, 3, 4)), g.edgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(0)), g.incomingEdgesOf(1));
-        assertEquals(new HashSet<>(Arrays.asList(1, 2, 3, 4)), g.outgoingEdgesOf(1));
+        assertEquals(Set.of(0, 1, 2, 3, 4), g.edgesOf(1));
+        assertEquals(Set.of(0), g.incomingEdgesOf(1));
+        assertEquals(Set.of(1, 2, 3, 4), g.outgoingEdgesOf(1));
 
         assertEquals(3, g.degreeOf(2));
         assertEquals(0, g.inDegreeOf(2));
         assertEquals(3, g.outDegreeOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(5, 6, 7)), g.edgesOf(2));
-        assertEquals(new HashSet<>(), g.incomingEdgesOf(2));
-        assertEquals(new HashSet<>(Arrays.asList(5, 6, 7)), g.outgoingEdgesOf(2));
+        assertEquals(Set.of(5, 6, 7), g.edgesOf(2));
+        assertEquals(Set.of(), g.incomingEdgesOf(2));
+        assertEquals(Set.of(5, 6, 7), g.outgoingEdgesOf(2));
 
         assertEquals(1, g.degreeOf(3));
         assertEquals(0, g.inDegreeOf(3));
         assertEquals(1, g.outDegreeOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(8)), g.edgesOf(3));
-        assertEquals(new HashSet<>(), g.incomingEdgesOf(3));
-        assertEquals(new HashSet<>(Arrays.asList(8)), g.outgoingEdgesOf(3));
+        assertEquals(Set.of(8), g.edgesOf(3));
+        assertEquals(Set.of(), g.incomingEdgesOf(3));
+        assertEquals(Set.of(8), g.outgoingEdgesOf(3));
 
         assertEquals(6, g.degreeOf(4));
         assertEquals(5, g.inDegreeOf(4));
         assertEquals(1, g.outDegreeOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(2, 5, 6, 7, 8, 9)), g.edgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(2, 5, 6, 7, 8)), g.incomingEdgesOf(4));
-        assertEquals(new HashSet<>(Arrays.asList(9)), g.outgoingEdgesOf(4));
+        assertEquals(Set.of(2, 5, 6, 7, 8, 9), g.edgesOf(4));
+        assertEquals(Set.of(2, 5, 6, 7, 8), g.incomingEdgesOf(4));
+        assertEquals(Set.of(9), g.outgoingEdgesOf(4));
 
         assertEquals(3, g.degreeOf(5));
         assertEquals(2, g.inDegreeOf(5));
         assertEquals(1, g.outDegreeOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(3, 9, 10)), g.edgesOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(3, 9)), g.incomingEdgesOf(5));
-        assertEquals(new HashSet<>(Arrays.asList(10)), g.outgoingEdgesOf(5));
+        assertEquals(Set.of(3, 9, 10), g.edgesOf(5));
+        assertEquals(Set.of(3, 9), g.incomingEdgesOf(5));
+        assertEquals(Set.of(10), g.outgoingEdgesOf(5));
 
         assertEquals(3, g.degreeOf(6));
         assertEquals(3, g.inDegreeOf(6));
         assertEquals(0, g.outDegreeOf(6));
-        assertEquals(new HashSet<>(Arrays.asList(4, 10, 11)), g.edgesOf(6));
-        assertEquals(new HashSet<>(Arrays.asList(4, 10, 11)), g.incomingEdgesOf(6));
-        assertEquals(new HashSet<>(), g.outgoingEdgesOf(6));
+        assertEquals(Set.of(4, 10, 11), g.edgesOf(6));
+        assertEquals(Set.of(4, 10, 11), g.incomingEdgesOf(6));
+        assertEquals(Set.of(), g.outgoingEdgesOf(6));
 
         assertEquals(3, g.degreeOf(7));
         assertEquals(1, g.inDegreeOf(7));
         assertEquals(2, g.outDegreeOf(7));
-        assertEquals(new HashSet<>(Arrays.asList(11, 12)), g.edgesOf(7));
-        assertEquals(new HashSet<>(Arrays.asList(12)), g.incomingEdgesOf(7));
-        assertEquals(new HashSet<>(Arrays.asList(11, 12)), g.outgoingEdgesOf(7));
+        assertEquals(Set.of(11, 12), g.edgesOf(7));
+        assertEquals(Set.of(12), g.incomingEdgesOf(7));
+        assertEquals(Set.of(11, 12), g.outgoingEdgesOf(7));
 
         assertEquals(Integer.valueOf(0), g.getEdgeSource(0));
         assertEquals(Integer.valueOf(1), g.getEdgeTarget(0));
@@ -657,27 +657,27 @@ public class SparseIntGraphTest
         assertFalse(type.isMixed());
 
         assertEquals(Integer.valueOf(0), g.getEdge(0, 1));
-        assertEquals(Collections.singleton(Integer.valueOf(0)), g.getAllEdges(0, 1));
+        assertEquals(Set.of(0), g.getAllEdges(0, 1));
         assertEquals(Integer.valueOf(1), g.getEdge(1, 0));
-        assertEquals(Collections.singleton(Integer.valueOf(1)), g.getAllEdges(1, 0));
+        assertEquals(Set.of(1), g.getAllEdges(1, 0));
         assertEquals(Integer.valueOf(2), g.getEdge(1, 4));
-        assertEquals(Collections.singleton(Integer.valueOf(2)), g.getAllEdges(1, 4));
+        assertEquals(Set.of(2), g.getAllEdges(1, 4));
         assertEquals(Integer.valueOf(3), g.getEdge(1, 5));
-        assertEquals(Collections.singleton(Integer.valueOf(3)), g.getAllEdges(1, 5));
+        assertEquals(Set.of(3), g.getAllEdges(1, 5));
         assertEquals(Integer.valueOf(4), g.getEdge(1, 6));
-        assertEquals(Collections.singleton(Integer.valueOf(4)), g.getAllEdges(1, 6));
+        assertEquals(Set.of(4), g.getAllEdges(1, 6));
         assertEquals(Integer.valueOf(5), g.getEdge(2, 4));
-        assertEquals(new HashSet<>(Arrays.asList(5, 6, 7)), g.getAllEdges(2, 4));
+        assertEquals(Set.of(5, 6, 7), g.getAllEdges(2, 4));
         assertEquals(Integer.valueOf(8), g.getEdge(3, 4));
-        assertEquals(Collections.singleton(Integer.valueOf(8)), g.getAllEdges(3, 4));
+        assertEquals(Set.of(8), g.getAllEdges(3, 4));
         assertEquals(Integer.valueOf(9), g.getEdge(4, 5));
-        assertEquals(Collections.singleton(Integer.valueOf(9)), g.getAllEdges(4, 5));
+        assertEquals(Set.of(9), g.getAllEdges(4, 5));
         assertEquals(Integer.valueOf(10), g.getEdge(5, 6));
-        assertEquals(Collections.singleton(Integer.valueOf(10)), g.getAllEdges(5, 6));
+        assertEquals(Set.of(10), g.getAllEdges(5, 6));
         assertEquals(Integer.valueOf(11), g.getEdge(7, 6));
-        assertEquals(Collections.singleton(Integer.valueOf(11)), g.getAllEdges(7, 6));
+        assertEquals(Set.of(11), g.getAllEdges(7, 6));
         assertEquals(Integer.valueOf(12), g.getEdge(7, 7));
-        assertEquals(Collections.singleton(Integer.valueOf(12)), g.getAllEdges(7, 7));
+        assertEquals(Set.of(12), g.getAllEdges(7, 7));
 
     }
 


### PR DESCRIPTION
In many tests constructs like one of the following or similar were used:
- `new HashSet<>(Arrays.asList(e1, e2, ...))`
- `new HashSet<>(Collections.singletonList(e))`

Since Java 11 the `Set` interface provides static factory methods to create immutable Sets (without null elements). So instead of one of the mentioned constructors `Set.of(e)` or `Set.of(e1, e2, ...)` can be used, which is much shorter and therefore increases the readability of tests.
In order to be consistent I also replaced creation of an empty Set via  `new HashSet<>()` or `Collections.emptySet()` with `Set.of()`, if `Set.of` was used in the vicinity.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
