### PR TITLE
Checkstyle: enforce TypeParameter-name conventions

### DIFF
--- a/etc/jgrapht_checks.xml
+++ b/etc/jgrapht_checks.xml
@@ -41,7 +41,13 @@
         <!-- Checks for naming convention -->
         <!-- See https://checkstyle.sourceforge.io/config_naming.html -->
         <module name="CatchParameterName" />
+        <module name="ClassTypeParameterName">
+            <property name="format" value="^[A-Z][A-Z1-9]?$" />
+        </module>
         <module name="ConstantName" />
+        <module name="InterfaceTypeParameterName">
+            <property name="format" value="^[A-Z][A-Z1-9]?$" />
+        </module>
         <module name="IllegalIdentifierName" />
         <module name="LambdaParameterName" />
         <module name="LocalFinalVariableName">
@@ -77,10 +83,16 @@
             <property name="id" value="MethodNameTest" />
             <property name="format" value="^[a-z](_?[a-zA-Z0-9]+)*$" />
         </module>
+        <module name="MethodTypeParameterName">
+            <property name="format" value="^[A-Z][A-Z1-9]?$" />
+        </module>
         <module name="PackageName" />
         <module name="ParameterName" />
         <module name="PatternVariableName" />
         <module name="RecordComponentName" />
+        <module name="RecordTypeParameterName">
+            <property name="format" value="^[A-Z][A-Z1-9]?$" />
+        </module>
         <module name="StaticVariableName" />
         <module name="TypeName">
             <!-- Use the default configuration, but consider Unicode characters and not only ASCII. -->

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/AbstractGraphIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/AbstractGraphIterator.java
@@ -42,7 +42,7 @@ public abstract class AbstractGraphIterator<V, E>
     // event firing calls can be skipped.
     protected int nListeners = 0;
 
-    protected final FlyweightEdgeEvent<V, E> reusableEdgeEvent;
+    protected final FlyweightEdgeEvent<E> reusableEdgeEvent;
     protected final FlyweightVertexEvent<V> reusableVertexEvent;
     protected final Graph<V, E> graph;
     protected boolean crossComponentTraversal;
@@ -224,9 +224,9 @@ public abstract class AbstractGraphIterator<V, E>
      *
      * @author Barak Naveh
      */
-    static class FlyweightEdgeEvent<VV, localE>
+    static class FlyweightEdgeEvent<E>
         extends
-        EdgeTraversalEvent<localE>
+        EdgeTraversalEvent<E>
     {
         private static final long serialVersionUID = 4051327833765000755L;
 
@@ -236,7 +236,7 @@ public abstract class AbstractGraphIterator<V, E>
          * @param eventSource the source of the event.
          * @param edge the traversed edge.
          */
-        public FlyweightEdgeEvent(Object eventSource, localE edge)
+        public FlyweightEdgeEvent(Object eventSource, E edge)
         {
             super(eventSource, edge);
         }
@@ -246,7 +246,7 @@ public abstract class AbstractGraphIterator<V, E>
          *
          * @param edge the edge to be set.
          */
-        protected void setEdge(localE edge)
+        protected void setEdge(E edge)
         {
             this.edge = edge;
         }
@@ -257,9 +257,9 @@ public abstract class AbstractGraphIterator<V, E>
      *
      * @author Barak Naveh
      */
-    static class FlyweightVertexEvent<VV>
+    static class FlyweightVertexEvent<V>
         extends
-        VertexTraversalEvent<VV>
+        VertexTraversalEvent<V>
     {
         private static final long serialVersionUID = 3834024753848399924L;
 
@@ -269,7 +269,7 @@ public abstract class AbstractGraphIterator<V, E>
          * @param eventSource the source of the event.
          * @param vertex the traversed vertex.
          */
-        public FlyweightVertexEvent(Object eventSource, VV vertex)
+        public FlyweightVertexEvent(Object eventSource, V vertex)
         {
             super(eventSource, vertex);
         }
@@ -279,7 +279,7 @@ public abstract class AbstractGraphIterator<V, E>
          *
          * @param vertex the vertex to be set.
          */
-        protected void setVertex(VV vertex)
+        protected void setVertex(V vertex)
         {
             this.vertex = vertex;
         }


### PR DESCRIPTION
This fourth PR regarding issue #1052 adds the `TypeParameterName` rules to jgrapht's checkstyle rule-set and fixes the only violation in `AbstractGraphIterator`.

Besides that the class type parameters of the package private nested static classes are cleaned up.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
