### PR TITLE
Succinct graph representations

### DIFF
--- a/jgrapht-unimi-dsi/pom.xml
+++ b/jgrapht-unimi-dsi/pom.xml
@@ -56,6 +56,10 @@
             <artifactId>jgrapht-core</artifactId>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>jgrapht-opt</artifactId>
+        </dependency>
+        <dependency>
             <groupId>it.unimi.dsi</groupId>
             <artifactId>fastutil</artifactId>
             <version>8.5.2</version>

--- a/jgrapht-unimi-dsi/src/main/java/module-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/module-info.java
@@ -1,12 +1,14 @@
 module org.jgrapht.unimi.dsi
 {
     exports org.jgrapht.webgraph;
+	exports org.jgrapht.sux4j;
 
     requires transitive org.jgrapht.core;
+	requires transitive org.jgrapht.opt;
     requires transitive it.unimi.dsi.fastutil;
     requires transitive it.unimi.dsi.webgraph;
     requires transitive it.unimi.dsi.big.webgraph;
     requires transitive it.unimi.dsi.dsiutils;
     requires transitive it.unimi.dsi.sux4j;
-    requires transitive com.google.common;    
+    requires transitive com.google.common;
 }

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctDirectedGraph.java
@@ -1,0 +1,171 @@
+/*
+ * (C) Copyright 2020-2021, by Sebastiano Vigna and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
+package org.jgrapht.sux4j;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphType;
+import org.jgrapht.Graphs;
+import org.jgrapht.graph.DefaultGraphType;
+
+import it.unimi.dsi.bits.Fast;
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+
+/**
+ * An abstract base class for all succinct directed implementations.
+ *
+ * <p>
+ * Two subclasses, {@link CumulativeSuccessors} and {@link CumulativeDegrees}, generate the monotone
+ * lists that will be encoded using the Elias&ndash;Fano representation.
+ */
+
+public abstract class AbstractSuccinctDirectedGraph<E>
+    extends
+    AbstractSuccinctGraph<E>
+{
+
+    public AbstractSuccinctDirectedGraph(final int n, final int m)
+    {
+        super(n, m);
+    }
+
+    /**
+     * Turns all edges <var>x</var>&nbsp;&rarr;&nbsp;<var>y</var> into a monotone sequence using the
+     * encoding <var>x</var>2<sup>&lceil;log&nbsp;<var>n</var>&rceil;</sup> + <var>y</var>, or the
+     * encoding <var>x</var><var>n</var> + <var>y</var> - <var>e</var>, where <var>e</var> is the
+     * index of the edge in lexicographical order, depending on the value of the {@code strict}
+     * parameter.
+     *
+     * @param <E> the graph edge type
+     */
+    protected final static class CumulativeSuccessors<E>
+        implements
+        LongIterator
+    {
+        private final Graph<Integer, E> graph;
+        private final long n;
+        private final int sourceShift;
+        private final Function<Integer, Iterable<E>> succ;
+        private final boolean strict;
+
+        private int x = -1, d, i, e;
+        private long next = -1;
+        private int[] s = IntArrays.EMPTY_ARRAY;
+
+        public CumulativeSuccessors(
+            final Graph<Integer, E> graph, final Function<Integer, Iterable<E>> succ,
+            final boolean strict)
+        {
+            this.n = graph.iterables().vertexCount();
+            this.sourceShift = Fast.ceilLog2(n);
+            this.graph = graph;
+            this.succ = succ;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            if (next != -1)
+                return true;
+            if (x == n)
+                return false;
+            while (i == d) {
+                if (++x == n)
+                    return false;
+                int d = 0;
+                for (final E e : succ.apply(x)) {
+                    s = IntArrays.grow(s, d + 1);
+                    s[d++] = Graphs.getOppositeVertex(graph, e, x);
+                }
+                Arrays.sort(s, 0, d);
+                this.d = d;
+                i = 0;
+            }
+            // The predecessor list will not be indexed, so we can gain a few bits of space by
+            // subtracting the edge position in the list
+            next = strict ? s[i] + ((long) x << sourceShift) : s[i] + x * n - e++;
+            i++;
+            return true;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            final long result = next;
+            next = -1;
+            return result;
+        }
+    }
+
+    /**
+     * Iterates over the cumulative degrees (starts with a zero).
+     */
+    protected final static class CumulativeDegrees
+        implements
+        LongIterator
+    {
+        private final Function<Integer, Integer> degreeOf;
+        private final int n;
+        private int i = -1;
+        private long cumul = 0;
+
+        public CumulativeDegrees(final int n, final Function<Integer, Integer> degreeOf)
+        {
+            this.n = n;
+            this.degreeOf = degreeOf;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return i < n;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            if (i == -1)
+                return ++i;
+            return cumul += degreeOf.apply(i++);
+        }
+    }
+
+    @Override
+    public int degreeOf(final Integer vertex)
+    {
+        return inDegreeOf(vertex) + outDegreeOf(vertex);
+    }
+
+    @Override
+    public GraphType getType()
+    {
+        return new DefaultGraphType.Builder()
+            .directed().weighted(false).modifiable(false).allowMultipleEdges(false)
+            .allowSelfLoops(true).build();
+    }
+}

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctDirectedGraph.java
@@ -37,6 +37,8 @@ import it.unimi.dsi.fastutil.longs.LongIterator;
  * <p>
  * Two subclasses, {@link CumulativeSuccessors} and {@link CumulativeDegrees}, generate the monotone
  * lists that will be encoded using the Elias&ndash;Fano representation.
+ *
+ * @param <E> the graph edge type
  */
 
 public abstract class AbstractSuccinctDirectedGraph<E>

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctDirectedGraph.java
@@ -48,7 +48,7 @@ import it.unimi.dsi.fastutil.longs.LongIterator;
  * <var>k</var>-th element of the sequence and some bit shifting (the encoding
  * <var>x</var><var>n</var> + <var>y</var> would be slightly more compact, but much slower to
  * decode). Since we know the list of cumulative outdegrees, we know which range of indices
- * corresponds to the edges outgoing from each vertex. If we need to now whether
+ * corresponds to the edges outgoing from each vertex. If we need to know whether
  * <var>x</var>&nbsp;&rarr;&nbsp;<var>y</var> is an edge we just look for
  * <var>x</var>2<sup>&lceil;log&nbsp;<var>n</var>&rceil;</sup> + <var>y</var> in the sequence.
  *

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctDirectedGraph.java
@@ -101,7 +101,7 @@ public abstract class AbstractSuccinctDirectedGraph<E>
         private long next = -1;
         private int[] s = IntArrays.EMPTY_ARRAY;
 
-        public CumulativeSuccessors(
+        protected CumulativeSuccessors(
             final Graph<Integer, E> graph, final Function<Integer, Iterable<E>> succ,
             final boolean strict)
         {
@@ -161,7 +161,7 @@ public abstract class AbstractSuccinctDirectedGraph<E>
         private int i = -1;
         private long cumul = 0;
 
-        public CumulativeDegrees(final int n, final Function<Integer, Integer> degreeOf)
+        protected CumulativeDegrees(final int n, final Function<Integer, Integer> degreeOf)
         {
             this.n = n;
             this.degreeOf = degreeOf;

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctDirectedGraph.java
@@ -38,6 +38,32 @@ import it.unimi.dsi.fastutil.longs.LongIterator;
  * Two subclasses, {@link CumulativeSuccessors} and {@link CumulativeDegrees}, generate the monotone
  * lists that will be encoded using the Elias&ndash;Fano representation.
  *
+ * <p>
+ * First, we store the monotone lists of cumulative outdegrees and indegrees.
+ *
+ * <p>
+ * Then, we store the outgoing edges <var>x</var>&nbsp;&rarr;&nbsp;<var>y</var> as a monotone
+ * sequence using the encoding <var>x</var>2<sup>&lceil;log&nbsp;<var>n</var>&rceil;</sup> +
+ * <var>y</var>. At that point the <var>k</var>-th edge can be obtained by retrieving the
+ * <var>k</var>-th element of the sequence and some bit shifting (the encoding
+ * <var>x</var><var>n</var> + <var>y</var> would be slightly more compact, but much slower to
+ * decode). Since we know the list of cumulative outdegrees, we know which range of indices
+ * corresponds to the edges outgoing from each vertex. If we need to now whether
+ * <var>x</var>&nbsp;&rarr;&nbsp;<var>y</var> is an edge we just look for
+ * <var>x</var>2<sup>&lceil;log&nbsp;<var>n</var>&rceil;</sup> + <var>y</var> in the sequence.
+ *
+ * <p>
+ * Finally, we store incoming edges <var>y</var>&nbsp;&rarr;&nbsp;<var>x</var> again as a monotone
+ * sequence using the encoding <var>x</var><var>n</var> + <var>y</var> - <var>e</var>, where
+ * <var>e</var> is the index of the edge in lexicographical order. In this case we just need to be
+ * able to recover the edges associated with a vertex, so we can use a more compact format.
+ *
+ * <p>
+ * However, in the case of a {@link SuccinctIntDirectedGraph} after retrieving the source and target
+ * of an incoming edge we need to index it. The slow indexing of the incoming edges is the reason
+ * why a {@link SuccinctIntDirectedGraph} enumerates incoming edges very slowly, whereas a
+ * {@link SuccinctDirectedGraph} does not.
+ *
  * @param <E> the graph edge type
  */
 
@@ -45,6 +71,7 @@ public abstract class AbstractSuccinctDirectedGraph<E>
     extends
     AbstractSuccinctGraph<E>
 {
+    private static final long serialVersionUID = 0L;
 
     public AbstractSuccinctDirectedGraph(final int n, final int m)
     {

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctGraph.java
@@ -18,6 +18,7 @@
 
 package org.jgrapht.sux4j;
 
+import java.io.Serializable;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -40,7 +41,11 @@ import it.unimi.dsi.fastutil.objects.ObjectSets;
 public abstract class AbstractSuccinctGraph<E>
     extends
     AbstractGraph<Integer, E>
+    implements
+    Serializable
 {
+    private static final long serialVersionUID = 0L;
+
     protected static final String UNMODIFIABLE = "this graph is unmodifiable";
 
     /** The number of vertices in the graph. */

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctGraph.java
@@ -33,6 +33,8 @@ import it.unimi.dsi.fastutil.objects.ObjectSets;
  * <p>
  * This class provides mutators throwing {@link UnsupportedOperationException} and operations
  * depending only on the number of vertices and edges.
+ *
+ * @param <E> the graph edge type
  */
 
 public abstract class AbstractSuccinctGraph<E>

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctGraph.java
@@ -1,0 +1,162 @@
+/*
+ * (C) Copyright 2020-2021, by Sebastiano Vigna and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
+package org.jgrapht.sux4j;
+
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.jgrapht.graph.AbstractGraph;
+
+import it.unimi.dsi.bits.Fast;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.fastutil.objects.ObjectSets;
+
+/**
+ * An abstract base class for all succinct implementations.
+ *
+ * <p>
+ * This class provides mutators throwing {@link UnsupportedOperationException} and operations
+ * depending only on the number of vertices and edges.
+ */
+
+public abstract class AbstractSuccinctGraph<E>
+    extends
+    AbstractGraph<Integer, E>
+{
+    protected static final String UNMODIFIABLE = "this graph is unmodifiable";
+
+    /** The number of vertices in the graph. */
+    protected final int n;
+    /** The number of edges in the graph. */
+    protected final int m;
+    /** The shift used to read sources in the successor list. */
+    protected final int sourceShift;
+    /** The mask used to read targets in the successor list (lowest {@link #sourceShift} bits). */
+    protected final long targetMask;
+
+    public AbstractSuccinctGraph(final int n, final int m)
+    {
+        super();
+        this.n = n;
+        this.m = m;
+        sourceShift = Fast.ceilLog2(n);
+        targetMask = (1L << sourceShift) - 1;
+    }
+
+    @Override
+    public Set<Integer> vertexSet()
+    {
+        return IntSets.fromTo(0, n);
+    }
+
+    /**
+     * Ensures that the specified vertex exists in this graph, or else throws exception.
+     *
+     * @param v vertex
+     * @return <code>true</code> if this assertion holds.
+     * @throws IllegalArgumentException if specified vertex does not exist in this graph.
+     */
+    @Override
+    protected boolean assertVertexExist(final Integer v)
+    {
+        if (v < 0 || v >= n)
+            throw new IllegalArgumentException();
+        return true;
+    }
+
+    @Override
+    public boolean containsVertex(final Integer v)
+    {
+        return v >= 0 && v < n;
+    }
+
+    @Override
+    public Set<E> getAllEdges(final Integer sourceVertex, final Integer targetVertex)
+    {
+        final E edge = getEdge(sourceVertex, targetVertex);
+        return edge == null ? ObjectSets.emptySet() : ObjectSets.singleton(edge);
+    }
+
+    @Override
+    public Supplier<Integer> getVertexSupplier()
+    {
+        return null;
+    }
+
+    @Override
+    public Supplier<E> getEdgeSupplier()
+    {
+        return null;
+    }
+
+    @Override
+    public E addEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean addEdge(final Integer sourceVertex, final Integer targetVertex, final E e)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public Integer addVertex()
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean addVertex(final Integer v)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public E removeEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean removeEdge(final E e)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean removeVertex(final Integer v)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public double getEdgeWeight(final E e)
+    {
+        return 1.0;
+    }
+
+    @Override
+    public void setEdgeWeight(final E e, final double weight)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+}

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctUndirectedGraph.java
@@ -38,6 +38,8 @@ import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList;
  * <p>
  * Two subclasses, {@link CumulativeSuccessors} and {@link CumulativeDegrees}, generate the monotone
  * lists that will be encoded using the Elias&ndash;Fano representation.
+ *
+ * @param <E> the graph edge type
  */
 
 public abstract class AbstractSuccinctUndirectedGraph<E>

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctUndirectedGraph.java
@@ -39,6 +39,23 @@ import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList;
  * Two subclasses, {@link CumulativeSuccessors} and {@link CumulativeDegrees}, generate the monotone
  * lists that will be encoded using the Elias&ndash;Fano representation.
  *
+ * <p>
+ * We use the representation described in {@link AbstractSuccinctDirectedGraph} applied to the
+ * directed graph obtained by choosing the direction <var>x</var>&nbsp;&rarr;&nbsp;<var>y</var> for
+ * an edge <var>x</var>&nbsp;&mdash;&nbsp;<var>y</var> if <var>x</var>&nbsp;&le;&nbsp;<var>y</var>
+ * (loops are represented twice). Each edge now appears exactly once in the list of outgoing edges,
+ * and thus can be indexed as in the directed base.
+ *
+ * <p>
+ * The set of vertices adjacent to a given vertex can then be retrieved by enumerating both outgoing
+ * and incoming edges, being careful to avoid enumerating twice loops.
+ *
+ * <p>
+ * However, in the case of a {@link SuccinctIntUndirectedGraph} after retrieving the source and
+ * target of an incoming edge we need to index it. The slow indexing of the incoming edges is the
+ * reason why a {@link SuccinctIntUndirectedGraph} enumerates edges very slowly, whereas a
+ * {@link SuccinctUndirectedGraph} does not.
+ *
  * @param <E> the graph edge type
  */
 
@@ -139,7 +156,7 @@ public abstract class AbstractSuccinctUndirectedGraph<E>
     /**
      * Iterates over the cumulative degrees (starts with a zero). Depending on the value of
      * {@code sorted}, only edges whose adjacent vertex is greater than or equal to the base vertex
-     * (or vice versa) are included, depending on the value of the {@code sorted} parameter.
+     * (or vice versa) are included.
      *
      * @param <E> the graph edge type
      */

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctUndirectedGraph.java
@@ -63,6 +63,7 @@ public abstract class AbstractSuccinctUndirectedGraph<E>
     extends
     AbstractSuccinctGraph<E>
 {
+    private static final long serialVersionUID = 0L;
 
     public AbstractSuccinctUndirectedGraph(final int n, final int m)
     {
@@ -95,7 +96,7 @@ public abstract class AbstractSuccinctUndirectedGraph<E>
         private long next = -1;
         private int[] s = IntArrays.EMPTY_ARRAY;
 
-        public CumulativeSuccessors(
+        protected CumulativeSuccessors(
             final Graph<Integer, E> graph, final boolean sorted,
             final Function<Integer, Iterable<E>> succ)
         {
@@ -171,7 +172,7 @@ public abstract class AbstractSuccinctUndirectedGraph<E>
         private final boolean sorted;
         private final Graph<Integer, E> graph;
 
-        public CumulativeDegrees(
+        protected CumulativeDegrees(
             final Graph<Integer, E> graph, final boolean sorted,
             final Function<Integer, Iterable<E>> succ)
         {

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctUndirectedGraph.java
@@ -1,0 +1,224 @@
+/*
+ * (C) Copyright 2020-2021, by Sebastiano Vigna and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
+package org.jgrapht.sux4j;
+
+import java.util.Arrays;
+import java.util.NoSuchElementException;
+import java.util.function.Function;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphType;
+import org.jgrapht.Graphs;
+import org.jgrapht.graph.DefaultGraphType;
+
+import it.unimi.dsi.bits.Fast;
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList;
+
+/**
+ * An abstract base class for all succinct undirected implementations.
+ *
+ * <p>
+ * Two subclasses, {@link CumulativeSuccessors} and {@link CumulativeDegrees}, generate the monotone
+ * lists that will be encoded using the Elias&ndash;Fano representation.
+ */
+
+public abstract class AbstractSuccinctUndirectedGraph<E>
+    extends
+    AbstractSuccinctGraph<E>
+{
+
+    public AbstractSuccinctUndirectedGraph(final int n, final int m)
+    {
+        super(n, m);
+    }
+
+    /**
+     * Turns all edges <var>x</var>&nbsp;&mdash;&nbsp;<var>y</var>,
+     * <var>x</var>&nbsp;&le;&nbsp;<var>y</var>, into a monotone sequence using the encoding
+     * <var>x</var>2<sup>&lceil;log&nbsp;<var>n</var>&rceil;</sup> + <var>y</var>, or all edges
+     * <var>x</var>&nbsp;&mdash;&nbsp;<var>y</var>, <var>x</var>&nbsp;&ge;&nbsp;<var>y</var>, using
+     * the encoding <var>x</var><var>n</var> + <var>y</var> - <var>e</var>, where <var>e</var> is
+     * the index of the edge in lexicographical order, depending on the value of the {@code sorted}
+     * parameter.
+     *
+     * @param <E> the graph edge type
+     */
+
+    protected final static class CumulativeSuccessors<E>
+        implements
+        LongIterator
+    {
+        private final Graph<Integer, E> graph;
+        private final long n;
+        private final int sourceShift;
+        private final Function<Integer, Iterable<E>> succ;
+        private final boolean sorted;
+
+        private int x = -1, d, i, e;
+        private long next = -1;
+        private int[] s = IntArrays.EMPTY_ARRAY;
+
+        public CumulativeSuccessors(
+            final Graph<Integer, E> graph, final boolean sorted,
+            final Function<Integer, Iterable<E>> succ)
+        {
+            this.n = (int) graph.iterables().vertexCount();
+            this.sourceShift = Fast.ceilLog2(n);
+            this.graph = graph;
+            this.sorted = sorted;
+            this.succ = succ;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            if (next != -1)
+                return true;
+            if (x == n)
+                return false;
+            while (i == d) {
+                if (++x == n)
+                    return false;
+                int d = 0;
+                for (final E e : succ.apply(x)) {
+                    final int y = Graphs.getOppositeVertex(graph, e, x);
+                    if (sorted) {
+                        if (x <= y) {
+                            s = IntArrays.grow(s, d + 1);
+                            s[d++] = y;
+                        }
+                    } else {
+                        if (x >= y) {
+                            s = IntArrays.grow(s, d + 1);
+                            s[d++] = y;
+                        }
+                    }
+                }
+                Arrays.sort(s, 0, d);
+                this.d = d;
+                i = 0;
+            }
+            // The predecessor list will not be indexed, so we can gain a few bits of space by
+            // subtracting the edge position in the list
+            next = sorted ? s[i] + ((long) x << sourceShift) : s[i] + x * n - e++;
+            i++;
+            return true;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            final long result = next;
+            next = -1;
+            return result;
+        }
+    }
+
+    /**
+     * Iterates over the cumulative degrees (starts with a zero). Depending on the value of
+     * {@code sorted}, only edges whose adjacent vertex is greater than or equal to the base vertex
+     * (or vice versa) are included, depending on the value of the {@code sorted} parameter.
+     *
+     * @param <E> the graph edge type
+     */
+    protected final static class CumulativeDegrees<E>
+        implements
+        LongIterator
+    {
+        private final int n;
+        private int x = -1;
+        private long cumul = 0;
+        private final Function<Integer, Iterable<E>> succ;
+        private final boolean sorted;
+        private final Graph<Integer, E> graph;
+
+        public CumulativeDegrees(
+            final Graph<Integer, E> graph, final boolean sorted,
+            final Function<Integer, Iterable<E>> succ)
+        {
+            this.n = (int) graph.iterables().vertexCount();
+            this.graph = graph;
+            this.succ = succ;
+            this.sorted = sorted;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return x < n;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            if (x == -1)
+                return ++x;
+            int d = 0;
+            if (sorted) {
+                for (final E e : succ.apply(x))
+                    if (x <= Graphs.getOppositeVertex(graph, e, x))
+                        d++;
+            } else {
+                for (final E e : succ.apply(x))
+                    if (x >= Graphs.getOppositeVertex(graph, e, x))
+                        d++;
+            }
+            x++;
+            return cumul += d;
+        }
+    }
+
+    @Override
+    public int inDegreeOf(final Integer vertex)
+    {
+        return degreeOf(vertex);
+    }
+
+    @Override
+    public int outDegreeOf(final Integer vertex)
+    {
+        return degreeOf(vertex);
+    }
+
+    protected boolean containsEdge(
+        final EliasFanoIndexedMonotoneLongBigList successors, int x, int y)
+    {
+        if (x > y) {
+            final int t = x;
+            x = y;
+            y = t;
+        }
+        return successors.indexOfUnsafe(((long) x << sourceShift) + y) != -1;
+    }
+
+    @Override
+    public GraphType getType()
+    {
+        return new DefaultGraphType.Builder()
+            .directed().weighted(false).modifiable(false).allowMultipleEdges(false)
+            .allowSelfLoops(true).build();
+    }
+
+}

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -384,23 +384,22 @@ public class SuccinctDirectedGraph
             final long[] result = new long[2];
             graph.cumulativeOutdegrees.get(vertex, result);
             final LongBigListIterator iterator = graph.successors.listIterator(result[0]);
-            final int d = (int) (result[1] - result[0]);
 
             return () -> new Iterator<>() {
-                private int i = 0;
+                private int d = (int) (result[1] - result[0]);
 
                 @Override
                 public boolean hasNext()
                 {
-                    return i < d;
+                    return d != 0;
                 }
 
                 @Override
                 public IntIntPair next()
                 {
-                    if (i == d)
+                    if (d == 0)
                         throw new NoSuchElementException();
-                    i++;
+                    d--;
                     final long e = iterator.nextLong();
                     return IntIntPair.of((int) (e >>> sourceShift), (int) (e & targetMask));
                 }

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -383,25 +383,26 @@ public class SuccinctDirectedGraph
             graph.assertVertexExist(vertex);
             final long[] result = new long[2];
             graph.cumulativeOutdegrees.get(vertex, result);
-            final var successors = graph.successors;
-            final int n = graph.n;
+            final LongBigListIterator iterator = graph.successors.listIterator(result[0]);
+            final int d = (int) (result[1] - result[0]);
 
             return () -> new Iterator<>() {
-                private long e = result[0];
+                private int i = 0;
 
                 @Override
                 public boolean hasNext()
                 {
-                    return e < result[1];
+                    return i < d;
                 }
 
                 @Override
                 public IntIntPair next()
                 {
-                    if (!hasNext())
+                    if (i == d)
                         throw new NoSuchElementException();
-                    final long t = successors.getLong(e++);
-                    return IntIntPair.of((int) (t >>> sourceShift), (int) (t & targetMask));
+                    i++;
+                    final long e = iterator.nextLong();
+                    return IntIntPair.of((int) (e >>> sourceShift), (int) (e & targetMask));
                 }
 
             };

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -53,8 +53,8 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * {@link SparseIntDirectedGraph}).
  *
  * <p>
- * All accessors are very fast. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are
- * very fast and happen in almost constant time.
+ * All accessors are very fast. {@linkplain org.jgrapht.Graph#containsEdge(Object) Adjacency tests}
+ * are very fast and happen in almost constant time.
  *
  * <p>
  * {@link SuccinctDirectedGraph} is a much slower implementation with a similar footprint using

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -39,7 +39,8 @@ import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList.EliasFanoInde
 import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
 
 /**
- * An immutable directed graph represented using quasi-succinct data structures.
+ * An immutable directed graph with {@link IntIntPair} edges represented using quasi-succinct data
+ * structures.
  *
  * <p>
  * The graph representation of this implementation uses the {@linkplain EliasFanoMonotoneLongBigList

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -54,7 +54,7 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  *
  * <p>
  * All accessors are very fast. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are
- * happen in almost constant time.
+ * very fast and happen in almost constant time.
  *
  * <p>
  * {@link SuccinctDirectedGraph} is a much slower implementation with a similar footprint using
@@ -197,15 +197,15 @@ public class SuccinctDirectedGraph
     public Set<IntIntPair> outgoingEdgesOf(final Integer vertex)
     {
         assertVertexExist(vertex);
+        final int x = vertex;
         final long[] result = new long[2];
-        cumulativeOutdegrees.get(vertex, result);
+        cumulativeOutdegrees.get(x, result);
         final ObjectOpenHashSet<IntIntPair> s = new ObjectOpenHashSet<>();
         final LongBigListIterator iterator = successors.listIterator(result[0]);
+        final long base = (long) x << sourceShift;
 
-        for (int d = (int) (result[1] - result[0]); d-- != 0;) {
-            final long t = iterator.nextLong();
-            s.add(IntIntPair.of((int) (t >>> sourceShift), (int) (t & targetMask)));
-        }
+        for (int d = (int) (result[1] - result[0]); d-- != 0;)
+            s.add(IntIntPair.of(x, (int) (iterator.nextLong() - base)));
         return s;
     }
 
@@ -383,9 +383,11 @@ public class SuccinctDirectedGraph
             final long targetMask = graph.targetMask;
 
             graph.assertVertexExist(vertex);
+            final int x = vertex;
             final long[] result = new long[2];
-            graph.cumulativeOutdegrees.get(vertex, result);
+            graph.cumulativeOutdegrees.get(x, result);
             final LongBigListIterator iterator = graph.successors.listIterator(result[0]);
+            final long base = (long) x << sourceShift;
 
             return () -> new Iterator<>() {
                 private int d = (int) (result[1] - result[0]);
@@ -402,8 +404,7 @@ public class SuccinctDirectedGraph
                     if (d == 0)
                         throw new NoSuchElementException();
                     d--;
-                    final long e = iterator.nextLong();
-                    return IntIntPair.of((int) (e >>> sourceShift), (int) (e & targetMask));
+                    return IntIntPair.of(x, (int) (iterator.nextLong() - base));
                 }
 
             };

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -62,6 +62,13 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * {@link Integer} as edge type. Please read the {@linkplain org.jgrapht.sux4j class documentation}
  * for more information.
  *
+ * <p>
+ * For convenience, and as a compromise with the approach of {@link SuccinctIntDirectedGraph}, this
+ * class provides methods {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getEdgeFromIndex(int)
+ * getEdgeFromIndex()} and
+ * {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getIndexFromEdge(it.unimi.dsi.fastutil.ints.IntIntPair)
+ * getIndexFromEdge()} that map bijectively the edge set into a contiguous set of longs.
+ *
  * @author Sebastiano Vigna
  * @see SuccinctIntDirectedGraph
  */
@@ -229,13 +236,13 @@ public class SuccinctDirectedGraph
      * @return the index associated with the edge, or &minus;1 if the edge is not part of the graph.
      * @see #getEdgeFromIndex(int)
      */
-    public int getIndexFromEdge(final IntIntPair e)
+    public long getIndexFromEdge(final IntIntPair e)
     {
         final int source = e.firstInt();
         final int target = e.secondInt();
         if (source < 0 || source >= n || target < 0 || target >= n)
             throw new IllegalArgumentException();
-        return (int) successors.indexOfUnsafe(((long) source << sourceShift) + target);
+        return successors.indexOfUnsafe(((long) source << sourceShift) + target);
     }
 
     /**
@@ -245,7 +252,7 @@ public class SuccinctDirectedGraph
      * @return the pair with index {@code i}.
      * @see #getIndexFromEdge(IntIntPair)
      */
-    public IntIntPair getEdgeFromIndex(final int i)
+    public IntIntPair getEdgeFromIndex(final long i)
     {
         if (i < 0 || i >= m)
             throw new IllegalArgumentException();

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -187,7 +187,6 @@ public class SuccinctDirectedGraph
      *
      * @param numVertices the number of vertices.
      * @param edges the edge list.
-     * @param incomingEdgesSupport whether to support incoming edges or not.
      * @see #SuccinctDirectedGraph(Graph)
      */
 

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -62,7 +62,7 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * are very fast and happen in almost constant time.
  *
  * <p>
- * {@link SuccinctDirectedGraph} is a much slower implementation with a similar footprint using
+ * {@link SuccinctIntDirectedGraph} is a much slower implementation with a similar footprint using
  * {@link Integer} as edge type. Please read the {@linkplain org.jgrapht.sux4j class documentation}
  * for more information.
  *

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -64,7 +64,7 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  *
  * <p>
  * For convenience, and as a compromise with the approach of {@link SuccinctIntDirectedGraph}, this
- * class provides methods {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getEdgeFromIndex(int)
+ * class provides methods {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getEdgeFromIndex(long)
  * getEdgeFromIndex()} and
  * {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getIndexFromEdge(it.unimi.dsi.fastutil.ints.IntIntPair)
  * getIndexFromEdge()} that map bijectively the edge set into a contiguous set of longs.
@@ -234,7 +234,7 @@ public class SuccinctDirectedGraph
      *
      * @param e an edge of the graph.
      * @return the index associated with the edge, or &minus;1 if the edge is not part of the graph.
-     * @see #getEdgeFromIndex(int)
+     * @see #getEdgeFromIndex(long)
      */
     public long getIndexFromEdge(final IntIntPair e)
     {

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -42,29 +42,27 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * An immutable directed graph represented using quasi-succinct data structures.
  *
  * <p>
- * The graph representation of this implementation is similar to that of
- * {@link SparseIntDirectedGraph}: nodes and edges are initial intervals of the natural numbers.
- * Under the hood, however, this class uses the {@linkplain EliasFanoMonotoneLongBigList
- * Elias&ndash;Fano representation of monotone sequences} to represent the positions of the ones
- * elements in the (linearized) adjacency matrix of the graph.
+ * The graph representation of this implementation uses the {@linkplain EliasFanoMonotoneLongBigList
+ * Elias&ndash;Fano representation of monotone sequences} to represent the positions of ones in the
+ * (linearized) adjacency matrix of the graph. Edges are represented by instances of
+ * {@link IntIntPair}. Instances are serializable and thread safe.
  *
  * <p>
  * If the vertex set is compact (i.e., vertices are numbered from 0 consecutively), space usage will
  * be close to the information-theoretical lower bound (typically, a few times smaller than a
- * {@link SparseIntDirectedGraph}). However, access times will be correspondingly slower.
+ * {@link SparseIntDirectedGraph}).
  *
  * <p>
- * Note that {@linkplain #containsEdge(Integer, Integer) adjacency checks} will be performed
- * essentially in constant time.
+ * All accessors are very fast. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are
+ * happen in almost constant time.
  *
  * <p>
- * The {@linkplain #SuccinctIntDirectedGraph(Graph) constructor} takes an existing graph: the
- * resulting object can be serialized and reused.
- *
- * <p>
- * This class is thread-safe.
+ * {@link SuccinctDirectedGraph} is a much slower implementation with a similar footprint using
+ * {@link Integer} as edge type. Please read the {@linkplain org.jgrapht.sux4j class documentation}
+ * for more information.
  *
  * @author Sebastiano Vigna
+ * @see SuccinctIntDirectedGraph
  */
 
 public class SuccinctDirectedGraph

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -126,11 +126,11 @@ public class SuccinctDirectedGraph
      *
      * <p>
      * This constructor just builds a {@link SparseIntDirectedGraph} and delegates to the
-     * {@linkplain #SuccinctIntDirectedGraph(Graph) main constructor}.
+     * {@linkplain #SuccinctDirectedGraph(Graph) main constructor}.
      *
      * @param numVertices the number of vertices.
      * @param edges the edge list.
-     * @see #SuccinctIntDirectedGraph(Graph)
+     * @see #SuccinctDirectedGraph(Graph)
      */
 
     public SuccinctDirectedGraph(final int numVertices, final List<Pair<Integer, Integer>> edges)

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -50,7 +50,7 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  *
  * <p>
  * If the vertex set is compact (i.e., vertices are numbered from 0 consecutively), space usage will
- * be close to the information-theoretical lower bound (typically, a few times smaller than a
+ * be close to twice the information-theoretical lower bound (typically, a few times smaller than a
  * {@link SparseIntDirectedGraph}).
  *
  * <p>

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -200,8 +200,10 @@ public class SuccinctDirectedGraph
         final long[] result = new long[2];
         cumulativeOutdegrees.get(vertex, result);
         final ObjectOpenHashSet<IntIntPair> s = new ObjectOpenHashSet<>();
-        for (int e = (int) result[0]; e < (int) result[1]; e++) {
-            final long t = successors.getLong(e);
+        final LongBigListIterator iterator = successors.listIterator(result[0]);
+
+        for (int d = (int) (result[1] - result[0]); d-- != 0;) {
+            final long t = iterator.nextLong();
             s.add(IntIntPair.of((int) (t >>> sourceShift), (int) (t & targetMask)));
         }
         return s;

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -1,0 +1,637 @@
+/*
+ * (C) Copyright 2020-2021, by Sebastiano Vigna and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
+package org.jgrapht.sux4j;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphIterables;
+import org.jgrapht.GraphType;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.graph.AbstractGraph;
+import org.jgrapht.graph.DefaultGraphType;
+import org.jgrapht.opt.graph.sparse.SparseIntDirectedGraph;
+
+import com.google.common.collect.Iterables;
+
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.ints.IntIntPair;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.fastutil.longs.LongBigListIterator;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSets;
+import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList;
+import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList.EliasFanoIndexedMonotoneLongBigListIterator;
+import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
+
+/**
+ * An immutable directed graph represented using quasi-succinct data structures.
+ *
+ * <p>
+ * The graph representation of this implementation is similar to that of
+ * {@link SparseIntDirectedGraph}: nodes and edges are initial intervals of the natural numbers.
+ * Under the hood, however, this class uses the {@linkplain EliasFanoMonotoneLongBigList
+ * Elias&ndash;Fano representation of monotone sequences} to represent the positions of the ones
+ * elements in the (linearized) adjacency matrix of the graph.
+ *
+ * <p>
+ * If the vertex set is compact (i.e., vertices are numbered from 0 consecutively), space usage will
+ * be close to the information-theoretical lower bound (typically, a few times smaller than a
+ * {@link SparseIntDirectedGraph}). However, access times will be correspondingly slower.
+ *
+ * <p>
+ * Note that {@linkplain #containsEdge(Integer, Integer) adjacency checks} will be performed
+ * essentially in constant time.
+ *
+ * <p>
+ * The {@linkplain #SuccinctIntDirectedGraph(Graph) constructor} takes an existing graph: the
+ * resulting object can be serialized and reused.
+ *
+ * <p>
+ * This class is thread-safe.
+ *
+ * @author Sebastiano Vigna
+ */
+
+public class SuccinctDirectedGraph
+    extends
+    AbstractGraph<Integer, IntIntPair>
+    implements
+    Serializable
+{
+    private static final long serialVersionUID = 0L;
+    protected static final String UNMODIFIABLE = "this graph is unmodifiable";
+
+    /**
+     * Turns all lists of successors into a single monotone sequence by representing an arc
+     * <var>x</var>&nbsp;&rarr;&nbsp;<var>y</var> as <var>x</var><var>n</var> + <var>y</var>.
+     *
+     * @param <E> the graph edge type
+     */
+    private final static class CumulativeSuccessors<E>
+        implements
+        LongIterator
+    {
+        private final Graph<Integer, E> graph;
+        private final long n;
+        private final Function<Integer, Iterable<E>> succ;
+        private final boolean strict;
+
+        private int x = -1, d, i, e;
+        private long next = -1;
+        private int[] s = IntArrays.EMPTY_ARRAY;
+
+        public CumulativeSuccessors(
+            final Graph<Integer, E> graph, final Function<Integer, Iterable<E>> succ,
+            final boolean strict)
+        {
+            this.n = graph.iterables().vertexCount();
+            this.graph = graph;
+            this.succ = succ;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            if (next != -1)
+                return true;
+            if (x == n)
+                return false;
+            while (i == d) {
+                if (++x == n)
+                    return false;
+                int d = 0;
+                for (final E e : succ.apply(x)) {
+                    s = IntArrays.grow(s, d + 1);
+                    s[d++] = Graphs.getOppositeVertex(graph, e, x);
+                }
+                Arrays.sort(s, 0, d);
+                this.d = d;
+                i = 0;
+            }
+            // The predecessor list will not be indexed, so we can gain a few bits of space by
+            // subtracting the edge position in the list
+            next = s[i] + x * n - (strict ? 0 : e++);
+            i++;
+            return true;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            final long result = next;
+            next = -1;
+            return result;
+        }
+    }
+
+    /**
+     * Iterates over the cumulative degrees (starts with a zero).
+     */
+    private final static class CumulativeDegrees
+        implements
+        LongIterator
+    {
+        private final Function<Integer, Integer> degreeOf;
+        private final int n;
+        private int i = -1;
+        private long cumul = 0;
+
+        public CumulativeDegrees(final int n, final Function<Integer, Integer> degreeOf)
+        {
+            this.n = n;
+            this.degreeOf = degreeOf;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return i < n;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            if (i == -1)
+                return ++i;
+            return cumul += degreeOf.apply(i++);
+        }
+    }
+
+    /** The number of vertices in the graph. */
+    private final int n;
+    /** The number of edges in the graph. */
+    private final int m;
+    /** The cumulative list of outdegrees. */
+    private final EliasFanoIndexedMonotoneLongBigList cumulativeOutdegrees;
+    /** The cumulative list of indegrees. */
+    private final EliasFanoMonotoneLongBigList cumulativeIndegrees;
+    /** The cumulative list of successor lists. */
+    private final EliasFanoIndexedMonotoneLongBigList successors;
+    /** The cumulative list of predecessor lists. */
+    private final EliasFanoMonotoneLongBigList predecessors;
+
+    /**
+     * Creates a new immutable succinct directed graph from a given directed graph.
+     *
+     * @param graph a directed graph: for good results, vertices should be numbered consecutively
+     *        starting from 0.
+     * @param <E> the graph edge type
+     */
+    public <E> SuccinctDirectedGraph(final Graph<Integer, E> graph)
+    {
+
+        if (graph.getType().isUndirected())
+            throw new IllegalArgumentException("This class supports directed graphs only");
+        assert graph.getType().isDirected();
+        final GraphIterables<Integer, E> iterables = graph.iterables();
+        if (iterables.vertexCount() > Integer.MAX_VALUE)
+            throw new IllegalArgumentException(
+                "The number of nodes (" + iterables.vertexCount() + ") is greater than "
+                    + Integer.MAX_VALUE);
+        if (iterables.edgeCount() > Integer.MAX_VALUE)
+            throw new IllegalArgumentException(
+                "The number of edges (" + iterables.edgeCount() + ") is greater than "
+                    + Integer.MAX_VALUE);
+
+        n = (int) iterables.vertexCount();
+        m = (int) iterables.edgeCount();
+
+        cumulativeOutdegrees = new EliasFanoIndexedMonotoneLongBigList(
+            n + 1, m, new CumulativeDegrees(n, graph::outDegreeOf));
+        cumulativeIndegrees =
+            new EliasFanoMonotoneLongBigList(n + 1, m, new CumulativeDegrees(n, graph::inDegreeOf));
+        assert cumulativeOutdegrees.getLong(cumulativeOutdegrees.size64() - 1) == m;
+        assert cumulativeIndegrees.getLong(cumulativeIndegrees.size64() - 1) == m;
+
+        successors = new EliasFanoIndexedMonotoneLongBigList(
+            m, (long) n * n, new CumulativeSuccessors<>(graph, iterables::outgoingEdgesOf, true));
+        predecessors = new EliasFanoIndexedMonotoneLongBigList(
+            m, (long) n * n - m,
+            new CumulativeSuccessors<>(graph, iterables::incomingEdgesOf, false));
+    }
+
+    /**
+     * Creates a new immutable succinct directed graph from an edge list.
+     *
+     * <p>
+     * This constructor just builds a {@link SparseIntDirectedGraph} and delegates to the
+     * {@linkplain #SuccinctIntDirectedGraph(Graph) main constructor}.
+     *
+     * @param numVertices the number of vertices.
+     * @param edges the edge list.
+     * @see #SuccinctIntDirectedGraph(Graph)
+     */
+
+    public SuccinctDirectedGraph(final int numVertices, final List<Pair<Integer, Integer>> edges)
+    {
+        this(new SparseIntDirectedGraph(numVertices, edges));
+    }
+
+    @Override
+    public Supplier<Integer> getVertexSupplier()
+    {
+        return null;
+    }
+
+    @Override
+    public Supplier<IntIntPair> getEdgeSupplier()
+    {
+        return null;
+    }
+
+    @Override
+    public IntIntPair addEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean addEdge(
+        final Integer sourceVertex, final Integer targetVertex, final IntIntPair e)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public Integer addVertex()
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean addVertex(final Integer v)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean containsEdge(final IntIntPair e)
+    {
+        return successors.indexOfUnsafe(e.firstInt() * (long) n + e.secondInt()) != -1;
+    }
+
+    @Override
+    public boolean containsVertex(final Integer v)
+    {
+        return v >= 0 && v < n;
+    }
+
+    @Override
+    public Set<IntIntPair> edgeSet()
+    {
+        return new ObjectOpenHashSet<>(iterables().edges().iterator());
+    }
+
+    @Override
+    public int degreeOf(final Integer vertex)
+    {
+        return inDegreeOf(vertex) + outDegreeOf(vertex);
+    }
+
+    @Override
+    public Set<IntIntPair> edgesOf(final Integer vertex)
+    {
+        final Set<IntIntPair> result = outgoingEdgesOf(vertex);
+        result.addAll(incomingEdgesOf(vertex));
+        return result;
+    }
+
+    @Override
+    public int inDegreeOf(final Integer vertex)
+    {
+        assertVertexExist(vertex);
+        return (int) cumulativeIndegrees.getDelta(vertex);
+    }
+
+    @Override
+    public Set<IntIntPair> incomingEdgesOf(final Integer target)
+    {
+        assertVertexExist(target);
+        final int t = target;
+        final long[] result = new long[2];
+        cumulativeIndegrees.get(t, result);
+        final int d = (int) (result[1] - result[0]);
+        final LongBigListIterator iterator = predecessors.listIterator(result[0]);
+
+        final ObjectOpenHashSet<IntIntPair> s = new ObjectOpenHashSet<>();
+        long base = (long) n * t - result[0];
+
+        for (int i = d; i-- != 0;) {
+            final long source = iterator.nextLong() - base--;
+            s.add(IntIntPair.of((int) source, target));
+        }
+
+        return s;
+    }
+
+    @Override
+    public int outDegreeOf(final Integer vertex)
+    {
+        assertVertexExist(vertex);
+        return (int) cumulativeOutdegrees.getDelta(vertex);
+    }
+
+    @Override
+    public Set<IntIntPair> outgoingEdgesOf(final Integer vertex)
+    {
+        assertVertexExist(vertex);
+        final long[] result = new long[2];
+        cumulativeOutdegrees.get(vertex, result);
+        final ObjectOpenHashSet<IntIntPair> s = new ObjectOpenHashSet<>();
+        for (int e = (int) result[0]; e < (int) result[1]; e++) {
+            final long t = successors.getLong(e);
+            s.add(IntIntPair.of((int) (t / n), (int) (t % n)));
+        }
+        return s;
+    }
+
+    @Override
+    public IntIntPair removeEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean removeEdge(final IntIntPair e)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean removeVertex(final Integer v)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public Set<Integer> vertexSet()
+    {
+        return IntSets.fromTo(0, n);
+    }
+
+    @Override
+    public Integer getEdgeSource(final IntIntPair e)
+    {
+        return e.firstInt();
+    }
+
+    @Override
+    public Integer getEdgeTarget(final IntIntPair e)
+    {
+        return e.secondInt();
+    }
+
+    @Override
+    public GraphType getType()
+    {
+        return new DefaultGraphType.Builder()
+            .directed().weighted(false).modifiable(false).allowMultipleEdges(false)
+            .allowSelfLoops(true).build();
+    }
+
+    @Override
+    public double getEdgeWeight(final IntIntPair e)
+    {
+        return 1.0;
+    }
+
+    @Override
+    public void setEdgeWeight(final IntIntPair e, final double weight)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public IntIntPair getEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        final long index = successors.indexOfUnsafe(sourceVertex * (long) n + targetVertex);
+        return index != -1 ? IntIntPair.of(sourceVertex, targetVertex) : null;
+    }
+
+    @Override
+    public boolean containsEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        return successors.indexOfUnsafe(sourceVertex * (long) n + targetVertex) != -1;
+    }
+
+    @Override
+    public Set<IntIntPair> getAllEdges(final Integer sourceVertex, final Integer targetVertex)
+    {
+        final IntIntPair edge = getEdge(sourceVertex, targetVertex);
+        return edge == null ? ObjectSets.emptySet() : ObjectSets.singleton(edge);
+    }
+
+    /**
+     * Ensures that the specified vertex exists in this graph, or else throws exception.
+     *
+     * @param v vertex
+     * @return <code>true</code> if this assertion holds.
+     * @throws IllegalArgumentException if specified vertex does not exist in this graph.
+     */
+    @Override
+    protected boolean assertVertexExist(final Integer v)
+    {
+        if (v < 0 || v >= n)
+            throw new IllegalArgumentException();
+        return true;
+    }
+
+    /**
+     * Ensures that the specified edge exists in this graph, or else throws exception.
+     *
+     * @param e edge
+     * @return <code>true</code> if this assertion holds.
+     * @throws IllegalArgumentException if specified edge does not exist in this graph.
+     */
+    protected boolean assertEdgeExist(final Integer e)
+    {
+        if (e < 0 || e >= m)
+            throw new IllegalArgumentException();
+        return true;
+
+    }
+
+    private final static class SuccinctGraphIterables
+        implements
+        GraphIterables<Integer, IntIntPair>,
+        Serializable
+    {
+        private static final long serialVersionUID = 0L;
+        private final SuccinctDirectedGraph graph;
+
+        private SuccinctGraphIterables()
+        {
+            graph = null;
+        }
+
+        private SuccinctGraphIterables(final SuccinctDirectedGraph graph)
+        {
+            this.graph = graph;
+        }
+
+        @Override
+        public Graph<Integer, IntIntPair> getGraph()
+        {
+            return graph;
+        }
+
+        @Override
+        public long vertexCount()
+        {
+            return graph.n;
+        }
+
+        @Override
+        public long edgeCount()
+        {
+            return graph.m;
+        }
+
+        @Override
+        public Iterable<IntIntPair> edges()
+        {
+            return () -> new Iterator<>()
+            {
+                private final EliasFanoIndexedMonotoneLongBigListIterator iterator = graph.successors.iterator();
+                private final int n = graph.n;
+
+                @Override
+                public boolean hasNext()
+                {
+                    return iterator.hasNext();
+                }
+
+                @Override
+                public IntIntPair next()
+                {
+                    final long t = iterator.nextLong();
+                    return IntIntPair.of((int) (t / n), (int) (t % n));
+                }
+
+            };
+        }
+
+        @Override
+        public Iterable<IntIntPair> edgesOf(final Integer source)
+        {
+            return Iterables.concat(outgoingEdgesOf(source), incomingEdgesOf(source, true));
+        }
+
+        private Iterable<IntIntPair> incomingEdgesOf(final int target, final boolean skipLoops)
+        {
+            final SuccinctDirectedGraph graph = this.graph;
+            final long[] result = new long[2];
+            graph.cumulativeIndegrees.get(target, result);
+            final int d = (int) (result[1] - result[0]);
+            final EliasFanoIndexedMonotoneLongBigList successors = graph.successors;
+            final LongBigListIterator iterator = graph.predecessors.listIterator(result[0]);
+
+            return () -> new Iterator<>()
+            {
+                int i = d;
+                IntIntPair edge = null;
+                long n = graph.n;
+                long base = target * n - result[0];
+
+                @Override
+                public boolean hasNext()
+                {
+                    if (edge == null && i > 0) {
+                        i--;
+                        final long source = iterator.nextLong() - base--;
+                        if (skipLoops && source == target && i-- != 0)
+                            return false;
+                        edge = IntIntPair.of((int) source, target);
+                    }
+                    return edge != null;
+                }
+
+                @Override
+                public IntIntPair next()
+                {
+                    if (!hasNext())
+                        throw new NoSuchElementException();
+                    final IntIntPair result = edge;
+                    edge = null;
+                    return result;
+                }
+            };
+        }
+
+        @Override
+        public Iterable<IntIntPair> outgoingEdgesOf(final Integer vertex)
+        {
+            graph.assertVertexExist(vertex);
+            final long[] result = new long[2];
+            graph.cumulativeOutdegrees.get(vertex, result);
+            final var successors = graph.successors;
+            final int n = graph.n;
+
+            return () -> new Iterator<>() {
+                private long e = result[0];
+
+                @Override
+                public boolean hasNext()
+                {
+                    return e < result[1];
+                }
+
+                @Override
+                public IntIntPair next()
+                {
+                    if (!hasNext())
+                        throw new NoSuchElementException();
+                    final long t = successors.getLong(e++);
+                    return IntIntPair.of((int) (t / n), (int) (t % n));
+                }
+
+            };
+        }
+
+        @Override
+        public Iterable<IntIntPair> incomingEdgesOf(final Integer vertex)
+        {
+            graph.assertVertexExist(vertex);
+            return incomingEdgesOf(vertex, false);
+        }
+    }
+
+    private final GraphIterables<Integer, IntIntPair> ITERABLES = new SuccinctGraphIterables(this);
+
+    @Override
+    public GraphIterables<Integer, IntIntPair> iterables()
+    {
+        return ITERABLES;
+    }
+}

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
@@ -1,0 +1,583 @@
+/*
+ * (C) Copyright 2020, by Sebastiano Vigna.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
+package org.jgrapht.opt.graph.sux4j;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphIterables;
+import org.jgrapht.GraphType;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.graph.AbstractGraph;
+import org.jgrapht.graph.DefaultGraphType;
+import org.jgrapht.opt.graph.sparse.SparseIntDirectedGraph;
+
+import com.google.common.collect.Iterables;
+
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.fastutil.longs.LongBigListIterator;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList;
+import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
+
+/**
+ * An immutable directed graph represented using quasi-succinct data structures.
+ *
+ * <p>
+ * The graph representation of this implementation is similar to that of
+ * {@link SparseIntDirectedGraph}: nodes and edges are initial intervals of the natural numbers.
+ * Under the hood, however, this class uses the {@linkplain EliasFanoMonotoneLongBigList
+ * Elias&ndash;Fano representation of monotone sequences} to represent the positions of the ones
+ * elements in the (linearized) adjacency matrix of the graph.
+ *
+ * <p>
+ * If the vertex set is compact (i.e., vertices are numbered from 0 consecutively), space usage will
+ * be close to the information-theoretical lower bound (typically, a few times smaller than a
+ * {@link SparseIntDirectedGraph}).
+ *
+ * <p>
+ * Note that {@linkplain #containsEdge(Integer, Integer) adjacency checks} will be performed
+ * essentially in constant time.
+ *
+ * <p>
+ * The {@linkplain #SuccinctIntDirectedGraph(Graph) constructor} takes an existing graph: the
+ * resulting object can be serialized and reused.
+ *
+ * <p>
+ * This class is thread-safe.
+ *
+ * @author Sebastiano Vigna
+ */
+
+public class SuccinctIntDirectedGraph
+    extends
+    AbstractGraph<Integer, Integer>
+    implements
+    Serializable
+{
+    private static final long serialVersionUID = 0L;
+    protected static final String UNMODIFIABLE = "this graph is unmodifiable";
+
+    /**
+     * Turns all lists of successors into a single monotone sequence by representing an arc
+     * <var>x</var>&nbsp;&rarr;&nbsp;<var>y</var> as <var>x</var><var>n</var> + <var>y</var>.
+     *
+     * @param <E> the graph edge type
+     */
+    private final static class CumulativeSuccessors<E>
+        implements
+        LongIterator
+    {
+        private final Graph<Integer, E> graph;
+        private final long n;
+        private final Function<Integer, Iterable<E>> succ;
+        private final boolean strict;
+
+        private int x = -1, d, i, e;
+        private long next = -1;
+        private int[] s = IntArrays.EMPTY_ARRAY;
+
+        public CumulativeSuccessors(
+            final Graph<Integer, E> graph, final Function<Integer, Iterable<E>> succ,
+            final boolean strict)
+        {
+            this.n = graph.iterables().vertexCount();
+            this.graph = graph;
+            this.succ = succ;
+            this.strict = strict;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            if (next != -1)
+                return true;
+            if (x == n)
+                return false;
+            while (i == d) {
+                if (++x == n)
+                    return false;
+                int d = 0;
+                for (final E e : succ.apply(x)) {
+                    s = IntArrays.grow(s, d + 1);
+                    s[d++] = Graphs.getOppositeVertex(graph, e, x);
+                }
+                Arrays.sort(s, 0, d);
+                this.d = d;
+                i = 0;
+            }
+            // The predecessor list will not be indexed, so we can gain a few bits of space by
+            // subtracting the edge position in the list
+            next = s[i] + x * n - (strict ? 0 : e++);
+            i++;
+            return true;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            final long result = next;
+            next = -1;
+            return result;
+        }
+    }
+
+    /**
+     * Iterates over the cumulative degrees (starts with a zero).
+     */
+    private final static class CumulativeDegrees
+        implements
+        LongIterator
+    {
+        private final Function<Integer, Integer> degreeOf;
+        private final int n;
+        private int i = -1;
+        private long cumul = 0;
+
+        public CumulativeDegrees(final int n, final Function<Integer, Integer> degreeOf)
+        {
+            this.n = n;
+            this.degreeOf = degreeOf;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return i < n;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            if (i == -1)
+                return ++i;
+            return cumul += degreeOf.apply(i++);
+        }
+    }
+
+    /** The number of vertices in the graph. */
+    private final int n;
+    /** The number of edges in the graph. */
+    private final int m;
+    /** The cumulative list of outdegrees. */
+    private final EliasFanoIndexedMonotoneLongBigList cumulativeOutdegrees;
+    /** The cumulative list of indegrees. */
+    private final EliasFanoMonotoneLongBigList cumulativeIndegrees;
+    /** The cumulative list of successor lists. */
+    private final EliasFanoIndexedMonotoneLongBigList successors;
+    /** The cumulative list of predecessor lists. */
+    private final EliasFanoMonotoneLongBigList predecessors;
+
+    /**
+     * Creates a new immutable succinct directed graph from a given directed graph.
+     *
+     * @param graph a directed graph: for good results, vertices should be numbered consecutively
+     *        starting from 0.
+     * @param <E> the graph edge type
+     */
+    public <E> SuccinctIntDirectedGraph(final Graph<Integer, E> graph)
+    {
+
+        if (graph.getType().isUndirected())
+            throw new IllegalArgumentException("This class supports directed graphs only");
+        assert graph.getType().isDirected();
+        final GraphIterables<Integer, E> iterables = graph.iterables();
+        if (iterables.vertexCount() > Integer.MAX_VALUE)
+            throw new IllegalArgumentException(
+                "The number of nodes (" + iterables.vertexCount() + ") is greater than "
+                    + Integer.MAX_VALUE);
+        if (iterables.edgeCount() > Integer.MAX_VALUE)
+            throw new IllegalArgumentException(
+                "The number of edges (" + iterables.edgeCount() + ") is greater than "
+                    + Integer.MAX_VALUE);
+
+        n = (int) iterables.vertexCount();
+        m = (int) iterables.edgeCount();
+
+        cumulativeOutdegrees = new EliasFanoIndexedMonotoneLongBigList(
+            n + 1, m, new CumulativeDegrees(n, graph::outDegreeOf));
+        cumulativeIndegrees =
+            new EliasFanoMonotoneLongBigList(n + 1, m, new CumulativeDegrees(n, graph::inDegreeOf));
+        assert cumulativeOutdegrees.getLong(cumulativeOutdegrees.size64() - 1) == m;
+        assert cumulativeIndegrees.getLong(cumulativeIndegrees.size64() - 1) == m;
+
+        successors = new EliasFanoIndexedMonotoneLongBigList(
+            m, (long) n * n, new CumulativeSuccessors<>(graph, iterables::outgoingEdgesOf, true));
+        predecessors = new EliasFanoIndexedMonotoneLongBigList(
+            m, (long) n * n - m,
+            new CumulativeSuccessors<>(graph, iterables::incomingEdgesOf, false));
+    }
+
+    /**
+     * Creates a new immutable succinct directed graph from an edge list.
+     *
+     * <p>
+     * This constructor just builds a {@link SparseIntDirectedGraph} and delegates to the
+     * {@linkplain #SuccinctIntDirectedGraph(Graph) main constructor}.
+     *
+     * @param numVertices the number of vertices.
+     * @param edges the edge list.
+     * @see #SuccinctIntDirectedGraph(Graph)
+     */
+
+    public SuccinctIntDirectedGraph(final int numVertices, final List<Pair<Integer, Integer>> edges)
+    {
+        this(new SparseIntDirectedGraph(numVertices, edges));
+    }
+
+    @Override
+    public Supplier<Integer> getVertexSupplier()
+    {
+        return null;
+    }
+
+    @Override
+    public Supplier<Integer> getEdgeSupplier()
+    {
+        return null;
+    }
+
+    @Override
+    public Integer addEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean addEdge(final Integer sourceVertex, final Integer targetVertex, final Integer e)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public Integer addVertex()
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean addVertex(final Integer v)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean containsEdge(final Integer e)
+    {
+        return e >= 0 && e < m;
+    }
+
+    @Override
+    public boolean containsVertex(final Integer v)
+    {
+        return v >= 0 && v < n;
+    }
+
+    @Override
+    public Set<Integer> edgeSet()
+    {
+        return IntSets.fromTo(0, m);
+    }
+
+    @Override
+    public int degreeOf(final Integer vertex)
+    {
+        return inDegreeOf(vertex) + outDegreeOf(vertex);
+    }
+
+    @Override
+    public IntSet edgesOf(final Integer vertex)
+    {
+        final IntSet result = outgoingEdgesOf(vertex);
+        result.addAll(incomingEdgesOf(vertex));
+        return result;
+    }
+
+    @Override
+    public int inDegreeOf(final Integer vertex)
+    {
+        assertVertexExist(vertex);
+        return (int) cumulativeIndegrees.getDelta(vertex);
+    }
+
+    @Override
+    public IntSet incomingEdgesOf(final Integer target)
+    {
+        assertVertexExist(target);
+        final int t = target;
+        final long[] result = new long[2];
+        cumulativeIndegrees.get(t, result);
+        final int d = (int) (result[1] - result[0]);
+        final LongBigListIterator iterator = predecessors.listIterator(result[0]);
+
+        final IntOpenHashSet s = new IntOpenHashSet();
+        long base = (long) n * t - result[0];
+
+        for (int i = d; i-- != 0;) {
+            final long source = iterator.nextLong() - base--;
+            final int e = (int) (successors.successorIndexUnsafe(source * n + t));
+            assert getEdgeSource(e).longValue() == source;
+            assert getEdgeTarget(e).longValue() == target;
+            s.add(e);
+        }
+
+        return s;
+    }
+
+    @Override
+    public int outDegreeOf(final Integer vertex)
+    {
+        assertVertexExist(vertex);
+        return (int) cumulativeOutdegrees.getDelta(vertex);
+    }
+
+    @Override
+    public IntSet outgoingEdgesOf(final Integer vertex)
+    {
+        assertVertexExist(vertex);
+        final long[] result = new long[2];
+        cumulativeOutdegrees.get(vertex, result);
+        return IntSets.fromTo((int) result[0], (int) result[1]);
+    }
+
+    @Override
+    public Integer removeEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean removeEdge(final Integer e)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean removeVertex(final Integer v)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public Set<Integer> vertexSet()
+    {
+        return IntSets.fromTo(0, n);
+    }
+
+    @Override
+    public Integer getEdgeSource(final Integer e)
+    {
+        assertEdgeExist(e);
+        return (int) (successors.getLong(e) / n);
+    }
+
+    @Override
+    public Integer getEdgeTarget(final Integer e)
+    {
+        assertEdgeExist(e);
+        return (int) (successors.getLong(e) % n);
+    }
+
+    @Override
+    public GraphType getType()
+    {
+        return new DefaultGraphType.Builder()
+            .directed().weighted(false).modifiable(false).allowMultipleEdges(false)
+            .allowSelfLoops(true).build();
+    }
+
+    @Override
+    public double getEdgeWeight(final Integer e)
+    {
+        return 1.0;
+    }
+
+    @Override
+    public void setEdgeWeight(final Integer e, final double weight)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public Integer getEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        final long index = successors.indexOfUnsafe(sourceVertex * (long) n + targetVertex);
+        return index != -1 ? (int) index : null;
+    }
+
+    @Override
+    public boolean containsEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        return successors.indexOfUnsafe(sourceVertex * (long) n + targetVertex) != -1;
+    }
+
+    @Override
+    public Set<Integer> getAllEdges(final Integer sourceVertex, final Integer targetVertex)
+    {
+        final Integer edge = getEdge(sourceVertex, targetVertex);
+        return edge == null ? IntSets.EMPTY_SET : IntSets.singleton(edge);
+    }
+
+    /**
+     * Ensures that the specified vertex exists in this graph, or else throws exception.
+     *
+     * @param v vertex
+     * @return <code>true</code> if this assertion holds.
+     * @throws IllegalArgumentException if specified vertex does not exist in this graph.
+     */
+    @Override
+    protected boolean assertVertexExist(final Integer v)
+    {
+        if (v < 0 || v >= n)
+            throw new IllegalArgumentException();
+        return true;
+    }
+
+    /**
+     * Ensures that the specified edge exists in this graph, or else throws exception.
+     *
+     * @param e edge
+     * @return <code>true</code> if this assertion holds.
+     * @throws IllegalArgumentException if specified edge does not exist in this graph.
+     */
+    protected boolean assertEdgeExist(final Integer e)
+    {
+        if (e < 0 || e >= m)
+            throw new IllegalArgumentException();
+        return true;
+
+    }
+
+    private final static class SuccinctGraphIterables
+        implements
+        GraphIterables<Integer, Integer>,
+        Serializable
+    {
+        private static final long serialVersionUID = 0L;
+        private final SuccinctIntDirectedGraph graph;
+
+        private SuccinctGraphIterables()
+        {
+            graph = null;
+        }
+
+        private SuccinctGraphIterables(final SuccinctIntDirectedGraph graph)
+        {
+            this.graph = graph;
+        }
+
+        @Override
+        public Graph<Integer, Integer> getGraph()
+        {
+            return graph;
+        }
+
+        @Override
+        public long vertexCount()
+        {
+            return graph.n;
+        }
+
+        @Override
+        public long edgeCount()
+        {
+            return graph.m;
+        }
+
+        @Override
+        public Iterable<Integer> edgesOf(final Integer source)
+        {
+            return Iterables.concat(outgoingEdgesOf(source), incomingEdgesOf(source, true));
+        }
+
+        private Iterable<Integer> incomingEdgesOf(final int target, final boolean skipLoops)
+        {
+            final SuccinctIntDirectedGraph graph = this.graph;
+            final long[] result = new long[2];
+            graph.cumulativeIndegrees.get(target, result);
+            final int d = (int) (result[1] - result[0]);
+            final EliasFanoIndexedMonotoneLongBigList successors = graph.successors;
+            final LongBigListIterator iterator = graph.predecessors.listIterator(result[0]);
+
+            return () -> new IntIterator()
+            {
+                int i = d;
+                int edge = -1;
+                long n = graph.n;
+                long base = target * n - result[0];
+
+                @Override
+                public boolean hasNext()
+                {
+                    if (edge == -1 && i > 0) {
+                        i--;
+                        final long source = iterator.nextLong() - base--;
+                        if (skipLoops && source == target && i-- != 0)
+                            return false;
+                        final long v = source * n + target;
+                        assert v == successors.successor(v) : v + " != " + successors.successor(v);
+                        edge = (int) successors.successorIndexUnsafe(v);
+                        assert graph.getEdgeSource(edge).longValue() == source;
+                        assert graph.getEdgeTarget(edge).longValue() == target;
+                    }
+                    return edge != -1;
+                }
+
+                @Override
+                public int nextInt()
+                {
+                    if (!hasNext())
+                        throw new NoSuchElementException();
+                    final int result = edge;
+                    edge = -1;
+                    return result;
+                }
+            };
+        }
+
+        @Override
+        public Iterable<Integer> incomingEdgesOf(final Integer vertex)
+        {
+            return incomingEdgesOf(vertex, false);
+        }
+    }
+
+    private final GraphIterables<Integer, Integer> ITERABLES = new SuccinctGraphIterables(this);
+
+    @Override
+    public GraphIterables<Integer, Integer> iterables()
+    {
+        return ITERABLES;
+    }
+}

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
@@ -46,23 +46,15 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * {@link SparseIntDirectedGraph}: nodes and edges are initial intervals of the natural numbers.
  * Under the hood, however, this class uses the {@linkplain EliasFanoMonotoneLongBigList
  * Elias&ndash;Fano representation of monotone sequences} to represent the positions of the ones
- * elements in the (linearized) adjacency matrix of the graph.
+ * elements in the (linearized) adjacency matrix of the graph. Instances are serializable and thread safe.
  *
  * <p>
  * If the vertex set is compact (i.e., vertices are numbered from 0 consecutively), space usage will
  * be close to the information-theoretical lower bound (typically, a few times smaller than a
- * {@link SparseIntDirectedGraph}). However, access times will be correspondingly slower.
+ * {@link SparseIntDirectedGraph}). 
+ 
+ *<p>
  *
- * <p>
- * Note that {@linkplain #containsEdge(Integer, Integer) adjacency checks} will be performed
- * essentially in constant time.
- *
- * <p>
- * The {@linkplain #SuccinctIntDirectedGraph(Graph) constructor} takes an existing graph: the
- * resulting object can be serialized and reused.
- *
- * <p>
- * This class is thread-safe.
  *
  * @author Sebastiano Vigna
  */

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
@@ -30,6 +30,7 @@ import org.jgrapht.opt.graph.sparse.SparseIntDirectedGraph;
 
 import com.google.common.collect.Iterables;
 
+import it.unimi.dsi.fastutil.ints.IntIntPair;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
@@ -45,18 +46,27 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * The graph representation of this implementation is similar to that of
  * {@link SparseIntDirectedGraph}: nodes and edges are initial intervals of the natural numbers.
  * Under the hood, however, this class uses the {@linkplain EliasFanoMonotoneLongBigList
- * Elias&ndash;Fano representation of monotone sequences} to represent the positions of the ones
- * elements in the (linearized) adjacency matrix of the graph. Instances are serializable and thread safe.
+ * Elias&ndash;Fano representation of monotone sequences} to represent the positions of ones in the
+ * (linearized) adjacency matrix of the graph. Instances are serializable and thread safe.
  *
  * <p>
  * If the vertex set is compact (i.e., vertices are numbered from 0 consecutively), space usage will
  * be close to the information-theoretical lower bound (typically, a few times smaller than a
- * {@link SparseIntDirectedGraph}). 
- 
- *<p>
+ * {@link SparseIntDirectedGraph}).
  *
+ * <p>
+ * {@linkplain org.jgrapht.GraphIterables#outgoingEdgesOf(Object) Enumeration of outgoing edges} is
+ * quite fast, but {@linkplain org.jgrapht.GraphIterables#incomingEdgesOf(Object) enumeration of
+ * incoming edges} is very slow. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are
+ * very fast and happen in almost constant time.
+ *
+ * <p>
+ * {@link SuccinctDirectedGraph} is a much faster implementation with a similar footprint using
+ * {@link IntIntPair} as edge type. Please read the {@linkplain org.jgrapht.sux4j class
+ * documentation} for more information.
  *
  * @author Sebastiano Vigna
+ * @see SuccinctDirectedGraph
  */
 
 public class SuccinctIntDirectedGraph

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
@@ -40,7 +40,8 @@ import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList;
 import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
 
 /**
- * An immutable directed graph represented using quasi-succinct data structures.
+ * An immutable directed graph with {@link Integer} edges represented using quasi-succinct data
+ * structures.
  *
  * <p>
  * The graph representation of this implementation is similar to that of

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
@@ -52,7 +52,7 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  *
  * <p>
  * If the vertex set is compact (i.e., vertices are numbered from 0 consecutively), space usage will
- * be close to the information-theoretical lower bound (typically, a few times smaller than a
+ * be close to twice the information-theoretical lower bound (typically, a few times smaller than a
  * {@link SparseIntDirectedGraph}).
  *
  * <p>

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
@@ -57,8 +57,8 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * <p>
  * {@linkplain org.jgrapht.GraphIterables#outgoingEdgesOf(Object) Enumeration of outgoing edges} is
  * quite fast, but {@linkplain org.jgrapht.GraphIterables#incomingEdgesOf(Object) enumeration of
- * incoming edges} is very slow. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are
- * very fast and happen in almost constant time.
+ * incoming edges} is very slow. {@linkplain org.jgrapht.Graph#containsEdge(Object) Adjacency tests}
+ * are very fast and happen in almost constant time.
  *
  * <p>
  * {@link SuccinctDirectedGraph} is a much faster implementation with a similar footprint using

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
  */
 
-package org.jgrapht.opt.graph.sux4j;
+package org.jgrapht.sux4j;
 
 import java.io.Serializable;
 import java.util.Arrays;

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2020, by Sebastiano Vigna.
+ * (C) Copyright 2020-2021, by Sebastiano Vigna and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -60,7 +60,7 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * <p>
  * If the vertex set is compact (i.e., vertices are numbered from 0 consecutively), space usage will
  * be close to the information-theoretical lower bound (typically, a few times smaller than a
- * {@link SparseIntDirectedGraph}).
+ * {@link SparseIntDirectedGraph}). However, access times will be correspondingly slower.
  *
  * <p>
  * Note that {@linkplain #containsEdge(Integer, Integer) adjacency checks} will be performed

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
@@ -185,7 +185,6 @@ public class SuccinctIntDirectedGraph
      *
      * @param numVertices the number of vertices.
      * @param edges the edge list.
-     * @param incomingEdgesSupport whether to support incoming edges or not.
      * @see #SuccinctIntDirectedGraph(Graph)
      */
 

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2020, by Sebastiano Vigna.
+ * (C) Copyright 2020-2021, by Sebastiano Vigna and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
@@ -1,0 +1,604 @@
+/*
+ * (C) Copyright 2020, by Sebastiano Vigna.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
+package org.jgrapht.opt.graph.sux4j;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphIterables;
+import org.jgrapht.GraphType;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.graph.AbstractGraph;
+import org.jgrapht.graph.DefaultGraphType;
+import org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph;
+
+import com.google.common.collect.Iterables;
+
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.ints.IntIterator;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.fastutil.longs.LongBigListIterator;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList;
+import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
+
+/**
+ * An immutable undirected graph represented using quasi-succinct data structures.
+ *
+ * <p>
+ * This class is the undirected counterpart of {@link SuccintIntDirectedGraph}: the same comments
+ * apply.
+ *
+ * @author Sebastiano Vigna
+ */
+
+public class SuccinctIntUndirectedGraph
+    extends
+    AbstractGraph<Integer, Integer>
+    implements
+    Serializable
+{
+    private static final long serialVersionUID = 0L;
+    protected static final String UNMODIFIABLE = "this graph is unmodifiable";
+
+    /**
+     * Turns all lists of adjacent nodes into a single monotone sequence by representing the edge
+     * <var>x</var>&nbsp;&mdash;&nbsp;<var>y</var> as <var>x</var><var>n</var> + <var>y</var>.
+     * Depending on the value of {@code sorted}, only edges with source less than or equal to the
+     * target (or vice versa) are included.
+     *
+     * @param <E> the graph edge type
+     */
+    private final static class CumulativeSuccessors<E>
+        implements
+        LongIterator
+    {
+        private final Graph<Integer, E> graph;
+        private final long n;
+        private final Function<Integer, Iterable<E>> succ;
+        private final boolean sorted;
+
+        private int x = -1, d, i, e;
+        private long next = -1;
+        private int[] s = IntArrays.EMPTY_ARRAY;
+
+        public CumulativeSuccessors(
+            final Graph<Integer, E> graph, final boolean sorted,
+            final Function<Integer, Iterable<E>> succ)
+        {
+            this.n = (int) graph.iterables().vertexCount();
+            this.graph = graph;
+            this.sorted = sorted;
+            this.succ = succ;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            if (next != -1)
+                return true;
+            if (x == n)
+                return false;
+            while (i == d) {
+                if (++x == n)
+                    return false;
+                int d = 0;
+                for (final E e : succ.apply(x)) {
+                    final int y = Graphs.getOppositeVertex(graph, e, x);
+                    if (sorted) {
+                        if (x <= y) {
+                            s = IntArrays.grow(s, d + 1);
+                            s[d++] = y;
+                        }
+                    } else {
+                        if (x >= y) {
+                            s = IntArrays.grow(s, d + 1);
+                            s[d++] = y;
+                        }
+                    }
+                }
+                Arrays.sort(s, 0, d);
+                this.d = d;
+                i = 0;
+            }
+            // The predecessor list will not be indexed, so we can gain a few bits of space by
+            // subtracting the edge position in the list
+            next = s[i] + x * n - (sorted ? 0 : e++);
+            i++;
+            return true;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            final long result = next;
+            next = -1;
+            return result;
+        }
+    }
+
+    /**
+     * Iterates over the cumulative degrees (starts with a zero). Depending on the value of
+     * {@code sorted}, only edges with source less than or equal to the target (or vice versa) are
+     * included.
+     *
+     * @param <E> the graph edge type
+     */
+    private final static class CumulativeDegrees<E>
+        implements
+        LongIterator
+    {
+        private final int n;
+        private int x = -1;
+        private long cumul = 0;
+        private final Function<Integer, Iterable<E>> succ;
+        private final boolean sorted;
+        private final Graph<Integer, E> graph;
+
+        public CumulativeDegrees(
+            final Graph<Integer, E> graph, final boolean sorted,
+            final Function<Integer, Iterable<E>> succ)
+        {
+            this.n = (int) graph.iterables().vertexCount();
+            this.graph = graph;
+            this.succ = succ;
+            this.sorted = sorted;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return x < n;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            if (x == -1)
+                return ++x;
+            int d = 0;
+            if (sorted) {
+                for (final E e : succ.apply(x))
+                    if (x <= Graphs.getOppositeVertex(graph, e, x))
+                        d++;
+            } else {
+                for (final E e : succ.apply(x))
+                    if (x >= Graphs.getOppositeVertex(graph, e, x))
+                        d++;
+            }
+            x++;
+            return cumul += d;
+        }
+    }
+
+    /** The number of vertices in the graph. */
+    private final int n;
+    /** The number of edges in the graph. */
+    private final int m;
+    /** The cumulative list of outdegrees (number of edges in sorted order, including loops). */
+    private final EliasFanoIndexedMonotoneLongBigList cumulativeOutdegrees;
+    /** The cumulative list of indegrees (number of edges in reversed order, including loops). */
+    private final EliasFanoMonotoneLongBigList cumulativeIndegrees;
+    /** The cumulative list of successor (edges in sorted order, including loops) lists. */
+    private final EliasFanoIndexedMonotoneLongBigList successors;
+    /** The cumulative list of predecessor (edges in reversed order, including loops) lists. */
+    private final EliasFanoMonotoneLongBigList predecessors;
+
+    /**
+     * Creates a new immutable succinct undirected graph from a given undirected graph.
+     *
+     * @param graph an undirected graph: for good results, vertices should be numbered consecutively
+     *        starting from 0.
+     * @param <E> the graph edge type
+     */
+    public <E> SuccinctIntUndirectedGraph(final Graph<Integer, E> graph)
+    {
+        if (graph.getType().isDirected())
+            throw new IllegalArgumentException("This class supports directed graphs only");
+        assert graph.getType().isUndirected();
+        final GraphIterables<Integer, E> iterables = graph.iterables();
+        if (iterables.vertexCount() > Integer.MAX_VALUE)
+            throw new IllegalArgumentException(
+                "The number of nodes (" + iterables.vertexCount() + ") is greater than "
+                    + Integer.MAX_VALUE);
+        if (iterables.edgeCount() > Integer.MAX_VALUE)
+            throw new IllegalArgumentException(
+                "The number of edges (" + iterables.edgeCount() + ") is greater than "
+                    + Integer.MAX_VALUE);
+
+        n = (int) iterables.vertexCount();
+        m = (int) iterables.edgeCount();
+
+        cumulativeOutdegrees = new EliasFanoIndexedMonotoneLongBigList(
+            n + 1, m, new CumulativeDegrees<>(graph, true, iterables::edgesOf));
+        cumulativeIndegrees = new EliasFanoMonotoneLongBigList(
+            n + 1, m, new CumulativeDegrees<>(graph, false, iterables::edgesOf));
+        assert cumulativeOutdegrees.getLong(cumulativeOutdegrees.size64() - 1) == m;
+        assert cumulativeIndegrees.getLong(cumulativeIndegrees.size64() - 1) == m;
+
+        successors = new EliasFanoIndexedMonotoneLongBigList(
+            m, (long) n * n, new CumulativeSuccessors<>(graph, true, iterables::outgoingEdgesOf));
+        predecessors = new EliasFanoIndexedMonotoneLongBigList(
+            m, (long) n * n - m,
+            new CumulativeSuccessors<>(graph, false, iterables::incomingEdgesOf));
+    }
+
+    /**
+     * Creates a new immutable succinct undirected graph from an edge list.
+     *
+     * <p>
+     * This constructor just builds a {@link SparseIntUndirectedGraph} and delegates to the
+     * {@linkplain #SuccinctIntUndirectedGraph(Graph) main constructor}.
+     *
+     * @param numVertices the number of vertices.
+     * @param edges the edge list.
+     * @see #SuccinctIntUndirectedGraph(Graph)
+     */
+
+    public SuccinctIntUndirectedGraph(
+        final int numVertices, final List<Pair<Integer, Integer>> edges)
+    {
+        this(new SparseIntUndirectedGraph(numVertices, edges));
+    }
+
+    @Override
+    public Supplier<Integer> getVertexSupplier()
+    {
+        return null;
+    }
+
+    @Override
+    public Supplier<Integer> getEdgeSupplier()
+    {
+        return null;
+    }
+
+    @Override
+    public Integer addEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean addEdge(final Integer sourceVertex, final Integer targetVertex, final Integer e)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public Integer addVertex()
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean addVertex(final Integer v)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean containsEdge(final Integer e)
+    {
+        return e >= 0 && e < m;
+    }
+
+    @Override
+    public boolean containsVertex(final Integer v)
+    {
+        return v >= 0 && v < n;
+    }
+
+    @Override
+    public Set<Integer> edgeSet()
+    {
+        return IntSets.fromTo(0, m);
+    }
+
+    @Override
+    public int degreeOf(final Integer vertex)
+    {
+        return (int) cumulativeIndegrees.getDelta(vertex)
+            + (int) cumulativeOutdegrees.getDelta(vertex);
+    }
+
+    @Override
+    public IntSet edgesOf(final Integer vertex)
+    {
+        final long[] result = new long[2];
+        cumulativeOutdegrees.get(vertex, result);
+        final IntSet s = new IntOpenHashSet(IntSets.fromTo((int) result[0], (int) result[1]));
+        for (final int e : ITERABLES.reverseSortedEdgesOfNoLoops(vertex))
+            s.add(e);
+        return s;
+    }
+
+    @Override
+    public int inDegreeOf(final Integer vertex)
+    {
+        return degreeOf(vertex);
+    }
+
+    @Override
+    public IntSet incomingEdgesOf(final Integer vertex)
+    {
+        return edgesOf(vertex);
+    }
+
+    @Override
+    public int outDegreeOf(final Integer vertex)
+    {
+        return degreeOf(vertex);
+    }
+
+    @Override
+    public IntSet outgoingEdgesOf(final Integer vertex)
+    {
+        return edgesOf(vertex);
+    }
+
+    @Override
+    public Integer removeEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean removeEdge(final Integer e)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean removeVertex(final Integer v)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public Set<Integer> vertexSet()
+    {
+        return IntSets.fromTo(0, n);
+    }
+
+    @Override
+    public Integer getEdgeSource(final Integer e)
+    {
+        assertEdgeExist(e);
+        return (int) (successors.getLong(e) / n);
+    }
+
+    @Override
+    public Integer getEdgeTarget(final Integer e)
+    {
+        assertEdgeExist(e);
+        final long cumul = cumulativeOutdegrees.weakPredecessorUnsafe(e);
+        return (int) (successors.getLong(e) % n);
+    }
+
+    @Override
+    public GraphType getType()
+    {
+        return new DefaultGraphType.Builder()
+            .directed().weighted(false).modifiable(false).allowMultipleEdges(false)
+            .allowSelfLoops(true).build();
+    }
+
+    @Override
+    public double getEdgeWeight(final Integer e)
+    {
+        return 1.0;
+    }
+
+    @Override
+    public void setEdgeWeight(final Integer e, final double weight)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public Integer getEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        int x = sourceVertex;
+        int y = targetVertex;
+        if (x > y) {
+            final int t = x;
+            x = y;
+            y = t;
+        }
+        final long index = successors.indexOfUnsafe(x * (long) n + y);
+        return index != -1 ? (int) index : null;
+    }
+
+    @Override
+    public boolean containsEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        int x = sourceVertex;
+        int y = targetVertex;
+        if (x > y) {
+            final int t = x;
+            x = y;
+            y = t;
+        }
+        return successors.indexOfUnsafe(x * (long) n + y) != -1;
+    }
+
+    @Override
+    public Set<Integer> getAllEdges(final Integer sourceVertex, final Integer targetVertex)
+    {
+        final Integer edge = getEdge(sourceVertex, targetVertex);
+        return edge == null ? IntSets.EMPTY_SET : IntSets.singleton(edge);
+    }
+
+    /**
+     * Ensures that the specified vertex exists in this graph, or else throws exception.
+     *
+     * @param v vertex
+     * @return <code>true</code> if this assertion holds.
+     * @throws IllegalArgumentException if specified vertex does not exist in this graph.
+     */
+    @Override
+    protected boolean assertVertexExist(final Integer v)
+    {
+        if (v < 0 || v >= n)
+            throw new IllegalArgumentException();
+        return true;
+    }
+
+    /**
+     * Ensures that the specified edge exists in this graph, or else throws exception.
+     *
+     * @param e edge
+     * @return <code>true</code> if this assertion holds.
+     * @throws IllegalArgumentException if specified edge does not exist in this graph.
+     */
+    protected boolean assertEdgeExist(final Integer e)
+    {
+        if (e < 0 || e >= m)
+            throw new IllegalArgumentException();
+        return true;
+
+    }
+
+    private final static class SuccinctGraphIterables
+        implements
+        GraphIterables<Integer, Integer>,
+        Serializable
+    {
+        private static final long serialVersionUID = 0L;
+        private final SuccinctIntUndirectedGraph graph;
+
+        private SuccinctGraphIterables()
+        {
+            graph = null;
+        }
+
+        private SuccinctGraphIterables(final SuccinctIntUndirectedGraph graph)
+        {
+            this.graph = graph;
+        }
+
+        @Override
+        public Graph<Integer, Integer> getGraph()
+        {
+            return graph;
+        }
+
+        @Override
+        public long vertexCount()
+        {
+            return graph.n;
+        }
+
+        @Override
+        public long edgeCount()
+        {
+            return graph.m;
+        }
+
+        @Override
+        public Iterable<Integer> edgesOf(final Integer source)
+        {
+            final long[] result = new long[2];
+            graph.cumulativeOutdegrees.get(source, result);
+            return Iterables
+                .concat(
+                    IntSets.fromTo((int) result[0], (int) result[1]),
+                    reverseSortedEdgesOfNoLoops(source));
+        }
+
+        private Iterable<Integer> reverseSortedEdgesOfNoLoops(final int target)
+        {
+            final SuccinctIntUndirectedGraph graph = this.graph;
+            final long[] result = new long[2];
+            graph.cumulativeIndegrees.get(target, result);
+            final int d = (int) (result[1] - result[0]);
+            final EliasFanoIndexedMonotoneLongBigList successors = graph.successors;
+            final LongBigListIterator iterator = graph.predecessors.listIterator(result[0]);
+
+            return () -> new IntIterator()
+            {
+                int i = d;
+                int edge = -1;
+                long n = graph.n;
+                long base = n * target - result[0];
+
+                @Override
+                public boolean hasNext()
+                {
+                    if (edge == -1 && i > 0) {
+                        i--;
+                        final long source = iterator.nextLong() - base--;
+                        if (source == target && i-- == 0)
+                            return false;
+                        final long v = source * n + target;
+                        assert v == successors.successor(v) : v + " != " + successors.successor(v);
+                        edge = (int) successors.successorIndexUnsafe(v);
+                        assert graph.getEdgeSource(edge).longValue() == source;
+                        assert graph.getEdgeTarget(edge).longValue() == target;
+                    }
+                    return edge != -1;
+                }
+
+                @Override
+                public int nextInt()
+                {
+                    if (!hasNext())
+                        throw new NoSuchElementException();
+                    final int result = edge;
+                    edge = -1;
+                    return result;
+                }
+            };
+        }
+
+        @Override
+        public Iterable<Integer> incomingEdgesOf(final Integer vertex)
+        {
+            return edgesOf(vertex);
+        }
+
+        @Override
+        public Iterable<Integer> outgoingEdgesOf(final Integer vertex)
+        {
+            return edgesOf(vertex);
+        }
+    }
+
+    private final SuccinctGraphIterables ITERABLES = new SuccinctGraphIterables(this);
+
+    @Override
+    public GraphIterables<Integer, Integer> iterables()
+    {
+        return ITERABLES;
+    }
+}

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
@@ -26,10 +26,12 @@ import java.util.Set;
 import org.jgrapht.Graph;
 import org.jgrapht.GraphIterables;
 import org.jgrapht.alg.util.Pair;
+import org.jgrapht.opt.graph.sparse.SparseIntDirectedGraph;
 import org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph;
 
 import com.google.common.collect.Iterables;
 
+import it.unimi.dsi.fastutil.ints.IntIntSortedPair;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
@@ -42,10 +44,29 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * An immutable undirected graph represented using quasi-succinct data structures.
  *
  * <p>
- * This class is the undirected counterpart of {@link SuccintIntDirectedGraph}: the same comments
- * apply.
+ * The graph representation of this implementation is similar to that of
+ * {@link SparseIntDirectedGraph}: nodes and edges are initial intervals of the natural numbers.
+ * Under the hood, however, this class uses the {@linkplain EliasFanoMonotoneLongBigList
+ * Elias&ndash;Fano representation of monotone sequences} to represent the positions of ones in the
+ * (linearized) adjacency matrix of the graph. Instances are serializable and thread safe.
+ *
+ * <p>
+ * If the vertex set is compact (i.e., vertices are numbered from 0 consecutively), space usage will
+ * be close to the information-theoretical lower bound (typically, a few times smaller than a
+ * {@link SparseIntUndirectedGraph}).
+ *
+ * <p>
+ * {@linkplain org.jgrapht.GraphIterables#outgoingEdgesOf(Object) Enumeration of edges} is is very
+ * slow. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are very fast and happen in
+ * almost constant time.
+ *
+ * <p>
+ * {@link SuccinctUndirectedGraph} is a much faster implementation with a similar footprint using
+ * {@link IntIntSortedPair} as edge type. Please read the {@linkplain org.jgrapht.sux4j class
+ * documentation} for more information.
  *
  * @author Sebastiano Vigna
+ * @see SuccinctUndirectedGraph
  */
 
 public class SuccinctIntUndirectedGraph

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
@@ -41,7 +41,8 @@ import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList;
 import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
 
 /**
- * An immutable undirected graph represented using quasi-succinct data structures.
+ * An immutable undirected graph with {@link Integer} edges represented using quasi-succinct data
+ * structures.
  *
  * <p>
  * The graph representation of this implementation is similar to that of

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
@@ -57,8 +57,8 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  *
  * <p>
  * {@linkplain org.jgrapht.GraphIterables#outgoingEdgesOf(Object) Enumeration of edges} is is very
- * slow. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are very fast and happen in
- * almost constant time.
+ * slow. {@linkplain org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are very fast and
+ * happen in almost constant time.
  *
  * <p>
  * {@link SuccinctUndirectedGraph} is a much faster implementation with a similar footprint using

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
@@ -57,7 +57,7 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * {@link SparseIntUndirectedGraph}).
  *
  * <p>
- * {@linkplain org.jgrapht.GraphIterables#outgoingEdgesOf(Object) Enumeration of edges} is is very
+ * {@linkplain org.jgrapht.GraphIterables#outgoingEdgesOf(Object) Enumeration of edges} is very
  * slow. {@linkplain org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are very fast and
  * happen in almost constant time.
  *

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
@@ -16,7 +16,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
  */
 
-package org.jgrapht.opt.graph.sux4j;
+package org.jgrapht.sux4j;
 
 import java.io.Serializable;
 import java.util.Arrays;

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -62,6 +62,13 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * {@link Integer} as edge type. Please read the {@linkplain org.jgrapht.sux4j class documentation}
  * for more information.
  *
+ * <p>
+ * For convenience, and as a compromise with the approach of {@link SuccinctIntUndirectedGraph},
+ * this class provides methods {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getEdgeFromIndex(int)
+ * getEdgeFromIndex()} and
+ * {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getIndexFromEdge(it.unimi.dsi.fastutil.ints.IntIntPair)
+ * getIndexFromEdge()} that map bijectively the edge set into a contiguous set of longs.
+ *
  * @author Sebastiano Vigna
  * @see SuccinctIntUndirectedGraph
  */
@@ -211,13 +218,13 @@ public class SuccinctUndirectedGraph
      * @return the index associated with the edge, or &minus;1 if the edge is not part of the graph.
      * @see #getEdgeFromIndex(int)
      */
-    public int getIndexFromEdge(final IntIntSortedPair e)
+    public long getIndexFromEdge(final IntIntSortedPair e)
     {
         final int source = e.firstInt();
         final int target = e.secondInt();
         if (source < 0 || source >= n || target < 0 || target >= n)
             throw new IllegalArgumentException();
-        return (int) successors.indexOfUnsafe(((long) source << sourceShift) + target);
+        return successors.indexOfUnsafe(((long) source << sourceShift) + target);
     }
 
     /**
@@ -227,7 +234,7 @@ public class SuccinctUndirectedGraph
      * @return the pair with index {@code i}.
      * @see #getIndexFromEdge(IntIntSortedPair)
      */
-    public IntIntSortedPair getEdgeFromIndex(final int i)
+    public IntIntSortedPair getEdgeFromIndex(final long i)
     {
         if (i < 0 || i >= m)
             throw new IllegalArgumentException();

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -64,6 +64,8 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  *
  * @author Sebastiano Vigna
  * @see SuccinctIntUndirectedGraph
+ *
+ * @param <E> the graph edge type
  */
 
 

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -164,17 +164,17 @@ public class SuccinctUndirectedGraph
     public Set<IntIntSortedPair> edgesOf(final Integer vertex)
     {
         assertVertexExist(vertex);
+        final int x = vertex;
         final long[] result = new long[2];
-        cumulativeOutdegrees.get(vertex, result);
+        cumulativeOutdegrees.get(x, result);
         final Set<IntIntSortedPair> s = new ObjectOpenHashSet<>();
         final LongBigListIterator iterator = successors.listIterator(result[0]);
+        final long base = (long) x << sourceShift;
 
-        for (int d = (int) (result[1] - result[0]); d-- != 0;) {
-            final long t = iterator.nextLong();
-            s.add(IntIntSortedPair.of((int) (t >>> sourceShift), (int) (t & targetMask)));
-        }
+        for (int d = (int) (result[1] - result[0]); d-- != 0;)
+            s.add(IntIntSortedPair.of(x, (int) (iterator.nextLong() - base)));
 
-        for (final IntIntSortedPair e : ITERABLES.reverseSortedEdgesOfNoLoops(vertex))
+        for (final IntIntSortedPair e : ITERABLES.reverseSortedEdgesOfNoLoops(x))
             s.add(e);
 
         return s;
@@ -332,6 +332,7 @@ public class SuccinctUndirectedGraph
             final long[] result = new long[2];
             graph.cumulativeOutdegrees.get(source, result);
             final var iterator = graph.successors.listIterator(result[0]);
+            final long base = (long) source << sourceShift;
 
             return () -> new Iterator<>()
             {
@@ -349,8 +350,7 @@ public class SuccinctUndirectedGraph
                     if (d == 0)
                         throw new NoSuchElementException();
                     d--;
-                    final long t = iterator.nextLong();
-                    return IntIntSortedPair.of((int) (t >>> sourceShift), (int) (t & targetMask));
+                    return IntIntSortedPair.of(source, (int) (iterator.nextLong() - base));
                 }
             };
         }

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -43,11 +43,29 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * An immutable undirected graph represented using quasi-succinct data structures.
  *
  * <p>
- * This class is the undirected counterpart of {@link SuccintIntDirectedGraph}: the same comments
- * apply.
+ * The graph representation of this implementation uses the {@linkplain EliasFanoMonotoneLongBigList
+ * Elias&ndash;Fano representation of monotone sequences} to represent the positions of ones in the
+ * (linearized) adjacency matrix of the graph. Edges are represented by instances of
+ * {@link IntIntSortedPair}. Instances are serializable and thread safe.
+ *
+ * <p>
+ * If the vertex set is compact (i.e., vertices are numbered from 0 consecutively), space usage will
+ * be close to the information-theoretical lower bound (typically, a few times smaller than a
+ * {@link SparseIntUndirectedGraph}).
+ *
+ * <p>
+ * All accessors are very fast. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are
+ * happen in almost constant time.
+ *
+ * <p>
+ * {@link SuccinctIntUndirectedGraph} is a much slower implementation with a similar footprint using
+ * {@link Integer} as edge type. Please read the {@linkplain org.jgrapht.sux4j class documentation}
+ * for more information.
  *
  * @author Sebastiano Vigna
+ * @see SuccinctIntUndirectedGraph
  */
+
 
 public class SuccinctUndirectedGraph
     extends

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -330,23 +330,25 @@ public class SuccinctUndirectedGraph
             final long targetMask = graph.targetMask;
             final long[] result = new long[2];
             graph.cumulativeOutdegrees.get(source, result);
-            final var successors = graph.successors;
-            final int n = graph.n;
+            final var iterator = graph.successors.listIterator(result[0]);
 
             return () -> new Iterator<>()
             {
-                private int e = (int) result[0];
+                private int d = (int) (result[1] - result[0]);
 
                 @Override
                 public boolean hasNext()
                 {
-                    return e < result[1];
+                    return d != 0;
                 }
 
                 @Override
                 public IntIntSortedPair next()
                 {
-                    final long t = successors.getLong(e++);
+                    if (d == 0)
+                        throw new NoSuchElementException();
+                    d--;
+                    final long t = iterator.nextLong();
                     return IntIntSortedPair.of((int) (t >>> sourceShift), (int) (t & targetMask));
                 }
             };

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -64,7 +64,7 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  *
  * <p>
  * For convenience, and as a compromise with the approach of {@link SuccinctIntUndirectedGraph},
- * this class provides methods {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getEdgeFromIndex(int)
+ * this class provides methods {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getEdgeFromIndex(long)
  * getEdgeFromIndex()} and
  * {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getIndexFromEdge(it.unimi.dsi.fastutil.ints.IntIntPair)
  * getIndexFromEdge()} that map bijectively the edge set into a contiguous set of longs.
@@ -216,7 +216,7 @@ public class SuccinctUndirectedGraph
      *
      * @param e an edge of the graph.
      * @return the index associated with the edge, or &minus;1 if the edge is not part of the graph.
-     * @see #getEdgeFromIndex(int)
+     * @see #getEdgeFromIndex(long)
      */
     public long getIndexFromEdge(final IntIntSortedPair e)
     {

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -167,9 +167,10 @@ public class SuccinctUndirectedGraph
         final long[] result = new long[2];
         cumulativeOutdegrees.get(vertex, result);
         final Set<IntIntSortedPair> s = new ObjectOpenHashSet<>();
+        final LongBigListIterator iterator = successors.listIterator(result[0]);
 
-        for (int e = (int) result[0]; e < (int) result[1]; e++) {
-            final long t = successors.getLong(e);
+        for (int d = (int) (result[1] - result[0]); d-- != 0;) {
+            final long t = iterator.nextLong();
             s.add(IntIntSortedPair.of((int) (t >>> sourceShift), (int) (t & targetMask)));
         }
 

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -39,7 +39,8 @@ import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList.EliasFanoInde
 import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
 
 /**
- * An immutable undirected graph represented using quasi-succinct data structures.
+ * An immutable undirected graph with {@link IntIntSortedPair} edges represented using
+ * quasi-succinct data structures.
  *
  * <p>
  * The graph representation of this implementation uses the {@linkplain EliasFanoMonotoneLongBigList

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -19,32 +19,22 @@
 package org.jgrapht.sux4j;
 
 import java.io.Serializable;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
-import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.jgrapht.Graph;
 import org.jgrapht.GraphIterables;
-import org.jgrapht.GraphType;
-import org.jgrapht.Graphs;
 import org.jgrapht.alg.util.Pair;
-import org.jgrapht.graph.AbstractGraph;
-import org.jgrapht.graph.DefaultGraphType;
 import org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph;
 
 import com.google.common.collect.Iterables;
 
-import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.ints.IntIntPair;
 import it.unimi.dsi.fastutil.ints.IntIntSortedPair;
-import it.unimi.dsi.fastutil.ints.IntSets;
 import it.unimi.dsi.fastutil.longs.LongBigListIterator;
-import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ObjectSets;
 import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList;
 import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList.EliasFanoIndexedMonotoneLongBigListIterator;
 import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
@@ -61,151 +51,12 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
 
 public class SuccinctUndirectedGraph
     extends
-    AbstractGraph<Integer, IntIntSortedPair>
+    AbstractSuccinctUndirectedGraph<IntIntSortedPair>
     implements
     Serializable
 {
     private static final long serialVersionUID = 0L;
-    protected static final String UNMODIFIABLE = "this graph is unmodifiable";
 
-    /**
-     * Turns all lists of adjacent nodes into a single monotone sequence by representing the edge
-     * <var>x</var>&nbsp;&mdash;&nbsp;<var>y</var> as <var>x</var><var>n</var> + <var>y</var>.
-     * Depending on the value of {@code sorted}, only edges with source less than or equal to the
-     * target (or vice versa) are included.
-     *
-     * @param <E> the graph edge type
-     */
-    private final static class CumulativeSuccessors<E>
-        implements
-        LongIterator
-    {
-        private final Graph<Integer, E> graph;
-        private final long n;
-        private final Function<Integer, Iterable<E>> succ;
-        private final boolean sorted;
-
-        private int x = -1, d, i, e;
-        private long next = -1;
-        private int[] s = IntArrays.EMPTY_ARRAY;
-
-        public CumulativeSuccessors(
-            final Graph<Integer, E> graph, final boolean sorted,
-            final Function<Integer, Iterable<E>> succ)
-        {
-            this.n = (int) graph.iterables().vertexCount();
-            this.graph = graph;
-            this.sorted = sorted;
-            this.succ = succ;
-        }
-
-        @Override
-        public boolean hasNext()
-        {
-            if (next != -1)
-                return true;
-            if (x == n)
-                return false;
-            while (i == d) {
-                if (++x == n)
-                    return false;
-                int d = 0;
-                for (final E e : succ.apply(x)) {
-                    final int y = Graphs.getOppositeVertex(graph, e, x);
-                    if (sorted) {
-                        if (x <= y) {
-                            s = IntArrays.grow(s, d + 1);
-                            s[d++] = y;
-                        }
-                    } else {
-                        if (x >= y) {
-                            s = IntArrays.grow(s, d + 1);
-                            s[d++] = y;
-                        }
-                    }
-                }
-                Arrays.sort(s, 0, d);
-                this.d = d;
-                i = 0;
-            }
-            // The predecessor list will not be indexed, so we can gain a few bits of space by
-            // subtracting the edge position in the list
-            next = s[i] + x * n - (sorted ? 0 : e++);
-            i++;
-            return true;
-        }
-
-        @Override
-        public long nextLong()
-        {
-            if (!hasNext())
-                throw new NoSuchElementException();
-            final long result = next;
-            next = -1;
-            return result;
-        }
-    }
-
-    /**
-     * Iterates over the cumulative degrees (starts with a zero). Depending on the value of
-     * {@code sorted}, only edges with source less than or equal to the target (or vice versa) are
-     * included.
-     *
-     * @param <E> the graph edge type
-     */
-    private final static class CumulativeDegrees<E>
-        implements
-        LongIterator
-    {
-        private final int n;
-        private int x = -1;
-        private long cumul = 0;
-        private final Function<Integer, Iterable<E>> succ;
-        private final boolean sorted;
-        private final Graph<Integer, E> graph;
-
-        public CumulativeDegrees(
-            final Graph<Integer, E> graph, final boolean sorted,
-            final Function<Integer, Iterable<E>> succ)
-        {
-            this.n = (int) graph.iterables().vertexCount();
-            this.graph = graph;
-            this.succ = succ;
-            this.sorted = sorted;
-        }
-
-        @Override
-        public boolean hasNext()
-        {
-            return x < n;
-        }
-
-        @Override
-        public long nextLong()
-        {
-            if (!hasNext())
-                throw new NoSuchElementException();
-            if (x == -1)
-                return ++x;
-            int d = 0;
-            if (sorted) {
-                for (final E e : succ.apply(x))
-                    if (x <= Graphs.getOppositeVertex(graph, e, x))
-                        d++;
-            } else {
-                for (final E e : succ.apply(x))
-                    if (x >= Graphs.getOppositeVertex(graph, e, x))
-                        d++;
-            }
-            x++;
-            return cumul += d;
-        }
-    }
-
-    /** The number of vertices in the graph. */
-    private final int n;
-    /** The number of edges in the graph. */
-    private final int m;
     /** The cumulative list of outdegrees (number of edges in sorted order, including loops). */
     private final EliasFanoIndexedMonotoneLongBigList cumulativeOutdegrees;
     /** The cumulative list of indegrees (number of edges in reversed order, including loops). */
@@ -224,6 +75,8 @@ public class SuccinctUndirectedGraph
      */
     public <E> SuccinctUndirectedGraph(final Graph<Integer, E> graph)
     {
+        super((int) graph.iterables().vertexCount(), (int) graph.iterables().edgeCount());
+
         if (graph.getType().isDirected())
             throw new IllegalArgumentException("This class supports directed graphs only");
         assert graph.getType().isUndirected();
@@ -237,9 +90,6 @@ public class SuccinctUndirectedGraph
                 "The number of edges (" + iterables.edgeCount() + ") is greater than "
                     + Integer.MAX_VALUE);
 
-        n = (int) iterables.vertexCount();
-        m = (int) iterables.edgeCount();
-
         cumulativeOutdegrees = new EliasFanoIndexedMonotoneLongBigList(
             n + 1, m, new CumulativeDegrees<>(graph, true, iterables::edgesOf));
         cumulativeIndegrees = new EliasFanoMonotoneLongBigList(
@@ -248,7 +98,8 @@ public class SuccinctUndirectedGraph
         assert cumulativeIndegrees.getLong(cumulativeIndegrees.size64() - 1) == m;
 
         successors = new EliasFanoIndexedMonotoneLongBigList(
-            m, (long) n * n, new CumulativeSuccessors<>(graph, true, iterables::outgoingEdgesOf));
+            m, (long) n << sourceShift,
+            new CumulativeSuccessors<>(graph, true, iterables::outgoingEdgesOf));
         predecessors = new EliasFanoIndexedMonotoneLongBigList(
             m, (long) n * n - m,
             new CumulativeSuccessors<>(graph, false, iterables::incomingEdgesOf));
@@ -273,52 +124,9 @@ public class SuccinctUndirectedGraph
     }
 
     @Override
-    public Supplier<Integer> getVertexSupplier()
-    {
-        return null;
-    }
-
-    @Override
-    public Supplier<IntIntSortedPair> getEdgeSupplier()
-    {
-        return null;
-    }
-
-    @Override
-    public IntIntSortedPair addEdge(final Integer sourceVertex, final Integer targetVertex)
-    {
-        throw new UnsupportedOperationException(UNMODIFIABLE);
-    }
-
-    @Override
-    public boolean addEdge(
-        final Integer sourceVertex, final Integer targetVertex, final IntIntSortedPair e)
-    {
-        throw new UnsupportedOperationException(UNMODIFIABLE);
-    }
-
-    @Override
-    public Integer addVertex()
-    {
-        throw new UnsupportedOperationException(UNMODIFIABLE);
-    }
-
-    @Override
-    public boolean addVertex(final Integer v)
-    {
-        throw new UnsupportedOperationException(UNMODIFIABLE);
-    }
-
-    @Override
     public boolean containsEdge(final IntIntSortedPair e)
     {
-        return successors.indexOfUnsafe(e.firstInt() * (long) n + e.secondInt()) != -1;
-    }
-
-    @Override
-    public boolean containsVertex(final Integer v)
-    {
-        return v >= 0 && v < n;
+        return successors.indexOfUnsafe(((long) e.firstInt() << sourceShift) + e.secondInt()) != -1;
     }
 
     @Override
@@ -344,7 +152,7 @@ public class SuccinctUndirectedGraph
 
         for (int e = (int) result[0]; e < (int) result[1]; e++) {
             final long t = successors.getLong(e);
-            s.add(IntIntSortedPair.of((int) (t / n), (int) (t % n)));
+            s.add(IntIntSortedPair.of((int) (t >>> sourceShift), (int) (t & targetMask)));
         }
 
         for (final IntIntSortedPair e : ITERABLES.reverseSortedEdgesOfNoLoops(vertex))
@@ -354,51 +162,15 @@ public class SuccinctUndirectedGraph
     }
 
     @Override
-    public int inDegreeOf(final Integer vertex)
-    {
-        return degreeOf(vertex);
-    }
-
-    @Override
     public Set<IntIntSortedPair> incomingEdgesOf(final Integer vertex)
     {
         return edgesOf(vertex);
     }
 
     @Override
-    public int outDegreeOf(final Integer vertex)
-    {
-        return degreeOf(vertex);
-    }
-
-    @Override
     public Set<IntIntSortedPair> outgoingEdgesOf(final Integer vertex)
     {
         return edgesOf(vertex);
-    }
-
-    @Override
-    public IntIntSortedPair removeEdge(final Integer sourceVertex, final Integer targetVertex)
-    {
-        throw new UnsupportedOperationException(UNMODIFIABLE);
-    }
-
-    @Override
-    public boolean removeEdge(final IntIntSortedPair e)
-    {
-        throw new UnsupportedOperationException(UNMODIFIABLE);
-    }
-
-    @Override
-    public boolean removeVertex(final Integer v)
-    {
-        throw new UnsupportedOperationException(UNMODIFIABLE);
-    }
-
-    @Override
-    public Set<Integer> vertexSet()
-    {
-        return IntSets.fromTo(0, n);
     }
 
     @Override
@@ -413,24 +185,35 @@ public class SuccinctUndirectedGraph
         return e.secondInt();
     }
 
-    @Override
-    public GraphType getType()
+    /**
+     * Returns the index associated with the given edge.
+     *
+     * @param e an edge of the graph.
+     * @return the index associated with the edge, or &minus;1 if the edge is not part of the graph.
+     * @see #getEdgeFromIndex(int)
+     */
+    public int getIndexFromEdge(final IntIntSortedPair e)
     {
-        return new DefaultGraphType.Builder()
-            .directed().weighted(false).modifiable(false).allowMultipleEdges(false)
-            .allowSelfLoops(true).build();
+        final int source = e.firstInt();
+        final int target = e.secondInt();
+        if (source < 0 || source >= n || target < 0 || target >= n)
+            throw new IllegalArgumentException();
+        return (int) successors.indexOfUnsafe(((long) source << sourceShift) + target);
     }
 
-    @Override
-    public double getEdgeWeight(final IntIntSortedPair e)
+    /**
+     * Returns the edge with given index.
+     *
+     * @param i an index between 0 (included) and the number of edges (excluded).
+     * @return the pair with index {@code i}.
+     * @see #getIndexFromEdge(IntIntPair)
+     */
+    public IntIntSortedPair getEdgeFromIndex(final int i)
     {
-        return 1.0;
-    }
-
-    @Override
-    public void setEdgeWeight(final IntIntSortedPair e, final double weight)
-    {
-        throw new UnsupportedOperationException(UNMODIFIABLE);
+        if (i < 0 || i >= m)
+            throw new IllegalArgumentException();
+        final long t = successors.getLong(i);
+        return IntIntSortedPair.of((int) (t >>> sourceShift), (int) (t & targetMask));
     }
 
     @Override
@@ -443,58 +226,14 @@ public class SuccinctUndirectedGraph
             x = y;
             y = t;
         }
-        final long index = successors.indexOfUnsafe(x * (long) n + y);
+        final long index = successors.indexOfUnsafe(((long) x << sourceShift) + y);
         return index != -1 ? IntIntSortedPair.of(x, y) : null;
     }
 
     @Override
     public boolean containsEdge(final Integer sourceVertex, final Integer targetVertex)
     {
-        int x = sourceVertex;
-        int y = targetVertex;
-        if (x > y) {
-            final int t = x;
-            x = y;
-            y = t;
-        }
-        return successors.indexOfUnsafe(x * (long) n + y) != -1;
-    }
-
-    @Override
-    public Set<IntIntSortedPair> getAllEdges(final Integer sourceVertex, final Integer targetVertex)
-    {
-        final IntIntSortedPair edge = getEdge(sourceVertex, targetVertex);
-        return edge == null ? ObjectSets.emptySet() : ObjectSets.singleton(edge);
-    }
-
-    /**
-     * Ensures that the specified vertex exists in this graph, or else throws exception.
-     *
-     * @param v vertex
-     * @return <code>true</code> if this assertion holds.
-     * @throws IllegalArgumentException if specified vertex does not exist in this graph.
-     */
-    @Override
-    protected boolean assertVertexExist(final Integer v)
-    {
-        if (v < 0 || v >= n)
-            throw new IllegalArgumentException();
-        return true;
-    }
-
-    /**
-     * Ensures that the specified edge exists in this graph, or else throws exception.
-     *
-     * @param e edge
-     * @return <code>true</code> if this assertion holds.
-     * @throws IllegalArgumentException if specified edge does not exist in this graph.
-     */
-    protected boolean assertEdgeExist(final Integer e)
-    {
-        if (e < 0 || e >= m)
-            throw new IllegalArgumentException();
-        return true;
-
+        return containsEdge(successors, sourceVertex, targetVertex);
     }
 
     private final static class SuccinctGraphIterables
@@ -536,6 +275,9 @@ public class SuccinctUndirectedGraph
         @Override
         public Iterable<IntIntSortedPair> edges()
         {
+            final int sourceShift = graph.sourceShift;
+            final long targetMask = graph.targetMask;
+
             return () -> new Iterator<>()
             {
                 private final EliasFanoIndexedMonotoneLongBigListIterator iterator =
@@ -552,7 +294,7 @@ public class SuccinctUndirectedGraph
                 public IntIntSortedPair next()
                 {
                     final long t = iterator.nextLong();
-                    return IntIntSortedPair.of((int) (t / n), (int) (t % n));
+                    return IntIntSortedPair.of((int) (t >>> sourceShift), (int) (t & targetMask));
                 }
 
             };
@@ -566,11 +308,14 @@ public class SuccinctUndirectedGraph
 
         private Iterable<IntIntSortedPair> sortedEdges(final int source)
         {
+            final int sourceShift = graph.sourceShift;
+            final long targetMask = graph.targetMask;
             final long[] result = new long[2];
             graph.cumulativeOutdegrees.get(source, result);
             final var successors = graph.successors;
             final int n = graph.n;
-            final Iterable<IntIntSortedPair> sortedEdgesIterable = () -> new Iterator<>()
+
+            return () -> new Iterator<>()
             {
                 private int e = (int) result[0];
 
@@ -584,10 +329,9 @@ public class SuccinctUndirectedGraph
                 public IntIntSortedPair next()
                 {
                     final long t = successors.getLong(e++);
-                    return IntIntSortedPair.of((int) (t / n), (int) (t % n));
+                    return IntIntSortedPair.of((int) (t >>> sourceShift), (int) (t & targetMask));
                 }
             };
-            return sortedEdgesIterable;
         }
 
         private Iterable<IntIntSortedPair> reverseSortedEdgesOfNoLoops(final int target)

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -54,8 +54,8 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  * {@link SparseIntUndirectedGraph}).
  *
  * <p>
- * All accessors are very fast. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are
- * happen in almost constant time.
+ * All accessors are very fast. {@linkplain org.jgrapht.Graph#containsEdge(Object) Adjacency tests}
+ * are very fast and happen in almost constant time.
  *
  * <p>
  * {@link SuccinctIntUndirectedGraph} is a much slower implementation with a similar footprint using

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -1,0 +1,652 @@
+/*
+ * (C) Copyright 2020-2021, by Sebastiano Vigna and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
+package org.jgrapht.sux4j;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphIterables;
+import org.jgrapht.GraphType;
+import org.jgrapht.Graphs;
+import org.jgrapht.alg.util.Pair;
+import org.jgrapht.graph.AbstractGraph;
+import org.jgrapht.graph.DefaultGraphType;
+import org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph;
+
+import com.google.common.collect.Iterables;
+
+import it.unimi.dsi.fastutil.ints.IntArrays;
+import it.unimi.dsi.fastutil.ints.IntIntSortedPair;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.fastutil.longs.LongBigListIterator;
+import it.unimi.dsi.fastutil.longs.LongIterator;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectSets;
+import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList;
+import it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList.EliasFanoIndexedMonotoneLongBigListIterator;
+import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
+
+/**
+ * An immutable undirected graph represented using quasi-succinct data structures.
+ *
+ * <p>
+ * This class is the undirected counterpart of {@link SuccintIntDirectedGraph}: the same comments
+ * apply.
+ *
+ * @author Sebastiano Vigna
+ */
+
+public class SuccinctUndirectedGraph
+    extends
+    AbstractGraph<Integer, IntIntSortedPair>
+    implements
+    Serializable
+{
+    private static final long serialVersionUID = 0L;
+    protected static final String UNMODIFIABLE = "this graph is unmodifiable";
+
+    /**
+     * Turns all lists of adjacent nodes into a single monotone sequence by representing the edge
+     * <var>x</var>&nbsp;&mdash;&nbsp;<var>y</var> as <var>x</var><var>n</var> + <var>y</var>.
+     * Depending on the value of {@code sorted}, only edges with source less than or equal to the
+     * target (or vice versa) are included.
+     *
+     * @param <E> the graph edge type
+     */
+    private final static class CumulativeSuccessors<E>
+        implements
+        LongIterator
+    {
+        private final Graph<Integer, E> graph;
+        private final long n;
+        private final Function<Integer, Iterable<E>> succ;
+        private final boolean sorted;
+
+        private int x = -1, d, i, e;
+        private long next = -1;
+        private int[] s = IntArrays.EMPTY_ARRAY;
+
+        public CumulativeSuccessors(
+            final Graph<Integer, E> graph, final boolean sorted,
+            final Function<Integer, Iterable<E>> succ)
+        {
+            this.n = (int) graph.iterables().vertexCount();
+            this.graph = graph;
+            this.sorted = sorted;
+            this.succ = succ;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            if (next != -1)
+                return true;
+            if (x == n)
+                return false;
+            while (i == d) {
+                if (++x == n)
+                    return false;
+                int d = 0;
+                for (final E e : succ.apply(x)) {
+                    final int y = Graphs.getOppositeVertex(graph, e, x);
+                    if (sorted) {
+                        if (x <= y) {
+                            s = IntArrays.grow(s, d + 1);
+                            s[d++] = y;
+                        }
+                    } else {
+                        if (x >= y) {
+                            s = IntArrays.grow(s, d + 1);
+                            s[d++] = y;
+                        }
+                    }
+                }
+                Arrays.sort(s, 0, d);
+                this.d = d;
+                i = 0;
+            }
+            // The predecessor list will not be indexed, so we can gain a few bits of space by
+            // subtracting the edge position in the list
+            next = s[i] + x * n - (sorted ? 0 : e++);
+            i++;
+            return true;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            final long result = next;
+            next = -1;
+            return result;
+        }
+    }
+
+    /**
+     * Iterates over the cumulative degrees (starts with a zero). Depending on the value of
+     * {@code sorted}, only edges with source less than or equal to the target (or vice versa) are
+     * included.
+     *
+     * @param <E> the graph edge type
+     */
+    private final static class CumulativeDegrees<E>
+        implements
+        LongIterator
+    {
+        private final int n;
+        private int x = -1;
+        private long cumul = 0;
+        private final Function<Integer, Iterable<E>> succ;
+        private final boolean sorted;
+        private final Graph<Integer, E> graph;
+
+        public CumulativeDegrees(
+            final Graph<Integer, E> graph, final boolean sorted,
+            final Function<Integer, Iterable<E>> succ)
+        {
+            this.n = (int) graph.iterables().vertexCount();
+            this.graph = graph;
+            this.succ = succ;
+            this.sorted = sorted;
+        }
+
+        @Override
+        public boolean hasNext()
+        {
+            return x < n;
+        }
+
+        @Override
+        public long nextLong()
+        {
+            if (!hasNext())
+                throw new NoSuchElementException();
+            if (x == -1)
+                return ++x;
+            int d = 0;
+            if (sorted) {
+                for (final E e : succ.apply(x))
+                    if (x <= Graphs.getOppositeVertex(graph, e, x))
+                        d++;
+            } else {
+                for (final E e : succ.apply(x))
+                    if (x >= Graphs.getOppositeVertex(graph, e, x))
+                        d++;
+            }
+            x++;
+            return cumul += d;
+        }
+    }
+
+    /** The number of vertices in the graph. */
+    private final int n;
+    /** The number of edges in the graph. */
+    private final int m;
+    /** The cumulative list of outdegrees (number of edges in sorted order, including loops). */
+    private final EliasFanoIndexedMonotoneLongBigList cumulativeOutdegrees;
+    /** The cumulative list of indegrees (number of edges in reversed order, including loops). */
+    private final EliasFanoMonotoneLongBigList cumulativeIndegrees;
+    /** The cumulative list of successor (edges in sorted order, including loops) lists. */
+    private final EliasFanoIndexedMonotoneLongBigList successors;
+    /** The cumulative list of predecessor (edges in reversed order, including loops) lists. */
+    private final EliasFanoMonotoneLongBigList predecessors;
+
+    /**
+     * Creates a new immutable succinct undirected graph from a given undirected graph.
+     *
+     * @param graph an undirected graph: for good results, vertices should be numbered consecutively
+     *        starting from 0.
+     * @param <E> the graph edge type
+     */
+    public <E> SuccinctUndirectedGraph(final Graph<Integer, E> graph)
+    {
+        if (graph.getType().isDirected())
+            throw new IllegalArgumentException("This class supports directed graphs only");
+        assert graph.getType().isUndirected();
+        final GraphIterables<Integer, E> iterables = graph.iterables();
+        if (iterables.vertexCount() > Integer.MAX_VALUE)
+            throw new IllegalArgumentException(
+                "The number of nodes (" + iterables.vertexCount() + ") is greater than "
+                    + Integer.MAX_VALUE);
+        if (iterables.edgeCount() > Integer.MAX_VALUE)
+            throw new IllegalArgumentException(
+                "The number of edges (" + iterables.edgeCount() + ") is greater than "
+                    + Integer.MAX_VALUE);
+
+        n = (int) iterables.vertexCount();
+        m = (int) iterables.edgeCount();
+
+        cumulativeOutdegrees = new EliasFanoIndexedMonotoneLongBigList(
+            n + 1, m, new CumulativeDegrees<>(graph, true, iterables::edgesOf));
+        cumulativeIndegrees = new EliasFanoMonotoneLongBigList(
+            n + 1, m, new CumulativeDegrees<>(graph, false, iterables::edgesOf));
+        assert cumulativeOutdegrees.getLong(cumulativeOutdegrees.size64() - 1) == m;
+        assert cumulativeIndegrees.getLong(cumulativeIndegrees.size64() - 1) == m;
+
+        successors = new EliasFanoIndexedMonotoneLongBigList(
+            m, (long) n * n, new CumulativeSuccessors<>(graph, true, iterables::outgoingEdgesOf));
+        predecessors = new EliasFanoIndexedMonotoneLongBigList(
+            m, (long) n * n - m,
+            new CumulativeSuccessors<>(graph, false, iterables::incomingEdgesOf));
+    }
+
+    /**
+     * Creates a new immutable succinct undirected graph from an edge list.
+     *
+     * <p>
+     * This constructor just builds a {@link SparseIntUndirectedGraph} and delegates to the
+     * {@linkplain #SuccinctIntUndirectedGraph(Graph) main constructor}.
+     *
+     * @param numVertices the number of vertices.
+     * @param edges the edge list.
+     * @see #SuccinctIntUndirectedGraph(Graph)
+     */
+
+    public SuccinctUndirectedGraph(
+        final int numVertices, final List<Pair<Integer, Integer>> edges)
+    {
+        this(new SparseIntUndirectedGraph(numVertices, edges));
+    }
+
+    @Override
+    public Supplier<Integer> getVertexSupplier()
+    {
+        return null;
+    }
+
+    @Override
+    public Supplier<IntIntSortedPair> getEdgeSupplier()
+    {
+        return null;
+    }
+
+    @Override
+    public IntIntSortedPair addEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean addEdge(
+        final Integer sourceVertex, final Integer targetVertex, final IntIntSortedPair e)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public Integer addVertex()
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean addVertex(final Integer v)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean containsEdge(final IntIntSortedPair e)
+    {
+        return successors.indexOfUnsafe(e.firstInt() * (long) n + e.secondInt()) != -1;
+    }
+
+    @Override
+    public boolean containsVertex(final Integer v)
+    {
+        return v >= 0 && v < n;
+    }
+
+    @Override
+    public Set<IntIntSortedPair> edgeSet()
+    {
+        return new ObjectOpenHashSet<>(iterables().edges().iterator());
+    }
+
+    @Override
+    public int degreeOf(final Integer vertex)
+    {
+        return (int) cumulativeIndegrees.getDelta(vertex)
+            + (int) cumulativeOutdegrees.getDelta(vertex);
+    }
+
+    @Override
+    public Set<IntIntSortedPair> edgesOf(final Integer vertex)
+    {
+        assertVertexExist(vertex);
+        final long[] result = new long[2];
+        cumulativeOutdegrees.get(vertex, result);
+        final Set<IntIntSortedPair> s = new ObjectOpenHashSet<>();
+
+        for (int e = (int) result[0]; e < (int) result[1]; e++) {
+            final long t = successors.getLong(e);
+            s.add(IntIntSortedPair.of((int) (t / n), (int) (t % n)));
+        }
+
+        for (final IntIntSortedPair e : ITERABLES.reverseSortedEdgesOfNoLoops(vertex))
+            s.add(e);
+
+        return s;
+    }
+
+    @Override
+    public int inDegreeOf(final Integer vertex)
+    {
+        return degreeOf(vertex);
+    }
+
+    @Override
+    public Set<IntIntSortedPair> incomingEdgesOf(final Integer vertex)
+    {
+        return edgesOf(vertex);
+    }
+
+    @Override
+    public int outDegreeOf(final Integer vertex)
+    {
+        return degreeOf(vertex);
+    }
+
+    @Override
+    public Set<IntIntSortedPair> outgoingEdgesOf(final Integer vertex)
+    {
+        return edgesOf(vertex);
+    }
+
+    @Override
+    public IntIntSortedPair removeEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean removeEdge(final IntIntSortedPair e)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public boolean removeVertex(final Integer v)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public Set<Integer> vertexSet()
+    {
+        return IntSets.fromTo(0, n);
+    }
+
+    @Override
+    public Integer getEdgeSource(final IntIntSortedPair e)
+    {
+        return e.firstInt();
+    }
+
+    @Override
+    public Integer getEdgeTarget(final IntIntSortedPair e)
+    {
+        return e.secondInt();
+    }
+
+    @Override
+    public GraphType getType()
+    {
+        return new DefaultGraphType.Builder()
+            .directed().weighted(false).modifiable(false).allowMultipleEdges(false)
+            .allowSelfLoops(true).build();
+    }
+
+    @Override
+    public double getEdgeWeight(final IntIntSortedPair e)
+    {
+        return 1.0;
+    }
+
+    @Override
+    public void setEdgeWeight(final IntIntSortedPair e, final double weight)
+    {
+        throw new UnsupportedOperationException(UNMODIFIABLE);
+    }
+
+    @Override
+    public IntIntSortedPair getEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        int x = sourceVertex;
+        int y = targetVertex;
+        if (x > y) {
+            final int t = x;
+            x = y;
+            y = t;
+        }
+        final long index = successors.indexOfUnsafe(x * (long) n + y);
+        return index != -1 ? IntIntSortedPair.of(x, y) : null;
+    }
+
+    @Override
+    public boolean containsEdge(final Integer sourceVertex, final Integer targetVertex)
+    {
+        int x = sourceVertex;
+        int y = targetVertex;
+        if (x > y) {
+            final int t = x;
+            x = y;
+            y = t;
+        }
+        return successors.indexOfUnsafe(x * (long) n + y) != -1;
+    }
+
+    @Override
+    public Set<IntIntSortedPair> getAllEdges(final Integer sourceVertex, final Integer targetVertex)
+    {
+        final IntIntSortedPair edge = getEdge(sourceVertex, targetVertex);
+        return edge == null ? ObjectSets.emptySet() : ObjectSets.singleton(edge);
+    }
+
+    /**
+     * Ensures that the specified vertex exists in this graph, or else throws exception.
+     *
+     * @param v vertex
+     * @return <code>true</code> if this assertion holds.
+     * @throws IllegalArgumentException if specified vertex does not exist in this graph.
+     */
+    @Override
+    protected boolean assertVertexExist(final Integer v)
+    {
+        if (v < 0 || v >= n)
+            throw new IllegalArgumentException();
+        return true;
+    }
+
+    /**
+     * Ensures that the specified edge exists in this graph, or else throws exception.
+     *
+     * @param e edge
+     * @return <code>true</code> if this assertion holds.
+     * @throws IllegalArgumentException if specified edge does not exist in this graph.
+     */
+    protected boolean assertEdgeExist(final Integer e)
+    {
+        if (e < 0 || e >= m)
+            throw new IllegalArgumentException();
+        return true;
+
+    }
+
+    private final static class SuccinctGraphIterables
+        implements
+        GraphIterables<Integer, IntIntSortedPair>,
+        Serializable
+    {
+        private static final long serialVersionUID = 0L;
+        private final SuccinctUndirectedGraph graph;
+
+        private SuccinctGraphIterables()
+        {
+            graph = null;
+        }
+
+        private SuccinctGraphIterables(final SuccinctUndirectedGraph graph)
+        {
+            this.graph = graph;
+        }
+
+        @Override
+        public Graph<Integer, IntIntSortedPair> getGraph()
+        {
+            return graph;
+        }
+
+        @Override
+        public long vertexCount()
+        {
+            return graph.n;
+        }
+
+        @Override
+        public long edgeCount()
+        {
+            return graph.m;
+        }
+
+        @Override
+        public Iterable<IntIntSortedPair> edges()
+        {
+            return () -> new Iterator<>()
+            {
+                private final EliasFanoIndexedMonotoneLongBigListIterator iterator =
+                    graph.successors.iterator();
+                private final int n = graph.n;
+
+                @Override
+                public boolean hasNext()
+                {
+                    return iterator.hasNext();
+                }
+
+                @Override
+                public IntIntSortedPair next()
+                {
+                    final long t = iterator.nextLong();
+                    return IntIntSortedPair.of((int) (t / n), (int) (t % n));
+                }
+
+            };
+        }
+
+        @Override
+        public Iterable<IntIntSortedPair> edgesOf(final Integer source)
+        {
+            return Iterables.concat(sortedEdges(source), reverseSortedEdgesOfNoLoops(source));
+        }
+
+        private Iterable<IntIntSortedPair> sortedEdges(final int source)
+        {
+            final long[] result = new long[2];
+            graph.cumulativeOutdegrees.get(source, result);
+            final var successors = graph.successors;
+            final int n = graph.n;
+            final Iterable<IntIntSortedPair> sortedEdgesIterable = () -> new Iterator<>()
+            {
+                private int e = (int) result[0];
+
+                @Override
+                public boolean hasNext()
+                {
+                    return e < result[1];
+                }
+
+                @Override
+                public IntIntSortedPair next()
+                {
+                    final long t = successors.getLong(e++);
+                    return IntIntSortedPair.of((int) (t / n), (int) (t % n));
+                }
+            };
+            return sortedEdgesIterable;
+        }
+
+        private Iterable<IntIntSortedPair> reverseSortedEdgesOfNoLoops(final int target)
+        {
+            final long[] result = new long[2];
+            graph.cumulativeIndegrees.get(target, result);
+            final int d = (int) (result[1] - result[0]);
+            final LongBigListIterator iterator = graph.predecessors.listIterator(result[0]);
+
+            return () -> new Iterator<>()
+            {
+                int i = d;
+                IntIntSortedPair edge = null;
+                long n = graph.n;
+                long base = n * target - result[0];
+
+                @Override
+                public boolean hasNext()
+                {
+                    if (edge == null && i > 0) {
+                        i--;
+                        final long source = iterator.nextLong() - base--;
+                        if (source == target && i-- == 0)
+                            return false;
+                        edge = IntIntSortedPair.of((int) source, target);
+                    }
+                    return edge != null;
+                }
+
+                @Override
+                public IntIntSortedPair next()
+                {
+                    if (!hasNext())
+                        throw new NoSuchElementException();
+                    final IntIntSortedPair result = edge;
+                    edge = null;
+                    return result;
+                }
+            };
+        }
+
+        @Override
+        public Iterable<IntIntSortedPair> incomingEdgesOf(final Integer vertex)
+        {
+            return edgesOf(vertex);
+        }
+
+        @Override
+        public Iterable<IntIntSortedPair> outgoingEdgesOf(final Integer vertex)
+        {
+            return edgesOf(vertex);
+        }
+    }
+
+    private final SuccinctGraphIterables ITERABLES = new SuccinctGraphIterables(this);
+
+    @Override
+    public GraphIterables<Integer, IntIntSortedPair> iterables()
+    {
+        return ITERABLES;
+    }
+}

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -31,7 +31,6 @@ import org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph;
 
 import com.google.common.collect.Iterables;
 
-import it.unimi.dsi.fastutil.ints.IntIntPair;
 import it.unimi.dsi.fastutil.ints.IntIntSortedPair;
 import it.unimi.dsi.fastutil.longs.LongBigListIterator;
 import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
@@ -128,11 +127,11 @@ public class SuccinctUndirectedGraph
      *
      * <p>
      * This constructor just builds a {@link SparseIntUndirectedGraph} and delegates to the
-     * {@linkplain #SuccinctIntUndirectedGraph(Graph) main constructor}.
+     * {@linkplain #SuccinctUndirectedGraph(Graph) main constructor}.
      *
      * @param numVertices the number of vertices.
      * @param edges the edge list.
-     * @see #SuccinctIntUndirectedGraph(Graph)
+     * @see #SuccinctUndirectedGraph(Graph)
      */
 
     public SuccinctUndirectedGraph(
@@ -225,7 +224,7 @@ public class SuccinctUndirectedGraph
      *
      * @param i an index between 0 (included) and the number of edges (excluded).
      * @return the pair with index {@code i}.
-     * @see #getIndexFromEdge(IntIntPair)
+     * @see #getIndexFromEdge(IntIntSortedPair)
      */
     public IntIntSortedPair getEdgeFromIndex(final int i)
     {

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -64,8 +64,6 @@ import it.unimi.dsi.sux4j.util.EliasFanoMonotoneLongBigList;
  *
  * @author Sebastiano Vigna
  * @see SuccinctIntUndirectedGraph
- *
- * @param <E> the graph edge type
  */
 
 

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
@@ -26,12 +26,12 @@
  * <li>{@link org.jgrapht.sux4j.SuccinctIntDirectedGraph} is an implementation for directed graphs.
  * {@linkplain org.jgrapht.GraphIterables#outgoingEdgesOf(Object) Enumeration of outgoing edges} is
  * quite fast, but {@linkplain org.jgrapht.GraphIterables#incomingEdgesOf(Object) enumeration of
- * incoming edges} is very slow. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are
- * very fast and happen in almost constant time.
+ * incoming edges} is very slow. {@linkplain org.jgrapht.Graph#containsEdge(Object) Adjacency tests}
+ * are very fast and happen in almost constant time.
  * <li>{@link org.jgrapht.sux4j.SuccinctIntUndirectedGraph} is an implementation for undirected
  * graphs. {@linkplain org.jgrapht.GraphIterables#edgesOf(Object) Enumeration of edges} is very
- * slow. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are very fast and happen in
- * almost constant time.
+ * slow. {@linkplain org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are very fast and
+ * happen in almost constant time.
  * </ul>
  *
  * <p>

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
@@ -20,7 +20,8 @@
  * We provide two classes mimicking {@link org.jgrapht.opt.graph.sparse.SparseIntDirectedGraph
  * SparseIntDirectedGraph} and {@link org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph
  * SparseIntUndirectedGraph}, in the sense that both vertices and edges are integers (and they are
- * numbered contiguously).
+ * numbered contiguously). Thus, by definition these classes cannot represent graphs with more than
+ * {@link Integer#MAX_VALUE} edges.
  *
  * <ul>
  * <li>{@link org.jgrapht.sux4j.SuccinctIntDirectedGraph} is an implementation for directed graphs.
@@ -48,15 +49,16 @@
  * integers stored in an {@link it.unimi.dsi.fastutil.ints.IntIntPair IntIntPair} (for directed
  * graphs) or an {@link it.unimi.dsi.fastutil.ints.IntIntSortedPair IntIntSortedPair} (for
  * undirected graphs). Storing the edges explicitly avoids the cumbersome back-and-forth
- * computations of the previous classes. All accessors are extremely fast.
+ * computations of the previous classes. All accessors are extremely fast. There is no limitation on
+ * the number of edges.
  *
  * <p>
  * Both classes provide methods {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getEdgeFromIndex(int)
  * getEdgeFromIndex()} and
  * {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getIndexFromEdge(it.unimi.dsi.fastutil.ints.IntIntPair)
- * getIndexFromEdge()} that map bijectively the edge set into a contiguous set of integers. In this
- * way the user can choose when and how to use the feature (e.g., to store compactly data associated
- * to edges).
+ * getIndexFromEdge()} that map bijectively the edge set into a contiguous set of longs. In this way
+ * the user can choose when and how to use the feature (e.g., to store compactly data associated to
+ * edges).
  *
  * <p>
  * Finally, note that the best performance and compression can be obtained by representing the graph

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
@@ -36,9 +36,10 @@
  *
  * <p>
  * The sometimes slow behavior of the previous classes is due to a clash between JGraphT's design
- * and the need of representing an edge with an {@link java.lang.Integer Integer}: there is no
- * information that can be carried by the object representing the edge. This limitation forces the
- * two classes above to compute two expensive functions that are one the inverse of the other.
+ * and the need of representing an edge with an {@link java.lang.Integer Integer}, which cannot be
+ * extended: there is no information that can be carried by the object representing the edge. This
+ * limitation forces the two classes above to compute two expensive functions that are one the
+ * inverse of the other.
  *
  * <p>
  * As an alternative, we provide classes {@link org.jgrapht.sux4j.SuccinctDirectedGraph
@@ -64,5 +65,28 @@
  * adapter}; in particular, one can represent graphs with more than {@link Integer#MAX_VALUE}
  * vertices. However, the adapters do not provide methods mapping bijectively edges into a
  * contiguous set of integers.
+ *
+ * <h2>Building and serializing with limited memory</h2>
+ *
+ * <p>
+ * All implementations provide a copy constructor taking a {@link org.jgrapht.Graph Graph} and a
+ * constructor accepting a list of edges; the latter just builds a sparse graph and delegates to the
+ * copy constructor. Both methods can be inconvenient if the graph to be represented is large, as
+ * the list of edges might have too large a footprint.
+ *
+ * <p>
+ * There is however a simple strategy that makes it possible to build succinct representations using
+ * a relatively small amount of additional memory with respect to the representation itself:
+ * <ol>
+ * <li>{@linkplain it.unimi.dsi.webgraph convert your graph to a WebGraph format} such as
+ * {@link it.unimi.dsi.big.webgraph.BVGraph BVGraph} or {@link it.unimi.dsi.webgraph.EFGraph
+ * EFGraph};
+ * <li>if your graph is directed, use {@link it.unimi.dsi.webgraph.Transform Transform} to store the
+ * transpose of your graph in the same way;
+ * <li>use a {@linkplain org.jgrapht.webgraph suitable adapter} to get a {@link org.jgrapht.Graph
+ * Graph} representing your graph, taking care of loading the WebGraph representations using
+ * {@link it.unimi.dsi.webgraph.ImmutableGraph#loadMapped() ImmutableGraph.loadMapped()};
+ * <li>use the copy constructor to obtain a quasi-succinct representation.
+ * </ol>
  */
 package org.jgrapht.sux4j;

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
@@ -53,8 +53,8 @@
  * the number of edges.
  *
  * <p>
- * Both classes provide methods {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getEdgeFromIndex(int)
- * getEdgeFromIndex()} and
+ * Both classes provide methods
+ * {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getEdgeFromIndex(long) getEdgeFromIndex()} and
  * {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getIndexFromEdge(it.unimi.dsi.fastutil.ints.IntIntPair)
  * getIndexFromEdge()} that map bijectively the edge set into a contiguous set of longs. In this way
  * the user can choose when and how to use the feature (e.g., to store compactly data associated to

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
@@ -11,9 +11,11 @@
  * <p>
  * The memory footprint of these implementation is close to the information-theoretical lower bound
  * in the undirected case, and close to twice the information-theoretical lower bound in the
- * directed case, because the transposed graph must be stored separately. The actual space used can
- * be easily measured as all implementations are serializable, and their in-memory footprint is very
- * closed to the on-disk footprint. Usually the size is a few times smaller than that of a
+ * directed case, because the transposed graph must be stored separately, but in the latter case you
+ * have the choice to not support incoming edges and obtain, again, footprint close to the
+ * information-theoretical lower bound. The actual space used can be easily measured as all
+ * implementations are serializable, and their in-memory footprint is very close to the on-disk
+ * footprint. Usually the size is a few times smaller than that of a
  * {@link org.jgrapht.opt.graph.sparse.SparseIntDirectedGraph
  * SparseIntDirectedGraph}/{@link org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph
  * SparseIntUndirectedGraph}.

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
@@ -9,10 +9,12 @@
  * adjacency matrix of a graph are represented as a monotone sequence of natural numbers.
  *
  * <p>
- * The memory footprint of these implementation is close to the information-theoretical lower bound;
- * the actual space used can be easily measured as all implementations are serializable, and their
- * in-memory footprint is very closed to the on-disk footprint. Usually the size is a few times
- * smaller than that of a {@link org.jgrapht.opt.graph.sparse.SparseIntDirectedGraph
+ * The memory footprint of these implementation is close to the information-theoretical lower bound
+ * in the undirected case, and close to twice the information-theoretical lower bound in the
+ * directed case, because the transposed graph must be stored separately. The actual space used can
+ * be easily measured as all implementations are serializable, and their in-memory footprint is very
+ * closed to the on-disk footprint. Usually the size is a few times smaller than that of a
+ * {@link org.jgrapht.opt.graph.sparse.SparseIntDirectedGraph
  * SparseIntDirectedGraph}/{@link org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph
  * SparseIntUndirectedGraph}.
  *

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
@@ -1,5 +1,70 @@
 /**
- * Adapters for graphs stored using
- * <a href="http://sux4j.di.unimi.it/">Sux4J</a>'s quasi-succinct data structures.
+ * Immutable graphs stored using <a href="http://sux4j.di.unimi.it/">Sux4J</a>'s quasi-succinct data
+ * structures.
+ *
+ * <p>
+ * This package contains implementations of immutable graphs based on the
+ * {@linkplain it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList Elias&ndash;Fano
+ * quasi-succinct representation of monotone sequences}. The entries of the adjacency matrix of a
+ * graph with <var>n</var> vertices are represented as a monotone sequence of natural numbers, where
+ * an arc <var>x</var>&nbsp;&rarr;&nbsp;<var>y</var> is represented by
+ * <var>x</var><var>n</var>&nbsp;+&nbsp;<var>y</var>.
+ *
+ * <p>
+ * The memory footprint of these implementation is close to the information-theoretical lower bound;
+ * the actual space used can be easily measured as all implementations are serializable, and their
+ * in-memory footprint is very closed to the on-disk footprint. Usually the size is a few times
+ * smaller than that of a {@link org.jgrapht.opt.graph.sparse.SparseIntDirectedGraph
+ * SparseIntDirectedGraph}/ {@link org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph
+ * SparseIntUndirectedGraph}.
+ *
+ * <p>
+ * We provide two classes mimicking {@link org.jgrapht.opt.graph.sparse.SparseIntDirectedGraph
+ * SparseIntDirectedGraph} and {@link org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph
+ * SparseIntUndirectedGraph}, in the sense that both vertices and edges are integers (and they are
+ * numbered contiguously).
+ *
+ * <ul>
+ * <li>{@link org.jgrapht.sux4j.SuccinctIntDirectedGraph} is an implementation for directed graphs.
+ * {@linkplain org.jgrapht.GraphIterables#outgoingEdgesOf(Object) Enumeration of outgoing edges} is
+ * quite fast, but {@linkplain org.jgrapht.GraphIterables#incomingEdgesOf(Object) enumeration of
+ * incoming edges} is very slow. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are
+ * very fast and happen in almost constant time.
+ * <li>{@link org.jgrapht.sux4j.SuccinctIntUndirectedGraph} is an implementation for undirected
+ * graphs. {@linkplain org.jgrapht.GraphIterables#edgesOf(Object) Enumeration of edges} is quite
+ * slow. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are very fast and happen in
+ * almost constant time.
+ * </ul>
+ *
+ * <p>
+ * The sometimes slow behavior of the previous classes is due to a clash between JGraphT's design
+ * and the need of representing an edge with an {@link java.lang.Integer Integer}: there is no
+ * information that can be carried by the object representing the edge. This limitation forces the
+ * two classes above to compute two expensive functions that are one the inverse of the other.
+ *
+ * <p>
+ * As an alternative, we provide classes {@link org.jgrapht.sux4j.SuccinctDirectedGraph
+ * SuccinctDirectedGraph} and {@link org.jgrapht.sux4j.SuccinctUndirectedGraph
+ * SuccinctUndirectedGraph} using the same amount of space, but having edges represented by pairs of
+ * integers stored in an {@link it.unimi.dsi.fastutil.ints.IntIntPair IntIntPair} (for directed
+ * graphs) or an {@link it.unimi.dsi.fastutil.ints.IntIntSortedPair IntIntSortedPair} (for
+ * undirected graphs). Storing the edges explicitly avoids the cumbersome back-and-forth
+ * computations of the previous classes. All accessors are extremely fast.
+ *
+ * <p>
+ * Both classes provide methods {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getEdgeFromIndex(int)
+ * getEdgeFromIndex()} and
+ * {@link org.jgrapht.sux4j.SuccinctDirectedGraph#getIndexFromEdge(it.unimi.dsi.fastutil.ints.IntIntPair)
+ * getIndexFromEdge()} that map bijectively the edge set into a contiguous set of integers. In this
+ * way the user can choose when and how to use the feature (e.g., to store compactly data associated
+ * to edges).
+ *
+ * <p>
+ * Finally, note that the best performance and compression can be obtained by representing the graph
+ * using <a href="http://webgraph.di.unimi.it/">WebGraph</a>'s {@link it.unimi.dsi.webgraph.EFGraph
+ * EFGraph} format and then accessing the graph using the suitable {@linkplain org.jgrapht.webgraph
+ * adapter}; in particular, one can represent graphs with more than {@link Integer#MAX_VALUE}
+ * vertices. However, the adapters to not provide methods mapping bijectively edges into a
+ * contiguous set of integers.
  */
 package org.jgrapht.sux4j;

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
@@ -5,17 +5,15 @@
  * <p>
  * This package contains implementations of immutable graphs based on the
  * {@linkplain it.unimi.dsi.sux4j.util.EliasFanoIndexedMonotoneLongBigList Elias&ndash;Fano
- * quasi-succinct representation of monotone sequences}. The entries of the adjacency matrix of a
- * graph with <var>n</var> vertices are represented as a monotone sequence of natural numbers, where
- * an arc <var>x</var>&nbsp;&rarr;&nbsp;<var>y</var> is represented by
- * <var>x</var><var>n</var>&nbsp;+&nbsp;<var>y</var>.
+ * quasi-succinct representation of monotone sequences}. The positions of the nonzero entries of the
+ * adjacency matrix of a graph are represented as a monotone sequence of natural numbers.
  *
  * <p>
  * The memory footprint of these implementation is close to the information-theoretical lower bound;
  * the actual space used can be easily measured as all implementations are serializable, and their
  * in-memory footprint is very closed to the on-disk footprint. Usually the size is a few times
  * smaller than that of a {@link org.jgrapht.opt.graph.sparse.SparseIntDirectedGraph
- * SparseIntDirectedGraph}/ {@link org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph
+ * SparseIntDirectedGraph}/{@link org.jgrapht.opt.graph.sparse.SparseIntUndirectedGraph
  * SparseIntUndirectedGraph}.
  *
  * <p>
@@ -31,7 +29,7 @@
  * incoming edges} is very slow. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are
  * very fast and happen in almost constant time.
  * <li>{@link org.jgrapht.sux4j.SuccinctIntUndirectedGraph} is an implementation for undirected
- * graphs. {@linkplain org.jgrapht.GraphIterables#edgesOf(Object) Enumeration of edges} is quite
+ * graphs. {@linkplain org.jgrapht.GraphIterables#edgesOf(Object) Enumeration of edges} is very
  * slow. {@link org.jgrapht.Graph#containsEdge(Object) Adjacency tests} are very fast and happen in
  * almost constant time.
  * </ul>
@@ -64,7 +62,7 @@
  * using <a href="http://webgraph.di.unimi.it/">WebGraph</a>'s {@link it.unimi.dsi.webgraph.EFGraph
  * EFGraph} format and then accessing the graph using the suitable {@linkplain org.jgrapht.webgraph
  * adapter}; in particular, one can represent graphs with more than {@link Integer#MAX_VALUE}
- * vertices. However, the adapters to not provide methods mapping bijectively edges into a
+ * vertices. However, the adapters do not provide methods mapping bijectively edges into a
  * contiguous set of integers.
  */
 package org.jgrapht.sux4j;

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Adapters for graphs stored using
+ * <a href="http://sux4j.di.unimi.it/">Sux4J</a>'s quasi-succinct data structures.
+ */
+package org.jgrapht.sux4j;

--- a/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctDirectedGraphTest.java
+++ b/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctDirectedGraphTest.java
@@ -1,0 +1,268 @@
+/*
+ * (C) Copyright 2020-2021, by Sebastiano Vigna and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.sux4j;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.jgrapht.generate.GnpRandomGraphGenerator;
+import org.jgrapht.graph.DefaultDirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.util.SupplierUtil;
+import org.junit.Test;
+
+import it.unimi.dsi.fastutil.ints.IntIntPair;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.util.XoRoShiRo128PlusPlusRandomGenerator;
+
+public class SuccinctDirectedGraphTest
+{
+    @Test
+    public void testDirected()
+    {
+        final DefaultDirectedGraph<Integer, DefaultEdge> d =
+            new DefaultDirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        for (int i = 0; i < 5; i++)
+            d.addVertex(i);
+        d.addEdge(0, 1);
+        d.addEdge(0, 2);
+        d.addEdge(1, 2);
+        d.addEdge(2, 1);
+        d.addEdge(2, 3);
+        d.addEdge(3, 0);
+        d.addEdge(3, 3);
+        d.addEdge(3, 4);
+        d.addEdge(4, 1);
+
+        final SuccinctDirectedGraph s = new SuccinctDirectedGraph(d);
+        assertEquals(2, s.outDegreeOf(0));
+        assertEquals(1, s.outDegreeOf(1));
+        assertEquals(2, s.outDegreeOf(2));
+        assertEquals(3, s.outDegreeOf(3));
+        assertEquals(1, s.outDegreeOf(4));
+        assertEquals(1, s.inDegreeOf(0));
+        assertEquals(3, s.inDegreeOf(1));
+        assertEquals(2, s.inDegreeOf(2));
+        assertEquals(2, s.inDegreeOf(3));
+        assertEquals(1, s.inDegreeOf(4));
+
+        assertEquals(IntIntPair.of(0, 1), s.getEdge(0, 1));
+        assertEquals(IntIntPair.of(0, 2), s.getEdge(0, 2));
+        assertEquals(IntIntPair.of(1, 2), s.getEdge(1, 2));
+        assertEquals(IntIntPair.of(2, 1), s.getEdge(2, 1));
+        assertEquals(IntIntPair.of(2, 3), s.getEdge(2, 3));
+        assertEquals(IntIntPair.of(3, 0), s.getEdge(3, 0));
+        assertEquals(IntIntPair.of(3, 3), s.getEdge(3, 3));
+        assertEquals(IntIntPair.of(3, 4), s.getEdge(3, 4));
+        assertEquals(IntIntPair.of(4, 1), s.getEdge(4, 1));
+
+        assertNull(s.getEdge(0, 0));
+        assertNull(s.getEdge(0, 3));
+        assertNull(s.getEdge(0, 4));
+        assertNull(s.getEdge(1, 0));
+        assertNull(s.getEdge(1, 1));
+        assertNull(s.getEdge(1, 3));
+        assertNull(s.getEdge(1, 4));
+        assertNull(s.getEdge(2, 0));
+        assertNull(s.getEdge(2, 2));
+        assertNull(s.getEdge(2, 4));
+        assertNull(s.getEdge(3, 1));
+        assertNull(s.getEdge(3, 2));
+        assertNull(s.getEdge(4, 0));
+        assertNull(s.getEdge(4, 4));
+        assertNull(s.getEdge(4, 2));
+        assertNull(s.getEdge(4, 3));
+
+        assertTrue(s.containsEdge(0, 1));
+        assertTrue(s.containsEdge(0, 2));
+        assertTrue(s.containsEdge(1, 2));
+        assertTrue(s.containsEdge(2, 1));
+        assertTrue(s.containsEdge(2, 3));
+        assertTrue(s.containsEdge(3, 0));
+        assertTrue(s.containsEdge(3, 3));
+        assertTrue(s.containsEdge(3, 4));
+        assertTrue(s.containsEdge(4, 1));
+
+        assertFalse(s.containsEdge(0, 0));
+        assertFalse(s.containsEdge(0, 3));
+        assertFalse(s.containsEdge(0, 4));
+        assertFalse(s.containsEdge(1, 0));
+        assertFalse(s.containsEdge(1, 1));
+        assertFalse(s.containsEdge(1, 3));
+        assertFalse(s.containsEdge(1, 4));
+        assertFalse(s.containsEdge(2, 0));
+        assertFalse(s.containsEdge(2, 2));
+        assertFalse(s.containsEdge(2, 4));
+        assertFalse(s.containsEdge(3, 1));
+        assertFalse(s.containsEdge(3, 2));
+        assertFalse(s.containsEdge(4, 0));
+        assertFalse(s.containsEdge(4, 4));
+        assertFalse(s.containsEdge(4, 2));
+        assertFalse(s.containsEdge(4, 3));
+
+        assertEquals(Set.of(IntIntPair.of(0, 1), IntIntPair.of(0, 2)), s.outgoingEdgesOf(0));
+        assertEquals(Set.of(IntIntPair.of(1, 2)), s.outgoingEdgesOf(1));
+        assertEquals(Set.of(IntIntPair.of(2, 1), IntIntPair.of(2, 3)), s.outgoingEdgesOf(2));
+        assertEquals(
+            Set.of(IntIntPair.of(3, 0), IntIntPair.of(3, 3), IntIntPair.of(3, 4)),
+            s.outgoingEdgesOf(3));
+        assertEquals(Set.of(IntIntPair.of(4, 1)), s.outgoingEdgesOf(4));
+
+        assertEquals(Set.of(IntIntPair.of(3, 0)), s.incomingEdgesOf(0));
+        assertEquals(
+            Set.of(IntIntPair.of(0, 1), IntIntPair.of(2, 1), IntIntPair.of(4, 1)),
+            s.incomingEdgesOf(1));
+        assertEquals(Set.of(IntIntPair.of(0, 2), IntIntPair.of(1, 2)), s.incomingEdgesOf(2));
+        assertEquals(Set.of(IntIntPair.of(2, 3), IntIntPair.of(3, 3)), s.incomingEdgesOf(3));
+        assertEquals(Set.of(IntIntPair.of(3, 4)), s.incomingEdgesOf(4));
+
+        assertEquals(
+            Set.of(IntIntPair.of(3, 0)),
+            new ObjectOpenHashSet<>(s.iterables().incomingEdgesOf(0).iterator()));
+        assertEquals(
+            Set.of(IntIntPair.of(0, 1), IntIntPair.of(2, 1), IntIntPair.of(4, 1)),
+            new ObjectOpenHashSet<>(s.iterables().incomingEdgesOf(1).iterator()));
+        assertEquals(
+            Set.of(IntIntPair.of(0, 2), IntIntPair.of(1, 2)),
+            new ObjectOpenHashSet<>(s.iterables().incomingEdgesOf(2).iterator()));
+        assertEquals(
+            Set.of(IntIntPair.of(2, 3), IntIntPair.of(3, 3)),
+            new ObjectOpenHashSet<>(s.iterables().incomingEdgesOf(3).iterator()));
+        assertEquals(
+            Set.of(IntIntPair.of(3, 4)),
+            new ObjectOpenHashSet<>(s.iterables().incomingEdgesOf(4).iterator()));
+
+        Iterator<IntIntPair> iterator = s.iterables().edgesOf(0).iterator();
+        while (iterator.hasNext())
+            iterator.next();
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
+        iterator = s.iterables().outgoingEdgesOf(0).iterator();
+        while (iterator.hasNext())
+            iterator.next();
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
+        iterator = s.iterables().incomingEdgesOf(0).iterator();
+        while (iterator.hasNext())
+            iterator.next();
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testSink()
+    {
+        final DefaultDirectedGraph<Integer, DefaultEdge> d =
+            new DefaultDirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        for (int i = 0; i < 3; i++)
+            d.addVertex(i);
+        d.addEdge(0, 1);
+        d.addEdge(2, 0);
+        final SuccinctDirectedGraph s = new SuccinctDirectedGraph(d);
+        assertEquals(IntIntPair.of(0, 1), s.getEdge(0, 1));
+        assertEquals(IntIntPair.of(2, 0), s.getEdge(2, 0));
+    }
+
+    @Test
+    public void testRandomDense()
+    {
+        final GnpRandomGraphGenerator<Integer, DefaultEdge> r =
+            new GnpRandomGraphGenerator<>(1000, .1, 0, false);
+        final DefaultDirectedGraph<Integer, DefaultEdge> s =
+            new DefaultDirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        r.generateGraph(s);
+        final SuccinctDirectedGraph t = new SuccinctDirectedGraph(s);
+        for (final IntIntPair e : t.edgeSet())
+            assertTrue(e.toString(), s.containsEdge(t.getEdgeSource(e), t.getEdgeTarget(e)));
+        for (final DefaultEdge e : s.edgeSet())
+            assertTrue(e.toString(), t.containsEdge(s.getEdgeSource(e), s.getEdgeTarget(e)));
+        final XoRoShiRo128PlusPlusRandomGenerator random =
+            new XoRoShiRo128PlusPlusRandomGenerator();
+        final int n = (int) s.iterables().vertexCount();
+        for (int i = 0; i < 10000; i++) {
+            final int x = random.nextInt(n);
+            final int y = random.nextInt(n);
+            assertEquals(s.containsEdge(x, y), t.containsEdge(x, y));
+        }
+    }
+
+    @Test
+    public void testRandomSparse()
+    {
+        final GnpRandomGraphGenerator<Integer, DefaultEdge> r =
+            new GnpRandomGraphGenerator<>(1000, .001, 0, false);
+        final DefaultDirectedGraph<Integer, DefaultEdge> s =
+            new DefaultDirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        r.generateGraph(s);
+        final SuccinctDirectedGraph t = new SuccinctDirectedGraph(s);
+        for (final IntIntPair e : t.edgeSet())
+            assertTrue(e.toString(), s.containsEdge(t.getEdgeSource(e), t.getEdgeTarget(e)));
+        for (final DefaultEdge e : s.edgeSet())
+            assertTrue(e.toString(), t.containsEdge(s.getEdgeSource(e), s.getEdgeTarget(e)));
+        final XoRoShiRo128PlusPlusRandomGenerator random =
+            new XoRoShiRo128PlusPlusRandomGenerator();
+        final int n = (int) s.iterables().vertexCount();
+        for (int i = 0; i < 10000; i++) {
+            final int x = random.nextInt(n);
+            final int y = random.nextInt(n);
+            assertEquals(s.containsEdge(x, y), t.containsEdge(x, y));
+        }
+    }
+}

--- a/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntDirectedGraphTest.java
+++ b/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntDirectedGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2020, by Dimitrios Michail and Contributors.
+ * (C) Copyright 2020-2021, by Sebastiano Vigna and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *

--- a/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntDirectedGraphTest.java
+++ b/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntDirectedGraphTest.java
@@ -1,0 +1,282 @@
+/*
+ * (C) Copyright 2019-2020, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.opt.graph.sux4j;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+import org.jgrapht.generate.GnpRandomGraphGenerator;
+import org.jgrapht.graph.DefaultDirectedGraph;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.util.SupplierUtil;
+import org.junit.Test;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.util.XoRoShiRo128PlusPlusRandomGenerator;
+
+public class SuccinctIntDirectedGraphTest
+{
+    @Test
+    public void testDirected()
+    {
+        final DefaultDirectedGraph<Integer, DefaultEdge> d =
+            new DefaultDirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        for (int i = 0; i < 5; i++)
+            d.addVertex(i);
+        d.addEdge(0, 1);
+        d.addEdge(0, 2);
+        d.addEdge(1, 2);
+        d.addEdge(2, 1);
+        d.addEdge(2, 3);
+        d.addEdge(3, 0);
+        d.addEdge(3, 3);
+        d.addEdge(3, 4);
+        d.addEdge(4, 1);
+
+        final SuccinctIntDirectedGraph s = new SuccinctIntDirectedGraph(d);
+        assertEquals(2, s.outDegreeOf(0));
+        assertEquals(1, s.outDegreeOf(1));
+        assertEquals(2, s.outDegreeOf(2));
+        assertEquals(3, s.outDegreeOf(3));
+        assertEquals(1, s.outDegreeOf(4));
+        assertEquals(1, s.inDegreeOf(0));
+        assertEquals(3, s.inDegreeOf(1));
+        assertEquals(2, s.inDegreeOf(2));
+        assertEquals(2, s.inDegreeOf(3));
+        assertEquals(1, s.inDegreeOf(4));
+
+        assertEquals(0, s.getEdge(0, 1).intValue());
+        assertEquals(1, s.getEdge(0, 2).intValue());
+        assertEquals(2, s.getEdge(1, 2).intValue());
+        assertEquals(3, s.getEdge(2, 1).intValue());
+        assertEquals(4, s.getEdge(2, 3).intValue());
+        assertEquals(5, s.getEdge(3, 0).intValue());
+        assertEquals(6, s.getEdge(3, 3).intValue());
+        assertEquals(7, s.getEdge(3, 4).intValue());
+        assertEquals(8, s.getEdge(4, 1).intValue());
+
+        assertNull(s.getEdge(0, 0));
+        assertNull(s.getEdge(0, 3));
+        assertNull(s.getEdge(0, 4));
+        assertNull(s.getEdge(1, 0));
+        assertNull(s.getEdge(1, 1));
+        assertNull(s.getEdge(1, 3));
+        assertNull(s.getEdge(1, 4));
+        assertNull(s.getEdge(2, 0));
+        assertNull(s.getEdge(2, 2));
+        assertNull(s.getEdge(2, 4));
+        assertNull(s.getEdge(3, 1));
+        assertNull(s.getEdge(3, 2));
+        assertNull(s.getEdge(4, 0));
+        assertNull(s.getEdge(4, 4));
+        assertNull(s.getEdge(4, 2));
+        assertNull(s.getEdge(4, 3));
+
+        assertTrue(s.containsEdge(0, 1));
+        assertTrue(s.containsEdge(0, 2));
+        assertTrue(s.containsEdge(1, 2));
+        assertTrue(s.containsEdge(2, 1));
+        assertTrue(s.containsEdge(2, 3));
+        assertTrue(s.containsEdge(3, 0));
+        assertTrue(s.containsEdge(3, 3));
+        assertTrue(s.containsEdge(3, 4));
+        assertTrue(s.containsEdge(4, 1));
+
+        assertFalse(s.containsEdge(0, 0));
+        assertFalse(s.containsEdge(0, 3));
+        assertFalse(s.containsEdge(0, 4));
+        assertFalse(s.containsEdge(1, 0));
+        assertFalse(s.containsEdge(1, 1));
+        assertFalse(s.containsEdge(1, 3));
+        assertFalse(s.containsEdge(1, 4));
+        assertFalse(s.containsEdge(2, 0));
+        assertFalse(s.containsEdge(2, 2));
+        assertFalse(s.containsEdge(2, 4));
+        assertFalse(s.containsEdge(3, 1));
+        assertFalse(s.containsEdge(3, 2));
+        assertFalse(s.containsEdge(4, 0));
+        assertFalse(s.containsEdge(4, 4));
+        assertFalse(s.containsEdge(4, 2));
+        assertFalse(s.containsEdge(4, 3));
+
+        assertEquals(0, s.getEdgeSource(0).intValue());
+        assertEquals(1, s.getEdgeTarget(0).intValue());
+
+        assertEquals(0, s.getEdgeSource(1).intValue());
+        assertEquals(2, s.getEdgeTarget(1).intValue());
+
+        assertEquals(1, s.getEdgeSource(2).intValue());
+        assertEquals(2, s.getEdgeTarget(2).intValue());
+
+        assertEquals(2, s.getEdgeSource(3).intValue());
+        assertEquals(1, s.getEdgeTarget(3).intValue());
+
+        assertEquals(2, s.getEdgeSource(4).intValue());
+        assertEquals(3, s.getEdgeTarget(4).intValue());
+
+        assertEquals(IntSets.fromTo(0, 2), s.outgoingEdgesOf(0));
+        assertEquals(IntSets.fromTo(2, 3), s.outgoingEdgesOf(1));
+        assertEquals(IntSets.fromTo(3, 5), s.outgoingEdgesOf(2));
+        assertEquals(IntSets.fromTo(5, 8), s.outgoingEdgesOf(3));
+        assertEquals(IntSets.fromTo(8, 9), s.outgoingEdgesOf(4));
+
+        assertEquals(new IntOpenHashSet(new int[] { 5 }), s.incomingEdgesOf(0));
+        assertEquals(new IntOpenHashSet(new int[] { 0, 3, 8 }), s.incomingEdgesOf(1));
+        assertEquals(new IntOpenHashSet(new int[] { 1, 2 }), s.incomingEdgesOf(2));
+        assertEquals(new IntOpenHashSet(new int[] { 4, 6 }), s.incomingEdgesOf(3));
+        assertEquals(new IntOpenHashSet(new int[] { 7 }), s.incomingEdgesOf(4));
+
+        assertEquals(
+            new IntOpenHashSet(new int[] { 5 }),
+            new IntOpenHashSet(s.iterables().incomingEdgesOf(0).iterator()));
+        assertEquals(
+            new IntOpenHashSet(new int[] { 0, 3, 8 }),
+            new IntOpenHashSet(s.iterables().incomingEdgesOf(1).iterator()));
+        assertEquals(
+            new IntOpenHashSet(new int[] { 1, 2 }),
+            new IntOpenHashSet(s.iterables().incomingEdgesOf(2).iterator()));
+        assertEquals(
+            new IntOpenHashSet(new int[] { 4, 6 }),
+            new IntOpenHashSet(s.iterables().incomingEdgesOf(3).iterator()));
+        assertEquals(
+            new IntOpenHashSet(new int[] { 7 }),
+            new IntOpenHashSet(s.iterables().incomingEdgesOf(4).iterator()));
+
+        Iterator<Integer> iterator = s.iterables().edgesOf(0).iterator();
+        while (iterator.hasNext())
+            iterator.next();
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
+        iterator = s.iterables().outgoingEdgesOf(0).iterator();
+        while (iterator.hasNext())
+            iterator.next();
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
+        iterator = s.iterables().incomingEdgesOf(0).iterator();
+        while (iterator.hasNext())
+            iterator.next();
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testSink()
+    {
+        final DefaultDirectedGraph<Integer, DefaultEdge> d =
+            new DefaultDirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        for (int i = 0; i < 3; i++)
+            d.addVertex(i);
+        d.addEdge(0, 1);
+        d.addEdge(2, 0);
+        final SuccinctIntDirectedGraph s = new SuccinctIntDirectedGraph(d);
+        assertEquals(0, s.getEdge(0, 1).intValue());
+        assertEquals(1, s.getEdge(2, 0).intValue());
+        assertEquals(0, s.getEdgeSource(0).intValue());
+        assertEquals(1, s.getEdgeTarget(0).intValue());
+        assertEquals(2, s.getEdgeSource(1).intValue());
+        assertEquals(0, s.getEdgeTarget(1).intValue());
+    }
+
+    @Test
+    public void testRandomDense()
+    {
+        final GnpRandomGraphGenerator<Integer, DefaultEdge> r =
+            new GnpRandomGraphGenerator<>(1000, .1, 0, false);
+        final DefaultDirectedGraph<Integer, DefaultEdge> s =
+            new DefaultDirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        r.generateGraph(s);
+        final SuccinctIntDirectedGraph t = new SuccinctIntDirectedGraph(s);
+        for (final Integer e : t.edgeSet())
+            assertTrue(e.toString(), s.containsEdge(t.getEdgeSource(e), t.getEdgeTarget(e)));
+        for (final DefaultEdge e : s.edgeSet())
+            assertTrue(e.toString(), t.containsEdge(s.getEdgeSource(e), s.getEdgeTarget(e)));
+        final XoRoShiRo128PlusPlusRandomGenerator random =
+            new XoRoShiRo128PlusPlusRandomGenerator();
+        final int n = (int) s.iterables().vertexCount();
+        for (int i = 0; i < 10000; i++) {
+            final int x = random.nextInt(n);
+            final int y = random.nextInt(n);
+            assertEquals(s.containsEdge(x, y), t.containsEdge(x, y));
+        }
+    }
+
+    @Test
+    public void testRandomSparse()
+    {
+        final GnpRandomGraphGenerator<Integer, DefaultEdge> r =
+            new GnpRandomGraphGenerator<>(1000, .001, 0, false);
+        final DefaultDirectedGraph<Integer, DefaultEdge> s =
+            new DefaultDirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        r.generateGraph(s);
+        final SuccinctIntDirectedGraph t = new SuccinctIntDirectedGraph(s);
+        for (final Integer e : t.edgeSet())
+            assertTrue(e.toString(), s.containsEdge(t.getEdgeSource(e), t.getEdgeTarget(e)));
+        for (final DefaultEdge e : s.edgeSet())
+            assertTrue(e.toString(), t.containsEdge(s.getEdgeSource(e), s.getEdgeTarget(e)));
+        final XoRoShiRo128PlusPlusRandomGenerator random =
+            new XoRoShiRo128PlusPlusRandomGenerator();
+        final int n = (int) s.iterables().vertexCount();
+        for (int i = 0; i < 10000; i++) {
+            final int x = random.nextInt(n);
+            final int y = random.nextInt(n);
+            assertEquals(s.containsEdge(x, y), t.containsEdge(x, y));
+        }
+    }
+}

--- a/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntDirectedGraphTest.java
+++ b/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntDirectedGraphTest.java
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
  */
-package org.jgrapht.opt.graph.sux4j;
+package org.jgrapht.sux4j;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraphTest.java
+++ b/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2019-2020, by Dimitrios Michail and Contributors.
+ * (C) Copyright 2020-2021, by Sebastiano Vigna and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *

--- a/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraphTest.java
+++ b/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraphTest.java
@@ -15,7 +15,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
  */
-package org.jgrapht.opt.graph.sux4j;
+package org.jgrapht.sux4j;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraphTest.java
+++ b/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraphTest.java
@@ -1,0 +1,270 @@
+/*
+ * (C) Copyright 2019-2020, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.opt.graph.sux4j;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+import org.jgrapht.generate.GnpRandomGraphGenerator;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultUndirectedGraph;
+import org.jgrapht.util.SupplierUtil;
+import org.junit.Test;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.util.XoRoShiRo128PlusPlusRandomGenerator;
+
+public class SuccinctIntUndirectedGraphTest
+{
+
+    @Test
+    public void testUndirected()
+    {
+        final DefaultUndirectedGraph<Integer, DefaultEdge> d =
+            new DefaultUndirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        for (int i = 0; i < 5; i++)
+            d.addVertex(i);
+        d.addEdge(0, 1);
+        d.addEdge(1, 2);
+        d.addEdge(2, 3);
+        d.addEdge(3, 0);
+        d.addEdge(3, 3);
+        d.addEdge(3, 4);
+        d.addEdge(4, 1);
+
+        final SuccinctIntUndirectedGraph s = new SuccinctIntUndirectedGraph(d);
+        assertEquals(2, s.outDegreeOf(0));
+        assertEquals(3, s.outDegreeOf(1));
+        assertEquals(2, s.outDegreeOf(2));
+        assertEquals(5, s.outDegreeOf(3));
+        assertEquals(2, s.outDegreeOf(4));
+
+        assertEquals(0, s.getEdge(0, 1).intValue());
+        assertEquals(1, s.getEdge(3, 0).intValue());
+        assertEquals(2, s.getEdge(1, 2).intValue());
+        assertEquals(3, s.getEdge(4, 1).intValue());
+        assertEquals(4, s.getEdge(2, 3).intValue());
+        assertEquals(5, s.getEdge(3, 3).intValue());
+        assertEquals(6, s.getEdge(3, 4).intValue());
+
+        assertNull(s.getEdge(0, 0));
+        assertNull(s.getEdge(0, 4));
+        assertNull(s.getEdge(1, 1));
+        assertNull(s.getEdge(1, 3));
+        assertNull(s.getEdge(2, 0));
+        assertNull(s.getEdge(2, 2));
+        assertNull(s.getEdge(2, 4));
+        assertNull(s.getEdge(3, 1));
+        assertNull(s.getEdge(4, 0));
+        assertNull(s.getEdge(4, 4));
+        assertNull(s.getEdge(4, 2));
+
+        assertTrue(s.containsEdge(0, 1));
+        assertTrue(s.containsEdge(1, 0));
+        assertTrue(s.containsEdge(1, 2));
+        assertTrue(s.containsEdge(2, 1));
+        assertTrue(s.containsEdge(2, 3));
+        assertTrue(s.containsEdge(3, 2));
+        assertTrue(s.containsEdge(3, 0));
+        assertTrue(s.containsEdge(0, 3));
+        assertTrue(s.containsEdge(3, 3));
+        assertTrue(s.containsEdge(3, 4));
+        assertTrue(s.containsEdge(4, 3));
+        assertTrue(s.containsEdge(4, 1));
+        assertTrue(s.containsEdge(1, 4));
+
+        assertFalse(s.containsEdge(0, 0));
+        assertFalse(s.containsEdge(0, 4));
+        assertFalse(s.containsEdge(1, 1));
+        assertFalse(s.containsEdge(1, 3));
+        assertFalse(s.containsEdge(2, 0));
+        assertFalse(s.containsEdge(2, 2));
+        assertFalse(s.containsEdge(2, 4));
+        assertFalse(s.containsEdge(3, 1));
+        assertFalse(s.containsEdge(4, 0));
+        assertFalse(s.containsEdge(4, 4));
+        assertFalse(s.containsEdge(4, 2));
+
+        assertEquals(0, s.getEdgeSource(0).intValue());
+        assertEquals(1, s.getEdgeTarget(0).intValue());
+
+        assertEquals(0, s.getEdgeSource(1).intValue());
+        assertEquals(3, s.getEdgeTarget(1).intValue());
+
+        assertEquals(1, s.getEdgeSource(2).intValue());
+        assertEquals(2, s.getEdgeTarget(2).intValue());
+
+        assertEquals(1, s.getEdgeSource(3).intValue());
+        assertEquals(4, s.getEdgeTarget(3).intValue());
+
+        assertEquals(2, s.getEdgeSource(4).intValue());
+        assertEquals(3, s.getEdgeTarget(4).intValue());
+
+        assertEquals(3, s.getEdgeSource(5).intValue());
+        assertEquals(3, s.getEdgeTarget(5).intValue());
+
+        assertEquals(3, s.getEdgeSource(6).intValue());
+        assertEquals(4, s.getEdgeTarget(6).intValue());
+
+        assertEquals(IntSets.fromTo(0, 2), s.edgesOf(0));
+        assertEquals(new IntOpenHashSet(new int[] { 0, 2, 3 }), s.edgesOf(1));
+        assertEquals(new IntOpenHashSet(new int[] { 2, 4 }), s.edgesOf(2));
+        assertEquals(new IntOpenHashSet(new int[] { 1, 4, 5, 6 }), s.edgesOf(3));
+        assertEquals(new IntOpenHashSet(new int[] { 3, 6 }), s.edgesOf(4));
+
+        assertEquals(IntSets.fromTo(0, 2), s.outgoingEdgesOf(0));
+        assertEquals(new IntOpenHashSet(new int[] { 0, 2, 3 }), s.outgoingEdgesOf(1));
+        assertEquals(new IntOpenHashSet(new int[] { 2, 4 }), s.outgoingEdgesOf(2));
+        assertEquals(new IntOpenHashSet(new int[] { 1, 4, 5, 6 }), s.outgoingEdgesOf(3));
+        assertEquals(new IntOpenHashSet(new int[] { 3, 6 }), s.outgoingEdgesOf(4));
+
+        assertEquals(IntSets.fromTo(0, 2), s.incomingEdgesOf(0));
+        assertEquals(new IntOpenHashSet(new int[] { 0, 2, 3 }), s.incomingEdgesOf(1));
+        assertEquals(new IntOpenHashSet(new int[] { 2, 4 }), s.incomingEdgesOf(2));
+        assertEquals(new IntOpenHashSet(new int[] { 1, 4, 5, 6 }), s.incomingEdgesOf(3));
+        assertEquals(new IntOpenHashSet(new int[] { 3, 6 }), s.incomingEdgesOf(4));
+
+        assertEquals(
+            new IntOpenHashSet(new int[] { 0, 1 }),
+            new IntOpenHashSet(s.iterables().incomingEdgesOf(0).iterator()));
+        assertEquals(
+            new IntOpenHashSet(new int[] { 0, 2, 3 }),
+            new IntOpenHashSet(s.iterables().incomingEdgesOf(1).iterator()));
+        assertEquals(
+            new IntOpenHashSet(new int[] { 2, 4 }),
+            new IntOpenHashSet(s.iterables().incomingEdgesOf(2).iterator()));
+        assertEquals(
+            new IntOpenHashSet(new int[] { 1, 4, 5, 6 }),
+            new IntOpenHashSet(s.iterables().incomingEdgesOf(3).iterator()));
+        assertEquals(
+            new IntOpenHashSet(new int[] { 6, 3 }),
+            new IntOpenHashSet(s.iterables().incomingEdgesOf(4).iterator()));
+
+        final Iterator<Integer> iterator = s.iterables().edgesOf(0).iterator();
+        while (iterator.hasNext())
+            iterator.next();
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testSink()
+    {
+        final DefaultUndirectedGraph<Integer, DefaultEdge> d =
+            new DefaultUndirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        for (int i = 0; i < 3; i++)
+            d.addVertex(i);
+        d.addEdge(0, 0);
+        d.addEdge(2, 0);
+        final SuccinctIntUndirectedGraph s = new SuccinctIntUndirectedGraph(d);
+        assertEquals(0, s.getEdge(0, 0).intValue());
+        assertEquals(1, s.getEdge(2, 0).intValue());
+        assertEquals(0, s.getEdgeSource(0).intValue());
+        assertEquals(0, s.getEdgeTarget(0).intValue());
+        assertEquals(0, s.getEdgeSource(1).intValue());
+        assertEquals(2, s.getEdgeTarget(1).intValue());
+    }
+
+    @Test
+    public void testRandomDense()
+    {
+        final GnpRandomGraphGenerator<Integer, DefaultEdge> r =
+            new GnpRandomGraphGenerator<>(1000, .1, 0, false);
+        final DefaultUndirectedGraph<Integer, DefaultEdge> s =
+            new DefaultUndirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        r.generateGraph(s);
+        final SuccinctIntUndirectedGraph t = new SuccinctIntUndirectedGraph(s);
+        for (final Integer e : t.edgeSet())
+            assertTrue(e.toString(), s.containsEdge(t.getEdgeSource(e), t.getEdgeTarget(e)));
+        for (final DefaultEdge e : s.edgeSet())
+            assertTrue(e.toString(), t.containsEdge(s.getEdgeSource(e), s.getEdgeTarget(e)));
+        final XoRoShiRo128PlusPlusRandomGenerator random =
+            new XoRoShiRo128PlusPlusRandomGenerator();
+        final int n = (int) s.iterables().vertexCount();
+        for (int i = 0; i < 10000; i++) {
+            final int x = random.nextInt(n);
+            final int y = random.nextInt(n);
+            assertEquals(s.containsEdge(x, y), t.containsEdge(x, y));
+        }
+    }
+
+    @Test
+    public void testRandomSparse()
+    {
+        final GnpRandomGraphGenerator<Integer, DefaultEdge> r =
+            new GnpRandomGraphGenerator<>(1000, .001, 0, false);
+        final DefaultUndirectedGraph<Integer, DefaultEdge> s =
+            new DefaultUndirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        r.generateGraph(s);
+        final SuccinctIntUndirectedGraph t = new SuccinctIntUndirectedGraph(s);
+        for (final Integer e : t.edgeSet())
+            assertTrue(e.toString(), s.containsEdge(t.getEdgeSource(e), t.getEdgeTarget(e)));
+        for (final DefaultEdge e : s.edgeSet())
+            assertTrue(e.toString(), t.containsEdge(s.getEdgeSource(e), s.getEdgeTarget(e)));
+        final XoRoShiRo128PlusPlusRandomGenerator random =
+            new XoRoShiRo128PlusPlusRandomGenerator();
+        final int n = (int) s.iterables().vertexCount();
+        for (int i = 0; i < 10000; i++) {
+            final int x = random.nextInt(n);
+            final int y = random.nextInt(n);
+            assertEquals(s.containsEdge(x, y), t.containsEdge(x, y));
+        }
+    }
+}

--- a/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraphTest.java
+++ b/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraphTest.java
@@ -63,6 +63,9 @@ public class SuccinctIntUndirectedGraphTest
         d.addEdge(4, 1);
 
         final SuccinctIntUndirectedGraph s = new SuccinctIntUndirectedGraph(d);
+        assertEquals(5, d.iterables().vertexCount());
+        assertEquals(7, d.iterables().edgeCount());
+
         assertEquals(2, s.outDegreeOf(0));
         assertEquals(3, s.outDegreeOf(1));
         assertEquals(2, s.outDegreeOf(2));

--- a/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctUndirectedGraphTest.java
+++ b/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctUndirectedGraphTest.java
@@ -1,0 +1,276 @@
+/*
+ * (C) Copyright 2020-2021, by Sebastiano Vigna and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.sux4j;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.jgrapht.generate.GnpRandomGraphGenerator;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultUndirectedGraph;
+import org.jgrapht.util.SupplierUtil;
+import org.junit.Test;
+
+import it.unimi.dsi.fastutil.ints.IntIntSortedPair;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import it.unimi.dsi.util.XoRoShiRo128PlusPlusRandomGenerator;
+
+public class SuccinctUndirectedGraphTest
+{
+
+    @Test
+    public void testUndirected()
+    {
+        final DefaultUndirectedGraph<Integer, DefaultEdge> d =
+            new DefaultUndirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        for (int i = 0; i < 5; i++)
+            d.addVertex(i);
+        d.addEdge(0, 1);
+        d.addEdge(1, 2);
+        d.addEdge(2, 3);
+        d.addEdge(3, 0);
+        d.addEdge(3, 3);
+        d.addEdge(3, 4);
+        d.addEdge(4, 1);
+
+        final SuccinctUndirectedGraph s = new SuccinctUndirectedGraph(d);
+        assertEquals(2, s.outDegreeOf(0));
+        assertEquals(3, s.outDegreeOf(1));
+        assertEquals(2, s.outDegreeOf(2));
+        assertEquals(5, s.outDegreeOf(3));
+        assertEquals(2, s.outDegreeOf(4));
+
+        assertEquals(IntIntSortedPair.of(0, 1), s.getEdge(0, 1));
+        assertEquals(IntIntSortedPair.of(3, 0), s.getEdge(3, 0));
+        assertEquals(IntIntSortedPair.of(1, 2), s.getEdge(1, 2));
+        assertEquals(IntIntSortedPair.of(4, 1), s.getEdge(4, 1));
+        assertEquals(IntIntSortedPair.of(2, 3), s.getEdge(2, 3));
+        assertEquals(IntIntSortedPair.of(3, 3), s.getEdge(3, 3));
+        assertEquals(IntIntSortedPair.of(3, 4), s.getEdge(3, 4));
+
+        assertNull(s.getEdge(0, 0));
+        assertNull(s.getEdge(0, 4));
+        assertNull(s.getEdge(1, 1));
+        assertNull(s.getEdge(1, 3));
+        assertNull(s.getEdge(2, 0));
+        assertNull(s.getEdge(2, 2));
+        assertNull(s.getEdge(2, 4));
+        assertNull(s.getEdge(3, 1));
+        assertNull(s.getEdge(4, 0));
+        assertNull(s.getEdge(4, 4));
+        assertNull(s.getEdge(4, 2));
+
+        assertTrue(s.containsEdge(0, 1));
+        assertTrue(s.containsEdge(1, 0));
+        assertTrue(s.containsEdge(1, 2));
+        assertTrue(s.containsEdge(2, 1));
+        assertTrue(s.containsEdge(2, 3));
+        assertTrue(s.containsEdge(3, 2));
+        assertTrue(s.containsEdge(3, 0));
+        assertTrue(s.containsEdge(0, 3));
+        assertTrue(s.containsEdge(3, 3));
+        assertTrue(s.containsEdge(3, 4));
+        assertTrue(s.containsEdge(4, 3));
+        assertTrue(s.containsEdge(4, 1));
+        assertTrue(s.containsEdge(1, 4));
+
+        assertFalse(s.containsEdge(0, 0));
+        assertFalse(s.containsEdge(0, 4));
+        assertFalse(s.containsEdge(1, 1));
+        assertFalse(s.containsEdge(1, 3));
+        assertFalse(s.containsEdge(2, 0));
+        assertFalse(s.containsEdge(2, 2));
+        assertFalse(s.containsEdge(2, 4));
+        assertFalse(s.containsEdge(3, 1));
+        assertFalse(s.containsEdge(4, 0));
+        assertFalse(s.containsEdge(4, 4));
+        assertFalse(s.containsEdge(4, 2));
+
+        assertEquals(Set.of(IntIntSortedPair.of(0, 1), IntIntSortedPair.of(0, 3)), s.edgesOf(0));
+        assertEquals(
+            Set.of(IntIntSortedPair.of(0, 1), IntIntSortedPair.of(1, 2), IntIntSortedPair.of(1, 4)),
+            s.edgesOf(1));
+        assertEquals(Set.of(IntIntSortedPair.of(2, 1), IntIntSortedPair.of(2, 3)), s.edgesOf(2));
+        assertEquals(
+            Set
+                .of(
+                    IntIntSortedPair.of(0, 3), IntIntSortedPair.of(3, 3), IntIntSortedPair.of(3, 4),
+                    IntIntSortedPair.of(3, 2)),
+            s.edgesOf(3));
+        assertEquals(Set.of(IntIntSortedPair.of(4, 1), IntIntSortedPair.of(4, 3)), s.edgesOf(4));
+
+        assertEquals(
+            Set.of(IntIntSortedPair.of(0, 1), IntIntSortedPair.of(0, 3)), s.outgoingEdgesOf(0));
+        assertEquals(
+            Set.of(IntIntSortedPair.of(0, 1), IntIntSortedPair.of(1, 2), IntIntSortedPair.of(1, 4)),
+            s.outgoingEdgesOf(1));
+        assertEquals(
+            Set.of(IntIntSortedPair.of(2, 1), IntIntSortedPair.of(2, 3)), s.outgoingEdgesOf(2));
+        assertEquals(
+            Set
+                .of(
+                    IntIntSortedPair.of(0, 3), IntIntSortedPair.of(3, 3), IntIntSortedPair.of(3, 4),
+                    IntIntSortedPair.of(3, 2)),
+            s.outgoingEdgesOf(3));
+        assertEquals(
+            Set.of(IntIntSortedPair.of(4, 1), IntIntSortedPair.of(4, 3)), s.outgoingEdgesOf(4));
+
+        assertEquals(
+            Set.of(IntIntSortedPair.of(0, 1), IntIntSortedPair.of(0, 3)), s.incomingEdgesOf(0));
+        assertEquals(
+            Set.of(IntIntSortedPair.of(0, 1), IntIntSortedPair.of(1, 2), IntIntSortedPair.of(1, 4)),
+            s.incomingEdgesOf(1));
+        assertEquals(
+            Set.of(IntIntSortedPair.of(2, 1), IntIntSortedPair.of(2, 3)), s.incomingEdgesOf(2));
+        assertEquals(
+            Set
+                .of(
+                    IntIntSortedPair.of(0, 3), IntIntSortedPair.of(3, 3), IntIntSortedPair.of(3, 4),
+                    IntIntSortedPair.of(3, 2)),
+            s.incomingEdgesOf(3));
+        assertEquals(
+            Set.of(IntIntSortedPair.of(4, 1), IntIntSortedPair.of(4, 3)), s.incomingEdgesOf(4));
+
+        assertEquals(
+            Set.of(IntIntSortedPair.of(0, 1), IntIntSortedPair.of(0, 3)),
+            new ObjectOpenHashSet<>(s.iterables().incomingEdgesOf(0).iterator()));
+        assertEquals(
+            Set.of(IntIntSortedPair.of(0, 1), IntIntSortedPair.of(1, 2), IntIntSortedPair.of(1, 4)),
+            new ObjectOpenHashSet<>(s.iterables().incomingEdgesOf(1).iterator()));
+        assertEquals(
+            Set.of(IntIntSortedPair.of(2, 1), IntIntSortedPair.of(2, 3)),
+            new ObjectOpenHashSet<>(s.iterables().incomingEdgesOf(2).iterator()));
+        assertEquals(
+            Set
+                .of(
+                    IntIntSortedPair.of(0, 3), IntIntSortedPair.of(3, 3), IntIntSortedPair.of(3, 4),
+                    IntIntSortedPair.of(3, 2)),
+            new ObjectOpenHashSet<>(s.iterables().incomingEdgesOf(3).iterator()));
+        assertEquals(
+            Set.of(IntIntSortedPair.of(4, 1), IntIntSortedPair.of(4, 3)),
+            new ObjectOpenHashSet<>(s.iterables().incomingEdgesOf(4).iterator()));
+
+        final Iterator<IntIntSortedPair> iterator = s.iterables().edgesOf(0).iterator();
+        while (iterator.hasNext())
+            iterator.next();
+        assertFalse(iterator.hasNext());
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    public void testSink()
+    {
+        final DefaultUndirectedGraph<Integer, DefaultEdge> d =
+            new DefaultUndirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        for (int i = 0; i < 3; i++)
+            d.addVertex(i);
+        d.addEdge(0, 0);
+        d.addEdge(2, 0);
+        final SuccinctUndirectedGraph s = new SuccinctUndirectedGraph(d);
+        assertEquals(IntIntSortedPair.of(0, 0), s.getEdge(0, 0));
+        assertEquals(IntIntSortedPair.of(2, 0), s.getEdge(2, 0));
+    }
+
+    @Test
+    public void testRandomDense()
+    {
+        final GnpRandomGraphGenerator<Integer, DefaultEdge> r =
+            new GnpRandomGraphGenerator<>(1000, .1, 0, false);
+        final DefaultUndirectedGraph<Integer, DefaultEdge> s =
+            new DefaultUndirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        r.generateGraph(s);
+        final SuccinctUndirectedGraph t = new SuccinctUndirectedGraph(s);
+        for (final IntIntSortedPair e : t.edgeSet())
+            assertTrue(e.toString(), s.containsEdge(t.getEdgeSource(e), t.getEdgeTarget(e)));
+        for (final DefaultEdge e : s.edgeSet())
+            assertTrue(e.toString(), t.containsEdge(s.getEdgeSource(e), s.getEdgeTarget(e)));
+        final XoRoShiRo128PlusPlusRandomGenerator random =
+            new XoRoShiRo128PlusPlusRandomGenerator();
+        final int n = (int) s.iterables().vertexCount();
+        for (int i = 0; i < 10000; i++) {
+            final int x = random.nextInt(n);
+            final int y = random.nextInt(n);
+            assertEquals(s.containsEdge(x, y), t.containsEdge(x, y));
+        }
+    }
+
+    @Test
+    public void testRandomSparse()
+    {
+        final GnpRandomGraphGenerator<Integer, DefaultEdge> r =
+            new GnpRandomGraphGenerator<>(1000, .001, 0, false);
+        final DefaultUndirectedGraph<Integer, DefaultEdge> s =
+            new DefaultUndirectedGraph<>(new Supplier<Integer>()
+            {
+                private int id = 0;
+
+                @Override
+                public Integer get()
+                {
+                    return id++;
+                }
+            }, SupplierUtil.createDefaultEdgeSupplier(), false);
+        r.generateGraph(s);
+        final SuccinctUndirectedGraph t = new SuccinctUndirectedGraph(s);
+        for (final IntIntSortedPair e : t.edgeSet())
+            assertTrue(e.toString(), s.containsEdge(t.getEdgeSource(e), t.getEdgeTarget(e)));
+        for (final DefaultEdge e : s.edgeSet())
+            assertTrue(e.toString(), t.containsEdge(s.getEdgeSource(e), s.getEdgeTarget(e)));
+        final XoRoShiRo128PlusPlusRandomGenerator random =
+            new XoRoShiRo128PlusPlusRandomGenerator();
+        final int n = (int) s.iterables().vertexCount();
+        for (int i = 0; i < 10000; i++) {
+            final int x = random.nextInt(n);
+            final int y = random.nextInt(n);
+            assertEquals(s.containsEdge(x, y), t.containsEdge(x, y));
+        }
+    }
+}

--- a/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctUndirectedGraphTest.java
+++ b/jgrapht-unimi-dsi/src/test/java/org/jgrapht/sux4j/SuccinctUndirectedGraphTest.java
@@ -64,6 +64,9 @@ public class SuccinctUndirectedGraphTest
         d.addEdge(4, 1);
 
         final SuccinctUndirectedGraph s = new SuccinctUndirectedGraph(d);
+        assertEquals(5, d.iterables().vertexCount());
+        assertEquals(7, d.iterables().edgeCount());
+
         assertEquals(2, s.outDegreeOf(0));
         assertEquals(3, s.outDegreeOf(1));
         assertEquals(2, s.outDegreeOf(2));


### PR DESCRIPTION
This PR adds to jgrapht-unimi-dsi two graph representations based on succinct data structures.

The WebGraph adapters already provide ways to use succinct representation (e.g., EFGraph), but the implementations in this PR are modeled after the sparse representations of JGraphT—nodes and arcs are represented by integers and numbered starting from zero (they should be usable from Python).

Unfortunately, JGraphT's architecture clashes a bit with the succinct representation. For example, getEdgeSource() and getEdgeTarget() have to make twice the same expensive call. The result is that while the graphs are about 5 times smaller, access is 5 times slower, too.

UPDATE: My claims about speed are quite wrong.

The problem is that I (stupidly) quickly tested enumeration time for the whole arc set, which is not a good idea because in these graphs the arc set is trivial.

More accurate testing shows that that the directed version is 50% slower than SparseIntDirectedGraph when enumerating successors, and it is 2-3 times faster when checking adjacency (but see #1042 — the speed test in this case might be meaningless). This figures will vary with the density of the graph.

The undirected implementation is unfortunately significantly slower (5 times slower when enumerating successors). Adjacency, however, is about 150 times faster. Is there some reason why adjacency in SparseIntUndirectedGraph is so slow?