### PR TITLE
Add checkstyle Variable/Methode/Type naming convention rules (#1052 - part 1)

### DIFF
--- a/etc/checkstyle_suppressions.xml
+++ b/etc/checkstyle_suppressions.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 
 <!DOCTYPE suppressions PUBLIC
-    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
-    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+    "-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+    "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
     <!-- Ignore header checks for package-info.java files -->
-    <suppress files="package-info\.java" checks="Header"/>
+    <suppress files="package-info\.java" checks="Header" />
 
     <!-- Suppression of Javadoc related checks for test files -->
-    <suppress files="[/\\]src[/\\]test[/\\].*" checks="JavadocMethod"/>
-    <suppress files="[/\\]src[/\\]test[/\\].*" checks="JavadocType"/>
-    <suppress files="[/\\]src[/\\]test[/\\].*" checks="JavadocPackage"/>
+    <suppress files="[/\\]src[/\\]test[/\\].*" checks="JavadocMethod" />
+    <suppress files="[/\\]src[/\\]test[/\\].*" checks="JavadocType" />
+    <suppress files="[/\\]src[/\\]test[/\\].*" checks="JavadocPackage" />
 </suppressions>

--- a/etc/checkstyle_suppressions.xml
+++ b/etc/checkstyle_suppressions.xml
@@ -12,4 +12,13 @@
     <suppress files="[/\\]src[/\\]test[/\\].*" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\]test[/\\].*" checks="JavadocType" />
     <suppress files="[/\\]src[/\\]test[/\\].*" checks="JavadocPackage" />
+    <!-- Suppress main-checks in test-code and test-checks in main-code -->
+    <suppress files="[/\\]src[/\\]test[/\\].*" id="LocalFinalVariableNameMain" />
+    <suppress files="[/\\]src[/\\]main[/\\].*" id="LocalFinalVariableNameTest" />
+    <suppress files="[/\\]src[/\\]test[/\\].*" id="LocalVariableNameMain" />
+    <suppress files="[/\\]src[/\\]main[/\\].*" id="LocalVariableNameTest" />
+    <suppress files="[/\\]src[/\\]test[/\\].*" id="MemberNameMain" />
+    <suppress files="[/\\]src[/\\]main[/\\].*" id="MemberNameTest" />
+    <suppress files="[/\\]src[/\\]test[/\\].*" id="MethodNameMain" />
+    <suppress files="[/\\]src[/\\]main[/\\].*" id="MethodNameTest" />
 </suppressions>

--- a/etc/jgrapht_checks.xml
+++ b/etc/jgrapht_checks.xml
@@ -84,6 +84,12 @@
 
         <module name="EqualsHashCode" />
         <module name="StringLiteralEquality" />
+
+        <module name="SuppressWithNearbyCommentFilter">
+            <property name="commentFormat" value="@CS\.suppress\[(\w+(\|\w+)*)\]" /> <!--  \w[-\.'`,:;\w ]{14,} -->
+            <property name="checkFormat" value="$1" />
+            <property name="influenceFormat" value="1" />
+        </module>
     </module>
 
     <module name="JavadocPackage" />

--- a/etc/jgrapht_checks.xml
+++ b/etc/jgrapht_checks.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-        "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-        "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+        "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+        "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
     <module name="BeforeExecutionExclusionFileFilter">
-        <property name="fileNamePattern" value="module\-info\.java$"/>
+        <property name="fileNamePattern" value="module\-info\.java$" />
     </module>
     <module name="SuppressionFilter">
-        <property name="file" value="etc/checkstyle_suppressions.xml"/>
+        <property name="file" value="etc/checkstyle_suppressions.xml" />
     </module>
 
     <!-- Checks for file header -->
     <!-- See http://checkstyle.sf.net/config_header.html -->
     <module name="Header">
-        <property name="headerFile" value="etc/header-boilerplate.txt"/>
-        <property name="ignoreLines" value="2"/>
-        <property name="fileExtensions" value="java"/>
+        <property name="headerFile" value="etc/header-boilerplate.txt" />
+        <property name="ignoreLines" value="2" />
+        <property name="fileExtensions" value="java" />
     </module>
 
     <!-- Checks for whitespace -->
@@ -38,6 +38,8 @@
         <module name="MissingDeprecated" />
         <module name="MissingOverride" />
 
+        <!-- Checks for naming convention -->
+        <!-- See https://checkstyle.sourceforge.io/config_naming.html -->
         <module name="ConstantName" />
 
         <module name="EqualsHashCode" />

--- a/etc/jgrapht_checks.xml
+++ b/etc/jgrapht_checks.xml
@@ -41,6 +41,46 @@
         <!-- Checks for naming convention -->
         <!-- See https://checkstyle.sourceforge.io/config_naming.html -->
         <module name="ConstantName" />
+        <module name="IllegalIdentifierName" />
+        <module name="LambdaParameterName" />
+        <module name="LocalFinalVariableName">
+            <property name="id" value="LocalFinalVariableNameMain" />
+            <!-- Use the default configuration in main code -->
+        </module>
+        <module name="LocalFinalVariableName">
+            <property name="id" value="LocalFinalVariableNameTest" />
+            <property name="format" value="^[a-z][a-zA-Z0-9]*(_[0-9]+)?$" />
+        </module>
+        <module name="LocalVariableName">
+            <property name="id" value="LocalVariableNameMain" />
+            <!-- Use the default configuration in main code -->
+        </module>
+        <module name="LocalVariableName">
+            <property name="id" value="LocalVariableNameTest" />
+            <property name="format" value="^[a-z][a-zA-Z0-9]*(_[0-9]+)?$" />
+        </module>
+        <module name="MemberName">
+            <property name="id" value="MemberNameMain" />
+            <!-- Use the default configuration in main code -->
+        </module>
+        <module name="MemberName">
+            <property name="id" value="MemberNameTest" />
+            <property name="format" value="^[a-z][a-zA-Z0-9]*(_[0-9]+)?$" />
+        </module>
+        <module name="MethodName">
+            <property name="id" value="MethodNameMain" />
+            <!-- Use the default configuration in main code -->
+        </module>
+        <module name="MethodName">
+            <property name="id" value="MethodNameTest" />
+            <property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$" />
+        </module>
+        <module name="PackageName" />
+        <module name="ParameterName" />
+        <module name="PatternVariableName" />
+        <module name="RecordComponentName" />
+        <module name="StaticVariableName" />
+        <module name="TypeName" />
 
         <module name="EqualsHashCode" />
         <module name="StringLiteralEquality" />

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphMetrics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphMetrics.java
@@ -102,7 +102,7 @@ public abstract class GraphMetrics
      */
     public static <V, E> int getGirth(Graph<V, E> graph)
     {
-        final int NIL = -1;
+        final int nil = -1;
         final boolean isAllowingMultipleEdges = graph.getType().isAllowingMultipleEdges();
 
         // Ordered sequence of vertices
@@ -139,8 +139,8 @@ public abstract class GraphMetrics
             for (int i = 0; i < vertices.size() - 2 && girth > 3; i++) {
 
                 // Reset data structures
-                Arrays.fill(depth, NIL);
-                Arrays.fill(parent, NIL);
+                Arrays.fill(depth, nil);
+                Arrays.fill(parent, nil);
                 queue.clear();
 
                 depth[i] = 0;
@@ -163,7 +163,7 @@ public abstract class GraphMetrics
                         }
 
                         int depthV = depth[indexV];
-                        if (depthV == NIL) { // New neighbor discovered
+                        if (depthV == nil) { // New neighbor discovered
                             queue.add(v);
                             depth[indexV] = depthU + 1;
                             parent[indexV] = indexU;
@@ -177,7 +177,7 @@ public abstract class GraphMetrics
             for (int i = 0; i < vertices.size() - 1 && girth > 2; i++) {
 
                 // Reset data structures
-                Arrays.fill(depth, NIL);
+                Arrays.fill(depth, nil);
                 queue.clear();
 
                 depth[i] = 0;
@@ -194,7 +194,7 @@ public abstract class GraphMetrics
                         int indexV = indexMap.get(v);
 
                         int depthV = depth[indexV];
-                        if (depthV == NIL) { // New neighbor discovered
+                        if (depthV == nil) { // New neighbor discovered
                             queue.add(v);
                             depth[indexV] = depthU + 1;
                         } else if (depthV == 0) { // Rediscover root: found cycle.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/TransitiveReduction.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/TransitiveReduction.java
@@ -154,10 +154,10 @@ public class TransitiveReduction
             final V v1 = directedGraph.getEdgeSource(edge);
             final V v2 = directedGraph.getEdgeTarget(edge);
 
-            final int v_1 = vertices.indexOf(v1);
-            final int v_2 = vertices.indexOf(v2);
+            final int i1 = vertices.indexOf(v1);
+            final int i2 = vertices.indexOf(v2);
 
-            originalMatrix[v_1].set(v_2);
+            originalMatrix[i1].set(i2);
         }
 
         // create path matrix from original matrix

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/clique/CliqueMinimalSeparatorDecomposition.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/clique/CliqueMinimalSeparatorDecomposition.java
@@ -128,7 +128,7 @@ public class CliqueMinimalSeparatorDecomposition<V, E>
         }
         for (int i = 1, n = graph.vertexSet().size(); i <= n; i++) {
             V v = getMaxLabelVertex(vertexLabels);
-            LinkedList<V> Y = new LinkedList<>(Graphs.neighborListOf(gprime, v));
+            LinkedList<V> neighborsY = new LinkedList<>(Graphs.neighborListOf(gprime, v));
 
             if (vertexLabels.get(v) <= s) {
                 generators.add(v);
@@ -144,7 +144,7 @@ public class CliqueMinimalSeparatorDecomposition<V, E>
             HashMap<Integer, HashSet<V>> reach = new HashMap<>();
 
             // mark y reached and add y to reach
-            for (V y : Y) {
+            for (V y : neighborsY) {
                 reached.add(y);
                 addToReach(vertexLabels.get(y), y, reach);
             }
@@ -162,7 +162,7 @@ public class CliqueMinimalSeparatorDecomposition<V, E>
                         if (!reached.contains(z)) {
                             reached.add(z);
                             if (vertexLabels.get(z) > j) {
-                                Y.add(z);
+                                neighborsY.add(z);
                                 E fillEdge = graph.getEdgeSupplier().get();
                                 fillEdges.add(fillEdge);
                                 addToReach(vertexLabels.get(z), z, reach);
@@ -174,7 +174,7 @@ public class CliqueMinimalSeparatorDecomposition<V, E>
                 }
             }
 
-            for (V y : Y) {
+            for (V y : neighborsY) {
                 chordalGraph.addEdge(v, y);
                 vertexLabels.put(y, vertexLabels.get(y) + 1);
             }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/clique/DegeneracyBronKerboschCliqueFinder.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/clique/DegeneracyBronKerboschCliqueFinder.java
@@ -110,29 +110,29 @@ public class DegeneracyBronKerboschCliqueFinder<V, E>
                     viNeighbors.add(Graphs.getOppositeVertex(graph, e, vi));
                 }
 
-                Set<V> P = new HashSet<>();
+                Set<V> p = new HashSet<>();
                 for (int j = i + 1; j < n; j++) {
                     V vj = ordering.get(j);
                     if (viNeighbors.contains(vj)) {
-                        P.add(vj);
+                        p.add(vj);
                     }
                 }
 
-                Set<V> R = new HashSet<>();
-                R.add(vi);
+                Set<V> r = new HashSet<>();
+                r.add(vi);
 
-                Set<V> X = new HashSet<>();
+                Set<V> x = new HashSet<>();
                 for (int j = 0; j < i; j++) {
                     V vj = ordering.get(j);
                     if (viNeighbors.contains(vj)) {
-                        X.add(vj);
+                        x.add(vj);
                     }
                 }
 
                 /*
                  * Call the pivot version
                  */
-                findCliques(P, R, X, nanosTimeLimit);
+                findCliques(p, r, x, nanosTimeLimit);
             }
         }
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/clique/PivotBronKerboschCliqueFinder.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/clique/PivotBronKerboschCliqueFinder.java
@@ -103,21 +103,21 @@ public class PivotBronKerboschCliqueFinder<V, E>
     /**
      * Choose a pivot.
      * 
-     * @param P vertices to consider adding to the clique
-     * @param X vertices which must be excluded from the clique
+     * @param p vertices to consider adding to the clique
+     * @param x vertices which must be excluded from the clique
      * @return a pivot
      */
-    private V choosePivot(Set<V> P, Set<V> X)
+    private V choosePivot(Set<V> p, Set<V> x)
     {
         int max = -1;
         V pivot = null;
 
-        Iterator<V> it = Stream.concat(P.stream(), X.stream()).iterator();
+        Iterator<V> it = Stream.concat(p.stream(), x.stream()).iterator();
         while (it.hasNext()) {
             V u = it.next();
             int count = 0;
             for (E e : graph.edgesOf(u)) {
-                if (P.contains(Graphs.getOppositeVertex(graph, e, u))) {
+                if (p.contains(Graphs.getOppositeVertex(graph, e, u))) {
                     count++;
                 }
             }
@@ -133,18 +133,18 @@ public class PivotBronKerboschCliqueFinder<V, E>
     /**
      * Recursive implementation of the Bron-Kerbosch with pivot.
      * 
-     * @param P vertices to consider adding to the clique
-     * @param R a possibly non-maximal clique
-     * @param X vertices which must be excluded from the clique
+     * @param p vertices to consider adding to the clique
+     * @param r a possibly non-maximal clique
+     * @param x vertices which must be excluded from the clique
      * @param nanosTimeLimit time limit
      */
-    protected void findCliques(Set<V> P, Set<V> R, Set<V> X, final long nanosTimeLimit)
+    protected void findCliques(Set<V> p, Set<V> r, Set<V> x, final long nanosTimeLimit)
     {
         /*
          * Check if maximal clique
          */
-        if (P.isEmpty() && X.isEmpty()) {
-            Set<V> maximalClique = new HashSet<>(R);
+        if (p.isEmpty() && x.isEmpty()) {
+            Set<V> maximalClique = new HashSet<>(r);
             allMaximalCliques.add(maximalClique);
             maxSize = Math.max(maxSize, maximalClique.size());
             return;
@@ -161,7 +161,7 @@ public class PivotBronKerboschCliqueFinder<V, E>
         /*
          * Choose pivot
          */
-        V u = choosePivot(P, X);
+        V u = choosePivot(p, x);
 
         /*
          * Find candidates for addition
@@ -171,7 +171,7 @@ public class PivotBronKerboschCliqueFinder<V, E>
             uNeighbors.add(Graphs.getOppositeVertex(graph, e, u));
         }
         Set<V> candidates = new HashSet<>();
-        for (V v : P) {
+        for (V v : p) {
             if (!uNeighbors.contains(v)) {
                 candidates.add(v);
             }
@@ -186,15 +186,15 @@ public class PivotBronKerboschCliqueFinder<V, E>
                 vNeighbors.add(Graphs.getOppositeVertex(graph, e, v));
             }
 
-            Set<V> newP = P.stream().filter(vNeighbors::contains).collect(Collectors.toSet());
-            Set<V> newX = X.stream().filter(vNeighbors::contains).collect(Collectors.toSet());
-            Set<V> newR = new HashSet<>(R);
+            Set<V> newP = p.stream().filter(vNeighbors::contains).collect(Collectors.toSet());
+            Set<V> newX = x.stream().filter(vNeighbors::contains).collect(Collectors.toSet());
+            Set<V> newR = new HashSet<>(r);
             newR.add(v);
 
             findCliques(newP, newR, newX, nanosTimeLimit);
 
-            P.remove(v);
-            X.add(v);
+            p.remove(v);
+            x.add(v);
         }
 
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/BergeGraphInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/BergeGraphInspector.java
@@ -85,8 +85,8 @@ public class BergeGraphInspector<V, E>
      * Assembles a GraphPath of the Paths S and T. Required for the Pyramid Checker
      * 
      * @param g A Graph
-     * @param S A Path in g
-     * @param T A Path in g
+     * @param pathS A Path in g
+     * @param pathT A Path in g
      * @param m A vertex
      * @param b1 A base vertex
      * @param b2 A base vertex
@@ -96,8 +96,8 @@ public class BergeGraphInspector<V, E>
      * @param s3 A vertex
      * @return The conjunct path of S and T
      */
-    private GraphPath<V, E> P(
-        Graph<V, E> g, GraphPath<V, E> S, GraphPath<V, E> T, V m, V b1, V b2, V b3, V s1, V s2,
+    private GraphPath<V, E> p(
+        Graph<V, E> g, GraphPath<V, E> pathS, GraphPath<V, E> pathT, V m, V b1, V b2, V b3, V s1, V s2,
         V s3)
     {
         if (s1 == b1) {
@@ -110,35 +110,35 @@ public class BergeGraphInspector<V, E>
             if (b1 == m)
                 return null;
             if (g.containsEdge(m, b2) || g.containsEdge(m, b3) || g.containsEdge(m, s2)
-                || g.containsEdge(m, s3) || S == null || T == null)
+                || g.containsEdge(m, s3) || pathS == null || pathT == null)
                 return null;
-            if (S
+            if (pathS
                 .getVertexList().stream().anyMatch(
                     t -> g.containsEdge(t, b2) || g.containsEdge(t, b3) || g.containsEdge(t, s2)
                         || g.containsEdge(t, s3))
-                || T
+                || pathT
                     .getVertexList().stream().anyMatch(
                         t -> t != b1 && (g.containsEdge(t, b2) || g.containsEdge(t, b3)
                             || g.containsEdge(t, s2) || g.containsEdge(t, s3))))
                 return null;
-            List<V> intersection = intersectGraphPaths(S, T);
+            List<V> intersection = intersectGraphPaths(pathS, pathT);
             if (intersection.size() != 1 || !intersection.contains(m))
                 return null;
-            if (S
+            if (pathS
                 .getVertexList().stream().anyMatch(
-                    s -> s != m && T
+                    s -> s != m && pathT
                         .getVertexList().stream().anyMatch(t -> t != m && g.containsEdge(s, t))))
                 return null;
             List<E> edgeList = new LinkedList<>();
-            edgeList.addAll(T.getEdgeList());
-            edgeList.addAll(S.getEdgeList());
+            edgeList.addAll(pathT.getEdgeList());
+            edgeList.addAll(pathS.getEdgeList());
             double weight = edgeList.stream().mapToDouble(g::getEdgeWeight).sum();
             return new GraphWalk<>(g, b1, s1, edgeList, weight);
 
         }
     }
 
-    private void BFOddHoleCertificate(Graph<V, E> g)
+    private void bfOddHoleCertificate(Graph<V, E> g)
     {
         for (V start : g.vertexSet()) {
             if (g.degreeOf(start) < 2)
@@ -253,24 +253,24 @@ public class BergeGraphInspector<V, E>
 
                                     // s1, s2, s3 could now be the closest vertices to the top
                                     // vertex of the pyramid
-                                    Set<V> M = new HashSet<>();
-                                    M.addAll(g.vertexSet());
-                                    M.remove(b1);
-                                    M.remove(b2);
-                                    M.remove(b3);
-                                    M.remove(s1);
-                                    M.remove(s2);
-                                    M.remove(s3);
+                                    Set<V> setM = new HashSet<>();
+                                    setM.addAll(g.vertexSet());
+                                    setM.remove(b1);
+                                    setM.remove(b2);
+                                    setM.remove(b3);
+                                    setM.remove(s1);
+                                    setM.remove(s2);
+                                    setM.remove(s3);
 
-                                    Map<V, GraphPath<V, E>> S1 = new HashMap<>(),
-                                        S2 = new HashMap<>(), S3 = new HashMap<>(),
-                                        T1 = new HashMap<>(), T2 = new HashMap<>(),
-                                        T3 = new HashMap<>();
+                                    Map<V, GraphPath<V, E>> mapS1 = new HashMap<>(),
+                                        mapS2 = new HashMap<>(), mapS3 = new HashMap<>(),
+                                        mapT1 = new HashMap<>(), mapT2 = new HashMap<>(),
+                                        mapT3 = new HashMap<>();
 
                                     // find paths which could be the edges of the pyramid
-                                    for (V m1 : M) {
+                                    for (V m1 : setM) {
                                         Set<V> validInterior = new HashSet<>();
-                                        validInterior.addAll(M);
+                                        validInterior.addAll(setM);
                                         validInterior
                                             .removeIf(
                                                 i -> g.containsEdge(i, b2) || g.containsEdge(i, s2)
@@ -280,22 +280,22 @@ public class BergeGraphInspector<V, E>
                                         validInterior.add(m1);
                                         validInterior.add(s1);
                                         Graph<V, E> subg = new AsSubgraph<>(g, validInterior);
-                                        S1
+                                        mapS1
                                             .put(
                                                 m1,
                                                 new DijkstraShortestPath<>(subg).getPath(m1, s1));
                                         validInterior.remove(s1);
                                         validInterior.add(b1);
                                         subg = new AsSubgraph<>(g, validInterior);
-                                        T1
+                                        mapT1
                                             .put(
                                                 m1,
                                                 new DijkstraShortestPath<>(subg).getPath(b1, m1));
 
                                     }
-                                    for (V m2 : M) {
+                                    for (V m2 : setM) {
                                         Set<V> validInterior = new HashSet<>();
-                                        validInterior.addAll(M);
+                                        validInterior.addAll(setM);
                                         validInterior
                                             .removeIf(
                                                 i -> g.containsEdge(i, b1) || g.containsEdge(i, s1)
@@ -304,22 +304,22 @@ public class BergeGraphInspector<V, E>
                                         validInterior.add(m2);
                                         validInterior.add(s2);
                                         Graph<V, E> subg = new AsSubgraph<>(g, validInterior);
-                                        S2
+                                        mapS2
                                             .put(
                                                 m2,
                                                 new DijkstraShortestPath<>(subg).getPath(m2, s2));
                                         validInterior.remove(s2);
                                         validInterior.add(b2);
                                         subg = new AsSubgraph<>(g, validInterior);
-                                        T2
+                                        mapT2
                                             .put(
                                                 m2,
                                                 new DijkstraShortestPath<>(subg).getPath(b2, m2));
 
                                     }
-                                    for (V m3 : M) {
+                                    for (V m3 : setM) {
                                         Set<V> validInterior = new HashSet<>();
-                                        validInterior.addAll(M);
+                                        validInterior.addAll(setM);
                                         validInterior
                                             .removeIf(
                                                 i -> g.containsEdge(i, b1) || g.containsEdge(i, s1)
@@ -329,73 +329,73 @@ public class BergeGraphInspector<V, E>
                                         validInterior.add(s3);
 
                                         Graph<V, E> subg = new AsSubgraph<>(g, validInterior);
-                                        S3
+                                        mapS3
                                             .put(
                                                 m3,
                                                 new DijkstraShortestPath<>(subg).getPath(m3, s3));
                                         validInterior.remove(s3);
                                         validInterior.add(b3);
                                         subg = new AsSubgraph<>(g, validInterior, null);
-                                        T3
+                                        mapT3
                                             .put(
                                                 m3,
                                                 new DijkstraShortestPath<>(subg).getPath(b3, m3));
                                     }
 
                                     // Check if all edges of a pyramid are valid
-                                    Set<V> M1 = new HashSet<>();
-                                    M1.addAll(M);
-                                    M1.add(b1);
-                                    for (V m1 : M1) {
-                                        GraphPath<V, E> P1 = P(
-                                            g, S1.get(m1), T1.get(m1), m1, b1, b2, b3, s1, s2, s3);
-                                        if (P1 == null)
+                                    Set<V> setM1 = new HashSet<>();
+                                    setM1.addAll(setM);
+                                    setM1.add(b1);
+                                    for (V m1 : setM1) {
+                                        GraphPath<V, E> pathP1 = p(
+                                            g, mapS1.get(m1), mapT1.get(m1), m1, b1, b2, b3, s1, s2, s3);
+                                        if (pathP1 == null)
                                             continue;
-                                        Set<V> M2 = new HashSet<>();
-                                        M2.addAll(M);
-                                        M2.add(b2);
-                                        for (V m2 : M) {
+                                        Set<V> setM2 = new HashSet<>();
+                                        setM2.addAll(setM);
+                                        setM2.add(b2);
+                                        for (V m2 : setM) {
                                             GraphPath<V,
-                                                E> P2 = P(
-                                                    g, S2.get(m2), T2.get(m2), m2, b2, b1, b3, s2,
+                                                E> pathP2 = p(
+                                                    g, mapS2.get(m2), mapT2.get(m2), m2, b2, b1, b3, s2,
                                                     s1, s3);
-                                            if (P2 == null)
+                                            if (pathP2 == null)
                                                 continue;
-                                            Set<V> M3 = new HashSet<>();
-                                            M3.addAll(M);
-                                            M3.add(b3);
-                                            for (V m3 : M3) {
+                                            Set<V> setM3 = new HashSet<>();
+                                            setM3.addAll(setM);
+                                            setM3.add(b3);
+                                            for (V m3 : setM3) {
                                                 GraphPath<V,
-                                                    E> P3 = P(
-                                                        g, S3.get(m3), T3.get(m3), m3, b3, b1, b2,
+                                                    E> pathP3 = p(
+                                                        g, mapS3.get(m3), mapT3.get(m3), m3, b3, b1, b2,
                                                         s3, s1, s2);
-                                                if (P3 == null)
+                                                if (pathP3 == null)
                                                     continue;
                                                 if (certify) {
-                                                    if ((P1.getLength() + P2.getLength())
+                                                    if ((pathP1.getLength() + pathP2.getLength())
                                                         % 2 == 0)
                                                     {
                                                         Set<V> set = new HashSet<>();
-                                                        set.addAll(P1.getVertexList());
-                                                        set.addAll(P2.getVertexList());
+                                                        set.addAll(pathP1.getVertexList());
+                                                        set.addAll(pathP2.getVertexList());
                                                         set.add(aCandidate);
-                                                        BFOddHoleCertificate(
+                                                        bfOddHoleCertificate(
                                                             new AsSubgraph<>(g, set));
-                                                    } else if ((P1.getLength() + P3.getLength())
+                                                    } else if ((pathP1.getLength() + pathP3.getLength())
                                                         % 2 == 0)
                                                     {
                                                         Set<V> set = new HashSet<>();
-                                                        set.addAll(P1.getVertexList());
-                                                        set.addAll(P3.getVertexList());
+                                                        set.addAll(pathP1.getVertexList());
+                                                        set.addAll(pathP3.getVertexList());
                                                         set.add(aCandidate);
-                                                        BFOddHoleCertificate(
+                                                        bfOddHoleCertificate(
                                                             new AsSubgraph<>(g, set));
                                                     } else {
                                                         Set<V> set = new HashSet<>();
-                                                        set.addAll(P3.getVertexList());
-                                                        set.addAll(P2.getVertexList());
+                                                        set.addAll(pathP3.getVertexList());
+                                                        set.addAll(pathP2.getVertexList());
                                                         set.add(aCandidate);
-                                                        BFOddHoleCertificate(
+                                                        bfOddHoleCertificate(
                                                             new AsSubgraph<>(g, set));
                                                     }
                                                 }
@@ -425,12 +425,12 @@ public class BergeGraphInspector<V, E>
      * Finds all Components of a set F contained in V(g)
      * 
      * @param g A graph
-     * @param F A vertex subset of g
+     * @param f A vertex subset of g
      * @return Components of F in g
      */
-    private List<Set<V>> findAllComponents(Graph<V, E> g, Set<V> F)
+    private List<Set<V>> findAllComponents(Graph<V, E> g, Set<V> f)
     {
-        return new ConnectivityInspector<>(new AsSubgraph<>(g, F)).connectedSets();
+        return new ConnectivityInspector<>(new AsSubgraph<>(g, f)).connectedSets();
     }
 
     /**
@@ -449,42 +449,42 @@ public class BergeGraphInspector<V, E>
                     if (v2 == v5 || v3 == v5)
                         continue;
 
-                    Set<V> F = new HashSet<>();
+                    Set<V> setF = new HashSet<>();
                     for (V f : g.vertexSet()) {
                         if (f == v2 || f == v3 || f == v5 || g.containsEdge(f, v2)
                             || g.containsEdge(f, v3) || g.containsEdge(f, v5))
                             continue;
-                        F.add(f);
+                        setF.add(f);
                     }
 
-                    List<Set<V>> componentsOfF = findAllComponents(g, F);
+                    List<Set<V>> componentsOfF = findAllComponents(g, setF);
 
-                    Set<V> X1 = new HashSet<>();
+                    Set<V> setX1 = new HashSet<>();
                     for (V x1 : g.vertexSet()) {
                         if (x1 == v2 || x1 == v3 || x1 == v5 || !g.containsEdge(x1, v2)
                             || !g.containsEdge(x1, v5) || g.containsEdge(x1, v3))
                             continue;
-                        X1.add(x1);
+                        setX1.add(x1);
                     }
-                    Set<V> X2 = new HashSet<>();
+                    Set<V> setX2 = new HashSet<>();
                     for (V x2 : g.vertexSet()) {
                         if (x2 == v2 || x2 == v3 || x2 == v5 || g.containsEdge(x2, v2)
                             || !g.containsEdge(x2, v5) || !g.containsEdge(x2, v3))
                             continue;
-                        X2.add(x2);
+                        setX2.add(x2);
                     }
 
-                    for (V v1 : X1) {
+                    for (V v1 : setX1) {
                         if (g.containsEdge(v1, v3))
                             continue;
-                        for (V v4 : X2) {
+                        for (V v4 : setX2) {
                             if (v1 == v4 || g.containsEdge(v1, v4) || g.containsEdge(v2, v4))
                                 continue;
-                            for (Set<V> FPrime : componentsOfF) {
-                                if (hasANeighbour(g, FPrime, v1) && hasANeighbour(g, FPrime, v4)) {
+                            for (Set<V> fPrime : componentsOfF) {
+                                if (hasANeighbour(g, fPrime, v1) && hasANeighbour(g, fPrime, v4)) {
                                     if (certify) {
                                         Set<V> validSet = new HashSet<>();
-                                        validSet.addAll(FPrime);
+                                        validSet.addAll(fPrime);
                                         validSet.add(v1);
                                         validSet.add(v4);
                                         GraphPath<V, E> p = new DijkstraShortestPath<>(
@@ -583,14 +583,14 @@ public class BergeGraphInspector<V, E>
      * @param g A Graph
      * @param start start vertex
      * @param end end vertex
-     * @param X set of vertices which should not be in the graph
+     * @param x set of vertices which should not be in the graph
      * @return A Path in G\X
      */
-    private GraphPath<V, E> getPathAvoidingX(Graph<V, E> g, V start, V end, Set<V> X)
+    private GraphPath<V, E> getPathAvoidingX(Graph<V, E> g, V start, V end, Set<V> x)
     {
         Set<V> vertexSet = new HashSet<>();
         vertexSet.addAll(g.vertexSet());
-        vertexSet.removeAll(X);
+        vertexSet.removeAll(x);
         vertexSet.add(start);
         vertexSet.add(end);
         Graph<V, E> subg = new AsSubgraph<>(g, vertexSet, null);
@@ -602,19 +602,19 @@ public class BergeGraphInspector<V, E>
      * Running time: O(|V(g)|^4)
      * 
      * @param g Graph containing neither pyramid nor jewel
-     * @param X Subset of V(g) and a possible Cleaner for an odd hole
+     * @param x Subset of V(g) and a possible Cleaner for an odd hole
      * @return Determines whether g has an odd hole such that X is a near-cleaner for it
      */
-    private boolean containsShortestOddHole(Graph<V, E> g, Set<V> X)
+    private boolean containsShortestOddHole(Graph<V, E> g, Set<V> x)
     {
         for (V y1 : g.vertexSet()) {
-            if (X.contains(y1))
+            if (x.contains(y1))
                 continue;
 
             for (V x1 : g.vertexSet()) {
                 if (x1 == y1)
                     continue;
-                GraphPath<V, E> rx1y1 = getPathAvoidingX(g, x1, y1, X);
+                GraphPath<V, E> rx1y1 = getPathAvoidingX(g, x1, y1, x);
                 for (V x3 : g.vertexSet()) {
                     if (x3 == x1 || x3 == y1 || !g.containsEdge(x1, x3))
                         continue;
@@ -623,7 +623,7 @@ public class BergeGraphInspector<V, E>
                             || !g.containsEdge(x3, x2))
                             continue;
 
-                        GraphPath<V, E> rx2y1 = getPathAvoidingX(g, x2, y1, X);
+                        GraphPath<V, E> rx2y1 = getPathAvoidingX(g, x2, y1, x);
 
                         double n;
                         if (rx1y1 == null || rx2y1 == null)
@@ -641,9 +641,9 @@ public class BergeGraphInspector<V, E>
                         if (y2 == null)
                             continue;
 
-                        GraphPath<V, E> rx3y1 = getPathAvoidingX(g, x3, y1, X);
-                        GraphPath<V, E> rx3y2 = getPathAvoidingX(g, x3, y2, X);
-                        GraphPath<V, E> rx1y2 = getPathAvoidingX(g, x1, y2, X);
+                        GraphPath<V, E> rx3y1 = getPathAvoidingX(g, x3, y1, x);
+                        GraphPath<V, E> rx3y2 = getPathAvoidingX(g, x3, y2, x);
+                        GraphPath<V, E> rx1y2 = getPathAvoidingX(g, x1, y2, x);
                         if (rx3y1 != null && rx3y2 != null && rx1y2 != null
                             && rx2y1.getLength() == (n = rx1y1.getLength() + 1)
                             && n == rx1y2.getLength() && rx3y1.getLength() >= n
@@ -675,13 +675,13 @@ public class BergeGraphInspector<V, E>
      * shortest odd hole
      * 
      * @param g A graph, containing no pyramid or jewel
-     * @param X A subset X of V(g) and a possible Cleaner for an odd hole
+     * @param x A subset X of V(g) and a possible Cleaner for an odd hole
      * @return Returns whether g has an odd hole or there is no shortest odd hole in C such that X
      *         is a near-cleaner for C.
      */
-    private boolean routine1(Graph<V, E> g, Set<V> X)
+    private boolean routine1(Graph<V, E> g, Set<V> x)
     {
-        return containsCleanShortestOddHole(g) || containsShortestOddHole(g, X);
+        return containsCleanShortestOddHole(g) || containsShortestOddHole(g, x);
     }
 
     /**
@@ -737,22 +737,22 @@ public class BergeGraphInspector<V, E>
      * 
      * @param g A Graph
      * @param y Vertex whose X-completeness is to assess
-     * @param X Set of vertices
+     * @param x Set of vertices
      * @return whether y is X-complete
      */
-    boolean isYXComplete(Graph<V, E> g, V y, Set<V> X)
+    boolean isYXComplete(Graph<V, E> g, V y, Set<V> x)
     {
-        return X.stream().allMatch(t -> g.containsEdge(t, y));
+        return x.stream().allMatch(t -> g.containsEdge(t, y));
     }
 
     /**
      * Returns all anticomponents of a graph and a vertex set.
      * 
      * @param g A Graph
-     * @param Y A set of vertices
+     * @param y A set of vertices
      * @return List of anticomponents of Y in g
      */
-    private List<Set<V>> findAllAnticomponentsOfY(Graph<V, E> g, Set<V> Y)
+    private List<Set<V>> findAllAnticomponentsOfY(Graph<V, E> g, Set<V> y)
     {
         Graph<V, E> target;
         if (g.getType().isSimple())
@@ -763,7 +763,7 @@ public class BergeGraphInspector<V, E>
                 g.getVertexSupplier(), g.getEdgeSupplier(), g.getType().isWeighted());
         new ComplementGraphGenerator<>(g).generateGraph(target);
 
-        return findAllComponents(target, Y);
+        return findAllComponents(target, y);
     }
 
     /**
@@ -802,35 +802,35 @@ public class BergeGraphInspector<V, E>
                         temp.add(v1);
                         temp.add(v2);
                         temp.add(v4);
-                        Set<V> Y = new HashSet<>();
+                        Set<V> setY = new HashSet<>();
                         for (V y : g.vertexSet()) {
                             if (isYXComplete(g, y, temp)) {
-                                Y.add(y);
+                                setY.add(y);
                             }
                         }
-                        List<Set<V>> anticomponentsOfY = findAllAnticomponentsOfY(g, Y);
-                        for (Set<V> X : anticomponentsOfY) {
+                        List<Set<V>> anticomponentsOfY = findAllAnticomponentsOfY(g, setY);
+                        for (Set<V> setX : anticomponentsOfY) {
                             Set<V> v2v3 = new HashSet<>();
                             v2v3.addAll(g.vertexSet());
                             v2v3.remove(v2);
                             v2v3.remove(v3);
-                            v2v3.removeAll(X);
+                            v2v3.removeAll(setX);
                             if (!v2v3.contains(v1) || !v2v3.contains(v4))
                                 continue;
 
-                            GraphPath<V, E> Path =
+                            GraphPath<V, E> path =
                                 new DijkstraShortestPath<>(new AsSubgraph<>(g, v2v3))
                                     .getPath(v1, v4);
-                            if (Path == null)
+                            if (path == null)
                                 continue;
-                            List<V> P = Path.getVertexList();
-                            if (!P.contains(v1) || !P.contains(v4))
+                            List<V> listP = path.getVertexList();
+                            if (!listP.contains(v1) || !listP.contains(v4))
                                 continue;
 
                             boolean cont = true;
-                            for (V p : P) {
+                            for (V p : listP) {
                                 if (p != v1 && p != v4 && (g.containsEdge(p, v2)
-                                    || g.containsEdge(p, v3) || isYXComplete(g, p, X)))
+                                    || g.containsEdge(p, v3) || isYXComplete(g, p, setX)))
                                 {
                                     cont = false;
                                     break;
@@ -839,14 +839,14 @@ public class BergeGraphInspector<V, E>
                             if (cont) {
                                 if (certify) {
                                     List<E> edgeList = new LinkedList<>();
-                                    if (Path.getLength() % 2 == 0) {
+                                    if (path.getLength() % 2 == 0) {
                                         edgeList.add(g.getEdge(v1, v2));
                                         edgeList.add(g.getEdge(v2, v3));
                                         edgeList.add(g.getEdge(v3, v4));
-                                        edgeList.addAll(Path.getEdgeList());
+                                        edgeList.addAll(path.getEdgeList());
                                     } else {
-                                        edgeList.addAll(Path.getEdgeList());
-                                        V x = X.iterator().next();
+                                        edgeList.addAll(path.getEdgeList());
+                                        V x = setX.iterator().next();
                                         edgeList.add(g.getEdge(v4, x));
                                         edgeList.add(g.getEdge(x, v1));
                                     }
@@ -884,21 +884,21 @@ public class BergeGraphInspector<V, E>
      * properties that v1,v2 have no neighbours in F' and no vertex of F'\v5 is X-complete
      * 
      * @param g A Graph
-     * @param X A set of vertices
+     * @param setX A set of vertices
      * @param v1 A vertex
      * @param v2 A vertex
      * @param v5 A Vertex
      * @return The maximal connected vertex subset containing v5, no neighbours of v1 and v2, and no
      *         X-complete vertex except v5
      */
-    private Set<V> findMaximalConnectedSubset(Graph<V, E> g, Set<V> X, V v1, V v2, V v5)
+    private Set<V> findMaximalConnectedSubset(Graph<V, E> g, Set<V> setX, V v1, V v2, V v5)
     {
-        Set<V> FPrime = new ConnectivityInspector<>(g).connectedSetOf(v5);
-        FPrime
+        Set<V> fPrime = new ConnectivityInspector<>(g).connectedSetOf(v5);
+        fPrime
             .removeIf(
-                t -> t != v5 && isYXComplete(g, t, X) || v1 == t || v2 == t || g.containsEdge(v1, t)
+                t -> t != v5 && isYXComplete(g, t, setX) || v1 == t || v2 == t || g.containsEdge(v1, t)
                     || g.containsEdge(v2, t));
-        return FPrime;
+        return fPrime;
     }
 
     /**
@@ -906,12 +906,12 @@ public class BergeGraphInspector<V, E>
      * 
      * @param g A Graph
      * @param v A Vertex
-     * @param X A set of vertices
+     * @param setX A set of vertices
      * @return whether v has a nonneighbour in X
      */
-    private boolean hasANonneighbourInX(Graph<V, E> g, V v, Set<V> X)
+    private boolean hasANonneighbourInX(Graph<V, E> g, V v, Set<V> setX)
     {
-        return X.stream().anyMatch(x -> !g.containsEdge(v, x));
+        return setX.stream().anyMatch(x -> !g.containsEdge(v, x));
     }
 
     /**
@@ -946,44 +946,44 @@ public class BergeGraphInspector<V, E>
                     triple.add(v1);
                     triple.add(v2);
                     triple.add(v5);
-                    Set<V> Y = new HashSet<>();
+                    Set<V> setY = new HashSet<>();
                     for (V y : g.vertexSet()) {
                         if (isYXComplete(g, y, triple)) {
-                            Y.add(y);
+                            setY.add(y);
                         }
                     }
-                    List<Set<V>> anticomponents = findAllAnticomponentsOfY(g, Y);
-                    for (Set<V> X : anticomponents) {
-                        Set<V> FPrime = findMaximalConnectedSubset(g, X, v1, v2, v5);
-                        Set<V> F = new HashSet<>();
-                        F.addAll(FPrime);
-                        for (V x : X) {
+                    List<Set<V>> anticomponents = findAllAnticomponentsOfY(g, setY);
+                    for (Set<V> setX : anticomponents) {
+                        Set<V> fPrime = findMaximalConnectedSubset(g, setX, v1, v2, v5);
+                        Set<V> setF = new HashSet<>();
+                        setF.addAll(fPrime);
+                        for (V x : setX) {
                             if (!g.containsEdge(x, v1) && !g.containsEdge(x, v2)
-                                && !g.containsEdge(x, v5) && hasANeighbour(g, FPrime, x))
-                                F.add(x);
+                                && !g.containsEdge(x, v5) && hasANeighbour(g, fPrime, x))
+                                setF.add(x);
                         }
 
                         for (V v4 : g.vertexSet()) {
                             if (v4 == v1 || v4 == v2 || v4 == v5 || g.containsEdge(v2, v4)
                                 || g.containsEdge(v5, v4) || !g.containsEdge(v1, v4)
-                                || !hasANeighbour(g, F, v4) || !hasANonneighbourInX(g, v4, X)
-                                || isYXComplete(g, v4, X))
+                                || !hasANeighbour(g, setF, v4) || !hasANonneighbourInX(g, v4, setX)
+                                || isYXComplete(g, v4, setX))
                                 continue;
 
                             for (V v3 : g.vertexSet()) {
                                 if (v3 == v1 || v3 == v2 || v3 == v4 || v3 == v5
                                     || !g.containsEdge(v2, v3) || !g.containsEdge(v3, v4)
                                     || !g.containsEdge(v5, v3) || g.containsEdge(v1, v3)
-                                    || !hasANonneighbourInX(g, v3, X) || isYXComplete(g, v3, X))
+                                    || !hasANonneighbourInX(g, v3, setX) || isYXComplete(g, v3, setX))
                                     continue;
-                                for (V v6 : F) {
+                                for (V v6 : setF) {
                                     if (v6 == v1 || v6 == v2 || v6 == v3 || v6 == v4 || v6 == v5
                                         || !g.containsEdge(v4, v6) || g.containsEdge(v1, v6)
                                         || g.containsEdge(v2, v6)
-                                        || g.containsEdge(v5, v6) && !isYXComplete(g, v6, X))
+                                        || g.containsEdge(v5, v6) && !isYXComplete(g, v6, setX))
                                         continue;
                                     Set<V> verticesForPv5v6 = new HashSet<>();
-                                    verticesForPv5v6.addAll(FPrime);
+                                    verticesForPv5v6.addAll(fPrime);
                                     verticesForPv5v6.add(v5);
                                     verticesForPv5v6.add(v6);
                                     verticesForPv5v6.remove(v1);
@@ -998,11 +998,11 @@ public class BergeGraphInspector<V, E>
                                             List<E> edgeList = new LinkedList<>();
                                             edgeList.add(g.getEdge(v1, v4));
                                             edgeList.add(g.getEdge(v4, v6));
-                                            GraphPath<V, E> P =
+                                            GraphPath<V, E> path =
                                                 new DijkstraShortestPath<>(g).getPath(v6, v5);
-                                            edgeList.addAll(P.getEdgeList());
-                                            if (P.getLength() % 2 == 1) {
-                                                V x = X.iterator().next();
+                                            edgeList.addAll(path.getEdgeList());
+                                            if (path.getLength() % 2 == 1) {
+                                                V x = setX.iterator().next();
                                                 edgeList.add(g.getEdge(v5, x));
                                                 edgeList.add(g.getEdge(x, v1));
                                             } else {
@@ -1052,7 +1052,7 @@ public class BergeGraphInspector<V, E>
      * @param b A Vertex
      * @return The set of all {a,b}-complete vertices
      */
-    private Set<V> N(Graph<V, E> g, V a, V b)
+    private Set<V> n(Graph<V, E> g, V a, V b)
     {
         return g
             .vertexSet().stream().filter(t -> g.containsEdge(t, a) && g.containsEdge(t, b))
@@ -1064,16 +1064,16 @@ public class BergeGraphInspector<V, E>
      * nonneighbour of c (or 0, if c is N(a,b)-complete)
      * 
      * @param g a Graph
-     * @param Nab The set of all {a,b}-complete vertices
+     * @param nAB The set of all {a,b}-complete vertices
      * @param c A vertex
      * @return The cardinality of the largest anticomponent of N(a,b) that contains a nonneighbour
      *         of c (or 0, if c is N(a,b)-complete)
      */
-    private int r(Graph<V, E> g, Set<V> Nab, V c)
+    private int r(Graph<V, E> g, Set<V> nAB, V c)
     {
-        if (isYXComplete(g, c, Nab))
+        if (isYXComplete(g, c, nAB))
             return 0;
-        List<Set<V>> anticomponents = findAllAnticomponentsOfY(g, Nab);
+        List<Set<V>> anticomponents = findAllAnticomponentsOfY(g, nAB);
         return anticomponents.stream().mapToInt(Set::size).max().getAsInt();
     }
 
@@ -1082,14 +1082,14 @@ public class BergeGraphInspector<V, E>
      * than r(a,b,c)
      * 
      * @param g A graph
-     * @param Nab The set of all {a,b}-complete vertices
+     * @param nAB The set of all {a,b}-complete vertices
      * @param c A vertex
      * @return A Set of vertices with cardinality greater r(a,b,c)
      */
-    private Set<V> Y(Graph<V, E> g, Set<V> Nab, V c)
+    private Set<V> y(Graph<V, E> g, Set<V> nAB, V c)
     {
-        int cutoff = r(g, Nab, c);
-        List<Set<V>> anticomponents = findAllAnticomponentsOfY(g, Nab);
+        int cutoff = r(g, nAB, c);
+        List<Set<V>> anticomponents = findAllAnticomponentsOfY(g, nAB);
         Set<V> res = new HashSet<>();
         for (Set<V> anticomponent : anticomponents) {
             if (anticomponent.size() > cutoff) {
@@ -1103,14 +1103,14 @@ public class BergeGraphInspector<V, E>
      * W(a,b,c) is the anticomponent of N(a,b)+{c} that contains c
      * 
      * @param g A graph
-     * @param Nab The set of all {a,b}-complete vertices
+     * @param nAB The set of all {a,b}-complete vertices
      * @param c A vertex
      * @return The anticomponent of N(a,b)+{c} containing c
      */
-    private Set<V> W(Graph<V, E> g, Set<V> Nab, V c)
+    private Set<V> w(Graph<V, E> g, Set<V> nAB, V c)
     {
-        Set<V> temp = new HashSet<V>();
-        temp.addAll(Nab);
+        Set<V> temp = new HashSet<>();
+        temp.addAll(nAB);
         temp.add(c);
         List<Set<V>> anticomponents = findAllAnticomponentsOfY(g, temp);
         for (Set<V> anticomponent : anticomponents)
@@ -1123,15 +1123,15 @@ public class BergeGraphInspector<V, E>
      * Z(a,b,c) is the set of all (Y(a,b,c)+W(a,b,c))-complete vertices
      * 
      * @param g A graph
-     * @param Nab The set of all {a,b}-complete vertices
+     * @param nAB The set of all {a,b}-complete vertices
      * @param c A vertex
      * @return A set of vertices
      */
-    private Set<V> Z(Graph<V, E> g, Set<V> Nab, V c)
+    private Set<V> z(Graph<V, E> g, Set<V> nAB, V c)
     {
         Set<V> temp = new HashSet<>();
-        temp.addAll(Y(g, Nab, c));
-        temp.addAll(W(g, Nab, c));
+        temp.addAll(y(g, nAB, c));
+        temp.addAll(w(g, nAB, c));
         Set<V> res = new HashSet<>();
         for (V it : g.vertexSet()) {
             if (isYXComplete(g, it, temp))
@@ -1144,15 +1144,15 @@ public class BergeGraphInspector<V, E>
      * X(a,b,c)=Y(a,b,c)+Z(a,b,c)
      * 
      * @param g A graph
-     * @param Nab The set of all {a,b}-complete vertices
+     * @param nAB The set of all {a,b}-complete vertices
      * @param c A vertex
      * @return The union of Y(a,b,c) and Z(a,b,c)
      */
-    private Set<V> X(Graph<V, E> g, Set<V> Nab, V c)
+    private Set<V> x(Graph<V, E> g, Set<V> nAB, V c)
     {
         Set<V> res = new HashSet<>();
-        res.addAll(Y(g, Nab, c));
-        res.addAll(Z(g, Nab, c));
+        res.addAll(y(g, nAB, c));
+        res.addAll(z(g, nAB, c));
         return res;
     }
 
@@ -1168,7 +1168,7 @@ public class BergeGraphInspector<V, E>
      */
     private boolean isTripleRelevant(Graph<V, E> g, V a, V b, V c)
     {
-        return a != b && !g.containsEdge(a, b) && !N(g, a, b).contains(c);
+        return a != b && !g.containsEdge(a, b) && !n(g, a, b).contains(c);
     }
 
     /**
@@ -1179,12 +1179,12 @@ public class BergeGraphInspector<V, E>
      */
     Set<Set<V>> routine3(Graph<V, E> g)
     {
-        Set<Set<V>> NuvList = new HashSet<>();
+        Set<Set<V>> nUVList = new HashSet<>();
         for (V u : g.vertexSet()) {
             for (V v : g.vertexSet()) {
                 if (u == v || !g.containsEdge(u, v))
                     continue;
-                NuvList.add(N(g, u, v));
+                nUVList.add(n(g, u, v));
             }
         }
 
@@ -1193,19 +1193,19 @@ public class BergeGraphInspector<V, E>
             for (V b : g.vertexSet()) {
                 if (a == b || g.containsEdge(a, b))
                     continue;
-                Set<V> Nab = N(g, a, b);
+                Set<V> nAB = n(g, a, b);
                 for (V c : g.vertexSet()) {
                     if (isTripleRelevant(g, a, b, c)) {
-                        tripleList.add(X(g, Nab, c));
+                        tripleList.add(x(g, nAB, c));
                     }
                 }
             }
         }
         Set<Set<V>> res = new HashSet<>();
-        for (Set<V> Nuv : NuvList) {
+        for (Set<V> nUV : nUVList) {
             for (Set<V> triple : tripleList) {
                 Set<V> temp = new HashSet<>();
-                temp.addAll(Nuv);
+                temp.addAll(nUV);
                 temp.addAll(triple);
                 res.add(temp);
             }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
@@ -50,8 +50,8 @@ public class HawickJamesSimpleCycles<V, E>
 
     // The main state of the algorithm
     private Integer start = 0;
-    private List<Integer>[] Ak = null;
-    private List<Integer>[] B = null;
+    private List<Integer>[] aK = null;
+    private List<Integer>[] b = null;
     private boolean[] blocked = null;
     private ArrayDeque<Integer> stack = null;
 
@@ -92,9 +92,9 @@ public class HawickJamesSimpleCycles<V, E>
         blocked = new boolean[nVertices];
         stack = new ArrayDeque<>(nVertices);
 
-        B = new ArrayList[nVertices];
+        b = new ArrayList[nVertices];
         for (int i = 0; i < nVertices; i++) {
-            B[i] = new ArrayList<>();
+            b[i] = new ArrayList<>();
         }
 
         iToV = (V[]) graph.vertexSet().toArray();
@@ -103,7 +103,7 @@ public class HawickJamesSimpleCycles<V, E>
             vToI.put(iToV[i], i);
         }
 
-        Ak = buildAdjacencyList();
+        aK = buildAdjacencyList();
 
         stack.clear();
     }
@@ -111,29 +111,29 @@ public class HawickJamesSimpleCycles<V, E>
     @SuppressWarnings("unchecked")
     private List<Integer>[] buildAdjacencyList()
     {
-        @SuppressWarnings("rawtypes") List[] Ak = new ArrayList[nVertices];
+        @SuppressWarnings("rawtypes") List[] listAk = new ArrayList[nVertices];
         for (int j = 0; j < nVertices; j++) {
             V v = iToV[j];
             List<V> s = Graphs.successorListOf(graph, v);
-            Ak[j] = new ArrayList<Integer>(s.size());
+            listAk[j] = new ArrayList<Integer>(s.size());
 
             for (V value : s) {
-                Ak[j].add(vToI.get(value));
+                listAk[j].add(vToI.get(value));
             }
         }
 
-        return Ak;
+        return listAk;
     }
 
     private void clearState()
     {
-        Ak = null;
+        aK = null;
         nVertices = 0;
         blocked = null;
         stack = null;
         iToV = null;
         vToI = null;
-        B = null;
+        b = null;
         operation = () -> {
         };
     }
@@ -145,7 +145,7 @@ public class HawickJamesSimpleCycles<V, E>
         stack.push(v);
         blocked[v] = true;
 
-        for (Integer w : Ak[v]) {
+        for (Integer w : aK[v]) {
             if (w < start) {
                 continue;
             }
@@ -164,13 +164,13 @@ public class HawickJamesSimpleCycles<V, E>
         if (f) {
             unblock(v);
         } else {
-            for (Integer w : Ak[v]) {
+            for (Integer w : aK[v]) {
                 if (w < start) {
                     continue;
                 }
 
-                if (!B[w].contains(v)) {
-                    B[w].add(v);
+                if (!b[w].contains(v)) {
+                    b[w].add(v);
                 }
             }
         }
@@ -184,12 +184,12 @@ public class HawickJamesSimpleCycles<V, E>
     {
         blocked[u] = false;
 
-        for (int wPos = 0; wPos < B[u].size(); wPos++) {
-            Integer w = B[u].get(wPos);
+        for (int wPos = 0; wPos < b[u].size(); wPos++) {
+            Integer w = b[u].get(wPos);
 
-            int sizeBeforeRemove = B[u].size();
-            B[u].removeAll(singletonList(w));
-            wPos -= (sizeBeforeRemove - B[u].size());
+            int sizeBeforeRemove = b[u].size();
+            b[u].removeAll(singletonList(w));
+            wPos -= (sizeBeforeRemove - b[u].size());
 
             if (blocked[w]) {
                 unblock(w);
@@ -285,7 +285,7 @@ public class HawickJamesSimpleCycles<V, E>
         for (int i = 0; i < nVertices; i++) {
             for (int j = 0; j < nVertices; j++) {
                 blocked[j] = false;
-                B[j].clear();
+                b[j].clear();
             }
 
             start = vToI.get(iToV[i]);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/JohnsonSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/JohnsonSimpleCycles.java
@@ -52,7 +52,7 @@ public class JohnsonSimpleCycles<V, E>
     private ArrayDeque<V> stack = null;
 
     // The state of the embedded Tarjan SCC algorithm.
-    private List<Set<V>> SCCs = null;
+    private List<Set<V>> foundSCCs = null;
     private int index = 0;
     private Map<V, Integer> vIndex = null;
     private Map<V, Integer> vLowlink = null;
@@ -121,12 +121,12 @@ public class JohnsonSimpleCycles<V, E>
          */
         initMinSCGState();
 
-        List<Set<V>> SCCs = findSCCS(startIndex);
+        List<Set<V>> foundSCCs = findSCCS(startIndex);
 
         // find the SCC with the minimum index
         int minIndexFound = Integer.MAX_VALUE;
         Set<V> minSCC = null;
-        for (Set<V> scc : SCCs) {
+        for (Set<V> scc : foundSCCs) {
             for (V v : scc) {
                 int t = toI(v);
                 if (t < minIndexFound) {
@@ -182,8 +182,8 @@ public class JohnsonSimpleCycles<V, E>
                 getSCCs(startIndex, vI);
             }
         }
-        List<Set<V>> result = SCCs;
-        SCCs = null;
+        List<Set<V>> result = foundSCCs;
+        foundSCCs = null;
         return result;
     }
 
@@ -221,10 +221,10 @@ public class JohnsonSimpleCycles<V, E>
             if (result.size() == 1) {
                 V v = result.iterator().next();
                 if (graph.containsEdge(vertex, v)) {
-                    SCCs.add(result);
+                    foundSCCs.add(result);
                 }
             } else {
-                SCCs.add(result);
+                foundSCCs.add(result);
             }
         }
     }
@@ -306,7 +306,7 @@ public class JohnsonSimpleCycles<V, E>
     private void initMinSCGState()
     {
         index = 0;
-        SCCs = new ArrayList<>();
+        foundSCCs = new ArrayList<>();
         vIndex = new HashMap<>();
         vLowlink = new HashMap<>();
         path = new ArrayDeque<>();
@@ -316,7 +316,7 @@ public class JohnsonSimpleCycles<V, E>
     private void clearMinSCCState()
     {
         index = 0;
-        SCCs = null;
+        foundSCCs = null;
         vIndex = null;
         vLowlink = null;
         path = null;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/GusfieldEquivalentFlowTree.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/GusfieldEquivalentFlowTree.java
@@ -69,7 +69,7 @@ public class GusfieldEquivalentFlowTree<V, E>
 {
 
     /* Number of vertices in the graph */
-    private final int N;
+    private final int n;
     /* Algorithm used to computed the Maximum s-t flows */
     private final MinimumSTCutAlgorithm<V, E> minimumSTCutAlgorithm;
 
@@ -116,8 +116,8 @@ public class GusfieldEquivalentFlowTree<V, E>
         Graph<V, E> network, MinimumSTCutAlgorithm<V, E> minimumSTCutAlgorithm)
     {
         GraphTests.requireUndirected(network);
-        this.N = network.vertexSet().size();
-        if (N < 2)
+        this.n = network.vertexSet().size();
+        if (n < 2)
             throw new IllegalArgumentException("Graph must have at least 2 vertices");
         this.minimumSTCutAlgorithm = minimumSTCutAlgorithm;
         vertexList.addAll(network.vertexSet());
@@ -130,18 +130,18 @@ public class GusfieldEquivalentFlowTree<V, E>
      */
     private void calculateEquivalentFlowTree()
     {
-        flowMatrix = new double[N][N];
-        p = new int[N];
-        neighbors = new int[N];
+        flowMatrix = new double[n][n];
+        p = new int[n];
+        neighbors = new int[n];
 
-        for (int s = 1; s < N; s++) {
+        for (int s = 1; s < n; s++) {
             int t = p[s];
             neighbors[s] = t;
             double flowValue =
                 minimumSTCutAlgorithm.calculateMinCut(vertexList.get(s), vertexList.get(t));
             Set<V> sourcePartition = minimumSTCutAlgorithm.getSourcePartition(); // Set X in the
                                                                                  // paper
-            for (int i = s; i < N; i++)
+            for (int i = s; i < n; i++)
                 if (sourcePartition.contains(vertexList.get(i)) && p[i] == t)
                     p[i] = s;
 
@@ -168,7 +168,7 @@ public class GusfieldEquivalentFlowTree<V, E>
         SimpleWeightedGraph<V, DefaultWeightedEdge> equivalentFlowTree =
             new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
         Graphs.addAllVertices(equivalentFlowTree, vertexList);
-        for (int i = 1; i < N; i++) {
+        for (int i = 1; i < n; i++) {
             DefaultWeightedEdge e =
                 equivalentFlowTree.addEdge(vertexList.get(i), vertexList.get(neighbors[i]));
             equivalentFlowTree.setEdgeWeight(e, flowMatrix[i][neighbors[i]]);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/GusfieldGomoryHuCutTree.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/GusfieldGomoryHuCutTree.java
@@ -74,7 +74,7 @@ public class GusfieldGomoryHuCutTree<V, E>
 
     private final Graph<V, E> network;
     /* Number of vertices in the graph */
-    private final int N;
+    private final int n;
     /* Algorithm used to computed the Maximum $s-t$ flows */
     private final MinimumSTCutAlgorithm<V, E> minimumSTCutAlgorithm;
 
@@ -123,8 +123,8 @@ public class GusfieldGomoryHuCutTree<V, E>
         Graph<V, E> network, MinimumSTCutAlgorithm<V, E> minimumSTCutAlgorithm)
     {
         this.network = GraphTests.requireUndirected(network);
-        this.N = network.vertexSet().size();
-        if (N < 2)
+        this.n = network.vertexSet().size();
+        if (n < 2)
             throw new IllegalArgumentException("Graph must have at least 2 vertices");
         this.minimumSTCutAlgorithm = minimumSTCutAlgorithm;
         vertexList.addAll(network.vertexSet());
@@ -137,11 +137,11 @@ public class GusfieldGomoryHuCutTree<V, E>
      */
     private void calculateGomoryHuTree()
     {
-        flowMatrix = new double[N][N];
-        p = new int[N];
-        fl = new double[N];
+        flowMatrix = new double[n][n];
+        p = new int[n];
+        fl = new double[n];
 
-        for (int s = 1; s < N; s++) {
+        for (int s = 1; s < n; s++) {
             int t = p[s];
             double flowValue =
                 minimumSTCutAlgorithm.calculateMinCut(vertexList.get(s), vertexList.get(t));
@@ -149,7 +149,7 @@ public class GusfieldGomoryHuCutTree<V, E>
                                                                                  // paper
             fl[s] = flowValue;
 
-            for (int i = 0; i < N; i++)
+            for (int i = 0; i < n; i++)
                 if (i != s && sourcePartition.contains(vertexList.get(i)) && p[i] == t)
                     p[i] = s;
             if (sourcePartition.contains(vertexList.get(p[t]))) {
@@ -185,7 +185,7 @@ public class GusfieldGomoryHuCutTree<V, E>
         SimpleWeightedGraph<V, DefaultWeightedEdge> gomoryHuTree =
             new SimpleWeightedGraph<>(DefaultWeightedEdge.class);
         Graphs.addAllVertices(gomoryHuTree, vertexList);
-        for (int i = 1; i < N; i++) {
+        for (int i = 1; i < n; i++) {
             Graphs.addEdge(gomoryHuTree, vertexList.get(i), vertexList.get(p[i]), fl[i]);
         }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -78,7 +78,7 @@ public class PushRelabelMFImpl<V, E>
     private PushRelabelDiagnostic diagnostic;
 
     // number of vertices
-    private final int N;
+    private final int n;
 
     private final VertexExtension[] vertexExtension;
 
@@ -116,8 +116,8 @@ public class PushRelabelMFImpl<V, E>
             this.diagnostic = new PushRelabelDiagnostic();
         }
 
-        this.N = network.vertexSet().size();
-        this.vertexExtension = (VertexExtension[]) Array.newInstance(VertexExtension.class, N);
+        this.n = network.vertexSet().size();
+        this.vertexExtension = (VertexExtension[]) Array.newInstance(VertexExtension.class, n);
     }
 
     private void enqueue(VertexExtension vx)
@@ -139,7 +139,7 @@ public class PushRelabelMFImpl<V, E>
     {
         super.init(source, sink, vertexExtensionsFactory, edgeExtensionsFactory);
 
-        this.countHeight = new int[2 * N + 1];
+        this.countHeight = new int[2 * n + 1];
 
         int id = 0;
         for (V v : network.vertexSet()) {
@@ -162,19 +162,19 @@ public class PushRelabelMFImpl<V, E>
     {
         this.activeVertices = active;
 
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             vertexExtension[i].excess = 0;
             vertexExtension[i].height = 0;
             vertexExtension[i].active = false;
             vertexExtension[i].currentArc = 0;
         }
 
-        source.height = N;
+        source.height = n;
         source.active = true;
         sink.active = true;
 
-        countHeight[N] = 1;
-        countHeight[0] = N - 1;
+        countHeight[n] = 1;
+        countHeight[0] = n - 1;
 
         for (AnnotatedFlowEdge ex : source.getOutgoing()) {
             source.excess += ex.capacity;
@@ -213,7 +213,7 @@ public class PushRelabelMFImpl<V, E>
 
         init(source, sink);
 
-        this.activeVertices = new ArrayDeque<>(N);
+        this.activeVertices = new ArrayDeque<>(n);
         initialize(getVertexExtension(source), getVertexExtension(sink), this.activeVertices);
 
         //
@@ -282,10 +282,10 @@ public class PushRelabelMFImpl<V, E>
 
     private void gapHeuristic(int l)
     {
-        for (int i = 0; i < N; i++) {
-            if (l < vertexExtension[i].height && vertexExtension[i].height < N) {
+        for (int i = 0; i < n; i++) {
+            if (l < vertexExtension[i].height && vertexExtension[i].height < n) {
                 countHeight[vertexExtension[i].height]--;
-                vertexExtension[i].height = Math.max(vertexExtension[i].height, N + 1);
+                vertexExtension[i].height = Math.max(vertexExtension[i].height, n + 1);
                 countHeight[vertexExtension[i].height]++;
             }
         }
@@ -305,7 +305,7 @@ public class PushRelabelMFImpl<V, E>
         // Increase the height of u; u.h = 1 + min(v.h : (u, v) in Ef)
 
         countHeight[ux.height]--;
-        ux.height = 2 * N;
+        ux.height = 2 * n;
 
         for (AnnotatedFlowEdge ex : ux.getOutgoing()) {
             if (ex.hasCapacity()) {
@@ -321,7 +321,7 @@ public class PushRelabelMFImpl<V, E>
              * |V| for which there is no node u such that u.height = h, then any node v with h <
              * v.height < |V| has been disconnected from sink and can be relabeled to (|V| + 1).
              */
-            if (0 < oldHeight && oldHeight < N && countHeight[oldHeight] == 0) {
+            if (0 < oldHeight && oldHeight < n && countHeight[oldHeight] == 0) {
                 gapHeuristic(oldHeight);
             }
         }
@@ -358,17 +358,17 @@ public class PushRelabelMFImpl<V, E>
     {
         Arrays.fill(countHeight, 0);
 
-        Queue<Integer> queue = new ArrayDeque<>(N);
-        boolean[] visited = new boolean[N];
+        Queue<Integer> queue = new ArrayDeque<>(n);
+        boolean[] visited = new boolean[n];
 
-        for (int i = 0; i < N; i++) {
-            vertexExtension[i].height = 2 * N;
+        for (int i = 0; i < n; i++) {
+            vertexExtension[i].height = 2 * n;
         }
 
         final int sinkID = getVertexExtension(getCurrentSink()).id;
         final int sourceID = getVertexExtension(getCurrentSource()).id;
 
-        vertexExtension[sourceID].height = N;
+        vertexExtension[sourceID].height = n;
         visited[sourceID] = true;
 
         vertexExtension[sinkID].height = 0;
@@ -380,7 +380,7 @@ public class PushRelabelMFImpl<V, E>
         queue.add(sourceID);
         bfs(queue, visited);
 
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             ++countHeight[vertexExtension[i].height];
         }
     }
@@ -401,10 +401,10 @@ public class PushRelabelMFImpl<V, E>
                 if (USE_GLOBAL_RELABELING_HEURISTIC) {
                     // If we already relabeled |V| vertices, then we do a global relabeling
                     // Note: Global relabelings are performed periodically
-                    if ((++relabelCounter) == N) {
+                    if ((++relabelCounter) == n) {
                         recomputeHeightsHeuristic();
 
-                        for (int i = 0; i < N; i++)
+                        for (int i = 0; i < n; i++)
                             vertexExtension[i].currentArc = 0;
 
                         relabelCounter = 0;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -63,8 +63,30 @@ public class PushRelabelMFImpl<V, E>
     // Diagnostic
     private static final boolean DIAGNOSTIC_ENABLED = false;
 
-    public static boolean USE_GLOBAL_RELABELING_HEURISTIC = true;
-    public static boolean USE_GAP_RELABELING_HEURISTIC = true;
+    /**
+     * @deprecated use {@link #setUseGlobalRelabelingHeuristic(boolean)} instead
+     */
+    @Deprecated(since = "1.5.2", forRemoval = true)
+    public static boolean USE_GLOBAL_RELABELING_HEURISTIC = true; // @CS.suppress[StaticVariableName]
+    // TODO: make this static field private, rename it to "useGapRelabelingHeuristic" to comply
+    // with checkstyle naming rules and remove the // @CS.supress comment
+    /**
+     * @deprecated use {@link #setUseGapRelabelingHeuristic(boolean)} instead
+     */
+    @Deprecated(since = "1.5.2", forRemoval = true)
+    public static boolean USE_GAP_RELABELING_HEURISTIC = true; // @CS.suppress[StaticVariableName]
+    // TODO: make this static field private, rename it to "useGapRelabelingHeuristic" to comply
+    // with checkstyle naming rules and remove the // @CS.supress comment
+
+    public static void setUseGlobalRelabelingHeuristic(boolean useGlobalRelabelingHeuristic)
+    {
+        USE_GLOBAL_RELABELING_HEURISTIC = useGlobalRelabelingHeuristic;
+    }
+
+    public static void setUseGapRelabelingHeuristic(boolean useGapRelabelingHeuristic)
+    {
+        USE_GAP_RELABELING_HEURISTIC = useGapRelabelingHeuristic;
+    }
 
     private final ExtensionFactory<VertexExtension> vertexExtensionsFactory;
     private final ExtensionFactory<AnnotatedFlowEdge> edgeExtensionsFactory;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/CapacityScalingMinimumCostFlow.java
@@ -184,7 +184,7 @@ public class CapacityScalingMinimumCostFlow<V, E>
     public CapacityScalingMinimumCostFlow(int scalingFactor)
     {
         this.scalingFactor = scalingFactor;
-        Node.ID = 0; // for debug
+        Node.nextID = 0; // for debug
     }
 
     /**
@@ -261,9 +261,9 @@ public class CapacityScalingMinimumCostFlow<V, E>
         init();
         if (scalingFactor > 1) {
             // run with scaling
-            int U = getU();
+            int u = getU();
             int delta = scalingFactor;
-            while (U >= delta) {
+            while (u >= delta) {
                 delta *= scalingFactor;
             }
             delta /= scalingFactor;
@@ -493,8 +493,8 @@ public class CapacityScalingMinimumCostFlow<V, E>
      */
     private void pushDijkstra(Node start, Set<Node> negativeExcessNodes, int delta)
     {
-        int TEMPORARILY_LABELED = counter++;
-        int PERMANENTLY_LABELED = counter++;
+        int temporarilyLabeledType = counter++;
+        int permanentlyLabeledType = counter++;
         AddressableHeap.Handle<Double, Node> currentFibNode;
         AddressableHeap<Double, Node> heap = new PairingHeap<>();
         List<Node> permanentlyLabeled = new LinkedList<>();
@@ -526,7 +526,7 @@ public class CapacityScalingMinimumCostFlow<V, E>
                 }
                 return;
             }
-            currentNode.labelType = PERMANENTLY_LABELED; // currentNode becomes permanently labeled
+            currentNode.labelType = permanentlyLabeledType; // currentNode becomes permanently labeled
             permanentlyLabeled.add(currentNode);
             for (Arc currentArc = currentNode.firstNonSaturated; currentArc != null;
                 currentArc = currentArc.next)
@@ -536,8 +536,8 @@ public class CapacityScalingMinimumCostFlow<V, E>
                     continue;
                 }
                 Node opposite = currentArc.head;
-                if (opposite.labelType != PERMANENTLY_LABELED) {
-                    if (opposite.labelType == TEMPORARILY_LABELED) {
+                if (opposite.labelType != permanentlyLabeledType) {
+                    if (opposite.labelType == temporarilyLabeledType) {
                         // opposite has been labeled already
                         if (distance + currentArc.getReducedCost() < opposite.handle.getKey()) {
                             opposite.handle.decreaseKey(distance + currentArc.getReducedCost());
@@ -545,7 +545,7 @@ public class CapacityScalingMinimumCostFlow<V, E>
                         }
                     } else {
                         // opposite is encountered for the first time
-                        opposite.labelType = TEMPORARILY_LABELED;
+                        opposite.labelType = temporarilyLabeledType;
                         opposite.handle =
                             heap.insert(distance + currentArc.getReducedCost(), opposite);
                         opposite.parentArc = currentArc;
@@ -670,7 +670,7 @@ public class CapacityScalingMinimumCostFlow<V, E>
         /**
          * Variable for debug purposes
          */
-        private static int ID = 0;
+        private static int nextID = 0;
         /**
          * Reference to the {@link FibonacciHeapNode} this node is contained in
          */
@@ -708,7 +708,7 @@ public class CapacityScalingMinimumCostFlow<V, E>
         /**
          * Variable for debug purposes
          */
-        private int id = ID++;
+        private int id = nextID++;
 
         /**
          * Constructs a new node with {@code excess}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java
@@ -65,9 +65,9 @@ public interface AStarAdmissibleHeuristic<V>
                 double weight = graph.getEdgeWeight(e);
                 V edgeSource = graph.getEdgeSource(e);
                 V edgeTarget = graph.getEdgeTarget(e);
-                double h_x = getCostEstimate(edgeSource, targetVertex);
-                double h_y = getCostEstimate(edgeTarget, targetVertex);
-                if (h_x > weight + h_y)
+                double hX = getCostEstimate(edgeSource, targetVertex);
+                double hY = getCostEstimate(edgeTarget, targetVertex);
+                if (hX > weight + hY)
                     return false;
             }
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/linkprediction/SørensenIndexLinkPrediction.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/linkprediction/SørensenIndexLinkPrediction.java
@@ -50,7 +50,7 @@ import org.jgrapht.alg.util.Pair;
  * 
  * @author Dimitrios Michail
  */
-public class SørensenIndexLinkPrediction<V, E>
+public class SørensenIndexLinkPrediction<V, E> // @CS.suppress[TypeName]
     implements
     LinkPredictionAlgorithm<V, E>
 {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/matching/HopcroftKarpMaximumCardinalityBipartiteMatching.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/matching/HopcroftKarpMaximumCardinalityBipartiteMatching.java
@@ -67,9 +67,9 @@ public class HopcroftKarpMaximumCardinalityBipartiteMatching<V, E>
     private int matchedVertices;
 
     /* Dummy vertex. All vertices are initially matched against this dummy vertex */
-    private final int DUMMY = 0;
+    private static final int DUMMY = 0;
     /* Infinity */
-    private final int INF = Integer.MAX_VALUE;
+    private static final int INF = Integer.MAX_VALUE;
 
     /* Array keeping track of the matching. */
     private int[] matching;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/matching/KuhnMunkresMinimalWeightBipartitePerfectMatching.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/matching/KuhnMunkresMinimalWeightBipartitePerfectMatching.java
@@ -163,29 +163,29 @@ public class KuhnMunkresMinimalWeightBipartitePerfectMatching<V, E>
         /**
          * Construct new instance
          * 
-         * @param G the input graph
-         * @param S first partition of the vertex set
-         * @param T second partition of the vertex set
+         * @param g the input graph
+         * @param s first partition of the vertex set
+         * @param t second partition of the vertex set
          */
         public KuhnMunkresMatrixImplementation(
-            final Graph<V, E> G, final List<? extends V> S, final List<? extends V> T)
+            final Graph<V, E> g, final List<? extends V> s, final List<? extends V> t)
         {
-            int partition = S.size();
+            int partition = s.size();
 
             // Build an excess-matrix corresponding to the supplied weighted
             // complete bipartite graph
 
             costMatrix = new double[partition][];
 
-            for (int i = 0; i < S.size(); ++i) {
-                V source = S.get(i);
+            for (int i = 0; i < s.size(); ++i) {
+                V source = s.get(i);
                 costMatrix[i] = new double[partition];
-                for (int j = 0; j < T.size(); ++j) {
-                    V target = T.get(j);
+                for (int j = 0; j < t.size(); ++j) {
+                    V target = t.get(j);
                     if (source.equals(target)) {
                         continue;
                     }
-                    costMatrix[i][j] = G.getEdgeWeight(G.getEdge(source, target));
+                    costMatrix[i][j] = g.getEdgeWeight(g.getEdge(source, target));
                 }
             }
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AStarShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AStarShortestPath.java
@@ -201,8 +201,8 @@ public class AStarShortestPath<V, E>
                 continue;
             }
 
-            double gScore_current = gScoreMap.get(currentNode.getValue());
-            double tentativeGScore = gScore_current + graph.getEdgeWeight(edge);
+            double gScore = gScoreMap.get(currentNode.getValue());
+            double tentativeGScore = gScore + graph.getEdgeWeight(edge);
             double fScore =
                 tentativeGScore + admissibleHeuristic.getCostEstimate(successor, endVertex);
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BidirectionalAStarShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BidirectionalAStarShortestPath.java
@@ -170,8 +170,8 @@ public class BidirectionalAStarShortestPath<V, E>
                 }
 
                 double edgeWeight = frontier.graph.getEdgeWeight(edge);
-                double gScore_current = frontier.getDistance(v);
-                double tentativeGScore = gScore_current + edgeWeight;
+                double gScore = frontier.getDistance(v);
+                double tentativeGScore = gScore + edgeWeight;
                 double fScore = tentativeGScore
                     + frontier.heuristic.getCostEstimate(successor, frontier.endVertex);
 
@@ -179,7 +179,7 @@ public class BidirectionalAStarShortestPath<V, E>
 
                 // check if best path can be updated
                 double pathDistance =
-                    gScore_current + edgeWeight + otherFrontier.getDistance(successor);
+                    gScore + edgeWeight + otherFrontier.getDistance(successor);
                 if (pathDistance < bestPath) {
                     bestPath = pathDistance;
                     bestPathCommonVertex = successor;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/FloydWarshallShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/FloydWarshallShortestPaths.java
@@ -139,10 +139,10 @@ public class FloydWarshallShortestPaths<V, E>
 
         lazyCalculateMatrix();
 
-        int v_a = vertexIndices.get(a);
-        int v_b = vertexIndices.get(b);
+        int vA = vertexIndices.get(a);
+        int vB = vertexIndices.get(b);
 
-        if (backtrace[v_a][v_b] == null) { // No path exists
+        if (backtrace[vA][vB] == null) { // No path exists
             return createEmptyPath(a, b);
         }
 
@@ -150,12 +150,12 @@ public class FloydWarshallShortestPaths<V, E>
         List<E> edges = new ArrayList<>();
         V u = a;
         while (!u.equals(b)) {
-            int v_u = vertexIndices.get(u);
-            E e = TypeUtil.uncheckedCast(backtrace[v_u][v_b]);
+            int vU = vertexIndices.get(u);
+            E e = TypeUtil.uncheckedCast(backtrace[vU][vB]);
             edges.add(e);
             u = Graphs.getOppositeVertex(graph, e, u);
         }
-        return new GraphWalk<>(graph, a, b, null, edges, d[v_a][v_b]);
+        return new GraphWalk<>(graph, a, b, null, edges, d[vA][vB]);
     }
 
     /**
@@ -201,13 +201,13 @@ public class FloydWarshallShortestPaths<V, E>
     {
         lazyCalculateMatrix();
 
-        int v_a = vertexIndices.get(a);
-        int v_b = vertexIndices.get(b);
+        int vA = vertexIndices.get(a);
+        int vB = vertexIndices.get(b);
 
-        if (backtrace[v_a][v_b] == null) { // No path exists
+        if (backtrace[vA][vB] == null) { // No path exists
             return null;
         } else {
-            E e = TypeUtil.uncheckedCast(backtrace[v_a][v_b]);
+            E e = TypeUtil.uncheckedCast(backtrace[vA][vB]);
             return Graphs.getOppositeVertex(graph, e, a);
         }
     }
@@ -229,14 +229,14 @@ public class FloydWarshallShortestPaths<V, E>
     {
         lazyCalculateMatrix();
 
-        int v_a = vertexIndices.get(a);
-        int v_b = vertexIndices.get(b);
+        int vA = vertexIndices.get(a);
+        int vB = vertexIndices.get(b);
 
-        if (backtrace[v_a][v_b] == null) { // No path exists
+        if (backtrace[vA][vB] == null) { // No path exists
             return null;
         } else {
             populateLastHopMatrix();
-            E e = TypeUtil.uncheckedCast(lastHopMatrix[v_a][v_b]);
+            E e = TypeUtil.uncheckedCast(lastHopMatrix[vA][vB]);
             return Graphs.getOppositeVertex(graph, e, b);
         }
     }
@@ -273,13 +273,13 @@ public class FloydWarshallShortestPaths<V, E>
                 V source = graph.getEdgeSource(edge);
                 V target = graph.getEdgeTarget(edge);
                 if (!source.equals(target)) {
-                    int v_1 = vertexIndices.get(source);
-                    int v_2 = vertexIndices.get(target);
+                    int v1 = vertexIndices.get(source);
+                    int v2 = vertexIndices.get(target);
                     double edgeWeight = graph.getEdgeWeight(edge);
-                    if (Double.compare(edgeWeight, d[v_1][v_2]) < 0) {
-                        d[v_1][v_2] = d[v_2][v_1] = edgeWeight;
-                        backtrace[v_1][v_2] = edge;
-                        backtrace[v_2][v_1] = edge;
+                    if (Double.compare(edgeWeight, d[v1][v2]) < 0) {
+                        d[v1][v2] = d[v2][v1] = edgeWeight;
+                        backtrace[v1][v2] = edge;
+                        backtrace[v2][v1] = edge;
                     }
                 }
             }
@@ -287,15 +287,15 @@ public class FloydWarshallShortestPaths<V, E>
                  // the arcs and querying source/sink does not suffice for graphs
                  // which contain both edges and arcs
             for (V v1 : graph.vertexSet()) {
-                int v_1 = vertexIndices.get(v1);
+                int i1 = vertexIndices.get(v1);
                 for (E e : graph.outgoingEdgesOf(v1)) {
                     V v2 = Graphs.getOppositeVertex(graph, e, v1);
                     if (!v1.equals(v2)) {
-                        int v_2 = vertexIndices.get(v2);
+                        int i2 = vertexIndices.get(v2);
                         double edgeWeight = graph.getEdgeWeight(e);
-                        if (Double.compare(edgeWeight, d[v_1][v_2]) < 0) {
-                            d[v_1][v_2] = edgeWeight;
-                            backtrace[v_1][v_2] = e;
+                        if (Double.compare(edgeWeight, d[i1][i2]) < 0) {
+                            d[i1][i2] = edgeWeight;
+                            backtrace[i1][i2] = e;
                         }
                     }
                 }
@@ -313,9 +313,9 @@ public class FloydWarshallShortestPaths<V, E>
                         continue;
                     }
 
-                    double ik_kj = d[i][k] + d[k][j];
-                    if (Double.compare(ik_kj, d[i][j]) < 0) {
-                        d[i][j] = ik_kj;
+                    double sumIKKJ = d[i][k] + d[k][j];
+                    if (Double.compare(sumIKKJ, d[i][j]) < 0) {
+                        d[i][j] = sumIKKJ;
                         backtrace[i][j] = backtrace[i][k];
                     }
                 }
@@ -349,8 +349,8 @@ public class FloydWarshallShortestPaths<V, E>
                 V u = vertices.get(i);
                 V b = vertices.get(j);
                 while (!u.equals(b)) {
-                    int v_u = vertexIndices.get(u);
-                    E e = TypeUtil.uncheckedCast(backtrace[v_u][j]);
+                    int vU = vertexIndices.get(u);
+                    E e = TypeUtil.uncheckedCast(backtrace[vU][j]);
                     V other = Graphs.getOppositeVertex(graph, e, u);
                     lastHopMatrix[i][vertexIndices.get(other)] = e;
                     u = other;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/PrimMinimumSpanningTree.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/PrimMinimumSpanningTree.java
@@ -68,7 +68,7 @@ public class PrimMinimumSpanningTree<V, E>
             CollectionUtil.newHashSetWithExpectedSize(g.vertexSet().size());
         double spanningTreeWeight = 0d;
 
-        final int N = g.vertexSet().size();
+        final int n = g.vertexSet().size();
 
         /*
          * Normalize the graph by mapping each vertex to an integer.
@@ -77,13 +77,13 @@ public class PrimMinimumSpanningTree<V, E>
         Map<V, Integer> vertexMap = vertexToIntegerMapping.getVertexMap();
         List<V> indexList = vertexToIntegerMapping.getIndexList();
 
-        VertexInfo[] vertices = (VertexInfo[]) Array.newInstance(VertexInfo.class, N);
+        VertexInfo[] vertices = (VertexInfo[]) Array.newInstance(VertexInfo.class, n);
         AddressableHeap.Handle<Double, VertexInfo>[] fibNodes =
             (AddressableHeap.Handle<Double, VertexInfo>[]) Array
-                .newInstance(AddressableHeap.Handle.class, N);
+                .newInstance(AddressableHeap.Handle.class, n);
         AddressableHeap<Double, VertexInfo> fibonacciHeap = new FibonacciHeap<>();
 
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             vertices[i] = new VertexInfo();
             vertices[i].id = i;
             vertices[i].distance = Double.MAX_VALUE;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/BarYehudaEvenTwoApproxVCImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/BarYehudaEvenTwoApproxVCImpl.java
@@ -85,9 +85,9 @@ public class BarYehudaEvenTwoApproxVCImpl<V, E>
         Set<V> cover = new LinkedHashSet<>();
         double weight = 0;
         Graph<V, E> copy = new AsSubgraph<>(graph, null, null);
-        Map<V, Double> W = new HashMap<>();
+        Map<V, Double> w = new HashMap<>();
         for (V v : graph.vertexSet())
-            W.put(v, vertexWeightMap.get(v));
+            w.put(v, vertexWeightMap.get(v));
 
         // Main loop
         Set<E> edgeSet = copy.edgeSet();
@@ -97,13 +97,13 @@ public class BarYehudaEvenTwoApproxVCImpl<V, E>
             V p = copy.getEdgeSource(e);
             V q = copy.getEdgeTarget(e);
 
-            if (W.get(p) <= W.get(q)) {
-                W.put(q, W.get(q) - W.get(p));
+            if (w.get(p) <= w.get(q)) {
+                w.put(q, w.get(q) - w.get(p));
                 cover.add(p);
                 weight += vertexWeightMap.get(p);
                 copy.removeVertex(p);
             } else {
-                W.put(p, W.get(p) - W.get(q));
+                w.put(p, w.get(p) - w.get(q));
                 cover.add(q);
                 weight += vertexWeightMap.get(q);
                 copy.removeVertex(q);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/ClarksonTwoApproxVCImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/ClarksonTwoApproxVCImpl.java
@@ -142,7 +142,7 @@ public class ClarksonTwoApproxVCImpl<V, E>
             weight += vertexWeightMap.get(vx.v);
             assert (!workingGraph
                 .parallelStream()
-                .anyMatch(ux -> ux.ID == vx.ID)) : "vx should no longer exist in the working graph";
+                .anyMatch(ux -> ux.id == vx.id)) : "vx should no longer exist in the working graph";
         }
         return new VertexCoverAlgorithm.VertexCoverImpl<>(cover, weight);
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/GreedyVCImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/GreedyVCImpl.java
@@ -150,7 +150,7 @@ public class GreedyVCImpl<V, E>
             weight += vertexWeightMap.get(vx.v);
             assert (workingGraph
                 .parallelStream().noneMatch(
-                    ux -> ux.ID == vx.ID)) : "vx should no longer exist in the working graph";
+                    ux -> ux.id == vx.id)) : "vx should no longer exist in the working graph";
         }
         return new VertexCoverAlgorithm.VertexCoverImpl<>(cover, weight);
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/RecursiveExactVCImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/RecursiveExactVCImpl.java
@@ -65,7 +65,7 @@ public class RecursiveExactVCImpl<V, E>
     /** Input graph **/
     private Graph<V, E> graph;
     /** Number of vertices in the graph **/
-    private int N;
+    private int n;
     /**
      * Neighbor cache TODO JK: It might be worth trying to replace the neighbors index by a bitset
      * view. As such, all operations can be simplified to bitset operations, which may improve the
@@ -132,7 +132,7 @@ public class RecursiveExactVCImpl<V, E>
         neighborCache = new NeighborCache<>(graph);
         vertexIDDictionary = new HashMap<>();
 
-        N = vertices.size();
+        n = vertices.size();
         // Sort vertices based on their weight/degree ratio in ascending order
         // TODO JK: Are there better orderings?
         vertices.sort(Comparator.comparingDouble(v -> vertexWeightMap.get(v) / graph.degreeOf(v)));
@@ -147,11 +147,11 @@ public class RecursiveExactVCImpl<V, E>
         upperBoundOnVertexCoverWeight = this.calculateUpperBound();
 
         // Invoke recursive algorithm
-        BitSetCover vertexCover = this.calculateCoverRecursively(0, new BitSet(N), 0);
+        BitSetCover vertexCover = this.calculateCoverRecursively(0, new BitSet(n), 0);
 
         // Build solution
         Set<V> verticesInCover = new LinkedHashSet<>();
-        for (int i = vertexCover.bitSetCover.nextSetBit(0); i >= 0 && i < N;
+        for (int i = vertexCover.bitSetCover.nextSetBit(0); i >= 0 && i < n;
             i = vertexCover.bitSetCover.nextSetBit(i + 1))
             verticesInCover.add(vertices.get(i));
         return new VertexCoverAlgorithm.VertexCoverImpl<>(verticesInCover, vertexCover.weight);
@@ -170,7 +170,7 @@ public class RecursiveExactVCImpl<V, E>
         // because it doesn't cover any edges)
         int indexNextVertex = -1;
         Set<V> neighbors = Collections.emptySet();
-        for (int index = visited.nextClearBit(indexNextCandidate); index >= 0 && index < N;
+        for (int index = visited.nextClearBit(indexNextCandidate); index >= 0 && index < n;
             index = visited.nextClearBit(index + 1))
         {
 
@@ -187,7 +187,7 @@ public class RecursiveExactVCImpl<V, E>
 
         // Base case 1: all vertices have been visited
         if (indexNextVertex == -1) { // We've visited all vertices, return the base case
-            BitSetCover vertexCover = new BitSetCover(N, 0);
+            BitSetCover vertexCover = new BitSetCover(n, 0);
             if (accumulatedWeight <= upperBoundOnVertexCoverWeight) { // Found new a solution that
                                                                       // matches our bound. Tighten
                                                                       // the bound.
@@ -198,7 +198,7 @@ public class RecursiveExactVCImpl<V, E>
             // already have. Return a cover with a large weight, such that the other branch will be
             // preferred over this branch.
         } else if (accumulatedWeight >= upperBoundOnVertexCoverWeight) {
-            return new BitSetCover(N, N);
+            return new BitSetCover(n, n);
         }
 
         // Recursion

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/util/RatioVertex.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/util/RatioVertex.java
@@ -51,13 +51,13 @@ public class RatioVertex<V>
     /**
      * Create a new ratio vertex
      * 
-     * @param ID unique id
+     * @param id unique id
      * @param v the vertex
      * @param weight the vertex weight
      */
-    public RatioVertex(int ID, V v, double weight)
+    public RatioVertex(int id, V v, double weight)
     {
-        this.ID = ID;
+        this.ID = id;
         this.v = v;
         this.weight = weight;
         neighbors = new LinkedHashMap<>();

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/util/RatioVertex.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/util/RatioVertex.java
@@ -39,8 +39,16 @@ public class RatioVertex<V>
     /** weight of the vertex **/
     public double weight;
 
+    /**
+     * unique id, used to guarantee that compareTo never returns 0
+     * 
+     * @deprecated use {@link #id} instead
+     **/
+    @Deprecated(since = "1.5.2", forRemoval = true)
+    public final int ID; // @CS.suppress[MemberName]
+
     /** unique id, used to guarantee that compareTo never returns 0 **/
-    public final int ID;
+    public final int id;
 
     /** degree of this vertex **/
     protected int degree = 0;
@@ -57,7 +65,7 @@ public class RatioVertex<V>
      */
     public RatioVertex(int id, V v, double weight)
     {
-        this.ID = id;
+        this.id = this.ID = id;
         this.v = v;
         this.weight = weight;
         neighbors = new LinkedHashMap<>();
@@ -113,11 +121,11 @@ public class RatioVertex<V>
     @Override
     public int compareTo(RatioVertex<V> other)
     {
-        if (this.ID == other.ID) // Same vertex
+        if (this.id == other.id) // Same vertex
             return 0;
         int result = Double.compare(this.getRatio(), other.getRatio());
         if (result == 0) // If vertices have the same value, resolve tie by an ID comparison
-            return Integer.compare(this.ID, other.ID);
+            return Integer.compare(this.id, other.id);
         else
             return result;
     }
@@ -125,7 +133,7 @@ public class RatioVertex<V>
     @Override
     public int hashCode()
     {
-        return ID;
+        return id;
     }
 
     @Override
@@ -136,12 +144,12 @@ public class RatioVertex<V>
         else if (!(o instanceof RatioVertex))
             return false;
         RatioVertex<V> other = TypeUtil.uncheckedCast(o);
-        return this.ID == other.ID;
+        return this.id == other.id;
     }
 
     @Override
     public String toString()
     {
-        return "v" + ID + "(" + degree + ")";
+        return "v" + id + "(" + degree + ")";
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GeneralizedPetersenGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GeneralizedPetersenGraphGenerator.java
@@ -44,11 +44,11 @@ public class GeneralizedPetersenGraphGenerator<V, E>
     /**
      * Key used to access the star polygon vertices in the resultMap
      */
-    public final String STAR = "star";
+    public static final String STAR = "star";
     /**
      * Key used to access the regular polygon vertices in the resultMap
      */
-    public final String REGULAR = "regular";
+    public static final String REGULAR = "regular";
 
     /**
      * Constructs a GeneralizedPetersenGraphGenerator used to generate a Generalized Petersen graphs

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/NamedGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/NamedGraphGenerator.java
@@ -160,7 +160,7 @@ public class NamedGraphGenerator<V, E>
      * 
      * @return the Dürer Graph
      */
-    public static Graph<Integer, DefaultEdge> dürerGraph()
+    public static Graph<Integer, DefaultEdge> dürerGraph() // @CS.suppress[MethodName]
     {
         return generalizedPetersenGraph(6, 2);
     }
@@ -174,7 +174,7 @@ public class NamedGraphGenerator<V, E>
      *        the result will be a disconnected graph since generated elements will not be connected
      *        to existing elements
      */
-    public void generateDürerGraph(Graph<V, E> targetGraph)
+    public void generateDürerGraph(Graph<V, E> targetGraph) // @CS.suppress[MethodName]
     {
         generateGeneralizedPetersenGraph(targetGraph, 6, 2);
     }
@@ -260,7 +260,7 @@ public class NamedGraphGenerator<V, E>
      * 
      * @return the Möbius-Kantor Graph
      */
-    public static Graph<Integer, DefaultEdge> möbiusKantorGraph()
+    public static Graph<Integer, DefaultEdge> möbiusKantorGraph() // @CS.suppress[MethodName]
     {
         return generalizedPetersenGraph(8, 3);
     }
@@ -274,7 +274,7 @@ public class NamedGraphGenerator<V, E>
      *        the result will be a disconnected graph since generated elements will not be connected
      *        to existing elements
      */
-    public void generateMöbiusKantorGraph(Graph<V, E> targetGraph)
+    public void generateMöbiusKantorGraph(Graph<V, E> targetGraph) // @CS.suppress[MethodName]
     {
         generateGeneralizedPetersenGraph(targetGraph, 8, 3);
     }
@@ -468,7 +468,7 @@ public class NamedGraphGenerator<V, E>
      * 
      * @return the Grötzsch Graph
      */
-    public static Graph<Integer, DefaultEdge> grötzschGraph()
+    public static Graph<Integer, DefaultEdge> grötzschGraph() // @CS.suppress[MethodName]
     {
         Graph<Integer,
             DefaultEdge> g = GraphTypeBuilder
@@ -487,7 +487,7 @@ public class NamedGraphGenerator<V, E>
      *        the result will be a disconnected graph since generated elements will not be connected
      *        to existing elements
      */
-    public void generateGrötzschGraph(Graph<V, E> targetGraph)
+    public void generateGrötzschGraph(Graph<V, E> targetGraph) // @CS.suppress[MethodName]
     {
         vertexMap.clear();
         for (int i = 1; i < 6; i++)
@@ -1581,7 +1581,7 @@ public class NamedGraphGenerator<V, E>
      * 
      * @return the Schläfli Graph
      */
-    public static Graph<Integer, DefaultEdge> schläfliGraph()
+    public static Graph<Integer, DefaultEdge> schläfliGraph() // @CS.suppress[MethodName]
     {
         Graph<Integer,
             DefaultEdge> g = GraphTypeBuilder
@@ -1600,7 +1600,7 @@ public class NamedGraphGenerator<V, E>
      *        the result will be a disconnected graph since generated elements will not be connected
      *        to existing elements
      */
-    public void generateSchläfliGraph(Graph<V, E> targetGraph)
+    public void generateSchläfliGraph(Graph<V, E> targetGraph) // @CS.suppress[MethodName]
     {
         vertexMap.clear();
         int[][] edges = { { 0, 11 }, { 0, 12 }, { 0, 13 }, { 0, 14 }, { 0, 15 }, { 0, 16 },

--- a/jgrapht-core/src/main/java/org/jgrapht/util/RadixSort.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/RadixSort.java
@@ -31,7 +31,18 @@ import java.util.*;
 public class RadixSort
 {
 
-    public static int CUT_OFF = 40;
+    /**
+     * @deprecated use {@link #setCutOff(int)} instead
+     */
+    @Deprecated(since = "1.5.2", forRemoval = true)
+    public static int CUT_OFF = 40; // @CS.suppress[StaticVariableName]
+    // TODO: make this static field private, rename it to "cutOff" to comply
+    // with checkstyle naming rules and remove the // @CS.supress comment
+
+    public static void setCutOff(int cutOff)
+    {
+        CUT_OFF = cutOff;
+    }
 
     private static final int MAX_DIGITS = 32;
     private static final int MAX_D = 4;

--- a/jgrapht-core/src/test/java/org/jgrapht/GraphMetricsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/GraphMetricsTest.java
@@ -265,18 +265,18 @@ public class GraphMetricsTest
     @Test
     public void testCountTriangles()
     {
-        final int NUM_TESTS = 300;
+        final int numTests = 300;
         Random random = new Random(0x88_88);
 
-        for (int test = 0; test < NUM_TESTS; test++) {
-            final int N = 20 + random.nextInt(100);
+        for (int test = 0; test < numTests; test++) {
+            final int n = 20 + random.nextInt(100);
 
             Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(
                 SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
 
             BarabasiAlbertGraphGenerator<Integer, DefaultEdge> generator =
                 new BarabasiAlbertGraphGenerator<>(
-                    10 + random.nextInt(10), 1 + random.nextInt(7), N, random);
+                    10 + random.nextInt(10), 1 + random.nextInt(7), n, random);
 
             generator.generateGraph(graph);
 
@@ -288,17 +288,17 @@ public class GraphMetricsTest
     @Test
     public void testCountTriangles2()
     {
-        final int NUM_TESTS = 100;
+        final int numTests = 100;
         Random random = new Random(0x88_88);
 
-        for (int test = 0; test < NUM_TESTS; test++) {
-            final int N = 1 + random.nextInt(100);
+        for (int test = 0; test < numTests; test++) {
+            final int n = 1 + random.nextInt(100);
 
             Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(
                 SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
 
             GraphGenerator<Integer, DefaultEdge, Integer> generator =
-                new GnpRandomGraphGenerator<>(N, .55, random.nextInt());
+                new GnpRandomGraphGenerator<>(n, .55, random.nextInt());
 
             generator.generateGraph(graph);
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/TransitiveClosureTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/TransitiveClosureTest.java
@@ -37,14 +37,14 @@ public class TransitiveClosureTest
         SimpleDirectedGraph<Integer, DefaultEdge> graph = new SimpleDirectedGraph<>(
             SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
 
-        int N = 10;
-        LinearGraphGenerator<Integer, DefaultEdge> gen = new LinearGraphGenerator<>(N);
+        int n = 10;
+        LinearGraphGenerator<Integer, DefaultEdge> gen = new LinearGraphGenerator<>(n);
         gen.generateGraph(graph);
         TransitiveClosure.INSTANCE.closeSimpleDirectedGraph(graph);
 
-        assertEquals(true, graph.edgeSet().size() == ((N * (N - 1)) / 2));
-        for (int i = 0; i < N; ++i) {
-            for (int j = i + 1; j < N; ++j) {
+        assertEquals(true, graph.edgeSet().size() == ((n * (n - 1)) / 2));
+        for (int i = 0; i < n; ++i) {
+            for (int j = i + 1; j < n; ++j) {
                 assertEquals(true, graph.getEdge(i, j) != null);
             }
         }
@@ -56,14 +56,14 @@ public class TransitiveClosureTest
         SimpleDirectedGraph<Integer, DefaultEdge> graph = new SimpleDirectedGraph<>(
             SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
 
-        int N = 10;
-        RingGraphGenerator<Integer, DefaultEdge> gen = new RingGraphGenerator<>(N);
+        int n = 10;
+        RingGraphGenerator<Integer, DefaultEdge> gen = new RingGraphGenerator<>(n);
         gen.generateGraph(graph);
         TransitiveClosure.INSTANCE.closeSimpleDirectedGraph(graph);
 
-        assertEquals(true, graph.edgeSet().size() == (N * (N - 1)));
-        for (int i = 0; i < N; ++i) {
-            for (int j = 0; j < N; ++j) {
+        assertEquals(true, graph.edgeSet().size() == (n * (n - 1)));
+        for (int i = 0; i < n; ++i) {
+            for (int j = 0; j < n; ++j) {
                 assertEquals(true, (i == j) || (graph.getEdge(i, j) != null));
             }
         }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/TransitiveReductionTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/TransitiveReductionTest.java
@@ -51,7 +51,7 @@ public class TransitiveReductionTest
     {
 
         // @formatter:off
-        final int[][] expected_path_matrix = new int[][] {
+        final int[][] expectedPathMatrix = new int[][] {
             {0, 1, 1, 1, 1},
             {0, 0, 0, 0, 0},
             {0, 1, 0, 1, 1},
@@ -65,37 +65,37 @@ public class TransitiveReductionTest
 
         final int n = MATRIX.length;
 
-        // calc path matrix
-        int[][] path_matrix = new int[n][n];
+        // calc pathMatrix
+        int[][] pathMatrix = new int[n][n];
         {
             {
-                System.arraycopy(MATRIX, 0, path_matrix, 0, MATRIX.length);
+                System.arraycopy(MATRIX, 0, pathMatrix, 0, MATRIX.length);
 
-                final BitSet[] pathMatrixAsBitSetArray = asBitSetArray(path_matrix);
+                final BitSet[] pathMatrixAsBitSetArray = asBitSetArray(pathMatrix);
 
                 TransitiveReduction.transformToPathMatrix(pathMatrixAsBitSetArray);
 
-                path_matrix = asIntArray(pathMatrixAsBitSetArray);
+                pathMatrix = asIntArray(pathMatrixAsBitSetArray);
             }
             // System.out.println(Arrays.deepToString(path_matrix) + " path
             // matrix");
 
-            Assert.assertArrayEquals(expected_path_matrix, path_matrix);
+            Assert.assertArrayEquals(expectedPathMatrix, pathMatrix);
         }
 
         // calc transitive reduction
         {
-            int[][] transitively_reduced_matrix = new int[n][n];
+            int[][] transitivelyReducedMatrix = new int[n][n];
             {
                 System
-                    .arraycopy(path_matrix, 0, transitively_reduced_matrix, 0, path_matrix.length);
+                    .arraycopy(pathMatrix, 0, transitivelyReducedMatrix, 0, pathMatrix.length);
 
                 final BitSet[] transitivelyReducedMatrixAsBitSetArray =
-                    asBitSetArray(transitively_reduced_matrix);
+                    asBitSetArray(transitivelyReducedMatrix);
 
                 TransitiveReduction.transitiveReduction(transitivelyReducedMatrixAsBitSetArray);
 
-                transitively_reduced_matrix = asIntArray(transitivelyReducedMatrixAsBitSetArray);
+                transitivelyReducedMatrix = asIntArray(transitivelyReducedMatrixAsBitSetArray);
             }
 
             // System.out.println(Arrays.deepToString(transitively_reduced_matrix)
@@ -103,7 +103,7 @@ public class TransitiveReductionTest
 
             Assert
                 .assertArrayEquals(
-                    EXPECTED_TRANSITIVELY_REDUCED_MATRIX, transitively_reduced_matrix);
+                    EXPECTED_TRANSITIVELY_REDUCED_MATRIX, transitivelyReducedMatrix);
         }
     }
 
@@ -273,8 +273,8 @@ public class TransitiveReductionTest
         assertTrue(graph.containsEdge(4, 1));
 
         // the full verification; less readable, but somewhat more complete :)
-        int[][] actual_transitively_reduced_matrix = fromDirectedGraphToMatrix(graph);
-        assertArrayEquals(EXPECTED_TRANSITIVELY_REDUCED_MATRIX, actual_transitively_reduced_matrix);
+        int[][] actualTransitivelyReducedMatrix = fromDirectedGraphToMatrix(graph);
+        assertArrayEquals(EXPECTED_TRANSITIVELY_REDUCED_MATRIX, actualTransitivelyReducedMatrix);
     }
 
     static private Graph<Integer, DefaultEdge> fromMatrixToDirectedGraph(final int[][] matrix)
@@ -306,10 +306,10 @@ public class TransitiveReductionTest
             final Integer v1 = directedGraph.getEdgeSource(edge);
             final Integer v2 = directedGraph.getEdgeTarget(edge);
 
-            final int v_1 = vertices.indexOf(v1);
-            final int v_2 = vertices.indexOf(v2);
+            final int i1 = vertices.indexOf(v1);
+            final int i2 = vertices.indexOf(v2);
 
-            matrix[v_1][v_2] = 1;
+            matrix[i1][i2] = 1;
         }
         return matrix;
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/color/ColorRefinementAlgorithmTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/color/ColorRefinementAlgorithmTest.java
@@ -51,8 +51,8 @@ public class ColorRefinementAlgorithmTest
         tree.addEdge(6, 7);
         tree.addEdge(6, 8);
 
-        ColorRefinementAlgorithm<Integer, DefaultEdge> CR = new ColorRefinementAlgorithm<>(tree);
-        Map<Integer, Integer> colors = CR.getColoring().getColors();
+        ColorRefinementAlgorithm<Integer, DefaultEdge> cr = new ColorRefinementAlgorithm<>(tree);
+        Map<Integer, Integer> colors = cr.getColoring().getColors();
 
         // symmetric pairs around 3 should have the same color and different colors otherwise
 
@@ -82,9 +82,9 @@ public class ColorRefinementAlgorithmTest
         regularGraph.addEdge(5, 6);
         regularGraph.addEdge(6, 4);
 
-        ColorRefinementAlgorithm<Integer, DefaultEdge> CR =
+        ColorRefinementAlgorithm<Integer, DefaultEdge> cr =
             new ColorRefinementAlgorithm<>(regularGraph);
-        Map<Integer, Integer> colors = CR.getColoring().getColors();
+        Map<Integer, Integer> colors = cr.getColoring().getColors();
 
         // all vertices should have the same color
 
@@ -128,8 +128,8 @@ public class ColorRefinementAlgorithmTest
 
         graph1.addEdge(10, 11);
 
-        ColorRefinementAlgorithm<Integer, DefaultEdge> CR = new ColorRefinementAlgorithm<>(graph1);
-        Map<Integer, Integer> colors = CR.getColoring().getColors();
+        ColorRefinementAlgorithm<Integer, DefaultEdge> cr = new ColorRefinementAlgorithm<>(graph1);
+        Map<Integer, Integer> colors = cr.getColoring().getColors();
 
         // 9 and 10 should have the same color, all others should have distinct colors
 
@@ -169,8 +169,8 @@ public class ColorRefinementAlgorithmTest
         graph1.addEdge(8, 4);
         graph1.addEdge(8, 6);
 
-        ColorRefinementAlgorithm<Integer, DefaultEdge> CR = new ColorRefinementAlgorithm<>(graph1);
-        Map<Integer, Integer> colors = CR.getColoring().getColors();
+        ColorRefinementAlgorithm<Integer, DefaultEdge> cr = new ColorRefinementAlgorithm<>(graph1);
+        Map<Integer, Integer> colors = cr.getColoring().getColors();
 
         // 1 and 3 should have the same color, all others should have distinct colors
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/connectivity/ConnectivityInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/connectivity/ConnectivityInspectorTest.java
@@ -44,7 +44,7 @@ public class ConnectivityInspectorTest
     DefaultEdge e1;
     DefaultEdge e2;
     DefaultEdge e3;
-    DefaultEdge e3_b;
+    DefaultEdge e3B;
     DefaultEdge u;
 
     // ~ Methods ----------------------------------------------------------------
@@ -79,9 +79,9 @@ public class ConnectivityInspectorTest
         e3 = g.addEdge(V3, V1);
         assertEquals(3, g.edgeSet().size());
 
-        e3_b = g.addEdge(V3, V1);
+        e3B = g.addEdge(V3, V1);
         assertEquals(4, g.edgeSet().size());
-        assertNotNull(e3_b);
+        assertNotNull(e3B);
 
         u = g.addEdge(V1, V1);
         assertEquals(5, g.edgeSet().size());

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/BergeGraphInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/BergeGraphInspectorTest.java
@@ -429,7 +429,7 @@ public class BergeGraphInspectorTest
 
     @Test
     @Category(OptionalTests.class)
-    public void checkMöbiusKantorGraph()
+    public void checkMoebiusKantorGraph()
     {
         reset();
         new NamedGraphGenerator<Integer, Integer>().generateMöbiusKantorGraph(stimulus);
@@ -465,7 +465,7 @@ public class BergeGraphInspectorTest
     }
 
     @Test
-    public void checkGrötzschGraph()
+    public void checkGroetzschGraph()
     {
         reset();
         new NamedGraphGenerator<Integer, Integer>().generateGrötzschGraph(stimulus);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/BergeGraphInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/BergeGraphInspectorTest.java
@@ -184,20 +184,20 @@ public class BergeGraphInspectorTest
         stimulus.addEdge(1, 4);
         stimulus.addEdge(1, 2);
         stimulus.addEdge(1, 3);
-        Set<Integer> X = new HashSet<>();
-        X.add(2);
-        X.add(3);
-        X.add(4);
-        assertTrue(dut.isYXComplete(stimulus, 1, X));
+        Set<Integer> x = new HashSet<>();
+        x.add(2);
+        x.add(3);
+        x.add(4);
+        assertTrue(dut.isYXComplete(stimulus, 1, x));
 
         stimulus.removeEdge(1, 4);
-        assertFalse(dut.isYXComplete(stimulus, 1, X));
+        assertFalse(dut.isYXComplete(stimulus, 1, x));
         stimulus.addEdge(1, 4);
 
-        X.clear();
-        X.add(2);
-        X.add(1);
-        assertFalse(dut.isYXComplete(stimulus, 3, X));
+        x.clear();
+        x.add(2);
+        x.add(1);
+        assertFalse(dut.isYXComplete(stimulus, 3, x));
 
     }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/ChordalityInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/ChordalityInspectorTest.java
@@ -272,10 +272,10 @@ public class ChordalityInspectorTest
     @Test
     public void testIsChordal11()
     {
-        Graph<Integer, DefaultEdge> schläfli = NamedGraphGenerator.schläfliGraph();
-        ChordalityInspector<Integer, DefaultEdge> inspector = new ChordalityInspector<>(schläfli);
+        Graph<Integer, DefaultEdge> schlaefli = NamedGraphGenerator.schläfliGraph();
+        ChordalityInspector<Integer, DefaultEdge> inspector = new ChordalityInspector<>(schlaefli);
         assertFalse(inspector.isChordal());
-        assertIsHole(schläfli, inspector.getHole());
+        assertIsHole(schlaefli, inspector.getHole());
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/DirectedSimpleCyclesTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/DirectedSimpleCyclesTest.java
@@ -28,8 +28,8 @@ import static org.junit.Assert.assertTrue;
 
 public class DirectedSimpleCyclesTest
 {
-    private static int MAX_SIZE = 9;
-    private static int[] RESULTS = { 0, 1, 3, 8, 24, 89, 415, 2372, 16072, 125673 };
+    private static final int MAX_SIZE = 9;
+    private static final int[] RESULTS = { 0, 1, 3, 8, 24, 89, 415, 2372, 16072, 125673 };
 
     @Test
     public void test()

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/PatonCycleBaseTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/PatonCycleBaseTest.java
@@ -34,8 +34,8 @@ import static org.junit.Assert.assertTrue;
 
 public class PatonCycleBaseTest
 {
-    private static int MAX_SIZE = 10;
-    private static int[] RESULTS = { 0, 0, 0, 1, 3, 6, 10, 15, 21, 28, 36 };
+    private static final int MAX_SIZE = 10;
+    private static final int[] RESULTS = { 0, 0, 0, 1, 3, 6, 10, 15, 21, 28, 36 };
 
     @Test
     public void testAlgorithm()

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/WeakChordalityInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/cycle/WeakChordalityInspectorTest.java
@@ -240,13 +240,13 @@ public class WeakChordalityInspectorTest
     @Test
     public void testIsWeaklyChordal14()
     {
-        Graph<Integer, DefaultEdge> grötzsch = NamedGraphGenerator.grötzschGraph();
+        Graph<Integer, DefaultEdge> groetzsch = NamedGraphGenerator.grötzschGraph();
         WeakChordalityInspector<Integer, DefaultEdge> inspector =
-            new WeakChordalityInspector<>(grötzsch);
+            new WeakChordalityInspector<>(groetzsch);
         assertFalse(inspector.isWeaklyChordal());
         GraphPath<Integer, DefaultEdge> graphPath = inspector.getCertificate();
         assertNotNull(graphPath);
-        assertIsHoleOrAntiHole(grötzsch, graphPath);
+        assertIsHoleOrAntiHole(groetzsch, graphPath);
     }
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/decomposition/HeavyPathDecompositionTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/decomposition/HeavyPathDecompositionTest.java
@@ -337,10 +337,10 @@ public class HeavyPathDecompositionTest
     @Category(SlowTests.class)
     public void testRandomTrees()
     {
-        final int NUM_TESTS = 100;
+        final int numTests = 100;
         Random random = new Random(0x2882);
 
-        for (int test = 0; test < NUM_TESTS; test++) {
+        for (int test = 0; test < numTests; test++) {
             Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(
                 SupplierUtil.createIntegerSupplier(0), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
 
@@ -362,10 +362,10 @@ public class HeavyPathDecompositionTest
     @Category(SlowTests.class)
     public void testRandomForests()
     {
-        final int NUM_TESTS = 1000;
+        final int numTests = 1000;
         Random random = new Random(0x1881);
 
-        for (int test = 0; test < NUM_TESTS; test++) {
+        for (int test = 0; test < numTests; test++) {
             Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(
                 SupplierUtil.createIntegerSupplier(0), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/densesubgraph/GoldbergMaximumDensitySubgraphTestBase.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/densesubgraph/GoldbergMaximumDensitySubgraphTestBase.java
@@ -37,7 +37,7 @@ import static org.junit.Assert.assertEquals;
 public abstract class GoldbergMaximumDensitySubgraphTestBase<V, E>
 {
 
-    protected final double DEFAULT_EPS = Math.pow(10, -5);
+    protected static final double DEFAULT_EPS = Math.pow(10, -5);
     protected V s, t;
 
     public GoldbergMaximumDensitySubgraphTestBase()

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHUForestIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHUForestIsomorphismInspectorTest.java
@@ -175,14 +175,14 @@ public class AHUForestIsomorphismInspectorTest
     @Category(SlowTests.class)
     public void testHugeNumberOfChildren()
     {
-        final int N = 100_000;
+        final int n = 100_000;
         Graph<Integer, DefaultEdge> tree1 = new SimpleGraph<>(DefaultEdge.class);
 
-        for (int i = 1; i <= N; i++) {
+        for (int i = 1; i <= n; i++) {
             tree1.addVertex(i);
         }
 
-        for (int i = 2; i <= N; i++) {
+        for (int i = 2; i <= n; i++) {
             tree1.addEdge(1, i);
         }
 
@@ -206,12 +206,12 @@ public class AHUForestIsomorphismInspectorTest
     public void testRandomForests()
     {
         Random random = new Random(0x2312);
-        final int NUM_TESTS = 1000;
+        final int numTests = 1000;
 
-        for (int test = 0; test < NUM_TESTS; test++) {
-            final int N = 10 + random.nextInt(200);
+        for (int test = 0; test < numTests; test++) {
+            final int n = 10 + random.nextInt(200);
 
-            Graph<Integer, DefaultEdge> tree1 = generateForest(N, random);
+            Graph<Integer, DefaultEdge> tree1 = generateForest(n, random);
 
             Pair<Graph<Integer, DefaultEdge>, Map<Integer, Integer>> pair =
                 generateIsomorphicGraph(tree1, random);
@@ -238,8 +238,8 @@ public class AHUForestIsomorphismInspectorTest
     @Category(SlowTests.class)
     public void testHugeRandomForest()
     {
-        final int N = 50_000;
-        Graph<Integer, DefaultEdge> tree1 = generateForest(N, new Random(0x88));
+        final int n = 50_000;
+        Graph<Integer, DefaultEdge> tree1 = generateForest(n, new Random(0x88));
 
         Pair<Graph<Integer, DefaultEdge>, Map<Integer, Integer>> pair =
             generateIsomorphicGraph(tree1, new Random(0x88));

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHURootedTreeIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHURootedTreeIsomorphismInspectorTest.java
@@ -313,14 +313,14 @@ public class AHURootedTreeIsomorphismInspectorTest
     @Test
     public void testLineGraph()
     {
-        final int N = 20_000;
+        final int n = 20_000;
         Graph<Integer, DefaultEdge> tree1 = new SimpleGraph<>(DefaultEdge.class);
 
-        for (int i = 1; i <= N; i++) {
+        for (int i = 1; i <= n; i++) {
             tree1.addVertex(i);
         }
 
-        for (int i = 1; i <= N - 1; i++) {
+        for (int i = 1; i <= n - 1; i++) {
             tree1.addEdge(i, i + 1);
         }
 
@@ -341,14 +341,14 @@ public class AHURootedTreeIsomorphismInspectorTest
     @Test
     public void testHugeNumberOfChildren()
     {
-        final int N = 100_000;
+        final int n = 100_000;
         Graph<Integer, DefaultEdge> tree1 = new SimpleGraph<>(DefaultEdge.class);
 
-        for (int i = 1; i <= N; i++) {
+        for (int i = 1; i <= n; i++) {
             tree1.addVertex(i);
         }
 
-        for (int i = 2; i <= N; i++) {
+        for (int i = 2; i <= n; i++) {
             tree1.addEdge(1, i);
         }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHUUnrootedTreeIsomorphismInspectorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/AHUUnrootedTreeIsomorphismInspectorTest.java
@@ -360,14 +360,14 @@ public class AHUUnrootedTreeIsomorphismInspectorTest
     @Category(SlowTests.class)
     public void testLineGraph()
     {
-        final int N = 20_000;
+        final int n = 20_000;
         Graph<Integer, DefaultEdge> tree1 = new SimpleGraph<>(DefaultEdge.class);
 
-        for (int i = 1; i <= N; i++) {
+        for (int i = 1; i <= n; i++) {
             tree1.addVertex(i);
         }
 
-        for (int i = 1; i <= N - 1; i++) {
+        for (int i = 1; i <= n - 1; i++) {
             tree1.addEdge(i, i + 1);
         }
 
@@ -389,14 +389,14 @@ public class AHUUnrootedTreeIsomorphismInspectorTest
     @Category(SlowTests.class)
     public void testHugeNumberOfChildren()
     {
-        final int N = 100_000;
+        final int n = 100_000;
         Graph<Integer, DefaultEdge> tree1 = new SimpleGraph<>(DefaultEdge.class);
 
-        for (int i = 1; i <= N; i++) {
+        for (int i = 1; i <= n; i++) {
             tree1.addVertex(i);
         }
 
-        for (int i = 2; i <= N; i++) {
+        for (int i = 2; i <= n; i++) {
             tree1.addEdge(1, i);
         }
 
@@ -417,8 +417,8 @@ public class AHUUnrootedTreeIsomorphismInspectorTest
     @Category(SlowTests.class)
     public void testHugeRandomTree()
     {
-        final int N = 50_000;
-        Graph<Integer, DefaultEdge> tree1 = generateTree(N, new Random(0x88));
+        final int n = 50_000;
+        Graph<Integer, DefaultEdge> tree1 = generateTree(n, new Random(0x88));
 
         Pair<Graph<Integer, DefaultEdge>, Map<Integer, Integer>> pair =
             generateIsomorphicGraph(tree1, new Random(0x88));
@@ -443,12 +443,12 @@ public class AHUUnrootedTreeIsomorphismInspectorTest
     public void testRandomTrees()
     {
         Random random = new Random(0x88_88);
-        final int NUM_TESTS = 1500;
+        final int numTests = 1500;
 
-        for (int test = 0; test < NUM_TESTS; test++) {
-            final int N = 10 + random.nextInt(100);
+        for (int test = 0; test < numTests; test++) {
+            final int n = 10 + random.nextInt(100);
 
-            Graph<Integer, DefaultEdge> tree1 = generateTree(N, random);
+            Graph<Integer, DefaultEdge> tree1 = generateTree(n, random);
 
             Pair<Graph<Integer, DefaultEdge>, Map<Integer, Integer>> pair =
                 generateIsomorphicGraph(tree1, random);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/GraphOrderingTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/GraphOrderingTest.java
@@ -62,67 +62,67 @@ public class GraphOrderingTest
             v3o = g1Ordering.getVertexNumber(v3), v4o = g1Ordering.getVertexNumber(v4),
             v5o = g1Ordering.getVertexNumber(v5);
 
-        int[] v1Outs = { v2o, v3o, v4o };
-        int[] v1Outs_ = g1Ordering.getOutEdges(v1o);
+        int[] v1OutsExpected = { v2o, v3o, v4o };
+        int[] v1Outs = g1Ordering.getOutEdges(v1o);
+        Arrays.sort(v1OutsExpected);
         Arrays.sort(v1Outs);
-        Arrays.sort(v1Outs_);
 
-        int[] v2Outs = { v1o, v4o };
-        int[] v2Outs_ = g1Ordering.getOutEdges(v2o);
+        int[] v2OutsExpected = { v1o, v4o };
+        int[] v2Outs = g1Ordering.getOutEdges(v2o);
+        Arrays.sort(v2OutsExpected);
         Arrays.sort(v2Outs);
-        Arrays.sort(v2Outs_);
 
-        int[] v3Outs = { v1o };
-        int[] v3Outs_ = g1Ordering.getOutEdges(v3o);
+        int[] v3OutsExpected = { v1o };
+        int[] v3Outs = g1Ordering.getOutEdges(v3o);
+        Arrays.sort(v3OutsExpected);
         Arrays.sort(v3Outs);
-        Arrays.sort(v3Outs_);
 
-        int[] v4Outs = { v1o, v2o };
-        int[] v4Outs_ = g1Ordering.getOutEdges(v4o);
+        int[] v4OutsExpected = { v1o, v2o };
+        int[] v4Outs = g1Ordering.getOutEdges(v4o);
+        Arrays.sort(v4OutsExpected);
         Arrays.sort(v4Outs);
-        Arrays.sort(v4Outs_);
 
-        int[] v5Outs = {};
-        int[] v5Outs_ = g1Ordering.getOutEdges(v5o);
+        int[] v5OutsExpected = {};
+        int[] v5Outs = g1Ordering.getOutEdges(v5o);
+        Arrays.sort(v5OutsExpected);
         Arrays.sort(v5Outs);
-        Arrays.sort(v5Outs_);
 
-        assertArrayEquals(v1Outs, v1Outs_);
-        assertArrayEquals(v2Outs, v2Outs_);
-        assertArrayEquals(v3Outs, v3Outs_);
-        assertArrayEquals(v4Outs, v4Outs_);
-        assertArrayEquals(v5Outs, v5Outs_);
+        assertArrayEquals(v1OutsExpected, v1Outs);
+        assertArrayEquals(v2OutsExpected, v2Outs);
+        assertArrayEquals(v3OutsExpected, v3Outs);
+        assertArrayEquals(v4OutsExpected, v4Outs);
+        assertArrayEquals(v5OutsExpected, v5Outs);
 
-        int[] v1Ins = { v2o, v3o, v4o };
-        int[] v1Ins_ = g1Ordering.getOutEdges(v1o);
+        int[] v1InsExpected = { v2o, v3o, v4o };
+        int[] v1Ins = g1Ordering.getOutEdges(v1o);
+        Arrays.sort(v1InsExpected);
         Arrays.sort(v1Ins);
-        Arrays.sort(v1Ins_);
 
-        int[] v2Ins = { v1o, v4o };
-        int[] v2Ins_ = g1Ordering.getOutEdges(v2o);
+        int[] v2InsExpected = { v1o, v4o };
+        int[] v2Ins = g1Ordering.getOutEdges(v2o);
+        Arrays.sort(v2InsExpected);
         Arrays.sort(v2Ins);
-        Arrays.sort(v2Ins_);
 
-        int[] v3Ins = { v1o };
-        int[] v3Ins_ = g1Ordering.getOutEdges(v3o);
+        int[] v3InsExpected = { v1o };
+        int[] v3Ins = g1Ordering.getOutEdges(v3o);
+        Arrays.sort(v3InsExpected);
         Arrays.sort(v3Ins);
-        Arrays.sort(v3Ins_);
 
-        int[] v4Ins = { v1o, v2o };
-        int[] v4Ins_ = g1Ordering.getOutEdges(v4o);
+        int[] v4InsExpected = { v1o, v2o };
+        int[] v4Ins = g1Ordering.getOutEdges(v4o);
+        Arrays.sort(v4InsExpected);
         Arrays.sort(v4Ins);
-        Arrays.sort(v4Ins_);
 
-        int[] v5Ins = {};
-        int[] v5Ins_ = g1Ordering.getOutEdges(v5o);
+        int[] v5InsExpected = {};
+        int[] v5Ins = g1Ordering.getOutEdges(v5o);
+        Arrays.sort(v5InsExpected);
         Arrays.sort(v5Ins);
-        Arrays.sort(v5Ins_);
 
-        assertArrayEquals(v1Ins, v1Ins_);
-        assertArrayEquals(v2Ins, v2Ins_);
-        assertArrayEquals(v3Ins, v3Ins_);
-        assertArrayEquals(v4Ins, v4Ins_);
-        assertArrayEquals(v5Ins, v5Ins_);
+        assertArrayEquals(v1InsExpected, v1Ins);
+        assertArrayEquals(v2InsExpected, v2Ins);
+        assertArrayEquals(v3InsExpected, v3Ins);
+        assertArrayEquals(v4InsExpected, v4Ins);
+        assertArrayEquals(v5InsExpected, v5Ins);
 
         assertEquals(false, g1Ordering.hasEdge(v1o, v1o));
         assertEquals(true, g1Ordering.hasEdge(v1o, v2o));
@@ -181,67 +181,68 @@ public class GraphOrderingTest
             v3o = g1Ordering.getVertexNumber(v3), v4o = g1Ordering.getVertexNumber(v4),
             v5o = g1Ordering.getVertexNumber(v5);
 
-        int[] v1Outs = { v2o };
-        int[] v1Outs_ = g1Ordering.getOutEdges(v1o);
+
+        int[] v1OutsExpected = { v2o };
+        int[] v1Outs = g1Ordering.getOutEdges(v1o);
+        Arrays.sort(v1OutsExpected);
         Arrays.sort(v1Outs);
-        Arrays.sort(v1Outs_);
 
-        int[] v2Outs = { v3o };
-        int[] v2Outs_ = g1Ordering.getOutEdges(v2o);
+        int[] v2OutsExpected = { v3o };
+        int[] v2Outs = g1Ordering.getOutEdges(v2o);
+        Arrays.sort(v2OutsExpected);
         Arrays.sort(v2Outs);
-        Arrays.sort(v2Outs_);
 
-        int[] v3Outs = { v2o, v4o };
-        int[] v3Outs_ = g1Ordering.getOutEdges(v3o);
+        int[] v3OutsExpected = { v2o, v4o };
+        int[] v3Outs = g1Ordering.getOutEdges(v3o);
+        Arrays.sort(v3OutsExpected);
         Arrays.sort(v3Outs);
-        Arrays.sort(v3Outs_);
 
-        int[] v4Outs = {};
-        int[] v4Outs_ = g1Ordering.getOutEdges(v4o);
+        int[] v4OutsExpected = {};
+        int[] v4Outs = g1Ordering.getOutEdges(v4o);
+        Arrays.sort(v4OutsExpected);
         Arrays.sort(v4Outs);
-        Arrays.sort(v4Outs_);
 
-        int[] v5Outs = {};
-        int[] v5Outs_ = g1Ordering.getOutEdges(v5o);
+        int[] v5OutsExpected = {};
+        int[] v5Outs = g1Ordering.getOutEdges(v5o);
+        Arrays.sort(v5OutsExpected);
         Arrays.sort(v5Outs);
-        Arrays.sort(v5Outs_);
 
-        assertArrayEquals(v1Outs, v1Outs_);
-        assertArrayEquals(v2Outs, v2Outs_);
-        assertArrayEquals(v3Outs, v3Outs_);
-        assertArrayEquals(v4Outs, v4Outs_);
-        assertArrayEquals(v5Outs, v5Outs_);
+        assertArrayEquals(v1OutsExpected, v1Outs);
+        assertArrayEquals(v2OutsExpected, v2Outs);
+        assertArrayEquals(v3OutsExpected, v3Outs);
+        assertArrayEquals(v4OutsExpected, v4Outs);
+        assertArrayEquals(v5OutsExpected, v5Outs);
 
-        int[] v1Ins = {};
-        int[] v1Ins_ = g1Ordering.getInEdges(v1o);
+        int[] v1InsExpected = {};
+        int[] v1Ins = g1Ordering.getInEdges(v1o);
+        Arrays.sort(v1InsExpected);
         Arrays.sort(v1Ins);
-        Arrays.sort(v1Ins_);
 
-        int[] v2Ins = { v1o, v3o };
-        int[] v2Ins_ = g1Ordering.getInEdges(v2o);
+        int[] v2InsExpected = { v1o, v3o };
+        int[] v2Ins = g1Ordering.getInEdges(v2o);
+        Arrays.sort(v2InsExpected);
         Arrays.sort(v2Ins);
-        Arrays.sort(v2Ins_);
 
-        int[] v3Ins = { v2o };
-        int[] v3Ins_ = g1Ordering.getInEdges(v3o);
+        int[] v3InsExpected = { v2o };
+        int[] v3Ins = g1Ordering.getInEdges(v3o);
+        Arrays.sort(v3InsExpected);
         Arrays.sort(v3Ins);
-        Arrays.sort(v3Ins_);
 
-        int[] v4Ins = { v3o };
-        int[] v4Ins_ = g1Ordering.getInEdges(v4o);
+        int[] v4InsExpected = { v3o };
+        int[] v4Ins = g1Ordering.getInEdges(v4o);
+        Arrays.sort(v4InsExpected);
         Arrays.sort(v4Ins);
-        Arrays.sort(v4Ins_);
 
-        int[] v5Ins = {};
-        int[] v5Ins_ = g1Ordering.getInEdges(v5o);
+        int[] v5InsExpected = {};
+        int[] v5Ins = g1Ordering.getInEdges(v5o);
+        Arrays.sort(v5InsExpected);
         Arrays.sort(v5Ins);
-        Arrays.sort(v5Ins_);
 
-        assertArrayEquals(v1Ins, v1Ins_);
-        assertArrayEquals(v2Ins, v2Ins_);
-        assertArrayEquals(v3Ins, v3Ins_);
-        assertArrayEquals(v4Ins, v4Ins_);
-        assertArrayEquals(v5Ins, v5Ins_);
+        assertArrayEquals(v1InsExpected, v1Ins);
+        assertArrayEquals(v2InsExpected, v2Ins);
+        assertArrayEquals(v3InsExpected, v3Ins);
+        assertArrayEquals(v4InsExpected, v4Ins);
+        assertArrayEquals(v5InsExpected, v5Ins);
 
         assertEquals(false, g1Ordering.hasEdge(v1o, v1o));
         assertEquals(true, g1Ordering.hasEdge(v1o, v2o));

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/IsomorphicGraphMappingTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/IsomorphicGraphMappingTest.java
@@ -97,13 +97,13 @@ public class IsomorphicGraphMappingTest
     @Test
     public void testCompositionOfRandomMappings()
     {
-        final int NUM_TESTS = 1000;
+        final int numTests = 1000;
         Random random = new Random(0x11_88_11);
 
-        for (int test = 0; test < NUM_TESTS; test++) {
-            final int N = 10 + random.nextInt(150);
+        for (int test = 0; test < numTests; test++) {
+            final int n = 10 + random.nextInt(150);
 
-            Graph<Integer, DefaultEdge> tree1 = generateTree(N, random);
+            Graph<Integer, DefaultEdge> tree1 = generateTree(n, random);
             Graph<Integer, DefaultEdge> tree2 = generateIsomorphicGraph(tree1, random).getFirst();
             Graph<Integer, DefaultEdge> tree3 = generateIsomorphicGraph(tree2, random).getFirst();
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/IsomorphismTestUtil.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/IsomorphismTestUtil.java
@@ -67,10 +67,10 @@ public class IsomorphismTestUtil
         return Pair.of(forest, generateMappedGraph(forest, map));
     }
 
-    public static Graph<Integer, DefaultEdge> generateForest(int N, Random random)
+    public static Graph<Integer, DefaultEdge> generateForest(int n, Random random)
     {
         BarabasiAlbertForestGenerator<Integer, DefaultEdge> generator =
-            new BarabasiAlbertForestGenerator<>(N / 10, N, random);
+            new BarabasiAlbertForestGenerator<>(n / 10, n, random);
 
         Graph<Integer, DefaultEdge> forest = new SimpleGraph<>(
             SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
@@ -101,10 +101,10 @@ public class IsomorphismTestUtil
         return Pair.of(generateMappedGraph(graph, mapping), mapping);
     }
 
-    public static Graph<Integer, DefaultEdge> generateTree(int N, Random random)
+    public static Graph<Integer, DefaultEdge> generateTree(int n, Random random)
     {
         BarabasiAlbertGraphGenerator<Integer, DefaultEdge> generator =
-            new BarabasiAlbertGraphGenerator<>(1, 1, N - 1, random);
+            new BarabasiAlbertGraphGenerator<>(1, 1, n - 1, random);
 
         Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(
             SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/SubgraphIsomorphismTestUtils.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/isomorphism/SubgraphIsomorphismTestUtils.java
@@ -24,7 +24,7 @@ import java.util.*;
 
 public class SubgraphIsomorphismTestUtils
 {
-    private static boolean DEBUG = false;
+    private static final boolean DEBUG = false;
 
     public static boolean allMatchingsCorrect(
         VF2SubgraphIsomorphismInspector<Integer, DefaultEdge> vf2, Graph<Integer, DefaultEdge> g1,

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/lca/LCATreeTestBase.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/lca/LCATreeTestBase.java
@@ -181,7 +181,7 @@ public abstract class LCATreeTestBase
     @Test
     public void testGraphAllPossibleQueries()
     {
-        final int N = 100;
+        final int n = 100;
 
         Random random = new Random(0x88_88);
 
@@ -189,7 +189,7 @@ public abstract class LCATreeTestBase
             SupplierUtil.createIntegerSupplier(0), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
 
         BarabasiAlbertForestGenerator<Integer, DefaultEdge> generator =
-            new BarabasiAlbertForestGenerator<>(1, N, random);
+            new BarabasiAlbertForestGenerator<>(1, n, random);
 
         generator.generateGraph(g, null);
 
@@ -204,10 +204,10 @@ public abstract class LCATreeTestBase
         else
             lcaAlgorithm2 = new EulerTourRMQLCAFinder<>(g, Collections.singleton(root));
 
-        List<Pair<Integer, Integer>> queries = new ArrayList<>(N * N);
+        List<Pair<Integer, Integer>> queries = new ArrayList<>(n * n);
 
-        for (int i = 0; i < N; i++) {
-            for (int j = 0; j < N; j++) {
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
                 queries.add(Pair.of(i, j));
             }
         }
@@ -223,28 +223,28 @@ public abstract class LCATreeTestBase
     @Test
     public void testLongChain()
     {
-        final int N = 2_000;
-        final int Q = 100_000;
+        final int n = 2_000;
+        final int q = 100_000;
 
         Random random = new Random(0x88);
 
         Graph<Integer, DefaultEdge> g = new SimpleGraph<>(DefaultEdge.class);
 
-        for (int i = 1; i <= N; i++)
+        for (int i = 1; i <= n; i++)
             g.addVertex(i);
 
-        for (int i = 1; i < N; i++)
+        for (int i = 1; i < n; i++)
             g.addEdge(i, i + 1);
 
         List<Pair<Integer, Integer>> queries =
-            generateQueries(Q, new ArrayList<>(g.vertexSet()), random);
+            generateQueries(q, new ArrayList<>(g.vertexSet()), random);
 
         LowestCommonAncestorAlgorithm<Integer> lcaAlgorithm =
-            createSolver(g, Collections.singleton(N));
+            createSolver(g, Collections.singleton(n));
 
         List<Integer> lcas = lcaAlgorithm.getBatchLCA(queries);
 
-        for (int i = 0; i < Q; i++) {
+        for (int i = 0; i < q; i++) {
             int a = queries.get(i).getFirst();
             int b = queries.get(i).getSecond();
 
@@ -403,8 +403,8 @@ public abstract class LCATreeTestBase
     @Test
     public void randomHugeConnectedTree()
     {
-        final int N = 100_000;
-        final int Q = 200_000;
+        final int n = 100_000;
+        final int q = 200_000;
 
         Random random = new Random(0x88);
 
@@ -412,7 +412,7 @@ public abstract class LCATreeTestBase
             SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
 
         BarabasiAlbertForestGenerator<Integer, DefaultEdge> generator =
-            new BarabasiAlbertForestGenerator<>(1, N, random);
+            new BarabasiAlbertForestGenerator<>(1, n, random);
 
         generator.generateGraph(g, null);
 
@@ -427,21 +427,21 @@ public abstract class LCATreeTestBase
         else
             lcaAlgorithm2 = new EulerTourRMQLCAFinder<>(g, vertexList.get(0));
 
-        List<Pair<Integer, Integer>> queries = generateQueries(Q, vertexList, random);
+        List<Pair<Integer, Integer>> queries = generateQueries(q, vertexList, random);
 
         List<Integer> lcas1 = lcaAlgorithm1.getBatchLCA(queries);
         List<Integer> lcas2 = lcaAlgorithm2.getBatchLCA(queries);
 
-        for (int i = 0; i < Q; i++) {
+        for (int i = 0; i < q; i++) {
             Assert.assertEquals(lcas1.get(i), lcas2.get(i));
         }
     }
 
-    public static <V> List<Pair<V, V>> generateQueries(int Q, List<V> vertexList, Random random)
+    public static <V> List<Pair<V, V>> generateQueries(int q, List<V> vertexList, Random random)
     {
-        List<Pair<V, V>> queries = new ArrayList<>(Q);
+        List<Pair<V, V>> queries = new ArrayList<>(q);
 
-        for (int i = 0; i < Q; i++) {
+        for (int i = 0; i < q; i++) {
             V a = vertexList.get(random.nextInt(vertexList.size()));
             V b = vertexList.get(random.nextInt(vertexList.size()));
 
@@ -454,18 +454,18 @@ public abstract class LCATreeTestBase
     @Test
     public void randomHugePossiblyDisconnectedTree()
     {
-        final int N = 100_000;
-        final int Q = 200_000;
+        final int n = 100_000;
+        final int q = 200_000;
 
         Random random = new Random(0x55);
 
-        final int NUM_TREES = 100 + random.nextInt(200);
+        final int numTrees = 100 + random.nextInt(200);
 
         Graph<Integer, DefaultEdge> g = new SimpleGraph<>(
             SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
 
         BarabasiAlbertForestGenerator<Integer, DefaultEdge> generator =
-            new BarabasiAlbertForestGenerator<>(NUM_TREES, N, random);
+            new BarabasiAlbertForestGenerator<>(numTrees, n, random);
 
         generator.generateGraph(g, null);
 
@@ -487,12 +487,12 @@ public abstract class LCATreeTestBase
         else
             lcaAlgorithm2 = new EulerTourRMQLCAFinder<>(g, roots);
 
-        List<Pair<Integer, Integer>> queries = generateQueries(Q, vertexList, random);
+        List<Pair<Integer, Integer>> queries = generateQueries(q, vertexList, random);
 
         List<Integer> lcas1 = lcaAlgorithm1.getBatchLCA(queries);
         List<Integer> lcas2 = lcaAlgorithm2.getBatchLCA(queries);
 
-        for (int i = 0; i < Q; i++) {
+        for (int i = 0; i < q; i++) {
             Assert.assertEquals(lcas1.get(i), lcas2.get(i));
         }
     }
@@ -501,14 +501,14 @@ public abstract class LCATreeTestBase
     public void testSmallConnectedTrees()
     {
         Random random = new Random(0x88);
-        final int TESTS = 10_000;
-        final int Q = 50;
+        final int tests = 10_000;
+        final int q = 50;
 
-        for (int test = 0; test < TESTS; test++) {
-            final int N = 10 + random.nextInt(100);
+        for (int test = 0; test < tests; test++) {
+            final int n = 10 + random.nextInt(100);
 
             GraphGenerator<Integer, DefaultEdge, Integer> gen =
-                new BarabasiAlbertForestGenerator<>(1, N, random.nextInt());
+                new BarabasiAlbertForestGenerator<>(1, n, random.nextInt());
 
             Graph<Integer, DefaultEdge> g = new SimpleGraph<>(
                 SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
@@ -526,12 +526,12 @@ public abstract class LCATreeTestBase
             else
                 lcaAlgorithm2 = new EulerTourRMQLCAFinder<>(g, roots);
 
-            List<Pair<Integer, Integer>> queries = generateQueries(Q, vertexList, random);
+            List<Pair<Integer, Integer>> queries = generateQueries(q, vertexList, random);
 
             List<Integer> lcas1 = lcaAlgorithm1.getBatchLCA(queries);
             List<Integer> lcas2 = lcaAlgorithm2.getBatchLCA(queries);
 
-            for (int i = 0; i < Q; i++) {
+            for (int i = 0; i < q; i++) {
                 Assert.assertEquals(lcas1.get(i), lcas2.get(i));
             }
         }
@@ -541,14 +541,14 @@ public abstract class LCATreeTestBase
     public void testSmallDisconnectedTrees()
     {
         Random random = new Random(0x88);
-        final int TESTS = 10_000;
-        final int Q = 50;
+        final int tests = 10_000;
+        final int q = 50;
 
-        for (int test = 0; test < TESTS; test++) {
-            final int N = 10 + random.nextInt(200);
+        for (int test = 0; test < tests; test++) {
+            final int n = 10 + random.nextInt(200);
 
             GraphGenerator<Integer, DefaultEdge, Integer> gen =
-                new BarabasiAlbertForestGenerator<>(N / 10, N, random.nextInt());
+                new BarabasiAlbertForestGenerator<>(n / 10, n, random.nextInt());
 
             Graph<Integer, DefaultEdge> g = new SimpleGraph<>(
                 SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
@@ -567,12 +567,12 @@ public abstract class LCATreeTestBase
                 lcaAlgorithm2 = new EulerTourRMQLCAFinder<>(g, roots);
 
             List<Pair<Integer, Integer>> queries =
-                generateQueries(Q, new ArrayList<>(g.vertexSet()), random);
+                generateQueries(q, new ArrayList<>(g.vertexSet()), random);
 
             List<Integer> lcas1 = lcaAlgorithm1.getBatchLCA(queries);
             List<Integer> lcas2 = lcaAlgorithm2.getBatchLCA(queries);
 
-            for (int i = 0; i < Q; i++) {
+            for (int i = 0; i < q; i++) {
                 Assert.assertEquals(lcas1.get(i), lcas2.get(i));
             }
         }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/linkprediction/SørensenIndexLinkPredictionTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/linkprediction/SørensenIndexLinkPredictionTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
  *
  * @author Dimitrios Michail
  */
-public class SørensenIndexLinkPredictionTest
+public class SørensenIndexLinkPredictionTest // @CS.suppress[TypeName]
 {
 
     @Test

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/matching/KuhnMunkresMinimalWeightBipartitePerfectMatchingTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/matching/KuhnMunkresMinimalWeightBipartitePerfectMatchingTest.java
@@ -36,7 +36,7 @@ public class KuhnMunkresMinimalWeightBipartitePerfectMatchingTest
     /**
      * First partition
      */
-    private enum FIRST_PARTITION
+    private enum FirstPartition
         implements
         V
     {
@@ -64,12 +64,12 @@ public class KuhnMunkresMinimalWeightBipartitePerfectMatchingTest
         V
     }
 
-    private static List<? extends V> firstPartition = Arrays.asList(FIRST_PARTITION.values());
+    private static List<? extends V> firstPartition = Arrays.asList(FirstPartition.values());
 
     /**
      * Second partition
      */
-    private enum SECOND_PARTITION
+    private enum SecondPartition
         implements
         V
     {
@@ -97,7 +97,7 @@ public class KuhnMunkresMinimalWeightBipartitePerfectMatchingTest
         V
     }
 
-    private static List<? extends V> secondPartition = Arrays.asList(SECOND_PARTITION.values());
+    private static List<? extends V> secondPartition = Arrays.asList(SecondPartition.values());
 
     private static Matching<V, DefaultWeightedEdge> match(
         final double[][] costMatrix, final int partitionCardinality)

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/partition/BipartitePartitioningTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/partition/BipartitePartitioningTest.java
@@ -231,11 +231,11 @@ public class BipartitePartitioningTest
             Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(
                 SupplierUtil.createIntegerSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
 
-            final int T = 10 + random.nextInt(50);
-            final int N = 100 + random.nextInt(200);
+            final int t = 10 + random.nextInt(50);
+            final int n = 100 + random.nextInt(200);
 
             BarabasiAlbertForestGenerator<Integer, DefaultEdge> generator =
-                new BarabasiAlbertForestGenerator<>(T, N);
+                new BarabasiAlbertForestGenerator<>(t, n);
             generator.generateGraph(graph);
 
             BipartitePartitioning<Integer, DefaultEdge> finder = new BipartitePartitioning<>(graph);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/EdgeBetweennessCentralityTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/scoring/EdgeBetweennessCentralityTest.java
@@ -60,18 +60,18 @@ public class EdgeBetweennessCentralityTest
         g.addEdge("B", "D");
         g.addEdge("C", "D");
 
-        DefaultEdge e_D_E = g.addEdge("D", "E");
+        DefaultEdge edgeDE = g.addEdge("D", "E");
 
         g.addEdge("E", "F");
-        DefaultEdge e_E_G = g.addEdge("E", "G");
+        DefaultEdge edgeEG = g.addEdge("E", "G");
         g.addEdge("F", "G");
         g.addEdge("F", "H");
         g.addEdge("G", "H");
 
         EdgeBetweennessCentrality<String, DefaultEdge> ebc = new EdgeBetweennessCentrality<>(g);
 
-        assertEquals(16.0, ebc.getEdgeScore(e_D_E), 1e-9);
-        assertEquals(7.5, ebc.getEdgeScore(e_E_G), 1e-9);
+        assertEquals(16.0, ebc.getEdgeScore(edgeDE), 1e-9);
+        assertEquals(7.5, ebc.getEdgeScore(edgeEG), 1e-9);
     }
 
     @Test
@@ -217,23 +217,23 @@ public class EdgeBetweennessCentralityTest
         g.addEdge("B", "D");
         g.addEdge("C", "D");
 
-        DefaultEdge e_D_E = g.addEdge("D", "E");
-        g.setEdgeWeight(e_D_E, 1000.0); // very large
+        DefaultEdge edgeDE = g.addEdge("D", "E");
+        g.setEdgeWeight(edgeDE, 1000.0); // very large
 
-        DefaultEdge e_D_F = g.addEdge("D", "F");
+        DefaultEdge edgeDF = g.addEdge("D", "F");
 
         g.addEdge("E", "F");
-        DefaultEdge e_E_G = g.addEdge("E", "G");
-        DefaultEdge e_F_G = g.addEdge("F", "G");
+        DefaultEdge edgeEG = g.addEdge("E", "G");
+        DefaultEdge edgeFG = g.addEdge("F", "G");
         g.addEdge("F", "H");
         g.addEdge("G", "H");
 
         EdgeBetweennessCentrality<String, DefaultEdge> ebc = new EdgeBetweennessCentrality<>(g);
 
-        assertEquals(0.0, ebc.getEdgeScore(e_D_E), 1e-9);
-        assertEquals(16.0, ebc.getEdgeScore(e_D_F), 1e-9);
-        assertEquals(1.5, ebc.getEdgeScore(e_E_G), 1e-9);
-        assertEquals(5.0, ebc.getEdgeScore(e_F_G), 1e-9);
+        assertEquals(0.0, ebc.getEdgeScore(edgeDE), 1e-9);
+        assertEquals(16.0, ebc.getEdgeScore(edgeDF), 1e-9);
+        assertEquals(1.5, ebc.getEdgeScore(edgeEG), 1e-9);
+        assertEquals(5.0, ebc.getEdgeScore(edgeFG), 1e-9);
     }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/GraphMeasurerTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/GraphMeasurerTest.java
@@ -38,7 +38,7 @@ import static org.junit.Assert.assertTrue;
 public class GraphMeasurerTest
 {
 
-    private final double EPSILON = 0.000000001;
+    private static final double EPSILON = 0.000000001;
 
     private Graph<Integer, DefaultEdge> getGraph1()
     {
@@ -74,21 +74,21 @@ public class GraphMeasurerTest
 
         Random random = new Random(12345678);
 
-        final int N = 100;
-        final int M = 100000;
+        final int n = 100;
+        final int m = 100000;
 
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             g.addVertex(i);
         }
 
-        for (int i = 0; i < N - 1; i++) {
+        for (int i = 0; i < n - 1; i++) {
             g.addEdge(i, i + 1);
             g.setEdgeWeight(g.getEdge(i, i + 1), 50 + random.nextInt(50));
         }
 
-        for (int i = N - 1; i < M; i++) {
-            int u = random.nextInt(N);
-            int v = random.nextInt(N);
+        for (int i = n - 1; i < m; i++) {
+            int u = random.nextInt(n);
+            int v = random.nextInt(n);
 
             if (u != v) {
                 g.addEdge(u, v);

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/MinimumSpanningTreeTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/spanning/MinimumSpanningTreeTest.java
@@ -49,13 +49,13 @@ public abstract class MinimumSpanningTreeTest
 
     // ~ Instance fields --------------------------------------------------------
 
-    public static DefaultWeightedEdge AB;
-    public static DefaultWeightedEdge AC;
-    public static DefaultWeightedEdge BD;
-    public static DefaultWeightedEdge DE;
-    public static DefaultWeightedEdge EG;
-    public static DefaultWeightedEdge GH;
-    public static DefaultWeightedEdge FH;
+    public static DefaultWeightedEdge ab;
+    public static DefaultWeightedEdge ac;
+    public static DefaultWeightedEdge bd;
+    public static DefaultWeightedEdge de;
+    public static DefaultWeightedEdge eg;
+    public static DefaultWeightedEdge gh;
+    public static DefaultWeightedEdge fh;
 
     // ~ Methods ----------------------------------------------------------------
 
@@ -64,7 +64,7 @@ public abstract class MinimumSpanningTreeTest
     {
         testMinimumSpanningTreeBuilding(
             createSolver(createSimpleDisconnectedWeightedGraph()).getSpanningTree(),
-            Arrays.asList(AB, AC, BD, EG, GH, FH), 60.0);
+            Arrays.asList(ab, ac, bd, eg, gh, fh), 60.0);
     }
 
     @Test
@@ -72,7 +72,7 @@ public abstract class MinimumSpanningTreeTest
     {
         testMinimumSpanningTreeBuilding(
             createSolver(createSimpleConnectedWeightedGraph()).getSpanningTree(),
-            Arrays.asList(AB, AC, BD, DE), 15.0);
+            Arrays.asList(ab, ac, bd, de), 15.0);
     }
 
     @Test
@@ -132,9 +132,9 @@ public abstract class MinimumSpanningTreeTest
         g.addVertex(C);
         g.addVertex(D);
 
-        AB = Graphs.addEdge(g, A, B, 5);
-        AC = Graphs.addEdge(g, A, C, 10);
-        BD = Graphs.addEdge(g, B, D, 15);
+        ab = Graphs.addEdge(g, A, B, 5);
+        ac = Graphs.addEdge(g, A, C, 10);
+        bd = Graphs.addEdge(g, B, D, 15);
         Graphs.addEdge(g, C, D, 20);
 
         g.addVertex(E);
@@ -143,9 +143,9 @@ public abstract class MinimumSpanningTreeTest
         g.addVertex(H);
 
         Graphs.addEdge(g, E, F, 20);
-        EG = Graphs.addEdge(g, E, G, 15);
-        GH = Graphs.addEdge(g, G, H, 10);
-        FH = Graphs.addEdge(g, F, H, 5);
+        eg = Graphs.addEdge(g, E, G, 15);
+        gh = Graphs.addEdge(g, G, H, 10);
+        fh = Graphs.addEdge(g, F, H, 5);
 
         return g;
     }
@@ -164,11 +164,11 @@ public abstract class MinimumSpanningTreeTest
         g.addVertex(D);
         g.addVertex(E);
 
-        AB = Graphs.addEdge(g, A, B, bias * 2);
-        AC = Graphs.addEdge(g, A, C, bias * 3);
-        BD = Graphs.addEdge(g, B, D, bias * 5);
+        ab = Graphs.addEdge(g, A, B, bias * 2);
+        ac = Graphs.addEdge(g, A, C, bias * 3);
+        bd = Graphs.addEdge(g, B, D, bias * 5);
         Graphs.addEdge(g, C, D, bias * 20);
-        DE = Graphs.addEdge(g, D, E, bias * 5);
+        de = Graphs.addEdge(g, D, E, bias * 5);
         Graphs.addEdge(g, A, E, bias * 100);
 
         return g;

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/tour/HeldKarpTSPTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/tour/HeldKarpTSPTest.java
@@ -340,10 +340,10 @@ public class HeldKarpTSPTest
          * Generate 500 'random' directed multigraphs that contain a tour
          */
 
-        final int NUM_TESTS = 500;
+        final int numTests = 500;
         Random random = new Random(123);
 
-        for (int test = 0; test < NUM_TESTS; test++) {
+        for (int test = 0; test < numTests; test++) {
             Graph<String, DefaultWeightedEdge> g =
                 new DirectedMultigraph<>(DefaultWeightedEdge.class);
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/tour/PalmerHamiltonianCycleTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/tour/PalmerHamiltonianCycleTest.java
@@ -83,8 +83,8 @@ public class PalmerHamiltonianCycleTest
 
     private void testRandomGraphs(Random random)
     {
-        final int NUM_TESTS = 500;
-        for (int test = 0; test < NUM_TESTS; test++) {
+        final int numTests = 500;
+        for (int test = 0; test < numTests; test++) {
             Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
             final int n = 3 + random.nextInt(150);
 
@@ -133,8 +133,8 @@ public class PalmerHamiltonianCycleTest
 
     private void testRandomGraphs2(Random random)
     {
-        final int NUM_TESTS = 500;
-        for (int test = 0; test < NUM_TESTS; test++) {
+        final int numTests = 500;
+        for (int test = 0; test < numTests; test++) {
             Graph<Integer, DefaultEdge> graph = new SimpleGraph<>(DefaultEdge.class);
             final int n = 3 + random.nextInt(150);
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/util/NeighborCacheTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/util/NeighborCacheTest.java
@@ -135,35 +135,35 @@ public class NeighborCacheTest
         ListenableGraph<String, DefaultEdge> graph =
             new DefaultListenableGraph<>(new SimpleGraph<>(DefaultEdge.class));
 
-        final String A = "A";
-        final String B = "B";
-        final String C = "C";
-        final String D = "D";
+        final String a = "A";
+        final String b = "B";
+        final String c = "C";
+        final String d = "D";
 
         NeighborCache<String, DefaultEdge> cache = new NeighborCache<>(graph);
 
         graph.addGraphListener(cache);
 
-        graph.addVertex(A);
-        graph.addVertex(B);
-        graph.addVertex(C);
-        graph.addVertex(D);
+        graph.addVertex(a);
+        graph.addVertex(b);
+        graph.addVertex(c);
+        graph.addVertex(d);
 
-        graph.addEdge(D, A);
-        graph.addEdge(D, B);
-        graph.addEdge(D, C);
+        graph.addEdge(d, a);
+        graph.addEdge(d, b);
+        graph.addEdge(d, c);
 
-        Set<String> neighborsOfD = cache.neighborsOf(D);
-        Set<String> neighborsOfC = cache.neighborsOf(C);
-        Set<String> neighborsOfB = cache.neighborsOf(B);
-        Set<String> neighborsOfA = cache.neighborsOf(A);
+        Set<String> neighborsOfD = cache.neighborsOf(d);
+        Set<String> neighborsOfC = cache.neighborsOf(c);
+        Set<String> neighborsOfB = cache.neighborsOf(b);
+        Set<String> neighborsOfA = cache.neighborsOf(a);
 
-        assertThat(neighborsOfD, hasItems(A, B, C));
+        assertThat(neighborsOfD, hasItems(a, b, c));
         assertThat(neighborsOfA.size(), is(1));
         assertThat(neighborsOfB.size(), is(1));
         assertThat(neighborsOfC.size(), is(1));
 
-        graph.removeVertex(D);
+        graph.removeVertex(d);
 
         assertTrue(neighborsOfD.isEmpty());
 
@@ -179,40 +179,40 @@ public class NeighborCacheTest
         ListenableGraph<String, DefaultEdge> graph =
             new DefaultListenableGraph<>(new SimpleGraph<>(DefaultEdge.class));
 
-        final String A = "A";
-        final String B = "B";
-        final String C = "C";
-        final String D = "D";
+        final String a = "A";
+        final String b = "B";
+        final String c = "C";
+        final String d = "D";
 
         NeighborCache<String, DefaultEdge> cache = new NeighborCache<>(graph);
 
         graph.addGraphListener(cache);
 
-        graph.addVertex(A);
-        graph.addVertex(B);
-        graph.addVertex(C);
-        graph.addVertex(D);
+        graph.addVertex(a);
+        graph.addVertex(b);
+        graph.addVertex(c);
+        graph.addVertex(d);
 
-        graph.addEdge(D, A);
-        graph.addEdge(D, B);
-        graph.addEdge(D, C);
+        graph.addEdge(d, a);
+        graph.addEdge(d, b);
+        graph.addEdge(d, c);
 
-        assertThat(cache.neighborListOf(B), hasItems(D));
-        assertThat(cache.neighborListOf(B).size(), is(1));
+        assertThat(cache.neighborListOf(b), hasItems(d));
+        assertThat(cache.neighborListOf(b).size(), is(1));
 
-        graph.addEdge(A, B);
+        graph.addEdge(a, b);
 
-        assertThat(cache.neighborListOf(B), hasItems(A, D));
-        assertThat(cache.neighborListOf(B).size(), is(2));
+        assertThat(cache.neighborListOf(b), hasItems(a, d));
+        assertThat(cache.neighborListOf(b).size(), is(2));
 
-        graph.removeEdge(D, B);
+        graph.removeEdge(d, b);
 
-        assertThat(cache.neighborListOf(B), hasItems(A));
-        assertThat(cache.neighborListOf(B).size(), is(1));
+        assertThat(cache.neighborListOf(b), hasItems(a));
+        assertThat(cache.neighborListOf(b).size(), is(1));
 
-        graph.removeVertex(B);
+        graph.removeVertex(b);
 
-        assertThrows(IllegalArgumentException.class, () -> cache.neighborListOf(B));
+        assertThrows(IllegalArgumentException.class, () -> cache.neighborListOf(b));
     }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/BarabasiAlbertForestGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/BarabasiAlbertForestGeneratorTest.java
@@ -151,20 +151,20 @@ public class BarabasiAlbertForestGeneratorTest
     {
         Random random = new Random(0x88);
 
-        final int NUM_TESTS = 10_000;
+        final int numTests = 10_000;
 
-        for (int test = 0; test < NUM_TESTS; test++) {
-            final int N = 10 + random.nextInt(100);
-            final int T = 1 + random.nextInt(N);
+        for (int test = 0; test < numTests; test++) {
+            final int n = 10 + random.nextInt(100);
+            final int t = 1 + random.nextInt(n);
 
             GraphGenerator<Integer, DefaultEdge, Integer> gen =
-                new BarabasiAlbertForestGenerator<>(T, N);
+                new BarabasiAlbertForestGenerator<>(t, n);
             Graph<Integer, DefaultEdge> g = new SimpleGraph<>(
                 SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
             gen.generateGraph(g);
 
-            assertEquals(N, g.vertexSet().size());
-            assertEquals(T, new ConnectivityInspector<>(g).connectedSets().size());
+            assertEquals(n, g.vertexSet().size());
+            assertEquals(t, new ConnectivityInspector<>(g).connectedSets().size());
         }
     }
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/GeneralizedPetersenGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/GeneralizedPetersenGraphGeneratorTest.java
@@ -57,7 +57,7 @@ public class GeneralizedPetersenGraphGeneratorTest
     }
 
     @Test
-    public void testDürerGraphGraph()
+    public void testDuererGraphGraph()
     {
         Graph<Integer, DefaultEdge> g = NamedGraphGenerator.dürerGraph();
         this.validateBasics(g, 12, 18, 3, 4, 3);
@@ -91,7 +91,7 @@ public class GeneralizedPetersenGraphGeneratorTest
     }
 
     @Test
-    public void testMöbiusKantorGraph()
+    public void testMoebiusKantorGraph()
     {
         Graph<Integer, DefaultEdge> g = NamedGraphGenerator.möbiusKantorGraph();
         this.validateBasics(g, 16, 24, 4, 4, 6);

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/NamedGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/NamedGraphGeneratorTest.java
@@ -77,7 +77,7 @@ public class NamedGraphGeneratorTest
     }
 
     @Test
-    public void testGrötzschGraph()
+    public void testGroetzschGraph()
     {
         Graph<Integer, DefaultEdge> g = NamedGraphGenerator.grötzschGraph();
         this.validateBasics(g, 11, 20, 2, 2, 4);
@@ -300,7 +300,7 @@ public class NamedGraphGeneratorTest
     }
 
     @Test
-    public void testSchläfliGraph()
+    public void testSchlaefliGraph()
     {
         Graph<Integer, DefaultEdge> g = NamedGraphGenerator.schläfliGraph();
         this.validateBasics(g, 27, 216, 2, 2, 3);

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/PlantedPartitionGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/PlantedPartitionGraphGeneratorTest.java
@@ -32,7 +32,7 @@ import static org.junit.Assert.*;
  */
 public class PlantedPartitionGraphGeneratorTest
 {
-    private final long SEED = 5;
+    private static final long SEED = 5;
 
     /* bad inputs */
 

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/PruferTreeGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/PruferTreeGeneratorTest.java
@@ -139,9 +139,9 @@ public class PruferTreeGeneratorTest
     public void testRandomSizes()
     {
         Random random = new Random(0x88);
-        final int NUM_TESTS = 500;
+        final int numTests = 500;
 
-        for (int test = 0; test < NUM_TESTS; test++) {
+        for (int test = 0; test < numTests; test++) {
             Graph<Integer, DefaultEdge> tree = new SimpleGraph<>(
                 SupplierUtil.createIntegerSupplier(1), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
 

--- a/jgrapht-core/src/test/java/org/jgrapht/generate/RandomRegularGraphGeneratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/generate/RandomRegularGraphGeneratorTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.fail;
  */
 public class RandomRegularGraphGeneratorTest
 {
-    private final long SEED = 5;
+    private static final long SEED = 5;
 
     @Test(expected = IllegalArgumentException.class)
     public void testNegativeN()

--- a/jgrapht-core/src/test/java/org/jgrapht/util/RadixSortTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/RadixSortTest.java
@@ -82,11 +82,11 @@ public class RadixSortTest
     public void testRandomHugeArray()
     {
         Random random = new Random(0x881);
-        final int N = 1_000_000;
+        final int n = 1_000_000;
 
-        List<Integer> list = new ArrayList<>(N);
+        List<Integer> list = new ArrayList<>(n);
 
-        for (int i = 0; i < N; i++) {
+        for (int i = 0; i < n; i++) {
             list.add(random.nextInt(Integer.MAX_VALUE));
         }
 
@@ -110,14 +110,14 @@ public class RadixSortTest
 
     private void testRandomArrays(Random random)
     {
-        final int NUM_TESTS = 500_000;
+        final int numTests = 500_000;
 
-        for (int test = 0; test < NUM_TESTS; test++) {
-            final int N = 1 + random.nextInt(100);
+        for (int test = 0; test < numTests; test++) {
+            final int n = 1 + random.nextInt(100);
 
-            List<Integer> list = new ArrayList<>(N);
+            List<Integer> list = new ArrayList<>(n);
 
-            for (int i = 0; i < N; i++) {
+            for (int i = 0; i < n; i++) {
                 list.add(random.nextInt(Integer.MAX_VALUE));
             }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/util/VertexToIntegerMappingTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/VertexToIntegerMappingTest.java
@@ -56,21 +56,21 @@ public class VertexToIntegerMappingTest
     public void testRandomInstances()
     {
         Random random = new Random(0x88);
-        final int NUM_TESTS = 1024;
+        final int numTests = 1024;
         Supplier<String> supplier = SupplierUtil.createStringSupplier(random.nextInt(100));
 
-        for (int test = 0; test < NUM_TESTS; test++) {
-            final int N = 10 + random.nextInt(1024);
+        for (int test = 0; test < numTests; test++) {
+            final int n = 10 + random.nextInt(1024);
 
             Set<String> vertices =
-                IntStream.range(0, N).mapToObj(x -> supplier.get()).collect(Collectors.toSet());
+                IntStream.range(0, n).mapToObj(x -> supplier.get()).collect(Collectors.toSet());
             VertexToIntegerMapping<String> mapping = new VertexToIntegerMapping<>(vertices);
 
             Map<String, Integer> vertexMap = mapping.getVertexMap();
             List<String> indexList = mapping.getIndexList();
 
-            Assert.assertEquals(N, vertexMap.size());
-            Assert.assertEquals(N, indexList.size());
+            Assert.assertEquals(n, vertexMap.size());
+            Assert.assertEquals(n, indexList.size());
 
             for (int i = 0; i < indexList.size(); i++) {
                 Assert.assertEquals(i, vertexMap.get(indexList.get(i)).intValue());

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/DefaultAttribute.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/DefaultAttribute.java
@@ -36,7 +36,7 @@ public class DefaultAttribute<T>
     /**
      * The null attribute.
      */
-    public static Attribute NULL = new DefaultAttribute<>(null, AttributeType.NULL);
+    public static final Attribute NULL = new DefaultAttribute<>(null, AttributeType.NULL);
 
     private T value;
     private AttributeType type;

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTEventDrivenImporter.java
@@ -54,7 +54,7 @@ public class DOTEventDrivenImporter
     public static final String DEFAULT_GRAPH_ID_KEY = "ID";
 
     // identifier unescape rule
-    private final CharSequenceTranslator UNESCAPE_ID;
+    private final CharSequenceTranslator unescapeId;
 
     private boolean notifyVertexAttributesOutOfOrder;
     private boolean notifyEdgeAttributesOutOfOrder;
@@ -84,7 +84,7 @@ public class DOTEventDrivenImporter
         lookupMap.put("\\\"", "\"");
         lookupMap.put("\\'", "'");
         lookupMap.put("\\", "");
-        UNESCAPE_ID = new AggregateTranslator(new LookupTranslator(lookupMap));
+        unescapeId = new AggregateTranslator(new LookupTranslator(lookupMap));
 
         this.notifyVertexAttributesOutOfOrder = notifyVertexAttributesOutOfOrder;
         this.notifyEdgeAttributesOutOfOrder = notifyEdgeAttributesOutOfOrder;
@@ -784,12 +784,12 @@ public class DOTEventDrivenImporter
      */
     private String unescapeId(String input)
     {
-        final char QUOTE = '"';
-        if (input.charAt(0) != QUOTE || input.charAt(input.length() - 1) != QUOTE) {
+        final char quote = '"';
+        if (input.charAt(0) != quote || input.charAt(input.length() - 1) != quote) {
             return input;
         }
         String noQuotes = input.subSequence(1, input.length() - 1).toString();
-        String unescaped = UNESCAPE_ID.translate(noQuotes);
+        String unescaped = unescapeId.translate(noQuotes);
         return unescaped;
     }
 

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/gexf/SimpleGEXFEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/gexf/SimpleGEXFEventDrivenImporter.java
@@ -183,23 +183,26 @@ public class SimpleGEXFEventDrivenImporter
         }
     }
 
+    private static final List<String> GRAPH_ATTRS =
+        List.of("defaultedgetype", "timeformat", "mode", "start", "end");
+    private static final List<String> NODE_ATTRS = List.of("label", "pid");
+    private static final List<String> EDGE_ATTRS = List.of("type", "label");
+
     // content handler
     private class GEXFHandler
         extends
         DefaultHandler
     {
         private static final String GRAPH = "graph";
-        private final List<String> GRAPH_ATTRS =
-            List.of("defaultedgetype", "timeformat", "mode", "start", "end");
+
         private static final String NODE = "node";
         private static final String NODE_ID = "id";
-        private final List<String> NODE_ATTRS = List.of("label", "pid");
+
         private static final String EDGE = "edge";
         private static final String EDGE_ID = "id";
         private static final String EDGE_SOURCE = "source";
         private static final String EDGE_TARGET = "target";
         private static final String EDGE_WEIGHT = "weight";
-        private final List<String> EDGE_ATTRS = List.of("type", "label");
 
         private static final String ATTRIBUTES = "attributes";
         private static final String ATTRIBUTES_CLASS = "class";

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/gexf/GEXFExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/gexf/GEXFExporterTest.java
@@ -99,7 +99,7 @@ public class GEXFExporterTest
 
         graph.addVertex("v1");
         graph.addVertex("v2");
-        DefaultEdge e_1_2 = graph.addEdge("v1", "v2");
+        DefaultEdge e12 = graph.addEdge("v1", "v2");
         graph.addVertex("v3");
         graph.addEdge("v3", "v1");
 
@@ -128,7 +128,7 @@ public class GEXFExporterTest
 
         exporter.setEdgeAttributeProvider(e -> {
             Map<String, Attribute> map = new HashMap<String, Attribute>();
-            if (e == e_1_2) {
+            if (e == e12) {
                 map.put("label", DefaultAttribute.createAttribute("Edge from node 1 to node 2"));
                 map.put("length", DefaultAttribute.createAttribute("100.0"));
             }
@@ -201,10 +201,10 @@ public class GEXFExporterTest
 
         graph.addVertex("v1");
         graph.addVertex("v2");
-        DefaultEdge e_1_2 = graph.addEdge("v1", "v2");
+        DefaultEdge e12 = graph.addEdge("v1", "v2");
         graph.addVertex("v3");
-        DefaultEdge e_3_1 = graph.addEdge("v3", "v1");
-        graph.setEdgeWeight(e_3_1, 13.5d);
+        DefaultEdge e31 = graph.addEdge("v3", "v1");
+        graph.setEdgeWeight(e31, 13.5d);
 
         GEXFExporter<String, DefaultEdge> exporter = new GEXFExporter<>();
         exporter.setParameter(GEXFExporter.Parameter.EXPORT_EDGE_WEIGHTS, true);
@@ -228,11 +228,11 @@ public class GEXFExporterTest
 
         exporter.setEdgeAttributeProvider(e -> {
             Map<String, Attribute> map = new HashMap<String, Attribute>();
-            if (e == e_1_2) {
+            if (e == e12) {
                 map.put("label", DefaultAttribute.createAttribute("Edge from node 1 to node 2"));
                 map.put("length", DefaultAttribute.createAttribute("100.0"));
             }
-            if (e == e_3_1) {
+            if (e == e31) {
                 map.put("length", DefaultAttribute.createAttribute("30.0"));
             }
             return map;

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctDirectedGraph.java
@@ -523,11 +523,11 @@ public class SuccinctDirectedGraph
         }
     }
 
-    private final GraphIterables<Integer, IntIntPair> ITERABLES = new SuccinctGraphIterables(this);
+    private final GraphIterables<Integer, IntIntPair> iterables = new SuccinctGraphIterables(this);
 
     @Override
     public GraphIterables<Integer, IntIntPair> iterables()
     {
-        return ITERABLES;
+        return iterables;
     }
 }

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
@@ -446,11 +446,11 @@ public class SuccinctIntDirectedGraph
         }
     }
 
-    private final GraphIterables<Integer, Integer> ITERABLES = new SuccinctGraphIterables(this);
+    private final GraphIterables<Integer, Integer> iterables = new SuccinctGraphIterables(this);
 
     @Override
     public GraphIterables<Integer, Integer> iterables()
     {
-        return ITERABLES;
+        return iterables;
     }
 }

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
@@ -169,7 +169,7 @@ public class SuccinctIntUndirectedGraph
         final long[] result = new long[2];
         cumulativeOutdegrees.get(vertex, result);
         final IntSet s = new IntOpenHashSet(IntSets.fromTo((int) result[0], (int) result[1]));
-        for (final int e : ITERABLES.reverseSortedEdgesOfNoLoops(vertex))
+        for (final int e : iterables.reverseSortedEdgesOfNoLoops(vertex))
             s.add(e);
         return s;
     }
@@ -340,11 +340,11 @@ public class SuccinctIntUndirectedGraph
         }
     }
 
-    private final SuccinctGraphIterables ITERABLES = new SuccinctGraphIterables(this);
+    private final SuccinctGraphIterables iterables = new SuccinctGraphIterables(this);
 
     @Override
     public GraphIterables<Integer, Integer> iterables()
     {
-        return ITERABLES;
+        return iterables;
     }
 }

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctUndirectedGraph.java
@@ -181,7 +181,7 @@ public class SuccinctUndirectedGraph
         for (int d = (int) (result[1] - result[0]); d-- != 0;)
             s.add(IntIntSortedPair.of(x, (int) (iterator.nextLong() - base)));
 
-        for (final IntIntSortedPair e : ITERABLES.reverseSortedEdgesOfNoLoops(x))
+        for (final IntIntSortedPair e : iterables.reverseSortedEdgesOfNoLoops(x))
             s.add(e);
 
         return s;
@@ -414,11 +414,11 @@ public class SuccinctUndirectedGraph
         }
     }
 
-    private final SuccinctGraphIterables ITERABLES = new SuccinctGraphIterables(this);
+    private final SuccinctGraphIterables iterables = new SuccinctGraphIterables(this);
 
     @Override
     public GraphIterables<Integer, IntIntSortedPair> iterables()
     {
-        return ITERABLES;
+        return iterables;
     }
 }

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableDirectedBigGraphAdapter.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableDirectedBigGraphAdapter.java
@@ -209,7 +209,7 @@ public class ImmutableDirectedBigGraphAdapter
             immutableGraph.copy(), immutableTranspose != null ? immutableTranspose.copy() : null);
     }
 
-    private final GraphIterables<Long, LongLongPair> ITERABLES = new GraphIterables<>()
+    private final GraphIterables<Long, LongLongPair> iterables = new GraphIterables<>()
     {
         @Override
         public ImmutableDirectedBigGraphAdapter getGraph()
@@ -359,6 +359,6 @@ public class ImmutableDirectedBigGraphAdapter
     @Override
     public GraphIterables<Long, LongLongPair> iterables()
     {
-        return ITERABLES;
+        return iterables;
     }
 }

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableDirectedGraphAdapter.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableDirectedGraphAdapter.java
@@ -267,7 +267,7 @@ public class ImmutableDirectedGraphAdapter
             immutableGraph.copy(), immutableTranspose != null ? immutableTranspose.copy() : null);
     }
 
-    private final GraphIterables<Integer, IntIntPair> ITERABLES = new GraphIterables<>()
+    private final GraphIterables<Integer, IntIntPair> iterables = new GraphIterables<>()
     {
         @Override
         public ImmutableDirectedGraphAdapter getGraph()
@@ -417,6 +417,6 @@ public class ImmutableDirectedGraphAdapter
     @Override
     public GraphIterables<Integer, IntIntPair> iterables()
     {
-        return ITERABLES;
+        return iterables;
     }
 }

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableUndirectedBigGraphAdapter.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableUndirectedBigGraphAdapter.java
@@ -219,7 +219,7 @@ public class ImmutableUndirectedBigGraphAdapter
         return new ImmutableUndirectedBigGraphAdapter(immutableGraph.copy());
     }
 
-    private final GraphIterables<Long, LongLongSortedPair> ITERABLES = new GraphIterables<>()
+    private final GraphIterables<Long, LongLongSortedPair> iterables = new GraphIterables<>()
     {
         @Override
         public ImmutableUndirectedBigGraphAdapter getGraph()
@@ -338,6 +338,6 @@ public class ImmutableUndirectedBigGraphAdapter
     @Override
     public GraphIterables<Long, LongLongSortedPair> iterables()
     {
-        return ITERABLES;
+        return iterables;
     }
 }

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableUndirectedGraphAdapter.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/ImmutableUndirectedGraphAdapter.java
@@ -205,7 +205,7 @@ public class ImmutableUndirectedGraphAdapter
         return new ImmutableUndirectedGraphAdapter(immutableGraph.copy());
     }
 
-    private final GraphIterables<Integer, IntIntSortedPair> ITERABLES = new GraphIterables<>()
+    private final GraphIterables<Integer, IntIntSortedPair> iterables = new GraphIterables<>()
     {
         @Override
         public ImmutableUndirectedGraphAdapter getGraph()
@@ -325,6 +325,6 @@ public class ImmutableUndirectedGraphAdapter
     @Override
     public GraphIterables<Integer, IntIntSortedPair> iterables()
     {
-        return ITERABLES;
+        return iterables;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@
                             <dependency>
                                 <groupId>com.puppycrawl.tools</groupId>
                                 <artifactId>checkstyle</artifactId>
-                                <version>8.33</version>
+                                <version>8.41</version>
                             </dependency>
                         </dependencies>
                         <executions>


### PR DESCRIPTION
This is the first PR to implement the checkstyle rules discussed in issue #1052 and adds new rules for variable, member, method and type naming conventions. All violations in non-API elements are fixed with this PR, violations in API-elements are suppressed.

In case of (static) fields that are part of the public API and violate the new naming convention rules, the fields are already deprecated and a proper replacement is provided (either a setter or another field with suitable name). This affects the classes `PushRelabelMFImpl`, `RatioVertex` and `RadixSort`.

I suggest to do same for the classes SørensenIndexLinkPrediction and methods of the NamedGraphGenerator that contain german Umlaute (🇩🇪). In a new class/method the `ø` can be replaced by an ordinary `o` and the Umlaute `ä`, `ö`, `ü` by `ae` `oe` `ue. I can add another commit to this PR for this, but wanted to ask for your permission first. Alternatively the violations can be just suppressed forever.
The third commit contains all changes in classes that have/had violations in parts of their API.


In the class `org.jgrapht.nio.DefaultAttribute` the static field `NULL` is made final. Even this is actually an API break (the field cannot be modified anymore), I assume it was never the intention to allow modifications by the user and it was more a bug than a feature.


Please see the exact rules in the `etc/jgrapht_checks.xml` file.
I relaxed the rules for tests a bit in the following ways:
- within test-method names underscores are allowed. I think this is useful because because expressive test-method names can be lengthy and therefore hard to read in camel case. I use this test-convention by myself, too.
- local variable and member names may end with an underscore and one or more digits in tests. The intention is to allow variables where the tested element actually ends with a number but occurs multiple times. For example edges between a vertex one and two like `e12_1`, `e12_2`. This pattern is used quite often in tests and I did not find a suitable replacement for them and think that the names are reasonable.


I want to kindly ask you for prioritized reviewing to lower the risk of potential merge conflicts. This PR was already a lot of monotonous work and affect many classes.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
