### PR TITLE
Reword: fix small typo in javadoc

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/similarity/ZhangShashaTreeEditDistance.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/similarity/ZhangShashaTreeEditDistance.java
@@ -38,7 +38,7 @@ import java.util.function.ToDoubleFunction;
  * 1245-1262. 10.1137/0218082.
  *
  * <p>
- * The time complexity of the algorithm if $O(|T_1|\cdot|T_2|\cdot min(depth(T_1),leaves(T_1)) \cdot
+ * The time complexity of the algorithm is $O(|T_1|\cdot|T_2|\cdot min(depth(T_1),leaves(T_1)) \cdot
  * min(depth(T_2),leaves(T_2)))$. Space complexity is $O(|T_1|\cdot |T_2|)$, where $|T_1|$ and
  * $|T_2|$ denote number of vertices in trees $T_1$ and $T_2$ correspondingly, $leaves()$ function
  * returns number of leaf vertices in a tree.


### PR DESCRIPTION
Fix typo in class description, changing from "if" to "is" in: "The time complexity of the algorithm if $O(...)$."

<!-- describe the changes you have made here: what, why, …
     Link issues by using the following pattern: [#333](https://github.com/jgrapht/jgrapht/issues/333).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [not applicable] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [not applicable] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [not applicable] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
