### PR TITLE
Make exceptions public top-level classes

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphWalk.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2016-2020, by Joris Kinable and Contributors.
+ * (C) Copyright 2016-2021, by Joris Kinable and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *
@@ -524,22 +524,6 @@ public class GraphWalk<V, E>
     {
         return new GraphWalk<>(
             graph, v, v, Collections.singletonList(v), Collections.emptyList(), weight);
-    }
-
-}
-
-/**
- * Exception thrown in the event that the path is invalid.
- */
-class InvalidGraphWalkException
-    extends
-    RuntimeException
-{
-    private static final long serialVersionUID = 3811666107707436479L;
-
-    public InvalidGraphWalkException(String message)
-    {
-        super(message);
     }
 
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/InvalidGraphWalkException.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/InvalidGraphWalkException.java
@@ -1,0 +1,34 @@
+/*
+ * (C) Copyright 2017-2021, by Joris Kinable and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.graph;
+
+/**
+ * Exception thrown in the event that the path is invalid.
+ */
+public class InvalidGraphWalkException
+    extends
+    RuntimeException
+{
+    private static final long serialVersionUID = 3811666107707436479L;
+
+    public InvalidGraphWalkException(String message)
+    {
+        super(message);
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/util/SupplierException.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/SupplierException.java
@@ -1,0 +1,37 @@
+/*
+ * (C) Copyright 2021-2021, by Hannes Wellmann and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.util;
+
+import java.util.function.*;
+
+/**
+ * Exception thrown to indicate that a {@link Supplier} is in an invalid state.
+ * 
+ * @author Hannes Wellmann
+ */
+public class SupplierException
+    extends
+    IllegalArgumentException
+{
+    private static final long serialVersionUID = -8192314371524515620L;
+
+    public SupplierException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/util/SupplierUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/SupplierUtil.java
@@ -252,16 +252,4 @@ public class SupplierUtil
             return new SerializedForm<>(constructor.getDeclaringClass());
         }
     }
-
-    static class SupplierException
-        extends
-        IllegalArgumentException
-    {
-        private static final long serialVersionUID = -8192314371524515620L;
-
-        public SupplierException(String message, Throwable cause)
-        {
-            super(message, cause);
-        }
-    }
 }


### PR DESCRIPTION
As discussed in the process of PR #1034 all Exceptions thrown by JGraphT's code and propagated outside should be public and a top-level classes in order to enable catching these exception and therefore simplify debugging and testing.

This PR adjusts all (i.e. two) Exceptions defined in JGraphT that violate this convention.

I've search the library for other Exceptions defined by JGraphT (using Eclipse's _Open Type_ dialog and the pattern `org.jgrapht.*Exception*`) and the only non public or nested Exceptions defined in JGraphT that remain are `org.jgrapht.alg.cycle.CycleDetector.CycleDetectedException` and `org.jgrapht.graph.DirectedAcyclicGraph.CycleFoundException`. But those are fully private and always catched internally, so they are not propagated outside and users should never see them.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
