### PR TITLE
Added support for custom names in vertices/edges collections in json IO

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONEventDrivenImporter.java
@@ -23,8 +23,9 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.UUID;
 
 import org.antlr.v4.runtime.BaseErrorListener;
 import org.antlr.v4.runtime.CharStreams;
@@ -98,8 +99,19 @@ public class JSONEventDrivenImporter
     implements
     EventDrivenImporter<String, Triple<String, String, Double>>
 {
+    /**
+     * Default name for the vertices collection
+     */
+    public static final String DEFAULT_VERTICES_COLLECTION_NAME = "nodes";
+    /**
+     * Default name for the edges collection
+     */
+    public static final String DEFAULT_EDGES_COLLECTION_NAME = "edges";
+
     private boolean notifyVertexAttributesOutOfOrder;
     private boolean notifyEdgeAttributesOutOfOrder;
+    private String verticesCollectionName = DEFAULT_VERTICES_COLLECTION_NAME;
+    private String edgesCollectionName = DEFAULT_EDGES_COLLECTION_NAME;
 
     /**
      * Constructs a new importer.
@@ -122,6 +134,46 @@ public class JSONEventDrivenImporter
     {
         this.notifyVertexAttributesOutOfOrder = notifyVertexAttributesOutOfOrder;
         this.notifyEdgeAttributesOutOfOrder = notifyEdgeAttributesOutOfOrder;
+    }
+
+    /**
+     * Get the name used for the vertices collection in the file.
+     * 
+     * @return the name used for the vertices collection in the file.
+     */
+    public String getVerticesCollectionName()
+    {
+        return verticesCollectionName;
+    }
+
+    /**
+     * Set the name used for the vertices collection in the file.
+     * 
+     * @param verticesCollectionName the name
+     */
+    public void setVerticesCollectionName(String verticesCollectionName)
+    {
+        this.verticesCollectionName = Objects.requireNonNull(verticesCollectionName);
+    }
+
+    /**
+     * Get the name used for the edges collection in the file.
+     * 
+     * @return the name used for the edges collection in the file.
+     */
+    public String getEdgesCollectionName()
+    {
+        return edgesCollectionName;
+    }
+
+    /**
+     * Set the name used for the edges collection in the file.
+     * 
+     * @param edgesCollectionName the name
+     */
+    public void setEdgesCollectionName(String edgesCollectionName)
+    {
+        this.edgesCollectionName = Objects.requireNonNull(edgesCollectionName);
     }
 
     @Override
@@ -175,8 +227,6 @@ public class JSONEventDrivenImporter
         JsonBaseListener
     {
         private static final String GRAPH = "graph";
-        private static final String NODES = "nodes";
-        private static final String EDGES = "edges";
         private static final String ID = "id";
 
         private static final String WEIGHT = "weight";
@@ -320,9 +370,9 @@ public class JSONEventDrivenImporter
             String name = unquote(ctx.STRING().getText());
 
             if (objectLevel == 1 && arrayLevel == 0) {
-                if (NODES.equals(name)) {
+                if (verticesCollectionName.equals(name)) {
                     insideNodes = true;
-                } else if (EDGES.equals(name)) {
+                } else if (edgesCollectionName.equals(name)) {
                     insideEdges = true;
                 }
             }
@@ -336,9 +386,9 @@ public class JSONEventDrivenImporter
             String name = unquote(ctx.STRING().getText());
 
             if (objectLevel == 1 && arrayLevel == 0) {
-                if (NODES.equals(name)) {
+                if (verticesCollectionName.equals(name)) {
                     insideNodes = false;
-                } else if (EDGES.equals(name)) {
+                } else if (edgesCollectionName.equals(name)) {
                     insideEdges = false;
                 }
             }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONExporter.java
@@ -17,13 +17,19 @@
  */
 package org.jgrapht.nio.json;
 
-import org.apache.commons.text.*;
-import org.jgrapht.*;
-import org.jgrapht.nio.*;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
 
-import java.io.*;
-import java.util.*;
-import java.util.function.*;
+import org.apache.commons.text.StringEscapeUtils;
+import org.jgrapht.Graph;
+import org.jgrapht.nio.Attribute;
+import org.jgrapht.nio.AttributeType;
+import org.jgrapht.nio.BaseExporter;
+import org.jgrapht.nio.GraphExporter;
+import org.jgrapht.nio.IntegerIdProvider;
 
 /**
  * Exports a graph using <a href="https://tools.ietf.org/html/rfc8259">JSON</a>.
@@ -53,8 +59,20 @@ public class JSONExporter<V, E>
     implements
     GraphExporter<V, E>
 {
+    /**
+     * Default name for the vertices collection
+     */
+    public static final String DEFAULT_VERTICES_COLLECTION_NAME = "nodes";
+    /**
+     * Default name for the edges collection
+     */
+
+    public static final String DEFAULT_EDGES_COLLECTION_NAME = "edges";
+
     private static final String CREATOR = "JGraphT JSON Exporter";
     private static final String VERSION = "1";
+    private String verticesCollectionName = DEFAULT_VERTICES_COLLECTION_NAME;
+    private String edgesCollectionName = DEFAULT_EDGES_COLLECTION_NAME;
 
     /**
      * Creates a new exporter with integers for the vertex identifiers.
@@ -72,6 +90,46 @@ public class JSONExporter<V, E>
     public JSONExporter(Function<V, String> vertexIdProvider)
     {
         super(vertexIdProvider);
+    }
+
+    /**
+     * Get the name used for the vertices collection in the file.
+     * 
+     * @return the name used for the vertices collection in the file.
+     */
+    public String getVerticesCollectionName()
+    {
+        return verticesCollectionName;
+    }
+
+    /**
+     * Set the name used for the vertices collection in the file.
+     * 
+     * @param verticesCollectionName the name
+     */
+    public void setVerticesCollectionName(String verticesCollectionName)
+    {
+        this.verticesCollectionName = Objects.requireNonNull(verticesCollectionName);
+    }
+
+    /**
+     * Get the name used for the edges collection in the file.
+     * 
+     * @return the name used for the edges collection in the file.
+     */
+    public String getEdgesCollectionName()
+    {
+        return edgesCollectionName;
+    }
+
+    /**
+     * Set the name used for the edges collection in the file.
+     * 
+     * @param edgesCollectionName the name
+     */
+    public void setEdgesCollectionName(String edgesCollectionName)
+    {
+        this.edgesCollectionName = Objects.requireNonNull(edgesCollectionName);
     }
 
     @Override
@@ -97,7 +155,7 @@ public class JSONExporter<V, E>
          * Vertices
          */
         out.print(',');
-        out.print(quoted("nodes"));
+        out.print(quoted(verticesCollectionName));
         out.print(':');
         out.print('[');
         boolean printComma = false;
@@ -115,7 +173,7 @@ public class JSONExporter<V, E>
          * Edges
          */
         out.print(',');
-        out.print(quoted("edges"));
+        out.print(quoted(edgesCollectionName));
         out.print(':');
         out.print('[');
         printComma = false;

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONImporter.java
@@ -20,6 +20,7 @@ package org.jgrapht.nio.json;
 import java.io.Reader;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -117,10 +118,20 @@ public class JSONImporter<V, E>
      * Default key used for vertex ID.
      */
     public static final String DEFAULT_VERTEX_ID_KEY = "ID";
+    /**
+     * Default name for the vertices collection
+     */
+    public static final String DEFAULT_VERTICES_COLLECTION_NAME = "nodes";
+    /**
+     * Default name for the edges collection
+     */
+    public static final String DEFAULT_EDGES_COLLECTION_NAME = "edges";
 
     private Function<String, V> vertexFactory;
     private BiFunction<String, Map<String, Attribute>, V> vertexWithAttributesFactory;
     private Function<Map<String, Attribute>, E> edgeWithAttributesFactory;
+    private String verticesCollectionName = DEFAULT_VERTICES_COLLECTION_NAME;
+    private String edgesCollectionName = DEFAULT_EDGES_COLLECTION_NAME;
 
     /**
      * Construct a new importer
@@ -153,6 +164,8 @@ public class JSONImporter<V, E>
         final boolean edgesOutOfOrder = edgeWithAttributesFactory == null;
         JSONEventDrivenImporter genericImporter =
             new JSONEventDrivenImporter(verticesOutOfOrder, edgesOutOfOrder);
+        genericImporter.setVerticesCollectionName(verticesCollectionName);
+        genericImporter.setEdgesCollectionName(edgesCollectionName);
 
         Consumers consumers = new Consumers(graph);
 
@@ -243,6 +256,46 @@ public class JSONImporter<V, E>
         Function<Map<String, Attribute>, E> edgeWithAttributesFactory)
     {
         this.edgeWithAttributesFactory = edgeWithAttributesFactory;
+    }
+
+    /**
+     * Get the name used for the vertices collection in the file.
+     * 
+     * @return the name used for the vertices collection in the file.
+     */
+    public String getVerticesCollectionName()
+    {
+        return verticesCollectionName;
+    }
+
+    /**
+     * Set the name used for the vertices collection in the file.
+     * 
+     * @param verticesCollectionName the name
+     */
+    public void setVerticesCollectionName(String verticesCollectionName)
+    {
+        this.verticesCollectionName = Objects.requireNonNull(verticesCollectionName);
+    }
+
+    /**
+     * Get the name used for the edges collection in the file.
+     * 
+     * @return the name used for the edges collection in the file.
+     */
+    public String getEdgesCollectionName()
+    {
+        return edgesCollectionName;
+    }
+
+    /**
+     * Set the name used for the edges collection in the file.
+     * 
+     * @param edgesCollectionName the name
+     */
+    public void setEdgesCollectionName(String edgesCollectionName)
+    {
+        this.edgesCollectionName = Objects.requireNonNull(edgesCollectionName);
     }
 
     private class Consumers

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/json/JSONExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/json/JSONExporterTest.java
@@ -343,4 +343,37 @@ public class JSONExporterTest
 
     }
 
+    @Test
+    public void testWithOtherNamesForVerticesAndEdges()
+        throws UnsupportedEncodingException
+    {
+        String expected =
+            "{\"creator\":\"JGraphT JSON Exporter\",\"version\":\"1\",\"vertices\":[{\"id\":\"1\"},{\"id\":\"2\"},{\"id\":\"3\"},{\"id\":\"4\"}],\"links\":[{\"id\":\"1\",\"source\":\"1\",\"target\":\"2\"},{\"id\":\"2\",\"source\":\"2\",\"target\":\"3\"},{\"id\":\"3\",\"source\":\"3\",\"target\":\"4\"},{\"id\":\"4\",\"source\":\"1\",\"target\":\"4\"}]}";
+
+        Graph<Integer,
+            DefaultEdge> graph = GraphTypeBuilder
+                .directed().edgeClass(DefaultEdge.class)
+                .vertexSupplier(SupplierUtil.createIntegerSupplier()).allowingMultipleEdges(false)
+                .allowingSelfLoops(false).buildGraph();
+
+        graph.addVertex(1);
+        graph.addVertex(2);
+        graph.addVertex(3);
+        graph.addVertex(4);
+
+        graph.addEdge(1, 2);
+        graph.addEdge(2, 3);
+        graph.addEdge(3, 4);
+        graph.addEdge(1, 4);
+
+        JSONExporter<Integer, DefaultEdge> exporter = new JSONExporter<>(v -> String.valueOf(v));
+        exporter.setVerticesCollectionName("vertices");
+        exporter.setEdgesCollectionName("links");
+        exporter.setEdgeIdProvider(new IntegerIdProvider<>(1));
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.exportGraph(graph, os);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(expected, res);
+    }
+    
 }

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/json/JSONImporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/json/JSONImporterTest.java
@@ -637,4 +637,44 @@ public class JSONImporterTest
         assertTrue(graph.containsEdge("e2"));
     }
 
+    @Test
+    public void testWithOtherNameForVerticesAndEdgesCollection()
+        throws ImportException
+    {
+        // @formatter:off
+        String input = "{\n"
+                     + "  \"vertices\": [\n"    
+                     + "  { \"id\":\"1\" },\n"
+                     + "  { \"id\":\"2\" },\n"
+                     + "  { \"id\":\"3\" },\n"
+                     + "  { \"id\":\"4\" }\n"
+                     + "  ],\n"
+                     + "  \"rels\": [\n"    
+                     + "  { \"source\":\"1\", \"target\":\"2\" },\n"
+                     + "  { \"source\":\"1\", \"target\":\"3\" }\n"
+                     + "  ]\n"
+                     + "}";
+        // @formatter:on
+
+        Graph<String,
+            DefaultEdge> g = GraphTypeBuilder
+                .undirected().allowingMultipleEdges(true).allowingSelfLoops(true)
+                .vertexSupplier(SupplierUtil.createStringSupplier(1))
+                .edgeSupplier(SupplierUtil.DEFAULT_EDGE_SUPPLIER).buildGraph();
+
+        JSONImporter<String, DefaultEdge> importer = new JSONImporter<>();
+        importer.setVerticesCollectionName("vertices");
+        importer.setEdgesCollectionName("rels");
+        importer.importGraph(g, new StringReader(input));
+
+        assertEquals(4, g.vertexSet().size());
+        assertEquals(2, g.edgeSet().size());
+        assertTrue(g.containsVertex("1"));
+        assertTrue(g.containsVertex("2"));
+        assertTrue(g.containsVertex("3"));
+        assertTrue(g.containsVertex("4"));
+        assertTrue(g.containsEdge("1", "2"));
+        assertTrue(g.containsEdge("1", "3"));
+    }
+    
 }


### PR DESCRIPTION
Added support for changing the name of the vertices and edges collection in the json file. 
Different systems and libraries tend to use slightly different names such as "vertices" or "nodes" and 
"edges", "links", or "rels". 

Motivated by #1071 and #1072.  

This implementation is slighly more general to allow the user to specify the actual name.

----
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
