### PR TITLE
Added support for vertex provider with attributes in JsonImporter

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONEventDrivenImporter.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2020, by Dimitrios Michail and Contributors.
+ * (C) Copyright 2019-2021, by Dimitrios Michail and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -17,17 +17,34 @@
  */
 package org.jgrapht.nio.json;
 
-import org.antlr.v4.runtime.*;
-import org.antlr.v4.runtime.misc.*;
-import org.antlr.v4.runtime.tree.*;
-import org.apache.commons.text.*;
-import org.jgrapht.*;
-import org.jgrapht.alg.util.Triple;
-import org.jgrapht.nio.*;
-import org.jgrapht.nio.json.JsonParser.*;
+import java.io.IOException;
+import java.io.Reader;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.Map.Entry;
 
-import java.io.*;
-import java.util.*;
+import org.antlr.v4.runtime.BaseErrorListener;
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.RecognitionException;
+import org.antlr.v4.runtime.Recognizer;
+import org.antlr.v4.runtime.misc.ParseCancellationException;
+import org.antlr.v4.runtime.tree.ParseTreeWalker;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.apache.commons.text.StringEscapeUtils;
+import org.jgrapht.Graph;
+import org.jgrapht.alg.util.Triple;
+import org.jgrapht.nio.Attribute;
+import org.jgrapht.nio.AttributeType;
+import org.jgrapht.nio.BaseEventDrivenImporter;
+import org.jgrapht.nio.DefaultAttribute;
+import org.jgrapht.nio.EventDrivenImporter;
+import org.jgrapht.nio.ImportEvent;
+import org.jgrapht.nio.ImportException;
+import org.jgrapht.nio.json.JsonParser.JsonContext;
 
 /**
  * Imports a graph from a <a href="https://tools.ietf.org/html/rfc8259">JSON</a> file.
@@ -81,12 +98,29 @@ public class JSONEventDrivenImporter
     implements
     EventDrivenImporter<String, Triple<String, String, Double>>
 {
+    private boolean notifyVertexAttributesOutOfOrder;
+    private boolean notifyEdgeAttributesOutOfOrder;
+    
     /**
      * Constructs a new importer.
      */
     public JSONEventDrivenImporter()
     {
-        super();
+        this(true, true);
+    }
+    
+    /**
+     * Constructs a new importer.
+     * 
+     * @param notifyVertexAttributesOutOfOrder whether to notify for vertex attributes out-of-order even if 
+     *        they appear together in the input
+     * @param notifyEdgeAttributesOutOfOrder whether to notify for edge attributes out-of-order even if 
+     *        they appear together in the input        
+     */
+    public JSONEventDrivenImporter(boolean notifyVertexAttributesOutOfOrder, boolean notifyEdgeAttributesOutOfOrder)
+    {
+        this.notifyVertexAttributesOutOfOrder = notifyVertexAttributesOutOfOrder;
+        this.notifyEdgeAttributesOutOfOrder = notifyEdgeAttributesOutOfOrder;
     }
 
     @Override
@@ -216,9 +250,13 @@ public class JSONEventDrivenImporter
                     if (nodeId == null) {
                         nodeId = "Singleton_" + singletonsUUID + "_" + (singletons++);
                     }
-                    notifyVertex(nodeId);
-                    for (String key : attributes.keySet()) {
-                        notifyVertexAttribute(nodeId, key, attributes.get(key));
+                    if (notifyVertexAttributesOutOfOrder) { 
+                        notifyVertex(nodeId);
+                        for(Entry<String, Attribute> entry: attributes.entrySet()) { 
+                            notifyVertexAttribute(nodeId, entry.getKey(), entry.getValue());
+                        }
+                    } else { 
+                        notifyVertexWithAttributes(nodeId, attributes);
                     }
                     insideNode = false;
                     attributes = null;
@@ -236,9 +274,15 @@ public class JSONEventDrivenImporter
                             }
                         }
                         Triple<String, String, Double> et = Triple.of(sourceId, targetId, weight);
-                        notifyEdge(et);
-                        for (String key : attributes.keySet()) {
-                            notifyEdgeAttribute(et, key, attributes.get(key));
+                        if (notifyEdgeAttributesOutOfOrder) { 
+                            // notify individually
+                            notifyEdge(et);
+                            for(Entry<String, Attribute> entry: attributes.entrySet()) { 
+                                notifyEdgeAttribute(et, entry.getKey(), entry.getValue());
+                            }
+                        } else { 
+                            // notify with all attributes
+                            notifyEdgeWithAttributes(et, attributes);
                         }
                     } else if (sourceId == null) {
                         throw new IllegalArgumentException("Edge with missing source detected");

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONImporter.java
@@ -17,13 +17,23 @@
  */
 package org.jgrapht.nio.json;
 
-import org.jgrapht.*;
-import org.jgrapht.alg.util.*;
-import org.jgrapht.nio.*;
+import java.io.Reader;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
-import java.io.*;
-import java.util.*;
-import java.util.function.*;
+import org.jgrapht.Graph;
+import org.jgrapht.GraphType;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.alg.util.Triple;
+import org.jgrapht.nio.Attribute;
+import org.jgrapht.nio.BaseEventDrivenImporter;
+import org.jgrapht.nio.DefaultAttribute;
+import org.jgrapht.nio.GraphImporter;
+import org.jgrapht.nio.ImportException;
 
 /**
  * Imports a graph from a <a href="https://tools.ietf.org/html/rfc8259">JSON</a> file.
@@ -79,7 +89,18 @@ import java.util.function.*;
  * The default behavior of the importer is to use the graph vertex supplier in order to create
  * vertices. The user can also bypass vertex creation by providing a custom vertex factory method
  * using {@link #setVertexFactory(Function)}. The factory method is responsible to create a new
- * graph vertex given the vertex identifier read from file.
+ * graph vertex given the vertex identifier read from file. Additionally this importer also supports
+ * creating vertices with {@link #setVertexWithAttributesFactory(BiFunction)}. This factory method
+ * is responsible for creating a new graph vertex given the vertex identifier read from file
+ * together with all available attributes of the vertex at the location of the file where the vertex
+ * is first defined.
+ * 
+ * <p>
+ * The default behavior of the importer is to use the graph edge supplier in order to create edges.
+ * The user can also bypass edge creation by providing a custom edge factory method using
+ * {@link #setEdgeWithAttributesFactory(Function)}. The factory method is responsible to create a
+ * new graph edge given all available attributes of the edge at the location of the file where the
+ * edge is first defined.
  * 
  * @param <V> the vertex type
  * @param <E> the edge type
@@ -98,6 +119,8 @@ public class JSONImporter<V, E>
     public static final String DEFAULT_VERTEX_ID_KEY = "ID";
 
     private Function<String, V> vertexFactory;
+    private BiFunction<String, Map<String, Attribute>, V> vertexWithAttributesFactory;
+    private Function<Map<String, Attribute>, E> edgeWithAttributesFactory;
 
     /**
      * Construct a new importer
@@ -126,12 +149,27 @@ public class JSONImporter<V, E>
     @Override
     public void importGraph(Graph<V, E> graph, Reader input)
     {
-        JSONEventDrivenImporter genericImporter = new JSONEventDrivenImporter();
+        final boolean verticesOutOfOrder = vertexWithAttributesFactory == null;
+        final boolean edgesOutOfOrder = edgeWithAttributesFactory == null;
+        JSONEventDrivenImporter genericImporter =
+            new JSONEventDrivenImporter(verticesOutOfOrder, edgesOutOfOrder);
+
         Consumers consumers = new Consumers(graph);
-        genericImporter.addVertexConsumer(consumers.vertexConsumer);
+
+        if (vertexWithAttributesFactory != null) {
+            genericImporter.addVertexWithAttributesConsumer(consumers.vertexWithAttributesConsumer);
+        } else {
+            genericImporter.addVertexConsumer(consumers.vertexConsumer);
+        }
         genericImporter.addVertexAttributeConsumer(consumers.vertexAttributeConsumer);
-        genericImporter.addEdgeConsumer(consumers.edgeConsumer);
+
+        if (edgeWithAttributesFactory != null) {
+            genericImporter.addEdgeWithAttributesConsumer(consumers.edgeWithAttributesConsumer);
+        } else {
+            genericImporter.addEdgeConsumer(consumers.edgeConsumer);
+        }
         genericImporter.addEdgeAttributeConsumer(consumers.edgeAttributeConsumer);
+
         genericImporter.importInput(input);
     }
 
@@ -159,6 +197,52 @@ public class JSONImporter<V, E>
     public void setVertexFactory(Function<String, V> vertexFactory)
     {
         this.vertexFactory = vertexFactory;
+    }
+
+    /**
+     * Set the user custom vertex factory with attributes. The default behavior is being null in
+     * which case the graph vertex supplier is used.
+     * 
+     * If supplied the vertex factory is called every time a new vertex is encountered in the input.
+     * The method is called with parameter the vertex identifier from the input and a set of
+     * attributes and should return the actual graph vertex to add to the graph. Note that the set
+     * of attributes might not be complete, as only attributes available at the first vertex
+     * definition are collected.
+     * 
+     * @param vertexWithAttributesFactory a vertex factory with attributes
+     */
+    public void setVertexWithAttributesFactory(
+        BiFunction<String, Map<String, Attribute>, V> vertexWithAttributesFactory)
+    {
+        this.vertexWithAttributesFactory = vertexWithAttributesFactory;
+    }
+
+    /**
+     * Get the user custom edges factory with attributes. This is null by default and the graph
+     * supplier is used instead.
+     * 
+     * @return the user custom edge factory with attributes.
+     */
+    public Function<Map<String, Attribute>, E> getEdgeWithAttributesFactory()
+    {
+        return edgeWithAttributesFactory;
+    }
+
+    /**
+     * Set the user custom edge factory with attributes. The default behavior is being null in which
+     * case the graph edge supplier is used.
+     * 
+     * If supplied the edge factory is called every time a new edge is encountered in the input. The
+     * method is called with parameter the set of attributes and should return the actual graph edge
+     * to add to the graph. Note that the set of attributes might not be complete, as only
+     * attributes available at the first edge definition are collected.
+     * 
+     * @param edgeWithAttributesFactory an edge factory with attributes
+     */
+    public void setEdgeWithAttributesFactory(
+        Function<Map<String, Attribute>, E> edgeWithAttributesFactory)
+    {
+        this.edgeWithAttributesFactory = edgeWithAttributesFactory;
     }
 
     private class Consumers
@@ -194,6 +278,25 @@ public class JSONImporter<V, E>
             notifyVertexAttribute(v, DEFAULT_VERTEX_ID_KEY, DefaultAttribute.createAttribute(t));
         };
 
+        public final BiConsumer<String, Map<String, Attribute>> vertexWithAttributesConsumer =
+            (t, attrs) -> {
+                if (map.containsKey(t)) {
+                    throw new ImportException("Node " + t + " already exists");
+                }
+                V v;
+                if (vertexWithAttributesFactory != null) {
+                    v = vertexWithAttributesFactory.apply(t, attrs);
+                    graph.addVertex(v);
+                } else {
+                    v = graph.addVertex();
+                }
+                map.put(t, v);
+
+                // notify with all collected attributes
+                attrs.put(DEFAULT_VERTEX_ID_KEY, DefaultAttribute.createAttribute(t));
+                notifyVertexWithAttributes(v, attrs);
+            };
+
         public final BiConsumer<Pair<String, String>, Attribute> vertexAttributeConsumer =
             (p, a) -> {
                 String vertex = p.getFirst();
@@ -205,7 +308,7 @@ public class JSONImporter<V, E>
 
         public final Consumer<Triple<String, String, Double>> edgeConsumer = (t) -> {
             String source = t.getFirst();
-            V from = map.get(t.getFirst());
+            V from = map.get(source);
             if (from == null) {
                 throw new ImportException("Node " + source + " does not exist");
             }
@@ -225,6 +328,34 @@ public class JSONImporter<V, E>
             lastTriple = t;
             lastEdge = e;
         };
+
+        public final BiConsumer<Triple<String, String, Double>,
+            Map<String, Attribute>> edgeWithAttributesConsumer = (t, attrs) -> {
+                String source = t.getFirst();
+                V from = map.get(source);
+                if (from == null) {
+                    throw new ImportException("Node " + source + " does not exist");
+                }
+
+                String target = t.getSecond();
+                V to = map.get(target);
+                if (to == null) {
+                    throw new ImportException("Node " + target + " does not exist");
+                }
+
+                E e;
+                if (edgeWithAttributesFactory != null) {
+                    e = edgeWithAttributesFactory.apply(attrs);
+                    graph.addEdge(from, to, e);
+                } else {
+                    e = graph.addEdge(from, to);
+                }
+
+                notifyEdgeWithAttributes(e, attrs);
+
+                lastTriple = t;
+                lastEdge = e;
+            };
 
         public final BiConsumer<Pair<Triple<String, String, Double>, String>,
             Attribute> edgeAttributeConsumer = (p, a) -> {

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/json/JSONImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/json/JSONImporterTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2020, by Dimitrios Michail and Contributors.
+ * (C) Copyright 2019-2021, by Dimitrios Michail and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -17,17 +17,23 @@
  */
 package org.jgrapht.nio.json;
 
-import org.jgrapht.*;
-import org.jgrapht.graph.*;
-import org.jgrapht.graph.builder.*;
-import org.jgrapht.nio.*;
-import org.jgrapht.util.*;
-import org.junit.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
-import java.io.*;
-import java.util.*;
+import java.io.StringReader;
+import java.util.HashMap;
+import java.util.Map;
 
-import static org.junit.Assert.*;
+import org.jgrapht.Graph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.jgrapht.graph.builder.GraphTypeBuilder;
+import org.jgrapht.nio.Attribute;
+import org.jgrapht.nio.AttributeType;
+import org.jgrapht.nio.ImportException;
+import org.jgrapht.util.SupplierUtil;
+import org.junit.Test;
 
 /**
  * Tests for {@link JsonImporter}.
@@ -529,7 +535,7 @@ public class JSONImporterTest
         assertEquals(1, g.edgeSet().size());
 
     }
-    
+
     @Test
     public void testNegativeIntegerWeights()
         throws ImportException
@@ -560,6 +566,75 @@ public class JSONImporterTest
         assertTrue(g.containsVertex("1"));
         assertTrue(g.containsVertex("2"));
         assertEquals(-2.0, g.getEdgeWeight(g.getEdge("1", "2")), 1e-9);
+    }
+
+    @Test
+    public void testCreateVerticesWithAttributes()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "{\n"
+                     + "  \"nodes\": [\n"    
+                     + "  { \"id\":\"a0\", \"color\":\"gray\" },\n"
+                     + "  { \"id\":\"a1\", \"color\":\"green\" },\n"
+                     + "  { \"id\":\"a2\", \"color\":\"white\" }\n"
+                     + "  ],"
+                     + "  \"edges\": [\n"    
+                     + "  { \"source\":\"a0\", \"target\":\"a1\" },\n"
+                     + "  { \"source\":\"a0\", \"target\":\"a2\" }\n"
+                     + "  ]\n"
+                     + "}";
+        // @formatter:on
+
+        JSONImporter<String, DefaultEdge> importer = new JSONImporter<>();
+
+        importer.setVertexWithAttributesFactory((id, attrs) -> {
+            return id + "-" + attrs.get("color").getValue();
+        });
+
+        DirectedPseudograph<String, DefaultEdge> graph = new DirectedPseudograph<>(
+            SupplierUtil.createStringSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        importer.importGraph(graph, new StringReader(input));
+
+        assertTrue(graph.containsVertex("a0-gray"));
+        assertTrue(graph.containsVertex("a1-green"));
+        assertTrue(graph.containsVertex("a2-white"));
+    }
+
+    @Test
+    public void testCreateEdgesWithAttributes()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "{\n"
+                     + "  \"nodes\": [\n"    
+                     + "  { \"id\":\"a0\", \"color\":\"gray\" },\n"
+                     + "  { \"id\":\"a1\", \"color\":\"green\" },\n"
+                     + "  { \"id\":\"a2\", \"color\":\"white\" }\n"
+                     + "  ],"
+                     + "  \"edges\": [\n"    
+                     + "  { \"source\":\"a0\", \"target\":\"a1\", \"label\":\"e1\" },\n"
+                     + "  { \"source\":\"a0\", \"target\":\"a2\", \"label\":\"e2\" }\n"
+                     + "  ]\n"
+                     + "}";
+        // @formatter:on
+
+        JSONImporter<String, String> importer = new JSONImporter<>();
+
+        importer.setVertexWithAttributesFactory((id, attrs) -> {
+            return id + "-" + attrs.get("color").getValue();
+        });
+
+        importer.setEdgeWithAttributesFactory((attrs) -> {
+            return attrs.get("label").getValue();
+        });
+
+        DirectedPseudograph<String, String> graph =
+            new DirectedPseudograph<>(SupplierUtil.createStringSupplier(), null, false);
+        importer.importGraph(graph, new StringReader(input));
+
+        assertTrue(graph.containsEdge("e1"));
+        assertTrue(graph.containsEdge("e2"));
     }
 
 }


### PR DESCRIPTION
This PR adds vertex providers with attributes in `JsonImporter`. Similar support was added a while back in `DotImporter`.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
