### PR TITLE
Checkstyle: enforce CatchParameter-name conventions

### DIFF
--- a/etc/jgrapht_checks.xml
+++ b/etc/jgrapht_checks.xml
@@ -40,6 +40,7 @@
 
         <!-- Checks for naming convention -->
         <!-- See https://checkstyle.sourceforge.io/config_naming.html -->
+        <module name="CatchParameterName" />
         <module name="ConstantName" />
         <module name="IllegalIdentifierName" />
         <module name="LambdaParameterName" />

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/csv/CSVEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/csv/CSVEventDrivenImporter.java
@@ -211,12 +211,8 @@ public class CSVEventDrivenImporter
             // Walk it and attach our listener
             ParseTreeWalker walker = new ParseTreeWalker();
             walker.walk(listener, graphContext);
-        } catch (IOException e) {
+        } catch (IOException | ParseCancellationException | IllegalArgumentException e) {
             throw new ImportException("Failed to import CSV graph: " + e.getMessage(), e);
-        } catch (ParseCancellationException pe) {
-            throw new ImportException("Failed to import CSV graph: " + pe.getMessage(), pe);
-        } catch (IllegalArgumentException iae) {
-            throw new ImportException("Failed to import CSV graph: " + iae.getMessage(), iae);
         }
     }
 

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/gexf/SimpleGEXFEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/gexf/SimpleGEXFEventDrivenImporter.java
@@ -143,8 +143,8 @@ public class SimpleGEXFEventDrivenImporter
             notifyImportEvent(ImportEvent.START);
             xmlReader.parse(new InputSource(input));
             notifyImportEvent(ImportEvent.END);
-        } catch (Exception se) {
-            throw new ImportException("Failed to parse GEXF", se);
+        } catch (Exception e) {
+            throw new ImportException("Failed to parse GEXF", e);
         }
     }
 
@@ -178,8 +178,8 @@ public class SimpleGEXFEventDrivenImporter
 
             // create reader
             return saxParser.getXMLReader();
-        } catch (Exception se) {
-            throw new ImportException("Failed to parse GEXF", se);
+        } catch (Exception e) {
+            throw new ImportException("Failed to parse GEXF", e);
         }
     }
 

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/gml/GmlEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/gml/GmlEventDrivenImporter.java
@@ -136,12 +136,8 @@ public class GmlEventDrivenImporter
             walker.walk(listener, graphContext);
             listener.notifySingletons();
             notifyImportEvent(ImportEvent.END);
-        } catch (IOException e) {
+        } catch (IOException | ParseCancellationException | IllegalArgumentException e) {
             throw new ImportException("Failed to import gml graph: " + e.getMessage(), e);
-        } catch (ParseCancellationException pe) {
-            throw new ImportException("Failed to import gml graph: " + pe.getMessage(), pe);
-        } catch (IllegalArgumentException iae) {
-            throw new ImportException("Failed to import gml graph: " + iae.getMessage(), iae);
         }
     }
 

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/graphml/GraphMLEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/graphml/GraphMLEventDrivenImporter.java
@@ -184,8 +184,8 @@ public class GraphMLEventDrivenImporter
             xmlReader.parse(new InputSource(input));
             handler.notifyInterestedParties();
             notifyImportEvent(ImportEvent.END);
-        } catch (Exception se) {
-            throw new ImportException("Failed to parse GraphML", se);
+        } catch (Exception e) {
+            throw new ImportException("Failed to parse GraphML", e);
         }
     }
 
@@ -224,8 +224,8 @@ public class GraphMLEventDrivenImporter
 
             // create reader
             return saxParser.getXMLReader();
-        } catch (Exception se) {
-            throw new ImportException("Failed to parse GraphML", se);
+        } catch (Exception e) {
+            throw new ImportException("Failed to parse GraphML", e);
         }
     }
 

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/graphml/SimpleGraphMLEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/graphml/SimpleGraphMLEventDrivenImporter.java
@@ -188,8 +188,8 @@ public class SimpleGraphMLEventDrivenImporter
             notifyImportEvent(ImportEvent.START);
             xmlReader.parse(new InputSource(input));
             notifyImportEvent(ImportEvent.END);
-        } catch (Exception se) {
-            throw new ImportException("Failed to parse GraphML", se);
+        } catch (Exception e) {
+            throw new ImportException("Failed to parse GraphML", e);
         }
     }
 
@@ -227,8 +227,8 @@ public class SimpleGraphMLEventDrivenImporter
 
             // create reader
             return saxParser.getXMLReader();
-        } catch (Exception se) {
-            throw new ImportException("Failed to parse GraphML", se);
+        } catch (Exception e) {
+            throw new ImportException("Failed to parse GraphML", e);
         }
     }
 

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONEventDrivenImporter.java
@@ -149,12 +149,8 @@ public class JSONEventDrivenImporter
             notifyImportEvent(ImportEvent.START);
             walker.walk(listener, graphContext);
             notifyImportEvent(ImportEvent.END);
-        } catch (IOException e) {
+        } catch (IOException | ParseCancellationException | IllegalArgumentException e) {
             throw new ImportException("Failed to import json graph: " + e.getMessage(), e);
-        } catch (ParseCancellationException pe) {
-            throw new ImportException("Failed to import json graph: " + pe.getMessage(), pe);
-        } catch (IllegalArgumentException iae) {
-            throw new ImportException("Failed to import json graph: " + iae.getMessage(), iae);
         }
     }
 


### PR DESCRIPTION
This third PR regarding issue #1052 adds the `CatchParameterName` rule to jgrapht's checkstyle rule-set and fixes the few violations.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
