### PR TITLE
Fixed NullPointerException when no path exists in DijkstraManyToManyShortestPaths

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPaths.java
@@ -139,6 +139,9 @@ public class DijkstraManyToManyShortestPaths<V, E>
             assertCorrectSourceAndTarget(source, target);
             if (reversed) {
                 GraphPath<V, E> reversedPath = searchSpaces.get(target).getPath(source);
+                if (reversedPath == null) { 
+                    return null;
+                }
                 List<V> vertices = reversedPath.getVertexList();
                 List<E> edges = reversedPath.getEdgeList();
                 Collections.reverse(vertices);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseManyToManyShortestPathsTest.java
@@ -483,5 +483,23 @@ public abstract class BaseManyToManyShortestPathsTest
 
         return graph;
     }
+    
+    protected void testNoPathMultiSet()
+    {
+        Graph<Integer, DefaultWeightedEdge> graph =
+            new DirectedWeightedMultigraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        graph.addVertex(2);
+        graph.addVertex(3);
+
+        ManyToManyShortestPathsAlgorithm.ManyToManyShortestPaths<Integer,
+            DefaultWeightedEdge> shortestPaths =
+                getAlgorithm(graph).getManyToManyPaths(Set.of(1), Set.of(2, 3));
+
+        assertEquals(Double.POSITIVE_INFINITY, shortestPaths.getWeight(1, 2), 1e-9);
+        assertEquals(Double.POSITIVE_INFINITY, shortestPaths.getWeight(1, 3), 1e-9);
+        assertNull(shortestPaths.getPath(1, 2));
+        assertNull(shortestPaths.getPath(1, 3));
+    }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPathsTest.java
@@ -55,6 +55,12 @@ public class DijkstraManyToManyShortestPathsTest
     {
         super.testNoPath();
     }
+    
+    @Test
+    public void testNoPathMultiset()
+    {
+        super.testNoPathMultiSet();
+    }
 
     @Test
     public void testDifferentSourcesAndTargetsSimpleGraph()


### PR DESCRIPTION
Fixes #1053 

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
