### PR TITLE
CI Maintenance

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/PR-workflow.yaml
+++ b/.github/workflows/PR-workflow.yaml
@@ -10,18 +10,13 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 11
-          distribution: 'zulu'
-      - name: Cache Maven packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Build with Maven
         run: |
           set -e

--- a/.github/workflows/master-workflow.yaml
+++ b/.github/workflows/master-workflow.yaml
@@ -16,30 +16,25 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           java-version: 11
-          distribution: 'zulu'
-
-      - name: Cache Maven packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
+          distribution: 'temurin'
+          cache: 'maven'
 
       - name: Build with Maven
         run: |
           set -e
           mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V && mvn verify -B && mvn javadoc:aggregate && mvn checkstyle:check -P checkstyle
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 14
+          cache: 'npm'
       - run: npm install -g hercule@5.0.0
 
       - name: Run prepareDocs script
@@ -54,7 +49,7 @@ jobs:
         shell: bash
 
       - name: Publish Github Pages
-        uses: JamesIves/github-pages-deploy-action@4.1.4
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           token: ${{ secrets.PAGES_TOKEN }}
           branch: gh-pages


### PR DESCRIPTION
This PR adds maintenance patches to GitHub Action workflows. This includes:

- Version bump for `actions/checkout` from `v2` (PR workflow) / `v3` (master workflow) to `v4` (refs: https://github.com/actions/checkout/issues/959#issuecomment-1342479774, https://github.com/actions/checkout/pull/1436)
- Version bump for `actions/setup-java` from `v2` (PR workflow) / `v3` (master workflow) to `v4` (refs: https://github.com/actions/setup-java/pull/290, https://github.com/actions/setup-java/pull/558)
- Changing `actions/setup-java` to use Eclipse Temurin build of OpenJDK (was using Azul Zulu OpenJDK)
  Unlike other distributions of OpenJDK, Temurin builds are cached in GH-hosted runners.
- Replacing `actions/cache` for Maven caching with [built-in cache implementation](https://github.com/actions/setup-java#caching-maven-dependencies) in `actions/setup-java`
- Version bump for `JamesIves/github-pages-deploy-action` from `4.1.4` to `v4.5.0`
- Adding [Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates) config to automate version updates

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] <s>I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)</s> (not applicable)
- [ ] <s>I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)</s> (not applicable)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
