### PR TITLE
[TSPLIBImporter] Consider multi-space delimiters (#1060)

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/GraphExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/GraphExporter.java
@@ -69,7 +69,7 @@ public interface GraphExporter<V, E>
      */
     default void exportGraph(Graph<V, E> g, File file)
     {
-        try (FileWriter writer = new FileWriter(file)) {
+        try (Writer writer = new FileWriter(file, StandardCharsets.UTF_8)) {
             exportGraph(g, writer);
         } catch (IOException e) {
             throw new ExportException(e);

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/GraphImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/GraphImporter.java
@@ -69,10 +69,7 @@ public interface GraphImporter<V, E>
      */
     default void importGraph(Graph<V, E> g, File file)
     {
-        try (
-            InputStreamReader reader =
-                new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8))
-        {
+        try (Reader reader = new FileReader(file, StandardCharsets.UTF_8)) {
             importGraph(g, reader);
         } catch (IOException e) {
             throw new ImportException(e);

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/TSPLIBImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/TSPLIBImporter.java
@@ -815,6 +815,7 @@ public class TSPLIBImporter<V, E>
 
     private String requireValidValue(String value, List<String> validValues, String valueType)
     {
+        value = extractValueBeforeWhitespace(value);
         for (String validValue : validValues) {
             if (validValue.equalsIgnoreCase(value)) {
                 return validValue; // always use the upper case version
@@ -825,12 +826,18 @@ public class TSPLIBImporter<V, E>
 
     private Integer parseInteger(String valueStr, String valueType)
     {
+        valueStr = extractValueBeforeWhitespace(valueStr);
         try {
             return Integer.valueOf(valueStr);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException(
                 "Invalid " + valueType + " integer value <" + valueStr + ">", e);
         }
+    }
+
+    public String extractValueBeforeWhitespace(String value)
+    {
+        return WHITE_SPACE.split(value, 2)[0]; // discard everything after first white-space
     }
 
     // read utilities

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/TSPLIBImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/TSPLIBImporter.java
@@ -837,7 +837,7 @@ public class TSPLIBImporter<V, E>
 
     public String extractValueBeforeWhitespace(String value)
     {
-        return WHITE_SPACE.split(value, 2)[0]; // discard everything after first white-space
+        return WHITE_SPACE.split(value.strip(), 2)[0]; // discard everything after first white-space
     }
 
     // read utilities
@@ -853,7 +853,7 @@ public class TSPLIBImporter<V, E>
         try {
             String line = reader.readLine();
             if (line != null) {
-                line = line.trim();
+                line = line.strip();
                 return "EOF".equals(line) ? null : line;
             }
             return null;
@@ -864,7 +864,7 @@ public class TSPLIBImporter<V, E>
 
     private static String getKey(String[] keyValue)
     {
-        return keyValue[0].trim().toUpperCase();
+        return keyValue[0].strip().toUpperCase();
     }
 
     private String getValue(String[] keyValue)
@@ -872,7 +872,7 @@ public class TSPLIBImporter<V, E>
         if (keyValue.length < 2) {
             throw new IllegalStateException("Missing value for key " + getKey(keyValue));
         }
-        return keyValue[1].trim();
+        return keyValue[1].strip();
     }
 
     private void requireNotSet(Object target, String keyName)

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/TSPLIBImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/TSPLIBImporter.java
@@ -24,10 +24,12 @@ import org.jgrapht.util.*;
 
 import java.io.*;
 import java.util.*;
+import java.util.ArrayList;
 import java.util.function.*;
+import java.util.regex.*;
 import java.util.stream.*;
 
-import static java.util.Arrays.asList;
+import static java.util.Arrays.*;
 
 /**
  * Importer for files in the
@@ -319,10 +321,7 @@ public class TSPLIBImporter<V, E>
                     double[] coordinates = node.getCoordinates();
                     // Arrays.equals checks identity. Conversion to a List<Double> and use of a
                     // HashSet has linear runtime. Unlike with a TreeSet using a comparator.
-                    Double[] coordinateObj = new Double[coordinates.length];
-                    for (int i = 0; i < coordinates.length; i++) {
-                        coordinateObj[i] = Double.valueOf(coordinates[i]);
-                    }
+                    Double[] coordinateObj = stream(coordinates).boxed().toArray(Double[]::new);
                     if (!distinctCoordinates.add(Arrays.asList(coordinateObj))) {
                         hasDistinctLocations = Boolean.FALSE;
                         return hasDistinctLocations;
@@ -619,9 +618,11 @@ public class TSPLIBImporter<V, E>
         return nodes;
     }
 
+    private static final Pattern WHITE_SPACE = Pattern.compile("[ \t]+");
+
     private Node parseNode(String line)
     {
-        String[] elements = line.split(" ");
+        String[] elements = WHITE_SPACE.split(line);
         if (elements.length != vectorLength + 1) {
             throw new IllegalArgumentException(
                 "Unexpected number of elements <" + elements.length + "> in line: " + line);

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/tsplib/TSPLIBImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/tsplib/TSPLIBImporterTest.java
@@ -23,6 +23,7 @@ import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.nio.*;
 import org.jgrapht.nio.tsplib.TSPLIBImporter.*;
+import org.jgrapht.nio.tsplib.TSPLIBImporter.Node;
 import org.junit.*;
 
 import java.io.*;
@@ -145,6 +146,43 @@ public class TSPLIBImporterTest
         assertEquals("TSP", spec.getType());
         assertEquals(
             Arrays.asList("The first line of the comment", "A second line"), spec.getComments());
+        assertEquals(Integer.valueOf(4), spec.getDimension());
+        assertEquals(Integer.valueOf(7), spec.getCapacity());
+        assertEquals("EUC_2D", spec.getEdgeWeightType());
+        assertEquals("FULL_MATRIX", spec.getEdgeWeightFormat());
+        assertEquals("ADJ_LIST", spec.getEdgeDataFormat());
+        assertEquals("THREED_COORDS", spec.getNodeCoordType());
+        assertEquals("TWOD_DISPLAY", spec.getDisplayDataType());
+
+        assertTrue(metaData.hasDistinctNodeLocations());
+        assertTrue(metaData.hasDistinctNeighborDistances());
+    }
+
+    @Test
+    public void testMetaDataValues_slightyOfSpecMetadata()
+    {
+        // The metadata/specification section of the following file is slightly off the standard
+        // containing changes that were observed in the wild.
+        StringJoiner fileContent = new StringJoiner(System.lineSeparator());
+        fileContent.add("NAME : theNameOfThisFile");
+        fileContent.add("TYPE : TSP (Some comment)");
+        fileContent.add("DIMENSION : 4 (Comment: number of elements)");
+        fileContent.add("EDGE_WEIGHT_TYPE : EUC_2D");
+        fileContent.add("NODE_COORD_TYPE: THREED_COORDS");
+        fileContent.add("CAPACITY : 7 # Capacitated vehicle routing problem data");
+        fileContent.add("EDGE_WEIGHT_FORMAT: FULL_MATRIX");
+        fileContent.add("EDGE_DATA_FORMAT: ADJ_LIST");
+        fileContent.add("DISPLAY_DATA_TYPE : WOD_DISPLAY");
+        fileContent.add("NODE_COORD_SECTION");
+        fileContent.add("1   10.2\t15.0");
+        fileContent.add("EOF");
+
+        Metadata<Object, DefaultWeightedEdge> metaData =
+            importGraphFromFile(fileContent).getSecond();
+
+        Specification spec = metaData.getSpecification();
+        assertEquals("theNameOfThisFile", spec.getName());
+        assertEquals("TSP", spec.getType());
         assertEquals(Integer.valueOf(4), spec.getDimension());
         assertEquals(Integer.valueOf(7), spec.getCapacity());
         assertEquals("EUC_2D", spec.getEdgeWeightType());
@@ -545,10 +583,10 @@ public class TSPLIBImporterTest
     public void testImportGraph_invalidSpecificationValue_ImportException()
     {
         StringJoiner fileContent = new StringJoiner(System.lineSeparator());
-        fileContent.add("EDGE_WEIGHT_FORMAT : some String");
+        fileContent.add("EDGE_WEIGHT_FORMAT : some_String");
 
         RuntimeException expectedCause =
-            new IllegalArgumentException("Invalid EDGE_WEIGHT_FORMAT value <some String>");
+            new IllegalArgumentException("Invalid EDGE_WEIGHT_FORMAT value <some_String>");
 
         expectGraphImportFailedException(() -> importGraphFromFile(fileContent), expectedCause);
     }

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/tsplib/TSPLIBImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/tsplib/TSPLIBImporterTest.java
@@ -22,7 +22,6 @@ import org.jgrapht.*;
 import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.*;
 import org.jgrapht.nio.*;
-import org.jgrapht.nio.tsplib.TSPLIBImporter.Node;
 import org.jgrapht.nio.tsplib.TSPLIBImporter.*;
 import org.junit.*;
 
@@ -102,8 +101,8 @@ public class TSPLIBImporterTest
         fileContent.add("NODE_COORD_SECTION");
         fileContent.add("1 10.2 15.0");
         fileContent.add("2 14.2 15.0");
-        fileContent.add("3 14.8 20.0");
-        fileContent.add("4 10.8 20.0");
+        fileContent.add("3  14.8    20.0"); // also use other white-space than just a single space
+        fileContent.add("4\t10.8\t\t20.0");
         fileContent.add("EOF");
         return fileContent;
     }

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/tsplib/TSPLIBImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/tsplib/TSPLIBImporterTest.java
@@ -167,12 +167,12 @@ public class TSPLIBImporterTest
         fileContent.add("NAME : theNameOfThisFile");
         fileContent.add("TYPE : TSP (Some comment)");
         fileContent.add("DIMENSION : 4 (Comment: number of elements)");
-        fileContent.add("EDGE_WEIGHT_TYPE : EUC_2D");
+        fileContent.add("EDGE_WEIGHT_TYPE : EUC_2D #use 2D edges");
         fileContent.add("NODE_COORD_TYPE: THREED_COORDS");
         fileContent.add("CAPACITY : 7 # Capacitated vehicle routing problem data");
         fileContent.add("EDGE_WEIGHT_FORMAT: FULL_MATRIX");
         fileContent.add("EDGE_DATA_FORMAT: ADJ_LIST");
-        fileContent.add("DISPLAY_DATA_TYPE : WOD_DISPLAY");
+        fileContent.add("DISPLAY_DATA_TYPE : TWOD_DISPLAY");
         fileContent.add("NODE_COORD_SECTION");
         fileContent.add("1   10.2\t15.0");
         fileContent.add("EOF");


### PR DESCRIPTION
This PR provides a patch to fix #1060 and adjusts the tests to cover the cases of the mentioned issue.

Additionally I simplified the default implementation of `GraphImporter.importGraph(Graph<V, E> g, File file)` by using a `FileReader`.

<!-- describe the changes you have made here: what, why, …
     Link issues by using the following pattern: [#333](https://github.com/jgrapht/jgrapht/issues/333).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
