### PR TITLE
chore(deps): update antlr4 to 4.11.1

### DIFF
--- a/jgrapht-io/pom.xml
+++ b/jgrapht-io/pom.xml
@@ -45,7 +45,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.8-1</version>
+                <version>4.11.1</version>
                 <executions>
                     <execution>
                         <id>antlr</id>
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.9.3</version>
+            <version>4.11.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Bump antlr4 to the latest version

 - antlr4 mainly driven by antlr4 bump in Quarkus 
   - Quarkus moved antlr4 from 4.9.2 to 4.10.1 and tests are now failing, antlr4 needs to updated to 4.10+ to overcome the trouble with antlr4 4.9.2 vs. 4.10+, for now I have added https://github.com/quarkiverse/quarkus-jgrapht/commit/922cde8435d6b08a566b484a700bdac2cb39d30e workaround