### PR TITLE
make some final VertexScoringAlgorithms non-final

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/Coreness.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/Coreness.java
@@ -25,7 +25,7 @@ import java.util.*;
 
 /**
  * Computes the coreness of each vertex in an undirected graph.
- * 
+ *
  * <p>
  * A $k$-core of a graph $G$ is a maximal connected subgraph of $G$ in which all vertices have
  * degree at least $k$. Equivalently, it is one of the connected components of the subgraph of $G$
@@ -52,7 +52,7 @@ import java.util.*;
  *
  * @author Dimitrios Michail
  */
-public final class Coreness<V, E>
+public class Coreness<V, E>
     implements VertexScoringAlgorithm<V, Integer>
 {
     private final Graph<V, E> g;
@@ -61,7 +61,7 @@ public final class Coreness<V, E>
 
     /**
      * Constructor
-     * 
+     *
      * @param g the input graph
      */
     public Coreness(Graph<V, E> g)
@@ -94,13 +94,13 @@ public final class Coreness<V, E>
 
     /**
      * Compute the degeneracy of a graph.
-     * 
+     *
      * <p>
      * The degeneracy of a graph is the smallest value of $k$ for which it is $k$-degenerate. In
      * graph theory, a $k$-degenerate graph is an undirected graph in which every subgraph has a
      * vertex of degree at most $k$: that is, some vertex in the subgraph touches $k$ or fewer of
      * the subgraph's edges.
-     * 
+     *
      * @return the degeneracy of a graph
      */
     public int getDegeneracy()

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/EigenvectorCentrality.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/EigenvectorCentrality.java
@@ -56,7 +56,7 @@ import org.jgrapht.alg.interfaces.VertexScoringAlgorithm;
  *
  * @author Sebastiano Vigna
  */
-public final class EigenvectorCentrality<V, E>
+public class EigenvectorCentrality<V, E>
     implements VertexScoringAlgorithm<V, Double>
 {
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/HarmonicCentrality.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/HarmonicCentrality.java
@@ -25,7 +25,7 @@ import java.util.*;
 
 /**
  * Harmonic centrality.
- * 
+ *
  * <p>
  * The harmonic centrality of a vertex $x$ is defined as $H(x)=\sum_{y \neq x} 1/d(x,y)$, where
  * $d(x,y)$ is the shortest path distance from $x$ to $y$. In case a distance $d(x,y)=\infinity$,
@@ -44,25 +44,25 @@ import java.util.*;
  * <p>
  * This implementation computes by default the centrality using outgoing paths and normalizes the
  * scores. This behavior can be adjusted by the constructor arguments.
- * 
+ *
  * <p>
  * Shortest paths are computed either by using Dijkstra's algorithm or Floyd-Warshall depending on
  * whether the graph has edges with negative edge weights. Thus, the running time is either $O(n (m
  * + n \log n))$ or $O(n^3)$ respectively, where $n$ is the number of vertices and $m$ the number of
  * edges of the graph.
- * 
+ *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
- * 
+ *
  * @author Dimitrios Michail
  */
-public final class HarmonicCentrality<V, E>
+public class HarmonicCentrality<V, E>
     extends ClosenessCentrality<V, E>
 {
     /**
      * Construct a new instance. By default the centrality is normalized and computed using outgoing
      * paths.
-     * 
+     *
      * @param graph the input graph
      */
     public HarmonicCentrality(Graph<V, E> graph)
@@ -72,7 +72,7 @@ public final class HarmonicCentrality<V, E>
 
     /**
      * Construct a new instance.
-     * 
+     *
      * @param graph the input graph
      * @param incoming if true incoming paths are used, otherwise outgoing paths
      * @param normalize whether to normalize by dividing the closeness by $n-1$, where $n$ is the

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/KatzCentrality.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/KatzCentrality.java
@@ -66,7 +66,7 @@ import org.jgrapht.alg.interfaces.VertexScoringAlgorithm;
  * @author Pratik Tibrewal
  * @author Sebastiano Vigna
  */
-public final class KatzCentrality<V, E>
+public class KatzCentrality<V, E>
     implements VertexScoringAlgorithm<V, Double>
 {
     /**

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/PageRank.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/PageRank.java
@@ -24,7 +24,7 @@ import java.util.*;
 
 /**
  * PageRank implementation.
- * 
+ *
  * <p>
  * The <a href="https://en.wikipedia.org/wiki/PageRank">wikipedia</a> article contains a nice
  * description of PageRank. The method can be found on the article: Sergey Brin and Larry Page: The
@@ -32,7 +32,7 @@ import java.util.*;
  * Conference, Brisbane, Australia, April 1998. See also the following
  * <a href="http://infolab.stanford.edu/~backrub/google.html">page</a>.
  * </p>
- * 
+ *
  * <p>
  * This is a simple iterative implementation of PageRank which stops after a given number of
  * iterations or if the PageRank values between two iterations do not change more than a predefined
@@ -45,19 +45,19 @@ import java.util.*;
  * $m$ the number of edges of the graph. The maximum number of iterations can be adjusted by the
  * caller. The default value is {@link PageRank#MAX_ITERATIONS_DEFAULT}.
  * </p>
- * 
+ *
  * <p>
  * If the graph is a weighted graph, a weighted variant is used where the probability of following
  * an edge e out of node $v$ is equal to the weight of $e$ over the sum of weights of all outgoing
  * edges of $v$.
  * </p>
- * 
+ *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
- * 
+ *
  * @author Dimitrios Michail
  */
-public final class PageRank<V, E>
+public class PageRank<V, E>
     implements VertexScoringAlgorithm<V, Double>
 {
     /**
@@ -104,7 +104,7 @@ public final class PageRank<V, E>
 
     /**
      * Create and execute an instance of PageRank.
-     * 
+     *
      * @param graph the input graph
      */
     public PageRank(Graph<V, E> graph)
@@ -114,7 +114,7 @@ public final class PageRank<V, E>
 
     /**
      * Create and execute an instance of PageRank.
-     * 
+     *
      * @param graph the input graph
      * @param dampingFactor the damping factor
      */
@@ -125,7 +125,7 @@ public final class PageRank<V, E>
 
     /**
      * Create and execute an instance of PageRank.
-     * 
+     *
      * @param graph the input graph
      * @param dampingFactor the damping factor
      * @param maxIterations the maximum number of iterations to perform
@@ -137,7 +137,7 @@ public final class PageRank<V, E>
 
     /**
      * Create and execute an instance of PageRank.
-     * 
+     *
      * @param graph the input graph
      * @param dampingFactor the damping factor
      * @param maxIterations the maximum number of iterations to perform
@@ -190,14 +190,14 @@ public final class PageRank<V, E>
 
     /**
      * The actual implementation.
-     * 
+     *
      * <p>
      * We use this pattern with the inner class in order to be able to cache the result but also
      * allow the garbage collector to acquire all auxiliary memory used during the execution of the
      * algorithm.
-     * 
+     *
      * @author Dimitrios Michail
-     * 
+     *
      * @param <V> the graph type
      * @param <E> the edge type
      */


### PR DESCRIPTION
I have a use-case where I dynamically create various **_VertexScoringAlgorithm_** via reflection, using the constructor that only takes a `Graph<V, E> graph` instance, because that constructor is available for all algorithm.
However, some algorithms use inconsistent defaults (e.g. **_HarmonicCentrality_** uses normalize=true per default, while _**BetweennessCentrality**_ uses normalize=false).

Since the default behaviour can't be changed anymore one way to solve this is to sub-class these algorithms and provide own default (with a `Graph<V, E> graph` instance) constructors. 
Unfortunately some algorithms don't allow this, while others do.

This PR makes all **_VertexScoringAlgorithm_** non-final to allow such customisation. It doesn't have any other side-effects and I couldn't find a (good) reason to prevent it (and it's indeed already allowed for some algorithms).

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
