### PR TITLE
Renaming abstract classes to make completion easier

### DIFF
--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/AbstractImmutableBigGraphAdapter.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/AbstractImmutableBigGraphAdapter.java
@@ -39,7 +39,7 @@ import it.unimi.dsi.fastutil.longs.LongSets;
  * @author Sebastiano Vigna
  */
 
-public abstract class ImmutableBigGraphAdapter<E extends LongLongPair>
+public abstract class AbstractImmutableBigGraphAdapter<E extends LongLongPair>
     extends
     AbstractGraph<Long, E>
 {
@@ -55,7 +55,7 @@ public abstract class ImmutableBigGraphAdapter<E extends LongLongPair>
      */
     protected long m = -1;
 
-    protected ImmutableBigGraphAdapter(final ImmutableGraph immutableGraph)
+    protected AbstractImmutableBigGraphAdapter(final ImmutableGraph immutableGraph)
     {
         this.immutableGraph = immutableGraph;
         this.n = immutableGraph.numNodes();

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/AbstractImmutableGraphAdapter.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/AbstractImmutableGraphAdapter.java
@@ -39,7 +39,7 @@ import it.unimi.dsi.webgraph.LazyIntSkippableIterator;
  * @author Sebastiano Vigna
  */
 
-public abstract class ImmutableGraphAdapter<E extends IntIntPair>
+public abstract class AbstractImmutableGraphAdapter<E extends IntIntPair>
     extends
     AbstractGraph<Integer, E>
 {
@@ -55,7 +55,7 @@ public abstract class ImmutableGraphAdapter<E extends IntIntPair>
      */
     protected long m = -1;
 
-    protected ImmutableGraphAdapter(final ImmutableGraph immutableGraph)
+    protected AbstractImmutableGraphAdapter(final ImmutableGraph immutableGraph)
     {
         this.immutableGraph = immutableGraph;
         this.n = immutableGraph.numNodes();

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableDirectedBigGraphAdapter.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableDirectedBigGraphAdapter.java
@@ -58,7 +58,7 @@ import it.unimi.dsi.lang.FlyweightPrototype;
 
 public class ImmutableDirectedBigGraphAdapter
     extends
-    ImmutableBigGraphAdapter<LongLongPair>
+    AbstractImmutableBigGraphAdapter<LongLongPair>
     implements
     FlyweightPrototype<ImmutableDirectedBigGraphAdapter>
 {

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableDirectedGraphAdapter.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableDirectedGraphAdapter.java
@@ -111,13 +111,13 @@ import it.unimi.dsi.webgraph.Transform;
  * skippable iterators} with fast skipping, adjacency can be tested more quickly (e.g., essentially
  * in constant time in the case of {@link EFGraph}).
  *
- * @see ImmutableBigGraphAdapter
+ * @see AbstractImmutableBigGraphAdapter
  * @author Sebastiano Vigna
  */
 
 public class ImmutableDirectedGraphAdapter
     extends
-    ImmutableGraphAdapter<IntIntPair>
+    AbstractImmutableGraphAdapter<IntIntPair>
     implements
     FlyweightPrototype<ImmutableDirectedGraphAdapter>
 {

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableUndirectedBigGraphAdapter.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableUndirectedBigGraphAdapter.java
@@ -56,7 +56,7 @@ import it.unimi.dsi.lang.FlyweightPrototype;
 
 public class ImmutableUndirectedBigGraphAdapter
     extends
-    ImmutableBigGraphAdapter<LongLongSortedPair>
+    AbstractImmutableBigGraphAdapter<LongLongSortedPair>
     implements
     FlyweightPrototype<ImmutableUndirectedBigGraphAdapter>
 {

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableUndirectedGraphAdapter.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableUndirectedGraphAdapter.java
@@ -92,13 +92,13 @@ import it.unimi.dsi.webgraph.NodeIterator;
  * skippable iterators} with fast skipping, adjacency can be tested more quickly (e.g., essentially
  * in constant time in the case of {@link EFGraph}).
  *
- * @see ImmutableBigGraphAdapter
+ * @see AbstractImmutableBigGraphAdapter
  * @author Sebastiano Vigna
  */
 
 public class ImmutableUndirectedGraphAdapter
     extends
-    ImmutableGraphAdapter<IntIntSortedPair>
+    AbstractImmutableGraphAdapter<IntIntSortedPair>
     implements
     FlyweightPrototype<ImmutableUndirectedGraphAdapter>
 {


### PR DESCRIPTION
This PR renames the abstract classes in org.jgrapht.webgraph so that their name starts with "Abstract". I don't know what went through my mind when I wrote this, but completion is a real pain because besides the 4 implementations you get completion for the 3 abstract classes, which have completely confusing names.