### PR TITLE
Allow Unicode characters for type and method names

### DIFF
--- a/etc/jgrapht_checks.xml
+++ b/etc/jgrapht_checks.xml
@@ -69,7 +69,8 @@
         </module>
         <module name="MethodName">
             <property name="id" value="MethodNameMain" />
-            <!-- Use the default configuration in main code -->
+            <!-- Use the default configuration, but consider Unicode characters and not only ASCII. -->
+            <property name="format" value="^\p{Ll}[\p{Ll}\p{Lu}0-9]*$" />
         </module>
         <module name="MethodName">
             <property name="id" value="MethodNameTest" />
@@ -80,13 +81,23 @@
         <module name="PatternVariableName" />
         <module name="RecordComponentName" />
         <module name="StaticVariableName" />
-        <module name="TypeName" />
+        <module name="TypeName">
+            <!-- Use the default configuration, but consider Unicode characters and not only ASCII. -->
+            <property name="format" value="^\p{Lu}[\p{Ll}\p{Lu}0-9]*$" />
+        </module>
+
+        <!-- Checks that only characters of the Unicode blocks BASIC_LATIN (ASCII) and LATIN_1_SUPPLEMENT are used. -->
+        <module name="IllegalIdentifierName">
+            <property name="format" value="^[\p{block=BASIC_LATIN}\p{block=LATIN_1_SUPPLEMENT}]+$" />
+        </module>
+
 
         <module name="EqualsHashCode" />
         <module name="StringLiteralEquality" />
 
         <module name="SuppressWithNearbyCommentFilter">
-            <property name="commentFormat" value="@CS\.suppress\[(\w+(\|\w+)*)\]" /> <!--  \w[-\.'`,:;\w ]{14,} -->
+            <!-- TODO: remove this after next release -->
+            <property name="commentFormat" value="@CS\.suppress\[(\w+(\|\w+)*)\]" />
             <property name="checkFormat" value="$1" />
             <property name="influenceFormat" value="1" />
         </module>

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -69,14 +69,16 @@ public class PushRelabelMFImpl<V, E>
     @Deprecated(since = "1.5.2", forRemoval = true)
     public static boolean USE_GLOBAL_RELABELING_HEURISTIC = true; // @CS.suppress[StaticVariableName]
     // TODO: make this static field private, rename it to "useGapRelabelingHeuristic" to comply
-    // with checkstyle naming rules and remove the // @CS.supress comment
+    // with checkstyle naming rules and remove the // @CS.supress comment and in jgrapht_checks.xml
+    // the rule SuppressWithNearbyCommentFilter
     /**
      * @deprecated use {@link #setUseGapRelabelingHeuristic(boolean)} instead
      */
     @Deprecated(since = "1.5.2", forRemoval = true)
     public static boolean USE_GAP_RELABELING_HEURISTIC = true; // @CS.suppress[StaticVariableName]
     // TODO: make this static field private, rename it to "useGapRelabelingHeuristic" to comply
-    // with checkstyle naming rules and remove the // @CS.supress comment
+    // with checkstyle naming rules and remove the // @CS.supress comment and in jgrapht_checks.xml
+    // the rule SuppressWithNearbyCommentFilter
 
     public static void setUseGlobalRelabelingHeuristic(boolean useGlobalRelabelingHeuristic)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/linkprediction/SørensenIndexLinkPrediction.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/linkprediction/SørensenIndexLinkPrediction.java
@@ -50,7 +50,7 @@ import org.jgrapht.alg.util.Pair;
  * 
  * @author Dimitrios Michail
  */
-public class SørensenIndexLinkPrediction<V, E> // @CS.suppress[TypeName]
+public class SørensenIndexLinkPrediction<V, E>
     implements
     LinkPredictionAlgorithm<V, E>
 {

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/NamedGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/NamedGraphGenerator.java
@@ -160,7 +160,7 @@ public class NamedGraphGenerator<V, E>
      * 
      * @return the Dürer Graph
      */
-    public static Graph<Integer, DefaultEdge> dürerGraph() // @CS.suppress[MethodName]
+    public static Graph<Integer, DefaultEdge> dürerGraph()
     {
         return generalizedPetersenGraph(6, 2);
     }
@@ -174,7 +174,7 @@ public class NamedGraphGenerator<V, E>
      *        the result will be a disconnected graph since generated elements will not be connected
      *        to existing elements
      */
-    public void generateDürerGraph(Graph<V, E> targetGraph) // @CS.suppress[MethodName]
+    public void generateDürerGraph(Graph<V, E> targetGraph)
     {
         generateGeneralizedPetersenGraph(targetGraph, 6, 2);
     }
@@ -260,7 +260,7 @@ public class NamedGraphGenerator<V, E>
      * 
      * @return the Möbius-Kantor Graph
      */
-    public static Graph<Integer, DefaultEdge> möbiusKantorGraph() // @CS.suppress[MethodName]
+    public static Graph<Integer, DefaultEdge> möbiusKantorGraph()
     {
         return generalizedPetersenGraph(8, 3);
     }
@@ -274,7 +274,7 @@ public class NamedGraphGenerator<V, E>
      *        the result will be a disconnected graph since generated elements will not be connected
      *        to existing elements
      */
-    public void generateMöbiusKantorGraph(Graph<V, E> targetGraph) // @CS.suppress[MethodName]
+    public void generateMöbiusKantorGraph(Graph<V, E> targetGraph)
     {
         generateGeneralizedPetersenGraph(targetGraph, 8, 3);
     }
@@ -468,7 +468,7 @@ public class NamedGraphGenerator<V, E>
      * 
      * @return the Grötzsch Graph
      */
-    public static Graph<Integer, DefaultEdge> grötzschGraph() // @CS.suppress[MethodName]
+    public static Graph<Integer, DefaultEdge> grötzschGraph()
     {
         Graph<Integer,
             DefaultEdge> g = GraphTypeBuilder
@@ -487,7 +487,7 @@ public class NamedGraphGenerator<V, E>
      *        the result will be a disconnected graph since generated elements will not be connected
      *        to existing elements
      */
-    public void generateGrötzschGraph(Graph<V, E> targetGraph) // @CS.suppress[MethodName]
+    public void generateGrötzschGraph(Graph<V, E> targetGraph)
     {
         vertexMap.clear();
         for (int i = 1; i < 6; i++)
@@ -1581,7 +1581,7 @@ public class NamedGraphGenerator<V, E>
      * 
      * @return the Schläfli Graph
      */
-    public static Graph<Integer, DefaultEdge> schläfliGraph() // @CS.suppress[MethodName]
+    public static Graph<Integer, DefaultEdge> schläfliGraph()
     {
         Graph<Integer,
             DefaultEdge> g = GraphTypeBuilder
@@ -1600,7 +1600,7 @@ public class NamedGraphGenerator<V, E>
      *        the result will be a disconnected graph since generated elements will not be connected
      *        to existing elements
      */
-    public void generateSchläfliGraph(Graph<V, E> targetGraph) // @CS.suppress[MethodName]
+    public void generateSchläfliGraph(Graph<V, E> targetGraph)
     {
         vertexMap.clear();
         int[][] edges = { { 0, 11 }, { 0, 12 }, { 0, 13 }, { 0, 14 }, { 0, 15 }, { 0, 16 },
@@ -1777,10 +1777,7 @@ public class NamedGraphGenerator<V, E>
     // --------------Helper methods-----------------/
     private V addVertex(Graph<V, E> targetGraph, int i)
     {
-        if (!vertexMap.containsKey(i)) {
-            vertexMap.put(i, targetGraph.addVertex());
-        }
-        return vertexMap.get(i);
+        return vertexMap.computeIfAbsent(i, i1 -> targetGraph.addVertex());
     }
 
     private void addEdge(Graph<V, E> targetGraph, int i, int j)

--- a/jgrapht-core/src/main/java/org/jgrapht/util/RadixSort.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/RadixSort.java
@@ -37,7 +37,8 @@ public class RadixSort
     @Deprecated(since = "1.5.2", forRemoval = true)
     public static int CUT_OFF = 40; // @CS.suppress[StaticVariableName]
     // TODO: make this static field private, rename it to "cutOff" to comply
-    // with checkstyle naming rules and remove the // @CS.supress comment
+    // with checkstyle naming rules and remove the // @CS.supress comment and in jgrapht_checks.xml
+    // the rule SuppressWithNearbyCommentFilter
 
     public static void setCutOff(int cutOff)
     {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/linkprediction/SørensenIndexLinkPredictionTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/linkprediction/SørensenIndexLinkPredictionTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
  *
  * @author Dimitrios Michail
  */
-public class SørensenIndexLinkPredictionTest // @CS.suppress[TypeName]
+public class SørensenIndexLinkPredictionTest 
 {
 
     @Test


### PR DESCRIPTION
This is a follow up PR of  #1066 that changes JGraphT's checkstyle rules allow the use of Unicode characters in identifiers.
This makes suppression of naming convention violations unnecessary (after next release) without the need to rename types and method.

@jsichi to answer your question from the mentioned PR: Yes checkstyle supports  the use of groups like `\p{Lu}`. The `format` properties for all the naming convention rules are of type Pattern which are parsed using `java.util.regex package.Pattern`: https://checkstyle.org/property_types.html#Pattern

I substituted the character ranges `a-z` by `\p{Ll}` and `A-Z` by `\p{Lu}` for the `TypeName` and the `MethodName` (for main-code) rule because some code in JGraphT that is not intended to be changed violates these rules. And as requested, the instructions to suppress the now extended naming rules are removed.

If you think this generalization should apply to other identifiers like fields or especially method-names of tests (this is actually inconsistent), I can adjust it accordingly.

Furthermore I added a general rule to allow only characters from the Unicode-blocks `BASIC_LATIN` (equal to ASCII) and `LATIN_1_SUPPLEMENT` for all kind of identifiers. I hope this is the character-set you intended, if not it can be easily extended.

With this adjustment, the `SuppressWithNearbyCommentFilter`-rule in `jgrapht_checks`.xml can be removed in the next deprecation-removal round.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
