### PR TITLE
Retrieve value from Attribute directly for graph attributes in the DO…

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTExporter.java
@@ -95,7 +95,8 @@ public class DOTExporter<V, E>
             out.print(INDENT);
             out.print(attr.getKey());
             out.print('=');
-            out.print(attr.getValue());
+            Attribute attribute = attr.getValue();
+            out.print(attribute.getValue());
             out.println(";");
         }
 


### PR DESCRIPTION
Closes [ #1152](https://github.com/jgrapht/jgrapht/issues/1152).

----
Fixes the bug that the `getValue()` method was called on the Map's `Entry` rather than on the `Attribute` value contained within the map.

 
* [x] I read and understood https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor
* [x] I read and understood https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution
* [] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
* [ ]  I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
* [x]  I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
* [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
* [x]  I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
