### PR TITLE
[GMLExporter] add option to export custom gml vertex graphics section…

### DIFF
--- a/jgrapht-io/src/test/java/org/jgrapht/nio/gml/GmlExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/gml/GmlExporterTest.java
@@ -79,7 +79,38 @@ public class GmlExporterTest
             + "\t\ttarget 1" + NL
             + "\t]" + NL
             + "]" + NL;
-    
+
+    private static final String UNDIRECTED_GRAPHICS_SECTION =
+            "Creator \"JGraphT GML Exporter\"" + NL
+            + "Version 1" + NL
+            + "graph" + NL
+            + "[" + NL
+            + "\tlabel \"\"" + NL
+            + "\tdirected 0" + NL
+            + "\tnode" + NL
+            + "\t[" + NL
+            + "\t\tid 1" + NL
+            + "\t\tgraphics" + NL
+            + "\t\t[" + NL
+            + "\t\t\tfill \"#FF0000\"" + NL
+            + "\t\t]" + NL
+            + "\t]" + NL
+            + "\tnode" + NL
+            + "\t[" + NL
+            + "\t\tid 2" + NL
+            + "\t\tgraphics" + NL
+            + "\t\t[" + NL
+            + "\t\t\tfill \"#FF0000\"" + NL
+            + "\t\t]" + NL
+            + "\t]" + NL
+            + "\tedge" + NL
+            + "\t[" + NL
+            + "\t\tid 1" + NL
+            + "\t\tsource 1" + NL
+            + "\t\ttarget 2" + NL
+            + "\t]" + NL
+            + "]" + NL;
+
     private static final String UNDIRECTED_WEIGHTED
             = "Creator \"JGraphT GML Exporter\"" + NL
             + "Version 1" + NL
@@ -311,6 +342,26 @@ public class GmlExporterTest
         exporter.exportGraph(g, os);
         String res = new String(os.toByteArray(), "UTF-8");
         assertEquals(UNDIRECTED, res);
+    }
+
+    @Test
+    public void testGraphicsSection()
+            throws UnsupportedEncodingException,
+            ExportException
+    {
+        Graph<String, DefaultEdge> g = new SimpleGraph<String, DefaultEdge>(DefaultEdge.class);
+        g.addVertex(V1);
+        g.addVertex(V2);
+        g.addEdge(V1, V2);
+
+        GmlExporter<String, DefaultEdge> exporter = new GmlExporter<String, DefaultEdge>();
+        exporter.setParameter(GmlExporter.Parameter.EXPORT_CUSTOM_VERTEX_GRAPHICS_ATTRIBUTES, true);
+        exporter.setEdgeIdProvider(new IntegerIdProvider<>());
+        exporter.setVertexGraphicsAttributeProvider(v -> Map.of("fill", DefaultAttribute.createAttribute("#FF0000")));
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        exporter.exportGraph(g, os);
+        String res = new String(os.toByteArray(), "UTF-8");
+        assertEquals(UNDIRECTED_GRAPHICS_SECTION, res);
     }
 
     @Test


### PR DESCRIPTION
Short: 
Add option to export custom gml vertex graphics section attributes. This can be used to set vertex shapes or colors in GML.

Long: 
The GMLExport class doesn't support setting attributes for the graphics section. See https://raw.githubusercontent.com/GunterMueller/UNI_PASSAU_FMI_Graph_Drawing/master/GML/gml-technical-report.pdf page 3 or http://docs.yworks.com/yfiles/doc/developers-guide/gml.html#GML_.graph.node.graphics_level

I think it might be useful to be able to write such sections in order to specify vertex shapes or colors to be able to differentiate different node types.



----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
