### PR TITLE
throw GraphCycleProhibitedException on adding Vertex to DAG that would cause a cycle; fixes #1099

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedAcyclicGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedAcyclicGraph.java
@@ -311,7 +311,8 @@ public class DirectedAcyclicGraph<V, E>
      * the "affected region", and should in general be faster than recomputing the whole topological
      * ordering from scratch.
      *
-     * @throws IllegalArgumentException if the edge would induce a cycle in the graph
+     * @throws IllegalArgumentException if the vertex is not in the graph
+     * @throws GraphCycleProhibitedException if the vertex would induce a cycle in the graph
      */
     @Override
     public E addEdge(V sourceVertex, V targetVertex)
@@ -335,7 +336,8 @@ public class DirectedAcyclicGraph<V, E>
      * the "affected region", and should in general be faster than recomputing the whole topological
      * ordering from scratch.
      *
-     * @throws IllegalArgumentException if the edge would induce a cycle in the graph
+     * @throws IllegalArgumentException if the vertex is not in the graph
+     * @throws GraphCycleProhibitedException if the vertex would induce a cycle in the graph
      */
     @Override
     public boolean addEdge(V sourceVertex, V targetVertex, E e)

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedAcyclicGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DirectedAcyclicGraph.java
@@ -17,13 +17,13 @@
  */
 package org.jgrapht.graph;
 
-import org.jgrapht.graph.builder.*;
-import org.jgrapht.traverse.*;
-import org.jgrapht.util.*;
-
 import java.io.*;
 import java.util.*;
 import java.util.function.*;
+
+import org.jgrapht.graph.builder.*;
+import org.jgrapht.traverse.*;
+import org.jgrapht.util.*;
 
 /**
  * A directed acyclic graph (DAG).
@@ -66,8 +66,6 @@ public class DirectedAcyclicGraph<V, E>
     Iterable<V>
 {
     private static final long serialVersionUID = 4522128427004938150L;
-
-    private static final String EDGE_WOULD_INDUCE_A_CYCLE = "Edge would induce a cycle";
 
     private final Comparator<V> topoComparator;
     private final TopoOrderMap<V> topoOrderMap;
@@ -321,14 +319,12 @@ public class DirectedAcyclicGraph<V, E>
         assertVertexExist(sourceVertex);
         assertVertexExist(targetVertex);
 
-        E result;
         try {
             updateDag(sourceVertex, targetVertex);
-            result = super.addEdge(sourceVertex, targetVertex);
+            return super.addEdge(sourceVertex, targetVertex);
         } catch (CycleFoundException e) {
-            throw new IllegalArgumentException(EDGE_WOULD_INDUCE_A_CYCLE);
+            throw new GraphCycleProhibitedException();
         }
-        return result;
     }
 
     /**
@@ -353,14 +349,12 @@ public class DirectedAcyclicGraph<V, E>
         assertVertexExist(sourceVertex);
         assertVertexExist(targetVertex);
 
-        boolean result;
         try {
             updateDag(sourceVertex, targetVertex);
-            result = super.addEdge(sourceVertex, targetVertex, e);
+            return super.addEdge(sourceVertex, targetVertex, e);
         } catch (CycleFoundException ex) {
-            throw new IllegalArgumentException(EDGE_WOULD_INDUCE_A_CYCLE);
+            throw new GraphCycleProhibitedException();
         }
-        return result;
     }
 
     /**
@@ -411,6 +405,7 @@ public class DirectedAcyclicGraph<V, E>
      *
      * @return a topological order iterator
      */
+    @Override
     public Iterator<V> iterator()
     {
         return new TopoIterator();

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphCycleProhibitedException.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphCycleProhibitedException.java
@@ -22,7 +22,7 @@ package org.jgrapht.graph;
  */
 public class GraphCycleProhibitedException
     extends
-    RuntimeException
+    IllegalArgumentException
 {
     private static final long serialVersionUID = 2440845437318796595L;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphCycleProhibitedException.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphCycleProhibitedException.java
@@ -1,0 +1,38 @@
+/*
+ * (C) Copyright 2021-2021, by Magnus Gunnarsson and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.graph;
+
+/**
+ * @author EnderCrypt (Magnus Gunnarsson)
+ */
+public class GraphCycleProhibitedException
+    extends
+    RuntimeException
+{
+    private static final long serialVersionUID = 2440845437318796595L;
+
+    public GraphCycleProhibitedException(String message)
+    {
+        super(message);
+    }
+
+    public GraphCycleProhibitedException(String message, Throwable cause)
+    {
+        super(message, cause);
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphCycleProhibitedException.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphCycleProhibitedException.java
@@ -26,13 +26,8 @@ public class GraphCycleProhibitedException
 {
     private static final long serialVersionUID = 2440845437318796595L;
 
-    public GraphCycleProhibitedException(String message)
+    public GraphCycleProhibitedException()
     {
-        super(message);
-    }
-
-    public GraphCycleProhibitedException(String message, Throwable cause)
-    {
-        super(message, cause);
+        super("Edge would induce a cycle");
     }
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphCycleProhibitedException.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphCycleProhibitedException.java
@@ -18,6 +18,9 @@
 package org.jgrapht.graph;
 
 /**
+ * Exception indicating that the vertexes supplied to {@link DirectedAcyclicGraph} would cause a
+ * cycle.
+ * 
  * @author EnderCrypt (Magnus Gunnarsson)
  */
 public class GraphCycleProhibitedException

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/DirectedAcyclicGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/DirectedAcyclicGraphTest.java
@@ -66,7 +66,7 @@ public class DirectedAcyclicGraphTest
                 boolean dagRejectedEdge = false;
                 try {
                     dag.addEdge(edgeSource, edgeTarget);
-                } catch (IllegalArgumentException e) {
+                } catch (GraphCycleProhibitedException e) {
                     // okay, it did't add that edge
                     dagRejectedEdge = true;
                 }


### PR DESCRIPTION
This pull request solves [#1099](https://github.com/jgrapht/jgrapht/issues/1099) by adding a ``GraphCycleProhibitedException`` to be thrown when ``DirectedAcyclicGraph.addEdge(v,v)`` would cause a cycle, rather than throwing ``IllegalArgumentException`` which is already thrown when an unrelated problem occurs making catching and dealing with the situation an issue

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
