### PR TITLE
Update SimpleGEXFEventDrivenImporter.java

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/gexf/SimpleGEXFEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/gexf/SimpleGEXFEventDrivenImporter.java
@@ -162,6 +162,9 @@ public class SimpleGEXFEventDrivenImporter
 
         SchemaFactory factory = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 
+        // disable DOCTYPE declaration
+        factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+
         return factory.newSchema(sources);
     }
 


### PR DESCRIPTION
This schema factory is probably vulnerable to an XXE attack. Disabling the DOCTYPE declaration should prevent this type of attack. The GEXF importer does not use the DOCTYPE statement, so even if an attacker cannot exploit this vulnerability it should not be enabled.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [ ] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [ ] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [ ] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
