### PR TITLE
Increase performance of creating of subgroup

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsSubgraph.java
@@ -541,12 +541,22 @@ public class AsSubgraph<V, E>
 
         // add edges
         if (edgeFilter == null) {
-            base
-                .edgeSet().stream()
-                .filter(
-                    e -> vertexSet.contains(base.getEdgeSource(e))
-                        && vertexSet.contains(base.getEdgeTarget(e)))
-                .forEach(edgeSet::add);
+            if (vertexSet.size() > base.edgeSet().size()) {
+                base
+                    .edgeSet().stream()
+                    .filter(
+                        e -> vertexSet.contains(base.getEdgeSource(e))
+                            && vertexSet.contains(base.getEdgeTarget(e)))
+                    .forEach(edgeSet::add);
+            } else {
+                vertexSet.forEach(v ->
+                    base.edgesOf(v).stream()
+                        .filter(
+                            e -> vertexSet.contains(base.getEdgeSource(e))
+                                && vertexSet.contains(base.getEdgeTarget(e)))
+                        .forEach(edgeSet::add)
+                    );
+            }
         } else {
             if (edgeFilter.size() > base.edgeSet().size()) {
                 base


### PR DESCRIPTION
An idea of this optimisation is adding a special case when subgroup has vertex set which is smaller than base's edge set.

For example when you have huge graph which very each vertex has a few connection, this optimisation allows to not walk across all edges, just across all desired vertexes.

- [ ] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [ ] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [ ] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [ ] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [ ] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)