### PR TITLE
Add and use NotDirectedAcyclicGraphException

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/NotDirectedAcyclicGraphException.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/NotDirectedAcyclicGraphException.java
@@ -1,0 +1,37 @@
+/*
+ * (C) Copyright 2021-2021, by Kaiichiro Ota and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.traverse;
+
+/**
+ * An exception to signal that {@link TopologicalOrderIterator} is used for a non-directed acyclic graph.
+ * Note that this class extends {@link IllegalArgumentException} for backward compatibility
+ *
+ * @author Kaiichiro Ota
+ */
+public class NotDirectedAcyclicGraphException
+    extends IllegalArgumentException
+{
+    private static final String GRAPH_IS_NOT_A_DAG = "Graph is not a DAG";
+
+    private static final long serialVersionUID = 1L;
+
+    public NotDirectedAcyclicGraphException()
+    {
+        super(GRAPH_IS_NOT_A_DAG);
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/TopologicalOrderIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/TopologicalOrderIterator.java
@@ -35,8 +35,8 @@ import java.util.*;
  * <p>
  * The iterator crosses components but does not track them, it only tracks visited vertices. The
  * iterator will detect (at some point) if the graph is not a directed acyclic graph and throw a
- * {@link IllegalArgumentException}.
- * 
+ * {@link NotDirectedAcyclicGraphException}.
+ *
  * <p>
  * For this iterator to work correctly the graph must not be modified during iteration. Currently
  * there are no means to ensure that, nor to fail-fast. The results of such modifications are
@@ -52,8 +52,6 @@ public class TopologicalOrderIterator<V, E>
     extends
     AbstractGraphIterator<V, E>
 {
-    private static final String GRAPH_IS_NOT_A_DAG = "Graph is not a DAG";
-
     private Queue<V> queue;
     private Map<V, ModifiableInteger> inDegreeMap;
     private int remainingVertices;
@@ -106,7 +104,7 @@ public class TopologicalOrderIterator<V, E>
             for (E e : graph.incomingEdgesOf(v)) {
                 V u = Graphs.getOppositeVertex(graph, e, v);
                 if (v.equals(u)) {
-                    throw new IllegalArgumentException(GRAPH_IS_NOT_A_DAG);
+                    throw new NotDirectedAcyclicGraphException();
                 }
                 d++;
             }
@@ -197,7 +195,7 @@ public class TopologicalOrderIterator<V, E>
              * Still expecting some vertices, but no vertex has zero degree.
              */
             if (remainingVertices > 0) {
-                throw new IllegalArgumentException(GRAPH_IS_NOT_A_DAG);
+                throw new NotDirectedAcyclicGraphException();
             }
         }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/traverse/TopologicalOrderIteratorTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/traverse/TopologicalOrderIteratorTest.java
@@ -208,7 +208,7 @@ public class TopologicalOrderIteratorTest
         assertFalse(it.hasNext());
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NotDirectedAcyclicGraphException.class)
     public void testWithSelfLoops()
     {
         Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);
@@ -222,7 +222,7 @@ public class TopologicalOrderIteratorTest
         new TopologicalOrderIterator<>(graph);
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test(expected = NotDirectedAcyclicGraphException.class)
     public void testGraphWithCycle()
     {
         Graph<String, DefaultEdge> graph = new DirectedPseudograph<>(DefaultEdge.class);


### PR DESCRIPTION
This PR addresses [#1095](https://github.com/jgrapht/jgrapht/issues/1095) by throwing the new `NotDirectedAcyclicGraphException` instead of generic `IllegalArgumentException`, when `TopologicalOrderIterator` is used with a non-DAG. This enables to discriminate non-DAG error cases from the others. The new exception extends `IllegalArgumentException` for backward compatibility.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
