### PR TITLE
Add callback api to DirectedSimpleCycles

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/DirectedSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/DirectedSimpleCycles.java
@@ -18,6 +18,7 @@
 package org.jgrapht.alg.cycle;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 /**
  * A common interface for classes implementing algorithms for enumeration of the simple cycles of a
@@ -35,5 +36,17 @@ public interface DirectedSimpleCycles<V, E>
      *
      * @return The list of all simple cycles. Possibly empty but never <code>null</code>.
      */
-    List<List<V>> findSimpleCycles();
+    default List<List<V>> findSimpleCycles()
+    {
+        List<List<V>> result = new ArrayList<>();
+        findSimpleCycles(result::add);
+        return result;
+    }
+
+    /**
+     * Find the simple cycles of the graph.
+     *
+     * @param consumer Consumer that will be called with each cycle found.
+     */
+    void findSimpleCycles(Consumer<List<V>> consumer);
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
@@ -20,6 +20,7 @@ package org.jgrapht.alg.cycle;
 import org.jgrapht.*;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
@@ -46,7 +47,6 @@ public class HawickJamesSimpleCycles<V, E>
 
     private int nVertices = 0;
     private long nCycles = 0;
-    private List<List<V>> cycles = null;
 
     // The main state of the algorithm
     private Integer start = 0;
@@ -199,7 +199,7 @@ public class HawickJamesSimpleCycles<V, E>
 
     /**
      * Get the graph
-     * 
+     *
      * @return graph
      */
     public Graph<V, E> getGraph()
@@ -209,7 +209,7 @@ public class HawickJamesSimpleCycles<V, E>
 
     /**
      * Set the graph
-     * 
+     *
      * @param graph graph
      */
     public void setGraph(Graph<V, E> graph)
@@ -221,7 +221,7 @@ public class HawickJamesSimpleCycles<V, E>
      * {@inheritDoc}
      */
     @Override
-    public List<List<V>> findSimpleCycles()
+    public void findSimpleCycles(Consumer<List<V>> consumer)
         throws IllegalArgumentException
     {
         if (graph == null) {
@@ -229,16 +229,13 @@ public class HawickJamesSimpleCycles<V, E>
         }
 
         initState();
-        cycles = new ArrayList<>();
         operation = () -> {
             List<V> cycle = stack.stream().map(v -> iToV[v]).collect(toList());
             Collections.reverse(cycle);
-            cycles.add(cycle);
+            consumer.accept(cycle);
         };
         analyzeCircuits();
-        List<List<V>> result = cycles;
         clearState();
-        return result;
     }
 
     /**
@@ -263,7 +260,7 @@ public class HawickJamesSimpleCycles<V, E>
 
     /**
      * Count the number of simple cycles. It can count up to Long.MAX cycles in a graph.
-     * 
+     *
      * @return the number of simple cycles
      */
     public long countSimpleCycles()

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/JohnsonSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/JohnsonSimpleCycles.java
@@ -22,6 +22,7 @@ import org.jgrapht.alg.util.*;
 import org.jgrapht.graph.builder.*;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 /**
  * Find all simple cycles of a directed graph using the Johnson's algorithm.
@@ -44,7 +45,7 @@ public class JohnsonSimpleCycles<V, E>
     private Graph<V, E> graph;
 
     // The main state of the algorithm.
-    private List<List<V>> cycles = null;
+    private Consumer<List<V>> cycleConsumer = null;
     private V[] iToV = null;
     private Map<V, Integer> vToI = null;
     private Set<V> blocked = null;
@@ -79,12 +80,12 @@ public class JohnsonSimpleCycles<V, E>
      * {@inheritDoc}
      */
     @Override
-    public List<List<V>> findSimpleCycles()
+    public void findSimpleCycles(Consumer<List<V>> consumer)
     {
         if (graph == null) {
             throw new IllegalArgumentException("Null graph.");
         }
-        initState();
+        initState(consumer);
 
         int startIndex = 0;
         int size = graph.vertexSet().size();
@@ -106,9 +107,7 @@ public class JohnsonSimpleCycles<V, E>
             }
         }
 
-        List<List<V>> result = cycles;
         clearState();
-        return result;
     }
 
     private Pair<Graph<V, E>, Integer> findMinSCSG(int startIndex)
@@ -245,7 +244,7 @@ public class JohnsonSimpleCycles<V, E>
             if (successorIndex == startIndex) {
                 List<V> cycle = new ArrayList<>(stack.size());
                 stack.descendingIterator().forEachRemaining(cycle::add);
-                cycles.add(cycle);
+                cycleConsumer.accept(cycle);
                 foundCycle = true;
             } else if (!blocked.contains(successor)) {
                 boolean gotCycle = findCyclesInSCG(startIndex, successorIndex, scg);
@@ -279,9 +278,9 @@ public class JohnsonSimpleCycles<V, E>
     }
 
     @SuppressWarnings("unchecked")
-    private void initState()
+    private void initState(Consumer<List<V>> consumer)
     {
-        cycles = new LinkedList<>();
+        cycleConsumer = consumer;
         iToV = (V[]) graph.vertexSet().toArray();
         vToI = new HashMap<>();
         blocked = new HashSet<>();
@@ -295,7 +294,7 @@ public class JohnsonSimpleCycles<V, E>
 
     private void clearState()
     {
-        cycles = null;
+        cycleConsumer = null;
         iToV = null;
         vToI = null;
         blocked = null;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/SzwarcfiterLauerSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/SzwarcfiterLauerSimpleCycles.java
@@ -21,6 +21,7 @@ import org.jgrapht.*;
 import org.jgrapht.alg.connectivity.*;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 /**
  * Find all simple cycles of a directed graph using the Schwarcfiter and Lauer's algorithm.
@@ -44,7 +45,7 @@ public class SzwarcfiterLauerSimpleCycles<V, E>
     private Graph<V, E> graph;
 
     // The state of the algorithm.
-    private List<List<V>> cycles = null;
+    private Consumer<List<V>> cycleConsumer = null;
     private V[] iToV = null;
     private Map<V, Integer> vToI = null;
     private Map<V, Set<V>> bSets = null;
@@ -77,7 +78,7 @@ public class SzwarcfiterLauerSimpleCycles<V, E>
 
     /**
      * Get the graph
-     * 
+     *
      * @return graph
      */
     public Graph<V, E> getGraph()
@@ -87,7 +88,7 @@ public class SzwarcfiterLauerSimpleCycles<V, E>
 
     /**
      * Set the graph
-     * 
+     *
      * @param graph graph
      */
     public void setGraph(Graph<V, E> graph)
@@ -99,14 +100,14 @@ public class SzwarcfiterLauerSimpleCycles<V, E>
      * {@inheritDoc}
      */
     @Override
-    public List<List<V>> findSimpleCycles()
+    public void findSimpleCycles(Consumer<List<V>> consumer)
     {
         // Just a straightforward implementation of
         // the algorithm.
         if (graph == null) {
             throw new IllegalArgumentException("Null graph.");
         }
-        initState();
+        initState(consumer);
         KosarajuStrongConnectivityInspector<V, E> inspector =
             new KosarajuStrongConnectivityInspector<>(graph);
         List<Set<V>> sccs = inspector.stronglyConnectedSets();
@@ -127,9 +128,7 @@ public class SzwarcfiterLauerSimpleCycles<V, E>
             cycle(toI(vertex), 0);
         }
 
-        List<List<V>> result = cycles;
         clearState();
-        return result;
     }
 
     private boolean cycle(int v, int q)
@@ -177,7 +176,7 @@ public class SzwarcfiterLauerSimpleCycles<V, E>
                         break;
                     }
                 }
-                cycles.add(cycle);
+                cycleConsumer.accept(cycle);
             } else {
                 noCycle(v, w);
             }
@@ -219,9 +218,9 @@ public class SzwarcfiterLauerSimpleCycles<V, E>
     }
 
     @SuppressWarnings("unchecked")
-    private void initState()
+    private void initState(Consumer<List<V>> consumer)
     {
-        cycles = new ArrayList<>();
+        cycleConsumer = consumer;
         iToV = (V[]) graph.vertexSet().toArray();
         vToI = new HashMap<>();
         bSets = new HashMap<>();
@@ -240,7 +239,7 @@ public class SzwarcfiterLauerSimpleCycles<V, E>
 
     private void clearState()
     {
-        cycles = null;
+        cycleConsumer = null;
         iToV = null;
         vToI = null;
         bSets = null;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/TarjanSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/TarjanSimpleCycles.java
@@ -20,6 +20,7 @@ package org.jgrapht.alg.cycle;
 import org.jgrapht.*;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 /**
  * Find all simple cycles of a directed graph using the Tarjan's algorithm.
@@ -40,7 +41,7 @@ public class TarjanSimpleCycles<V, E>
 {
     private Graph<V, E> graph;
 
-    private List<List<V>> cycles;
+    private Consumer<List<V>> cycleConsumer = null;
     private Set<V> marked;
     private ArrayDeque<V> markedStack;
     private ArrayDeque<V> pointStack;
@@ -69,7 +70,7 @@ public class TarjanSimpleCycles<V, E>
 
     /**
      * Get the graph
-     * 
+     *
      * @return graph
      */
     public Graph<V, E> getGraph()
@@ -79,7 +80,7 @@ public class TarjanSimpleCycles<V, E>
 
     /**
      * Set the graph
-     * 
+     *
      * @param graph graph
      */
     public void setGraph(Graph<V, E> graph)
@@ -91,12 +92,12 @@ public class TarjanSimpleCycles<V, E>
      * {@inheritDoc}
      */
     @Override
-    public List<List<V>> findSimpleCycles()
+    public void findSimpleCycles(Consumer<List<V>> consumer)
     {
         if (graph == null) {
             throw new IllegalArgumentException("Null graph.");
         }
-        initState();
+        initState(consumer);
 
         for (V start : graph.vertexSet()) {
             backtrack(start, start);
@@ -105,9 +106,7 @@ public class TarjanSimpleCycles<V, E>
             }
         }
 
-        List<List<V>> result = cycles;
         clearState();
-        return result;
     }
 
     private boolean backtrack(V start, V vertex)
@@ -140,7 +139,7 @@ public class TarjanSimpleCycles<V, E>
                 while (it.hasNext()) {
                     cycle.add(it.next());
                 }
-                cycles.add(cycle);
+                cycleConsumer.accept(cycle);
             } else if (!marked.contains(currentVertex)) {
                 boolean gotCycle = backtrack(start, currentVertex);
                 foundCycle = foundCycle || gotCycle;
@@ -158,9 +157,9 @@ public class TarjanSimpleCycles<V, E>
         return foundCycle;
     }
 
-    private void initState()
+    private void initState(Consumer<List<V>> consumer)
     {
-        cycles = new ArrayList<>();
+        cycleConsumer = consumer;
         marked = new HashSet<>();
         markedStack = new ArrayDeque<>();
         pointStack = new ArrayDeque<>();
@@ -174,7 +173,7 @@ public class TarjanSimpleCycles<V, E>
 
     private void clearState()
     {
-        cycles = null;
+        cycleConsumer = null;
         marked = null;
         markedStack = null;
         pointStack = null;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/TiernanSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/TiernanSimpleCycles.java
@@ -20,6 +20,7 @@ package org.jgrapht.alg.cycle;
 import org.jgrapht.*;
 
 import java.util.*;
+import java.util.function.Consumer;
 
 /**
  * Find all simple cycles of a directed graph using the Tiernan's algorithm.
@@ -62,7 +63,7 @@ public class TiernanSimpleCycles<V, E>
 
     /**
      * Get the graph
-     * 
+     *
      * @return graph
      */
     public Graph<V, E> getGraph()
@@ -72,7 +73,7 @@ public class TiernanSimpleCycles<V, E>
 
     /**
      * Set the graph
-     * 
+     *
      * @param graph graph
      */
     public void setGraph(Graph<V, E> graph)
@@ -84,7 +85,7 @@ public class TiernanSimpleCycles<V, E>
      * {@inheritDoc}
      */
     @Override
-    public List<List<V>> findSimpleCycles()
+    public void findSimpleCycles(Consumer<List<V>> consumer)
     {
         if (graph == null) {
             throw new IllegalArgumentException("Null graph.");
@@ -93,7 +94,6 @@ public class TiernanSimpleCycles<V, E>
         List<V> path = new ArrayList<>();
         Set<V> pathSet = new HashSet<>();
         Map<V, Set<V>> blocked = new HashMap<>();
-        List<List<V>> cycles = new LinkedList<>();
 
         int index = 0;
         for (V v : graph.vertexSet()) {
@@ -103,7 +103,7 @@ public class TiernanSimpleCycles<V, E>
 
         Iterator<V> vertexIterator = graph.vertexSet().iterator();
         if (!vertexIterator.hasNext()) {
-            return cycles;
+            return;
         }
 
         V startOfPath;
@@ -141,7 +141,7 @@ public class TiernanSimpleCycles<V, E>
             startOfPath = path.get(0);
             if (graph.containsEdge(endOfPath, startOfPath)) {
                 List<V> cycle = new ArrayList<>(path);
-                cycles.add(cycle);
+                consumer.accept(cycle);
             }
 
             // vertex closure
@@ -173,7 +173,5 @@ public class TiernanSimpleCycles<V, E>
             // terminate
             break;
         }
-
-        return cycles;
     }
 }


### PR DESCRIPTION
Currently some relatively large manually created graphs end up using an excessive amount of memory when detecting cycle, ultimately causing out of memory Errors due to the sheer amount of detected cycles that are held in a list.

While the HawickJamesSimpleCycles implementation already provides the path limit as a way to mitigate this problem, there are use cases where not all cycles matter to the application and as such this commit adds a callback API to all DirectedSimpleCycle implementations allowing users of this library to decide how to deal with each detected cycle, without forcing the the whole list of detected cycles to remain in memory until the algorithm finishes.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
