### PR TITLE
Fix (Eclipse) warnings in tests

### DIFF
--- a/jgrapht-core/src/test/java/org/jgrapht/GraphTestsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/GraphTestsTest.java
@@ -24,8 +24,11 @@ import org.junit.*;
 import java.util.*;
 
 import static junit.framework.TestCase.fail;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Test class GraphTests.

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/ChinesePostmanTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/ChinesePostmanTest.java
@@ -300,7 +300,7 @@ public class ChinesePostmanTest
         g.addVertex(1);
         g.addEdge(0, 1);
         g.addEdge(1, 0);
-        GraphPath<Integer, DefaultEdge> path = alg.getCPPSolution(g);
+        alg.getCPPSolution(g);
     }
 
     private <V,

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/HowardMinimumMeanCycleTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/HowardMinimumMeanCycleTest.java
@@ -21,7 +21,6 @@ import org.jgrapht.Graph;
 import org.jgrapht.GraphPath;
 import org.jgrapht.TestUtil;
 import org.jgrapht.graph.DefaultEdge;
-import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.DirectedWeightedPseudograph;
 import org.jgrapht.graph.GraphWalk;
 import org.junit.Test;

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/decomposition/HeavyPathDecompositionTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/decomposition/HeavyPathDecompositionTest.java
@@ -29,7 +29,7 @@ import org.junit.experimental.categories.*;
 import java.util.*;
 import java.util.stream.*;
 
-import static org.jgrapht.util.MathUtil.log2;
+import static org.jgrapht.util.MathUtil.*;
 
 /**
  * Tests for {@link HeavyPathDecomposition}
@@ -188,8 +188,7 @@ public class HeavyPathDecompositionTest
     @Test(expected = NullPointerException.class)
     public void testNullGraph()
     {
-        HeavyPathDecomposition<Integer, DefaultEdge> heavyPathDecomposition =
-            new HeavyPathDecomposition<>(null, 1);
+        new HeavyPathDecomposition<>(null, 1);
     }
 
     @Test(expected = NullPointerException.class)
@@ -198,8 +197,7 @@ public class HeavyPathDecompositionTest
         Graph<String, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
         String s = null;
 
-        HeavyPathDecomposition<String, DefaultEdge> heavyPathDecomposition =
-            new HeavyPathDecomposition<>(graph, s);
+        new HeavyPathDecomposition<>(graph, s);
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -208,8 +206,7 @@ public class HeavyPathDecompositionTest
         Graph<String, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
         graph.addVertex("a");
 
-        HeavyPathDecomposition<String, DefaultEdge> heavyPathDecomposition =
-            new HeavyPathDecomposition<>(graph, "b");
+        new HeavyPathDecomposition<>(graph, "b");
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/independentset/ChordalGraphIndependentSetFinderTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/independentset/ChordalGraphIndependentSetFinderTest.java
@@ -41,7 +41,7 @@ public class ChordalGraphIndependentSetFinderTest
     public void testGetMaximumIndependentSet1()
     {
         Graph<Integer, DefaultEdge> graph = new DefaultUndirectedGraph<>(DefaultEdge.class);
-        ChordalityInspector<Integer, DefaultEdge> inspector = new ChordalityInspector<>(graph);
+        new ChordalityInspector<>(graph);
         Set<Integer> set = new ChordalGraphIndependentSetFinder<>(graph).getIndependentSet();
         assertNotNull(set);
         assertEquals(0, set.size());
@@ -84,7 +84,7 @@ public class ChordalGraphIndependentSetFinderTest
             { 3, 4 }, { 3, 4 }, { 4, 4 }, { 4, 4 }, { 4, 5 }, { 4, 5 }, };
         Graph<Integer, DefaultEdge> graph = TestUtil.createPseudograph(edges);
 
-        ChordalityInspector<Integer, DefaultEdge> inspector = new ChordalityInspector<>(graph);
+        new ChordalityInspector<>(graph);
         Set<Integer> set = new ChordalGraphIndependentSetFinder<>(graph).getIndependentSet();
         assertNotNull(set);
         assertEquals(2, set.size());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHURootedTreeIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHURootedTreeIsomorphismInspectorTest.java
@@ -55,8 +55,7 @@ public class AHURootedTreeIsomorphismInspectorTest
     @Test(expected = NullPointerException.class)
     public void testNullGraphs()
     {
-        AHURootedTreeIsomorphismInspector<String, DefaultEdge> isomorphism =
-            new AHURootedTreeIsomorphismInspector<>(null, null, null, null);
+        new AHURootedTreeIsomorphismInspector<>(null, null, null, null);
     }
 
     @Test(expected = NullPointerException.class)
@@ -64,8 +63,7 @@ public class AHURootedTreeIsomorphismInspectorTest
     {
         Graph<String, DefaultEdge> tree1 = new SimpleGraph<>(DefaultEdge.class);
 
-        AHURootedTreeIsomorphismInspector<String, DefaultEdge> isomorphism =
-            new AHURootedTreeIsomorphismInspector<>(tree1, null, null, null);
+        new AHURootedTreeIsomorphismInspector<>(tree1, null, null, null);
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/lca/NaiveLCAFinderTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/lca/NaiveLCAFinderTest.java
@@ -19,8 +19,6 @@ package org.jgrapht.alg.lca;
 
 import org.jgrapht.*;
 import org.jgrapht.graph.*;
-import org.jgrapht.graph.builder.GraphTypeBuilder;
-import org.jgrapht.util.SupplierUtil;
 import org.junit.*;
 
 import java.util.*;

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVDualUpdaterTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVDualUpdaterTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.*;
  *
  * @author Timofey Chudakov
  */
+@SuppressWarnings("unused")
 public class BlossomVDualUpdaterTest
 {
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVInitializerTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVInitializerTest.java
@@ -44,6 +44,7 @@ public class BlossomVInitializerTest
      * Tests greedy initialization
      */
     @Test
+    @SuppressWarnings("unused")
     public void testGreedyInitialization()
     {
         DefaultUndirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
@@ -88,6 +89,7 @@ public class BlossomVInitializerTest
      * Tests simple initialization
      */
     @Test
+    @SuppressWarnings("unused")
     public void testSimpleInitialization()
     {
         Graph<Integer, DefaultWeightedEdge> graph =

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVNodeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVNodeTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.*;
  *
  * @author Timofey Chudakov
  */
+@SuppressWarnings("unused")
 public class BlossomVNodeTest
 {
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVPrimalUpdaterTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVPrimalUpdaterTest.java
@@ -32,6 +32,7 @@ import static org.junit.Assert.*;
  *
  * @author Timofey Chudakov
  */
+@SuppressWarnings("unused")
 public class BlossomVPrimalUpdaterTest
 {
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/blossom/v5/BlossomVTreeTest.java
@@ -38,6 +38,7 @@ public class BlossomVTreeTest
     private BlossomVOptions noneOptions = new BlossomVOptions(NONE);
 
     @Test
+    @SuppressWarnings("unused")
     public void testTreeNodeIterator()
     {
         Graph<Integer, DefaultWeightedEdge> graph =

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/ClusteringCoefficientTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/ClusteringCoefficientTest.java
@@ -23,7 +23,7 @@ import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
 import org.junit.*;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * Tests for {@link ClusteringCoefficient}
@@ -120,8 +120,7 @@ public class ClusteringCoefficientTest
     @Test(expected = NullPointerException.class)
     public void testNullGraphClusteringCoefficient()
     {
-        ClusteringCoefficient<String, DefaultEdge> clusteringCoefficient =
-            new ClusteringCoefficient<>(null);
+        new ClusteringCoefficient<>(null);
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstraTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/ContractionHierarchyBidirectionalDijkstraTest.java
@@ -19,17 +19,16 @@ package org.jgrapht.alg.shortestpath;
 
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
+import org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.*;
 import org.jgrapht.generate.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
 import org.junit.*;
 
 import java.util.*;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.*;
 
-import static org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.ContractionHierarchy;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 /**
  * Tests for the {@link ContractionHierarchyBidirectionalDijkstra}.
@@ -70,8 +69,7 @@ public class ContractionHierarchyBidirectionalDijkstraTest
     {
         Graph<Integer, DefaultWeightedEdge> graph =
             new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
-        ContractionHierarchyBidirectionalDijkstra<Integer, DefaultWeightedEdge> dijkstra =
-            new ContractionHierarchyBidirectionalDijkstra<>(graph, executor);
+        new ContractionHierarchyBidirectionalDijkstra<>(graph, executor);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DeltaSteppingShortestPathTest.java
@@ -19,18 +19,16 @@ package org.jgrapht.alg.shortestpath;
 
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
-import org.jgrapht.alg.util.Triple;
+import org.jgrapht.alg.util.*;
 import org.jgrapht.generate.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.util.*;
 import org.junit.*;
-import org.junit.rules.*;
 
 import java.util.*;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 /**
  * Test case for {@link DeltaSteppingShortestPath}.
@@ -69,9 +67,6 @@ public class DeltaSteppingShortestPathTest
     private static final String X = "X";
     private static final String Z = "Z";
 
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
-
     @Test
     public void testEmptyGraph()
     {
@@ -90,8 +85,9 @@ public class DeltaSteppingShortestPathTest
         Graphs.addAllVertices(graph, Arrays.asList(S, T));
         Graphs.addEdge(graph, S, T, -10.0);
 
-        exception.expect(IllegalArgumentException.class);
-        new DeltaSteppingShortestPath<>(graph, executor).getPaths(S);
+        DeltaSteppingShortestPath<String, DefaultWeightedEdge> shortestPath =
+            new DeltaSteppingShortestPath<>(graph, executor);
+        assertThrows(IllegalArgumentException.class, () -> shortestPath.getPaths(S));
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/TransitNodeRoutingShortestPathTest.java
@@ -17,31 +17,19 @@
  */
 package org.jgrapht.alg.shortestpath;
 
-import org.jgrapht.Graph;
-import org.jgrapht.GraphPath;
-import org.jgrapht.Graphs;
-import org.jgrapht.alg.interfaces.ShortestPathAlgorithm;
-import org.jgrapht.generate.GnmRandomGraphGenerator;
-import org.jgrapht.generate.GraphGenerator;
-import org.jgrapht.graph.DefaultWeightedEdge;
-import org.jgrapht.graph.DirectedWeightedPseudograph;
-import org.jgrapht.graph.GraphWalk;
-import org.jgrapht.util.ConcurrencyUtil;
-import org.jgrapht.util.SupplierUtil;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.jgrapht.*;
+import org.jgrapht.alg.interfaces.*;
+import org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.*;
+import org.jgrapht.alg.shortestpath.TransitNodeRoutingPrecomputation.*;
+import org.jgrapht.generate.*;
+import org.jgrapht.graph.*;
+import org.jgrapht.util.*;
+import org.junit.*;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Random;
-import java.util.Set;
-import java.util.concurrent.ThreadPoolExecutor;
+import java.util.*;
+import java.util.concurrent.*;
 
-import static org.jgrapht.alg.shortestpath.ContractionHierarchyPrecomputation.ContractionHierarchy;
-import static org.jgrapht.alg.shortestpath.TransitNodeRoutingPrecomputation.TransitNodeRouting;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 /**
  * Test for the {@link TransitNodeRoutingShortestPath}.
@@ -94,6 +82,7 @@ public class TransitNodeRoutingShortestPathTest
     }
 
     @Test
+    @SuppressWarnings("unused")
     public void testTwoVertices()
     {
         Integer v1 = 1;

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest.java
@@ -186,8 +186,7 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
     public void testInstance3()
     {
         Graph<Integer, DefaultWeightedEdge> graph =
-            new DefaultUndirectedWeightedGraph<Integer, DefaultWeightedEdge>(
-                DefaultWeightedEdge.class);
+            new DefaultUndirectedWeightedGraph<>(DefaultWeightedEdge.class);
 
         for (int i = 0; i < 6; ++i) {
             graph.addVertex(i);
@@ -269,8 +268,7 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
     public void testInstance4()
     {
         Graph<Integer, DefaultWeightedEdge> graph =
-            new DefaultUndirectedWeightedGraph<Integer, DefaultWeightedEdge>(
-                DefaultWeightedEdge.class);
+            new DefaultUndirectedWeightedGraph<>(DefaultWeightedEdge.class);
 
         for (int i = 0; i < 8; ++i) {
             graph.addVertex(i);
@@ -363,8 +361,7 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
     public void testInstance5()
     {
         Graph<Integer, DefaultWeightedEdge> graph =
-            new DefaultUndirectedWeightedGraph<Integer, DefaultWeightedEdge>(
-                DefaultWeightedEdge.class);
+            new DefaultUndirectedWeightedGraph<>(DefaultWeightedEdge.class);
 
         for (int i = 0; i < 9; ++i) {
             graph.addVertex(i);
@@ -464,8 +461,7 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
     public void testInstance6()
     {
         Graph<Integer, DefaultWeightedEdge> graph =
-            new DefaultUndirectedWeightedGraph<Integer, DefaultWeightedEdge>(
-                DefaultWeightedEdge.class);
+            new DefaultUndirectedWeightedGraph<>(DefaultWeightedEdge.class);
 
         for (int i = 0; i < 6; ++i) {
             graph.addVertex(i);
@@ -782,11 +778,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         boolean testOK = false;
 
         try {
-            CapacitatedSpanningTreeAlgorithm<Integer,
-                DefaultWeightedEdge> capacitatedSpanningTreeAlgorithm =
-                    new AhujaOrlinSharmaCapacitatedMinimumSpanningTree<>(
-                        graph.getFirst(), 0, capacity, graph.getSecond(), 7, true, 1, true, false,
-                        true, 10, 15);
+            new AhujaOrlinSharmaCapacitatedMinimumSpanningTree<>(
+                graph.getFirst(), 0, capacity, graph.getSecond(), 7, true, 1, true, false, true, 10,
+                15);
         } catch (IllegalArgumentException e) {
             testOK = true;
         }
@@ -808,11 +802,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTreeTest
         boolean testOK = false;
 
         try {
-            CapacitatedSpanningTreeAlgorithm<Integer,
-                DefaultWeightedEdge> capacitatedSpanningTreeAlgorithm =
-                    new AhujaOrlinSharmaCapacitatedMinimumSpanningTree<>(
-                        graph.getFirst(), 0, capacity, graph.getSecond(), 7, true, 1, true, false,
-                        true, 10, 15);
+            new AhujaOrlinSharmaCapacitatedMinimumSpanningTree<>(
+                graph.getFirst(), 0, capacity, graph.getSecond(), 7, true, 1, true, false, true, 10,
+                15);
         } catch (IllegalArgumentException e) {
             testOK = true;
         }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/EsauWilliamsCapacitatedMinimumSpanningTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/EsauWilliamsCapacitatedMinimumSpanningTreeTest.java
@@ -37,8 +37,7 @@ public class EsauWilliamsCapacitatedMinimumSpanningTreeTest
     public void testInstance1()
     {
         Graph<Integer, DefaultWeightedEdge> graph =
-            new DefaultUndirectedWeightedGraph<Integer, DefaultWeightedEdge>(
-                DefaultWeightedEdge.class);
+            new DefaultUndirectedWeightedGraph<>(DefaultWeightedEdge.class);
 
         for (int i = 0; i < 7; ++i) {
             graph.addVertex(i);
@@ -114,8 +113,7 @@ public class EsauWilliamsCapacitatedMinimumSpanningTreeTest
     public void testInstance2()
     {
         Graph<Integer, DefaultWeightedEdge> graph =
-            new DefaultUndirectedWeightedGraph<Integer, DefaultWeightedEdge>(
-                DefaultWeightedEdge.class);
+            new DefaultUndirectedWeightedGraph<>(DefaultWeightedEdge.class);
 
         for (int i = 0; i < 6; ++i) {
             graph.addVertex(i);
@@ -181,8 +179,7 @@ public class EsauWilliamsCapacitatedMinimumSpanningTreeTest
     public void testInstance3()
     {
         Graph<Integer, DefaultWeightedEdge> graph =
-            new DefaultUndirectedWeightedGraph<Integer, DefaultWeightedEdge>(
-                DefaultWeightedEdge.class);
+            new DefaultUndirectedWeightedGraph<>(DefaultWeightedEdge.class);
 
         for (int i = 0; i < 6; ++i) {
             graph.addVertex(i);
@@ -245,8 +242,7 @@ public class EsauWilliamsCapacitatedMinimumSpanningTreeTest
     public void testInstanceWithRandomness()
     {
         Graph<Integer, DefaultWeightedEdge> graph =
-            new DefaultUndirectedWeightedGraph<Integer, DefaultWeightedEdge>(
-                DefaultWeightedEdge.class);
+            new DefaultUndirectedWeightedGraph<>(DefaultWeightedEdge.class);
 
         for (int i = 0; i < 7; ++i) {
             graph.addVertex(i);
@@ -313,18 +309,9 @@ public class EsauWilliamsCapacitatedMinimumSpanningTreeTest
 
         double capacity = 30.0;
 
-        boolean testOK = false;
-
-        try {
-            CapacitatedSpanningTreeAlgorithm<Integer,
-                DefaultWeightedEdge> capacitatedSpanningTreeAlgorithm =
-                    new EsauWilliamsCapacitatedMinimumSpanningTree<>(
-                        graph, 0, capacity, demands, 1);
-        } catch (IllegalArgumentException e) {
-            testOK = true;
-        }
-
-        assertTrue(testOK);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new EsauWilliamsCapacitatedMinimumSpanningTree<>(graph, 0, capacity, demands, 1));
     }
 
     /**
@@ -344,18 +331,9 @@ public class EsauWilliamsCapacitatedMinimumSpanningTreeTest
 
         double capacity = -1.0;
 
-        boolean testOK = false;
-
-        try {
-            CapacitatedSpanningTreeAlgorithm<Integer,
-                DefaultWeightedEdge> capacitatedSpanningTreeAlgorithm =
-                    new EsauWilliamsCapacitatedMinimumSpanningTree<>(
-                        graph, 0, capacity, demands, 1);
-        } catch (IllegalArgumentException e) {
-            testOK = true;
-        }
-
-        assertTrue(testOK);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new EsauWilliamsCapacitatedMinimumSpanningTree<>(graph, 0, capacity, demands, 1));
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/util/NeighborCacheTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/util/NeighborCacheTest.java
@@ -20,12 +20,11 @@ package org.jgrapht.alg.util;
 import org.jgrapht.*;
 import org.jgrapht.graph.*;
 import org.junit.*;
-import org.junit.rules.*;
 
 import java.util.*;
 
-import static org.hamcrest.CoreMatchers.hasItems;
-import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 /**
@@ -40,9 +39,6 @@ public class NeighborCacheTest
     private static final String V1 = "v1";
     private static final String V2 = "v2";
     private static final String V3 = "v3";
-
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 
     // ~ Methods ----------------------------------------------------------------
 
@@ -216,9 +212,7 @@ public class NeighborCacheTest
 
         graph.removeVertex(B);
 
-        exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("no such vertex");
-        cache.neighborListOf(B);
+        assertThrows(IllegalArgumentException.class, () -> cache.neighborListOf(B));
     }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/util/VertexDegreeComparatorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/util/VertexDegreeComparatorTest.java
@@ -25,7 +25,7 @@ import org.junit.*;
 
 import java.util.*;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 /**
  * Unit tests for VertexDegreeComparator
@@ -37,12 +37,8 @@ public class VertexDegreeComparatorTest
 
     protected static final int TEST_REPEATS = 20;
 
-    private GraphGenerator<Integer, DefaultEdge, Integer> randomGraphGenerator;
-
-    public VertexDegreeComparatorTest()
-    {
-        randomGraphGenerator = new GnmRandomGraphGenerator<>(100, 1000, 0);
-    }
+    private final GraphGenerator<Integer, DefaultEdge, Integer> randomGraphGenerator =
+        new GnmRandomGraphGenerator<>(100, 1000, 0);
 
     @Test
     public void testVertexDegreeComparator()
@@ -52,23 +48,14 @@ public class VertexDegreeComparatorTest
                 SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
             randomGraphGenerator.generateGraph(graph);
             List<Integer> vertices = new ArrayList<>(graph.vertexSet());
+
             // Sort in ascending vertex degree
-            Collections
-                .sort(
-                    vertices,
-                    new VertexDegreeComparator<>(graph, VertexDegreeComparator.Order.ASCENDING));
-            for (int i = 0; i < vertices.size() - 1; i++)
+            vertices.sort(VertexDegreeComparator.of(graph));
+
+            for (int i = 0; i < vertices.size() - 1; i++) {
                 assertTrue(graph.degreeOf(vertices.get(i)) <= graph.degreeOf(vertices.get(i + 1)));
-
-            // Sort in descending vertex degree
-            Collections
-                .sort(
-                    vertices,
-                    new VertexDegreeComparator<>(graph, VertexDegreeComparator.Order.DESCENDING));
-            for (int i = 0; i < vertices.size() - 1; i++)
-                assertTrue(graph.degreeOf(vertices.get(i)) >= graph.degreeOf(vertices.get(i + 1)));
+            }
         }
-
     }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/PlantedPartitionGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/PlantedPartitionGraphGeneratorTest.java
@@ -335,11 +335,8 @@ public class PlantedPartitionGraphGeneratorTest
 
         PlantedPartitionGraphGenerator<Integer, DefaultEdge> gen =
             new PlantedPartitionGraphGenerator<>(l, k, p, q, SEED);
-        try {
-            List<Set<Integer>> communities = gen.getCommunities();
-            fail("gen.getCommunities() did not throw an IllegalStateException as expected");
-        } catch (IllegalStateException e) {
-        }
+
+        assertThrows(IllegalStateException.class, () -> gen.getCommunities());
     }
 
     @Test
@@ -357,11 +354,8 @@ public class PlantedPartitionGraphGeneratorTest
         gen.generateGraph(g);
         Graph<Integer, DefaultEdge> f = new SimpleGraph<>(
             SupplierUtil.createIntegerSupplier(), SupplierUtil.createDefaultEdgeSupplier(), false);
-        try {
-            gen.generateGraph(f);
-            fail("gen.getCommunities() did not throw an IllegalStateException as expected");
-        } catch (IllegalStateException e) {
-        }
+
+        assertThrows(IllegalStateException.class, () -> gen.generateGraph(f));
     }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/PruferTreeGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/PruferTreeGeneratorTest.java
@@ -35,10 +35,7 @@ public class PruferTreeGeneratorTest
     @Test(expected = IllegalArgumentException.class)
     public void testNullPruferSequence()
     {
-        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(
-            SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
-
-        PruferTreeGenerator<Integer, DefaultEdge> generator = new PruferTreeGenerator<>(null);
+        new PruferTreeGenerator<>(null);
     }
 
     @Test
@@ -57,11 +54,7 @@ public class PruferTreeGeneratorTest
     @Test(expected = IllegalArgumentException.class)
     public void testInvalidPruferSequence()
     {
-        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(
-            SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
-
-        PruferTreeGenerator<Integer, DefaultEdge> generator =
-            new PruferTreeGenerator<>(new int[] { 10 });
+        new PruferTreeGenerator<>(new int[] { 10 });
     }
 
     @Test
@@ -86,19 +79,13 @@ public class PruferTreeGeneratorTest
     @Test(expected = IllegalArgumentException.class)
     public void testZeroVertices()
     {
-        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(
-            SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
-
-        PruferTreeGenerator<Integer, DefaultEdge> generator = new PruferTreeGenerator<>(0);
+        new PruferTreeGenerator<>(0);
     }
 
     @Test(expected = NullPointerException.class)
     public void testNullRNG()
     {
-        Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(
-            SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
-
-        PruferTreeGenerator<Integer, DefaultEdge> generator = new PruferTreeGenerator<>(100, null);
+        new PruferTreeGenerator<>(100, null);
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/netgen/DistributorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/netgen/DistributorTest.java
@@ -17,12 +17,10 @@
  */
 package org.jgrapht.generate.netgen;
 
-import org.junit.Test;
+import org.junit.*;
 
-import java.util.List;
-import java.util.Random;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.util.*;
+import java.util.stream.*;
 
 import static org.junit.Assert.*;
 
@@ -74,7 +72,7 @@ public class DistributorTest
                 return 0;
             }
         });
-        List<Integer> distribution = distributor.getDistribution(List.of(1, 2, 3), 12);
+        distributor.getDistribution(List.of(1, 2, 3), 12);
     }
 
     @Test
@@ -116,7 +114,7 @@ public class DistributorTest
             }
         });
 
-        List<Integer> distribution = distributor.getDistribution(List.of(1, 2, 3), 8);
+        distributor.getDistribution(List.of(1, 2, 3), 8);
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/netgen/NetworkGeneratorConfigBuilderTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/netgen/NetworkGeneratorConfigBuilderTest.java
@@ -17,7 +17,7 @@
  */
 package org.jgrapht.generate.netgen;
 
-import org.junit.Test;
+import org.junit.*;
 
 import static org.jgrapht.generate.netgen.NetworkGenerator.*;
 
@@ -58,7 +58,7 @@ public class NetworkGeneratorConfigBuilderTest
     @Test(expected = IllegalArgumentException.class)
     public void testNodeNum_NodeNumNotSet_IllegalArgumentException()
     {
-        NetworkGeneratorConfig config = new NetworkGeneratorConfigBuilder()
+        new NetworkGeneratorConfigBuilder()
             .setArcNum(20).setSourceNum(2).setSinkNum(3).setTSourceNum(1).setTSinkNum(1)
             .setTotalSupply(50).setMinCap(1).setMaxCap(10).setMinCost(0).setMaxCost(10)
             .setPercentCapacitated(100).setPercentWithInfCost(0).build();
@@ -81,7 +81,7 @@ public class NetworkGeneratorConfigBuilderTest
     @Test(expected = IllegalArgumentException.class)
     public void testArcNum_ArcNumNotSet_IllegalArgumentException()
     {
-        NetworkGeneratorConfig config = new NetworkGeneratorConfigBuilder()
+        new NetworkGeneratorConfigBuilder()
             .setNodeNum(10).setSourceNum(2).setSinkNum(3).setTSourceNum(1).setTSinkNum(1)
             .setTotalSupply(50).setMinCap(1).setMaxCap(10).setMinCost(0).setMaxCost(10)
             .setPercentCapacitated(100).setPercentWithInfCost(0).build();
@@ -152,7 +152,7 @@ public class NetworkGeneratorConfigBuilderTest
     @Test(expected = IllegalArgumentException.class)
     public void testSourceNum_SourceNumNotSet_IllegalArgumentException()
     {
-        NetworkGeneratorConfig config = new NetworkGeneratorConfigBuilder()
+        new NetworkGeneratorConfigBuilder()
             .setNodeNum(10).setArcNum(20).setSinkNum(3).setTSourceNum(1).setTSinkNum(1)
             .setTotalSupply(50).setMinCap(1).setMaxCap(10).setMinCost(0).setMaxCost(10)
             .setPercentCapacitated(100).setPercentWithInfCost(0).build();
@@ -173,7 +173,7 @@ public class NetworkGeneratorConfigBuilderTest
     @Test(expected = IllegalArgumentException.class)
     public void testSourceNum_SinkNumNotSet_IllegalArgumentException()
     {
-        NetworkGeneratorConfig config = new NetworkGeneratorConfigBuilder()
+        new NetworkGeneratorConfigBuilder()
             .setNodeNum(10).setArcNum(20).setSourceNum(2).setTSourceNum(1).setTSinkNum(1)
             .setTotalSupply(50).setMinCap(1).setMaxCap(10).setMinCost(0).setMaxCost(10)
             .setPercentCapacitated(100).setPercentWithInfCost(0).build();
@@ -228,7 +228,7 @@ public class NetworkGeneratorConfigBuilderTest
     @Test(expected = IllegalArgumentException.class)
     public void testSupply_SupplyNotSet_IllegalArgumentException()
     {
-        NetworkGeneratorConfig config = new NetworkGeneratorConfigBuilder()
+        new NetworkGeneratorConfigBuilder()
             .setNodeNum(10).setArcNum(20).setSourceNum(2).setSinkNum(3).setTSourceNum(1)
             .setTSinkNum(1).setMinCap(1).setMaxCap(10).setMinCost(0).setMaxCost(10)
             .setPercentCapacitated(100).setPercentWithInfCost(0).build();
@@ -275,7 +275,7 @@ public class NetworkGeneratorConfigBuilderTest
     @Test(expected = IllegalArgumentException.class)
     public void testCapacities_MinimumCapacityNotSet_IllegalArgumentException()
     {
-        NetworkGeneratorConfig config = new NetworkGeneratorConfigBuilder()
+        new NetworkGeneratorConfigBuilder()
             .setNodeNum(10).setArcNum(20).setSourceNum(2).setSinkNum(3).setTSourceNum(1)
             .setTSinkNum(1).setTotalSupply(50).setMaxCap(10).setMinCost(0).setMaxCost(10)
             .setPercentCapacitated(100).setPercentWithInfCost(0).build();
@@ -284,7 +284,7 @@ public class NetworkGeneratorConfigBuilderTest
     @Test(expected = IllegalArgumentException.class)
     public void testCapacities_MaximumCapacityNotSet_IllegalArgumentException()
     {
-        NetworkGeneratorConfig config = new NetworkGeneratorConfigBuilder()
+        new NetworkGeneratorConfigBuilder()
             .setNodeNum(10).setArcNum(20).setSourceNum(2).setSinkNum(3).setTSourceNum(1)
             .setTSinkNum(1).setTotalSupply(50).setMaxCap(10).setMinCost(0).setMaxCost(10)
             .setPercentCapacitated(100).setPercentWithInfCost(0).build();

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/AsUnweightedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/AsUnweightedGraphTest.java
@@ -21,8 +21,11 @@ import org.jgrapht.*;
 import org.junit.*;
 
 import static junit.framework.TestCase.fail;
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 
 public class AsUnweightedGraphTest
 {

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/IncomingOutgoingEdgesTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/IncomingOutgoingEdgesTest.java
@@ -18,7 +18,6 @@
 package org.jgrapht.graph;
 
 import org.jgrapht.*;
-import org.jgrapht.graph.BaseIntrusiveEdgesSpecifics.*;
 import org.jgrapht.graph.builder.*;
 import org.jgrapht.util.*;
 import org.junit.*;

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/MaskEdgeSetTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/MaskEdgeSetTest.java
@@ -61,6 +61,7 @@ public class MaskEdgeSetTest
     }
 
     @Test
+    @SuppressWarnings("unlikely-arg-type")
     public void testContains()
     {
         assertFalse(testMaskedEdgeSet.contains(e1));

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/MaskVertexSetTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/MaskVertexSetTest.java
@@ -57,6 +57,7 @@ public class MaskVertexSetTest
     }
 
     @Test
+    @SuppressWarnings("unlikely-arg-type")
     public void testContains()
     {
         assertFalse(testMaskVertexSet.contains(v1));

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleDirectedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/SimpleDirectedGraphTest.java
@@ -18,7 +18,6 @@
 package org.jgrapht.graph;
 
 import org.jgrapht.*;
-import org.jgrapht.graph.BaseIntrusiveEdgesSpecifics.*;
 import org.jgrapht.util.*;
 import org.junit.*;
 

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/BreadthFirstIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/BreadthFirstIteratorTest.java
@@ -21,8 +21,7 @@ import org.jgrapht.*;
 import org.jgrapht.graph.*;
 import org.junit.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.*;
 
 /**
  * Tests for the {@link BreadthFirstIterator} class.
@@ -157,8 +156,8 @@ public class BreadthFirstIteratorTest
         assertEquals(e3, bfs.getSpanningTreeEdge(3));
 
         assertNull(bfs.getParent(0));
-        assertEquals(new Integer(0), bfs.getParent(1));
-        assertEquals(new Integer(1), bfs.getParent(2));
-        assertEquals(new Integer(2), bfs.getParent(3));
+        assertEquals(Integer.valueOf(0), bfs.getParent(1));
+        assertEquals(Integer.valueOf(1), bfs.getParent(2));
+        assertEquals(Integer.valueOf(2), bfs.getParent(3));
     }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/CrossComponentIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/CrossComponentIteratorTest.java
@@ -25,8 +25,7 @@ import org.junit.*;
 
 import java.util.*;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.*;
 
 /**
  * A basis for testing {@link org.jgrapht.traverse.BreadthFirstIterator} and
@@ -77,33 +76,34 @@ public abstract class CrossComponentIteratorTest
     @Test
     public void testNonCrossComponentTraversal()
     {
-        final ModifiableInteger iteratorCalls = new ModifiableInteger();
-        final ModifiableInteger sizeCalls = new ModifiableInteger();
+        final ModifiableInteger iteratorCalls = new ModifiableInteger(0);
+        final ModifiableInteger sizeCalls = new ModifiableInteger(0);
         Graph<String, DefaultWeightedEdge> graph = createDirectedGraph();
-        Graph<String, DefaultWeightedEdge> wrapper =
-            new GraphDelegator<String, DefaultWeightedEdge>(graph)
-            {
-                @Override
-                public Set<String> vertexSet()
-                {
-                    return new AbstractSet<String>()
-                    {
-                        @Override
-                        public Iterator<String> iterator()
-                        {
-                            iteratorCalls.increment();
-                            return getDelegate().vertexSet().iterator();
-                        }
+        Graph<String, DefaultWeightedEdge> wrapper = new GraphDelegator<>(graph)
+        {
+            private static final long serialVersionUID = 1L;
 
-                        @Override
-                        public int size()
-                        {
-                            sizeCalls.increment();
-                            return getDelegate().vertexSet().size();
-                        }
-                    };
-                }
-            };
+            @Override
+            public Set<String> vertexSet()
+            {
+                return new AbstractSet<>()
+                {
+                    @Override
+                    public Iterator<String> iterator()
+                    {
+                        iteratorCalls.increment();
+                        return getDelegate().vertexSet().iterator();
+                    }
+
+                    @Override
+                    public int size()
+                    {
+                        sizeCalls.increment();
+                        return getDelegate().vertexSet().size();
+                    }
+                };
+            }
+        };
 
         AbstractGraphIterator<String, DefaultWeightedEdge> iterator =
             createIterator(wrapper, Arrays.asList("orphan"));

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/EdgeSelectionTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/EdgeSelectionTest.java
@@ -24,7 +24,7 @@ import org.junit.*;
 import java.util.*;
 import java.util.stream.*;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 /**
  * Tests for overriding the {@link CrossComponentIterator#selectOutgoingEdges selectOutgoingEdges}
@@ -44,7 +44,7 @@ public class EdgeSelectionTest
     {
         Graph<StatefulVertex, StatefulEdge> graph = createGraph();
         DepthFirstIterator<StatefulVertex, StatefulEdge> iterator =
-            new DepthFirstIterator<StatefulVertex, StatefulEdge>(graph)
+            new DepthFirstIterator<>(graph)
             {
                 String evenEdgeColor = "BLUE";
                 String oddEdgeColor = "RED";
@@ -119,6 +119,7 @@ public class EdgeSelectionTest
         extends
         DefaultWeightedEdge
     {
+        private static final long serialVersionUID = 1L;
         private final String color;
 
         StatefulEdge(String color)

--- a/jgrapht-core/src/test/java/org/jgrapht/util/AVLTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/AVLTreeTest.java
@@ -208,12 +208,6 @@ public class AVLTreeTest
         }
     }
 
-    private List<TreeNode<Integer>> fillNodes(AVLTree<Integer> tree)
-    {
-        final int nodeNum = 100;
-        return fillNodes(tree, 0, nodeNum);
-    }
-
     private List<TreeNode<Integer>> fillNodes(AVLTree<Integer> tree, int from, int to)
     {
         Deque<TreeNode<Integer>> nodes = new ArrayDeque<>();

--- a/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
@@ -19,13 +19,13 @@ package org.jgrapht.util;
 
 import org.jgrapht.util.DoublyLinkedList.*;
 import org.junit.*;
-import org.junit.rules.*;
 import org.junit.runner.*;
 import org.junit.runners.*;
 import org.junit.runners.Parameterized.*;
 
 import java.util.*;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
 import static org.junit.Assert.*;
 
@@ -57,9 +57,6 @@ public class DoublyLinkedListTest
         }
         return parameterSets;
     }
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Parameterized.Parameter(0)
     public int size;
@@ -284,7 +281,8 @@ public class DoublyLinkedListTest
     public void testGetFirstNode()
     {
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
+            assertThrows(NoSuchElementException.class, () -> list.getFirstNode());
+            return;
         }
 
         ListNode<String> firstNode = list.getFirstNode();
@@ -298,7 +296,8 @@ public class DoublyLinkedListTest
     public void testGetLastNode()
     {
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
+            assertThrows(NoSuchElementException.class, () -> list.getLastNode());
+            return;
         }
 
         ListNode<String> firstNode = list.getLastNode();
@@ -622,15 +621,19 @@ public class DoublyLinkedListTest
     public void testAddElementBeforeNode_sucessorInList_ElementAdded()
     {
         if (size == 0) {
-            thrown.expect(NullPointerException.class);
+            ListNode<String> nodeBefore = null;
+            assertThrows(
+                NullPointerException.class, () -> list.addElementBeforeNode(nodeBefore, "another"));
+            return;
         }
+
         String another = "another";
         int i = (int) (size / 2.5);
 
         List<String> expectedList = new ArrayList<>(expectedElements);
         expectedList.add(i, another);
 
-        ListNode<String> nodeBefore = size > 0 ? list.getNode(i) : null;
+        ListNode<String> nodeBefore = list.getNode(i);
         ListNode<String> addedNode = list.addElementBeforeNode(nodeBefore, another);
 
         assertThat(addedNode, is(sameInstance(list.getNode(i))));
@@ -720,7 +723,8 @@ public class DoublyLinkedListTest
     public void testRemoveInt_atIndex0()
     {
         if (size == 0) {
-            thrown.expect(IndexOutOfBoundsException.class);
+            assertThrows(IndexOutOfBoundsException.class, () -> list.remove(0));
+            return;
         }
         List<String> expectedList = new ArrayList<>(expectedElements);
         String expectedRemoved = expectedList.remove(0);
@@ -736,7 +740,8 @@ public class DoublyLinkedListTest
     public void testRemoveInt_inTheMiddle()
     {
         if (size == 0) {
-            thrown.expect(IndexOutOfBoundsException.class);
+            assertThrows(IndexOutOfBoundsException.class, () -> list.remove(size / 2));
+            return;
         }
         List<String> expectedList = new ArrayList<>(expectedElements);
         String expectedRemoved = expectedList.remove(size / 2);
@@ -752,7 +757,8 @@ public class DoublyLinkedListTest
     public void testRemoveInt_atIndexSizeMinusOne()
     {
         if (size == 0) {
-            thrown.expect(IndexOutOfBoundsException.class);
+            assertThrows(IndexOutOfBoundsException.class, () -> list.remove(size - 1));
+            return;
         }
         List<String> expectedList = new ArrayList<>(expectedElements);
         String expectedRemoved = expectedList.remove(size - 1);
@@ -836,7 +842,8 @@ public class DoublyLinkedListTest
     public void testRemoveFirst()
     {
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
+            assertThrows(NoSuchElementException.class, () -> list.removeFirst());
+            return;
         }
         List<String> expectedList = new ArrayList<>(expectedElements);
         String expectedFirst = size > 0 ? expectedList.remove(0) : null;
@@ -854,7 +861,8 @@ public class DoublyLinkedListTest
     public void testRemoveLast()
     {
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
+            assertThrows(NoSuchElementException.class, () -> list.removeLast());
+            return;
         }
         List<String> expectedList = new ArrayList<>(expectedElements);
         String expectedLast = size > 0 ? expectedList.remove(size - 1) : null;
@@ -902,7 +910,8 @@ public class DoublyLinkedListTest
     public void testGetFirst()
     {
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
+            assertThrows(NoSuchElementException.class, () -> list.getFirst());
+            return;
         }
         String first = list.getFirst();
 
@@ -917,7 +926,8 @@ public class DoublyLinkedListTest
     public void testGetLast()
     {
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
+            assertThrows(NoSuchElementException.class, () -> list.getLast());
+            return;
         }
         String last = list.getLast();
 
@@ -1008,7 +1018,8 @@ public class DoublyLinkedListTest
     public void testRemove()
     {
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
+            assertThrows(NoSuchElementException.class, () -> list.remove());
+            return;
         }
         List<String> expectedList = new ArrayList<>(expectedElements);
         String expectedFirst = size > 0 ? expectedList.remove(0) : null;
@@ -1041,7 +1052,8 @@ public class DoublyLinkedListTest
     public void testElement()
     {
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
+            assertThrows(NoSuchElementException.class, () -> list.element());
+            return;
         }
         String first = list.element();
 
@@ -1086,7 +1098,8 @@ public class DoublyLinkedListTest
     public void testPop()
     {
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
+            assertThrows(NoSuchElementException.class, () -> list.pop());
+            return;
         }
         List<String> expectedList = new ArrayList<>(expectedElements);
         String expectedFirst = size > 0 ? expectedList.remove(0) : null;
@@ -1185,8 +1198,7 @@ public class DoublyLinkedListTest
     public void testCircularIterator()
     {
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
-            list.circularIterator("anything");
+            assertThrows(NoSuchElementException.class, () -> list.circularIterator("anything"));
             return;
         }
 
@@ -1211,8 +1223,8 @@ public class DoublyLinkedListTest
     public void testReverseCircularIterator()
     {
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
-            list.reverseCircularIterator("anything");
+            assertThrows(
+                NoSuchElementException.class, () -> list.reverseCircularIterator("anything"));
             return;
         }
         int startIndex = size / 3;
@@ -1262,14 +1274,11 @@ public class DoublyLinkedListTest
     @Test
     public void testListIteratorE()
     { // test only if returned ListIterator starts expected position beginning.
-        String element;
         if (size == 0) {
-            thrown.expect(NoSuchElementException.class);
-            element = null;
-        } else {
-            element = expectedElements.get(size / 3);
+            assertThrows(NoSuchElementException.class, () -> list.listIterator(null));
+            return;
         }
-
+        String element = expectedElements.get(size / 3);
         ListNodeIterator<String> listIterator = list.listIterator(element);
 
         assertTrue(listIterator.hasNext());
@@ -1362,7 +1371,7 @@ public class DoublyLinkedListTest
         assertThat(listIterator.nextIndex(), is(equalTo(size)));
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testListIterator_iterateBehindTail()
     {
         ListNodeIterator<String> iterator = list.listIterator();
@@ -1370,10 +1379,10 @@ public class DoublyLinkedListTest
             iterator.next();
         }
         assertFalse(iterator.hasNext());
-        iterator.next();
+        assertThrows(NoSuchElementException.class, () -> iterator.next());
     }
 
-    @Test(expected = NoSuchElementException.class)
+    @Test
     public void testListIterator_iterateBeforeHead()
     {
         ListNodeIterator<String> iterator = list.listIterator(size);
@@ -1381,7 +1390,7 @@ public class DoublyLinkedListTest
             iterator.previous();
         }
         assertFalse(iterator.hasPrevious());
-        iterator.previous();
+        assertThrows(NoSuchElementException.class, () -> iterator.previous());
     }
 
     @Test(expected = ConcurrentModificationException.class)
@@ -1400,12 +1409,11 @@ public class DoublyLinkedListTest
         if (size == 0) {
             return;
         }
-        thrown.expect(ConcurrentModificationException.class);
 
         ListNodeIterator<String> listIterator = list.listIterator();
         list.removeLast();
 
-        listIterator.next();
+        assertThrows(ConcurrentModificationException.class, () -> listIterator.next());
     }
 
     /** Test for {@link DoublyLinkedList.ListNodeIterator#remove()}. */
@@ -1475,9 +1483,7 @@ public class DoublyLinkedListTest
 
         // check if the last-node of the iterator is cleared correctly
 
-        thrown.expect(IllegalStateException.class);
-
-        listIterator.remove();
+        assertThrows(IllegalStateException.class, () -> listIterator.remove());
     }
 
     @Test
@@ -1492,9 +1498,7 @@ public class DoublyLinkedListTest
 
         // check if the last-node of the iterator is cleared correctly in add()
 
-        thrown.expect(IllegalStateException.class);
-
-        listIterator.remove();
+        assertThrows(IllegalStateException.class, () -> listIterator.remove());
     }
 
     /** Test for {@link DoublyLinkedList.ListNodeIterator#add(Object)}. */
@@ -1680,13 +1684,11 @@ public class DoublyLinkedListTest
     {
         if (size == 0) {
             return;
-        } else {
-            thrown.expect(IllegalStateException.class);
         }
         ListNodeIterator<String> listIterator = list.listIterator();
         listIterator.next();
         listIterator.remove();
-        listIterator.set("another");
+        assertThrows(IllegalStateException.class, () -> listIterator.set("another"));
     }
 
     // utility methods

--- a/jgrapht-core/src/test/java/org/jgrapht/util/SupplierUtilTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/SupplierUtilTest.java
@@ -18,7 +18,6 @@
 package org.jgrapht.util;
 
 import org.jgrapht.graph.*;
-import org.jgrapht.util.SupplierUtil.*;
 import org.junit.*;
 
 import java.lang.reflect.*;

--- a/jgrapht-core/src/test/java/org/jgrapht/util/UnmodifiableUnionSetTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/UnmodifiableUnionSetTest.java
@@ -209,8 +209,10 @@ public class UnmodifiableUnionSetTest
         smaller.clearCallCounts();
         bigger.clearCallCounts();
 
-        int count = union.size();
-
+        int count = 0;
+        for (Integer i : union) {
+            count++;
+        }
         assertEquals(10, count);
         assertEquals(1, smaller.getSizeCallCount());
         assertEquals(1, bigger.getSizeCallCount());

--- a/jgrapht-core/src/test/java/org/jgrapht/util/UnmodifiableUnionSetTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/UnmodifiableUnionSetTest.java
@@ -209,10 +209,8 @@ public class UnmodifiableUnionSetTest
         smaller.clearCallCounts();
         bigger.clearCallCounts();
 
-        int count = 0;
-        for (Integer i : union) {
-            count++;
-        }
+        int count = union.size();
+
         assertEquals(10, count);
         assertEquals(1, smaller.getSizeCallCount());
         assertEquals(1, bigger.getSizeCallCount());
@@ -257,15 +255,17 @@ public class UnmodifiableUnionSetTest
         public Iterator<E> iterator()
         {
             iteratorCalls++;
-            return new Iterator<E>()
+            return new Iterator<>()
             {
                 private Iterator<E> delegateIterator = delegate.iterator();
 
+                @Override
                 public boolean hasNext()
                 {
                     return delegateIterator.hasNext();
                 }
 
+                @Override
                 public E next()
                 {
                     iteratorNextCalls++;

--- a/jgrapht-core/src/test/java/org/jgrapht/util/VertexToIntegerMappingTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/VertexToIntegerMappingTest.java
@@ -34,7 +34,7 @@ public class VertexToIntegerMappingTest
     @Test(expected = NullPointerException.class)
     public void testNullSet()
     {
-        VertexToIntegerMapping<Integer> mapping = new VertexToIntegerMapping<>((Set<Integer>) null);
+        new VertexToIntegerMapping<>((Set<Integer>) null);
     }
 
     @Test
@@ -49,8 +49,7 @@ public class VertexToIntegerMappingTest
     @Test(expected = IllegalArgumentException.class)
     public void testNotUniqueElements()
     {
-        VertexToIntegerMapping<Integer> mapping =
-            new VertexToIntegerMapping<>(Arrays.asList(1, 2, 1));
+        new VertexToIntegerMapping<>(Arrays.asList(1, 2, 1));
     }
 
     @Test

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableGraphAdapterTest.java
@@ -17,12 +17,12 @@
  */
 package org.jgrapht.graph.guava;
 
-import com.google.common.graph.*;
 import org.jgrapht.Graph;
-import org.jgrapht.graph.*;
 import org.junit.*;
 
 import java.util.*;
+
+import com.google.common.graph.*;
 
 import static org.junit.Assert.*;
 

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableValueGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/ImmutableValueGraphAdapterTest.java
@@ -17,14 +17,14 @@
  */
 package org.jgrapht.graph.guava;
 
-import com.google.common.graph.*;
 import org.jgrapht.Graph;
-import org.jgrapht.graph.*;
 import org.junit.*;
 
 import java.io.*;
 import java.util.*;
 import java.util.function.*;
+
+import com.google.common.graph.*;
 
 import static org.junit.Assert.*;
 
@@ -56,7 +56,7 @@ public class ImmutableValueGraphAdapterTest
         graph.putEdgeValue("v4", "v4", new MyValue(5.0));
         graph.putEdgeValue("v5", "v2", new MyValue(6.0));
 
-        Graph<String,
+        @SuppressWarnings("unchecked") Graph<String,
             EndpointPair<String>> g = new ImmutableValueGraphAdapter<>(
                 ImmutableValueGraph.copyOf(graph),
                 (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
@@ -74,12 +74,8 @@ public class ImmutableValueGraphAdapterTest
         assertEquals(5.0, g.getEdgeWeight(EndpointPair.ordered("v4", "v4")), 1e-9);
         assertEquals(6.0, g.getEdgeWeight(EndpointPair.ordered("v5", "v2")), 1e-9);
 
-        try {
-            g.setEdgeWeight(EndpointPair.ordered("v1", "v2"), 1.0);
-            fail("Immutable");
-        } catch (UnsupportedOperationException e) {
-            // ignore
-        }
+        EndpointPair<String> endPoints = EndpointPair.ordered("v1", "v2");
+        assertThrows(UnsupportedOperationException.class, () -> g.setEdgeWeight(endPoints, 1.0));
     }
 
     /**
@@ -118,12 +114,8 @@ public class ImmutableValueGraphAdapterTest
         assertEquals(5.0, g.getEdgeWeight(EndpointPair.ordered("v4", "v4")), 1e-9);
         assertEquals(6.0, g.getEdgeWeight(EndpointPair.ordered("v5", "v2")), 1e-9);
 
-        try {
-            g.setEdgeWeight(EndpointPair.ordered("v1", "v2"), 1.0);
-            fail("Immutable");
-        } catch (UnsupportedOperationException e) {
-            // ignore
-        }
+        EndpointPair<String> endPoints = EndpointPair.ordered("v1", "v2");
+        assertThrows(UnsupportedOperationException.class, () -> g.setEdgeWeight(endPoints, 1.0));
     }
 
     /**
@@ -142,10 +134,11 @@ public class ImmutableValueGraphAdapterTest
         ImmutableValueGraph<String, MyValue> immutableValueGraph =
             ImmutableValueGraph.copyOf(mutableValueGraph);
 
-        Graph<String, EndpointPair<String>> graph = new ImmutableValueGraphAdapter<>(
-            immutableValueGraph, (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
+        @SuppressWarnings("unchecked") Graph<String, EndpointPair<String>> graph =
+            new ImmutableValueGraphAdapter<>(
+                immutableValueGraph, (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
 
-        assertEquals(graph.getEdgeWeight(EndpointPair.ordered("v1", "v2")), 5.0, 1e-9);
+        assertEquals(5.0, graph.getEdgeWeight(EndpointPair.ordered("v1", "v2")), 1e-9);
     }
 
     /**
@@ -168,7 +161,7 @@ public class ImmutableValueGraphAdapterTest
         graph.putEdgeValue("v4", "v4", new MyValue(5.0));
         graph.putEdgeValue("v5", "v2", new MyValue(6.0));
 
-        Graph<String,
+        @SuppressWarnings("unchecked") Graph<String,
             EndpointPair<String>> g = new ImmutableValueGraphAdapter<>(
                 ImmutableValueGraph.copyOf(graph),
                 (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
@@ -288,7 +281,7 @@ public class ImmutableValueGraphAdapterTest
         graph.putEdgeValue("v4", "v4", new MyValue(5.0));
         graph.putEdgeValue("v5", "v2", new MyValue(6.0));
 
-        Graph<String,
+        @SuppressWarnings("unchecked") Graph<String,
             EndpointPair<String>> initialGraph = new ImmutableValueGraphAdapter<>(
                 ImmutableValueGraph.copyOf(graph),
                 (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
@@ -354,7 +347,7 @@ public class ImmutableValueGraphAdapterTest
 
         private static final long serialVersionUID = 1L;
 
-        private double value;
+        private final double value;
 
         public MyValue(double value)
         {

--- a/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableValueGraphAdapterTest.java
+++ b/jgrapht-guava/src/test/java/org/jgrapht/graph/guava/MutableValueGraphAdapterTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.*;
  *
  * @author Dimitrios Michail
  */
+@SuppressWarnings("unchecked")
 public class MutableValueGraphAdapterTest
 {
 
@@ -77,12 +78,8 @@ public class MutableValueGraphAdapterTest
         assertEquals(1.0d, g.getEdgeWeight(EndpointPair.ordered("v1", "v5")), 1e-9);
 
         // check that the adapter is only one way
-        try {
-            g.setEdgeWeight(EndpointPair.ordered("v1", "v2"), 1.0);
-            fail("One way adapter only");
-        } catch (UnsupportedOperationException e) {
-            // ignore
-        }
+        EndpointPair<String> endPoints = EndpointPair.ordered("v1", "v2");
+        assertThrows(UnsupportedOperationException.class, () -> g.setEdgeWeight(endPoints, 1.0));
     }
 
     /**
@@ -146,11 +143,11 @@ public class MutableValueGraphAdapterTest
                 valueGraph, new MyValue(1.0),
                 (ToDoubleFunction<MyValue> & Serializable) MyValue::getValue);
 
-        assertEquals(graph.getEdgeWeight(EndpointPair.ordered("v1", "v2")), 5.0, 1e-9);
+        assertEquals(5.0, graph.getEdgeWeight(EndpointPair.ordered("v1", "v2")), 1e-9);
 
         valueGraph.putEdgeValue("v1", "v2", new MyValue(9.0));
 
-        assertEquals(graph.getEdgeWeight(EndpointPair.ordered("v1", "v2")), 9.0, 1e-9);
+        assertEquals(9.0, graph.getEdgeWeight(EndpointPair.ordered("v1", "v2")), 1e-9);
     }
 
     /**
@@ -353,8 +350,8 @@ public class MutableValueGraphAdapterTest
         assertTrue(g2.containsVertex("v3"));
         assertTrue(g2.containsVertex("v4"));
         assertTrue(g2.containsVertex("v5"));
-        assertTrue(g2.vertexSet().size() == 5);
-        assertTrue(g2.edgeSet().size() == 6);
+        assertEquals(5, g2.vertexSet().size());
+        assertEquals(6, g2.edgeSet().size());
         assertTrue(g2.containsEdge("v1", "v2"));
         assertTrue(g2.containsEdge("v2", "v3"));
         assertTrue(g2.containsEdge("v2", "v4"));
@@ -402,8 +399,8 @@ public class MutableValueGraphAdapterTest
         assertTrue(g2.containsVertex("v1"));
         assertTrue(g2.containsVertex("v2"));
         assertTrue(g2.containsVertex("v3"));
-        assertTrue(g2.vertexSet().size() == 3);
-        assertTrue(g2.edgeSet().size() == 3);
+        assertEquals(3, g2.vertexSet().size());
+        assertEquals(3, g2.edgeSet().size());
         assertTrue(g2.containsEdge("v1", "v2"));
         assertTrue(g2.containsEdge("v2", "v3"));
         assertTrue(g2.containsEdge("v3", "v3"));

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/dot/DOTExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/dot/DOTExporterTest.java
@@ -25,7 +25,8 @@ import org.junit.*;
 import java.io.*;
 import java.util.*;
 
-import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.*;
 
 /**
@@ -83,7 +84,7 @@ public class DOTExporterTest
 
         DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>();
 
-        exporter.setVertexAttributeProvider((v) -> {
+        exporter.setVertexAttributeProvider(v -> {
             Map<String, Attribute> map = new LinkedHashMap<>();
             switch (v) {
             case V1:
@@ -137,7 +138,7 @@ public class DOTExporterTest
     public void testValidNodeIDs()
         throws ExportException
     {
-        DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(x -> String.valueOf(x));
+        DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(String::valueOf);
 
         List<String> validVertices =
             Arrays.asList("-9.78", "-.5", "12", "a", "12", "abc_78", "\"--34asdf\"");
@@ -152,21 +153,17 @@ public class DOTExporterTest
             Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
             graph.addVertex(vertex);
 
-            try {
-                exporter.exportGraph(graph, new ByteArrayOutputStream());
-                fail(vertex);
-            } catch (RuntimeException re) {
-                // this is a negative test so exception is expected
-            }
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            assertThrows(RuntimeException.class, () -> exporter.exportGraph(graph, out));
         }
     }
 
     @Test
     public void testQuotedNodeIDs()
     {
-        DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(x -> String.valueOf(x));
+        DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(String::valueOf);
 
-        exporter.setVertexAttributeProvider((v) -> {
+        exporter.setVertexAttributeProvider(v -> {
             Map<String, Attribute> map = new LinkedHashMap<>();
             map.put("label", DefaultAttribute.createAttribute(v));
             return map;
@@ -186,9 +183,9 @@ public class DOTExporterTest
     @Test
     public void testNodeHtmlLabelFromAttribute()
     {
-        DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(x -> String.valueOf(x));
+        DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>(String::valueOf);
 
-        exporter.setVertexAttributeProvider((v) -> {
+        exporter.setVertexAttributeProvider(v -> {
             Map<String, Attribute> map = new LinkedHashMap<>();
             map.put("label", new DefaultAttribute<>("<b>html label</b>", AttributeType.HTML));
             return map;
@@ -213,9 +210,7 @@ public class DOTExporterTest
         final String customID = "MyGraph";
 
         DOTExporter<String, DefaultEdge> exporter = new DOTExporter<>();
-        exporter.setGraphIdProvider(() -> {
-            return customID;
-        });
+        exporter.setGraphIdProvider(() -> customID);
 
         final String correctResult = "strict graph " + customID + " {" + NL + "}" + NL;
 


### PR DESCRIPTION
In order to solve #1056 I fixed all warnings that displayed by Eclipse in JGraphT's tests.


For this is I replace deprecated code by the recommended alternative method or structure, fixed _unused_ warnings by either removing the unused method/variable or by adding an suppress warning annotation, if removal would disturb the code structure and solved all remaining warnings in the test-code. In total 274 (Eclipse) warnings are fixed by this PR.

At some places I also did marginal clean-ups.

<!-- describe the changes you have made here: what, why, …
     Link issues by using the following pattern: [#333](https://github.com/jgrapht/jgrapht/issues/333).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
