### PR TITLE
Javadoc Maintenance

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/Graph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/Graph.java
@@ -25,8 +25,8 @@ import org.jgrapht.graph.DefaultGraphIterables;
 
 /**
  * The root interface in the graph hierarchy. A mathematical graph-theory graph object
- * <code>G(V,E)</code> contains a set <code>V</code> of vertices and a set <code>
- * E</code> of edges. Each edge e=(v1,v2) in E connects vertex v1 to vertex v2. for more information
+ * {@code G(V,E)} contains a set {@code V} of vertices and a set {@code E} of edges.
+ * Each edge e=(v1,v2) in E connects vertex v1 to vertex v2. for more information
  * about graphs and their related definitions see <a href="http://mathworld.wolfram.com/Graph.html">
  * http://mathworld.wolfram.com/Graph.html</a>.
  *
@@ -34,7 +34,7 @@ import org.jgrapht.graph.DefaultGraphIterables;
  * This library generally follows the terminology found at:
  * <a href="http://mathworld.wolfram.com/topics/GraphTheory.html">
  * http://mathworld.wolfram.com/topics/GraphTheory.html</a>. Implementation of this interface can
- * provide simple-graphs, multigraphs, pseudographs etc. The package <code>org.jgrapht.graph</code>
+ * provide simple-graphs, multigraphs, pseudographs etc. The package {@code org.jgrapht.graph}
  * provides a gallery of abstract and concrete graph implementations.
  * </p>
  *
@@ -44,10 +44,9 @@ import org.jgrapht.graph.DefaultGraphIterables;
  * </p>
  *
  * <p>
- * Through generics, a graph can be typed to specific classes for vertices <code>V</code> and edges
- * <code>E&lt;T&gt;</code>. Such a graph can contain vertices of type <code>V</code> and all
- * sub-types and Edges of type <code>
- * E</code> and all sub-types.
+ * Through generics, a graph can be typed to specific classes for vertices {@code V} and edges
+ * {@code E&lt;T&gt;}. Such a graph can contain vertices of type {@code V} and all
+ * sub-types and Edges of type {@code E} and all sub-types.
  * </p>
  *
  * <p>
@@ -63,8 +62,8 @@ public interface Graph<V, E>
 {
     /**
      * Returns a set of all edges connecting source vertex to target vertex if such vertices exist
-     * in this graph. If any of the vertices does not exist or is <code>null</code>, returns
-     * <code>null</code>. If both vertices exist but no edges found, returns an empty set.
+     * in this graph. If any of the vertices does not exist or is {@code null}, returns
+     * {@code null}. If both vertices exist but no edges found, returns an empty set.
      *
      * <p>
      * In undirected graphs, some of the returned edges may have their source and target vertices in
@@ -80,8 +79,8 @@ public interface Graph<V, E>
 
     /**
      * Returns an edge connecting source vertex to target vertex if such vertices and such edge
-     * exist in this graph. Otherwise returns <code>
-     * null</code>. If any of the specified vertices is <code>null</code> returns <code>null</code>
+     * exist in this graph. Otherwise returns {@code null}.
+     * If any of the specified vertices is {@code null} returns {@code null}
      *
      * <p>
      * In undirected graphs, the returned edge may have its source and target vertices in the
@@ -106,9 +105,9 @@ public interface Graph<V, E>
      * <p>
      * In contrast with the {@link Supplier} interface, the vertex supplier has the additional
      * requirement that a new and distinct result is returned every time it is invoked. More
-     * specifically for a new vertex to be added in a graph <code>v</code> must <i>not</i> be equal
+     * specifically for a new vertex to be added in a graph {@code v} must <i>not</i> be equal
      * to any other vertex in the graph. More formally, the graph must not contain any vertex
-     * <code>v2</code> such that <code>v2.equals(v)</code>.
+     * {@code v2} such that {@code v2.equals(v)}.
      * 
      * <p>
      * Care must also be taken when interchanging calls to methods {@link Graph#addVertex(Object)}
@@ -117,7 +116,7 @@ public interface Graph<V, E>
      * the future by the supplied vertex supplier. Such a sequence will result into an
      * {@link IllegalArgumentException} when calling method {@link Graph#addVertex()}.
      * 
-     * @return the vertex supplier or <code>null</code> if the graph has no such supplier
+     * @return the vertex supplier or {@code null} if the graph has no such supplier
      */
     Supplier<V> getVertexSupplier();
 
@@ -132,11 +131,11 @@ public interface Graph<V, E>
      * <p>
      * In contrast with the {@link Supplier} interface, the edge supplier has the additional
      * requirement that a new and distinct result is returned every time it is invoked. More
-     * specifically for a new edge to be added in a graph <code>e</code> must <i>not</i> be equal to
+     * specifically for a new edge to be added in a graph {@code e} must <i>not</i> be equal to
      * any other edge in the graph (even if the graph allows edge-multiplicity). More formally, the
-     * graph must not contain any edge <code>e2</code> such that <code>e2.equals(e)</code>.
+     * graph must not contain any edge {@code e2} such that {@code e2.equals(e)}.
      * 
-     * @return the edge supplier <code>null</code> if the graph has no such supplier
+     * @return the edge supplier {@code null} if the graph has no such supplier
      */
     Supplier<E> getEdgeSupplier();
 
@@ -144,34 +143,34 @@ public interface Graph<V, E>
      * Creates a new edge in this graph, going from the source vertex to the target vertex, and
      * returns the created edge. Some graphs do not allow edge-multiplicity. In such cases, if the
      * graph already contains an edge from the specified source to the specified target, then this
-     * method does not change the graph and returns <code>null</code>.
+     * method does not change the graph and returns {@code null}.
      *
      * <p>
      * The source and target vertices must already be contained in this graph. If they are not found
      * in graph {@link IllegalArgumentException} is thrown.
      *
      * <p>
-     * This method creates the new edge <code>e</code> using this graph's edge supplier (see
-     * {@link #getEdgeSupplier()}). For the new edge to be added <code>e</code> must <i>not</i> be
+     * This method creates the new edge {@code e} using this graph's edge supplier (see
+     * {@link #getEdgeSupplier()}). For the new edge to be added {@code e} must <i>not</i> be
      * equal to any other edge the graph (even if the graph allows edge-multiplicity). More
-     * formally, the graph must not contain any edge <code>e2</code> such that
-     * <code>e2.equals(e)</code>. If such <code>
-     * e2</code> is found then the newly created edge <code>e</code> is abandoned, the method leaves
-     * this graph unchanged and returns <code>null</code>.
+     * formally, the graph must not contain any edge {@code e2} such that
+     * {@code e2.equals(e)}. If such {@code 
+     * e2} is found then the newly created edge {@code e} is abandoned, the method leaves
+     * this graph unchanged and returns {@code null}.
      * 
      * <p>
      * If the underlying graph implementation's {@link #getEdgeSupplier()} returns
-     * <code>null</code>, then this method cannot create edges and throws an
+     * {@code null}, then this method cannot create edges and throws an
      * {@link UnsupportedOperationException}.
      *
      * @param sourceVertex source vertex of the edge.
      * @param targetVertex target vertex of the edge.
      *
-     * @return The newly created edge if added to the graph, otherwise <code>
-     * null</code>.
+     * @return The newly created edge if added to the graph, otherwise {@code 
+     * null}.
      *
      * @throws IllegalArgumentException if source or target vertices are not found in the graph.
-     * @throws NullPointerException if any of the specified vertices is <code>null</code>.
+     * @throws NullPointerException if any of the specified vertices is {@code null}.
      * @throws UnsupportedOperationException if the graph was not initialized with an edge supplier
      *
      * @see #getEdgeSupplier()
@@ -180,14 +179,14 @@ public interface Graph<V, E>
 
     /**
      * Adds the specified edge to this graph, going from the source vertex to the target vertex.
-     * More formally, adds the specified edge, <code>
-     * e</code>, to this graph if this graph contains no edge <code>e2</code> such that
-     * <code>e2.equals(e)</code>. If this graph already contains such an edge, the call leaves this
-     * graph unchanged and returns <code>false</code>. Some graphs do not allow edge-multiplicity.
+     * More formally, adds the specified edge, {@code 
+     * e}, to this graph if this graph contains no edge {@code e2} such that
+     * {@code e2.equals(e)}. If this graph already contains such an edge, the call leaves this
+     * graph unchanged and returns {@code false}. Some graphs do not allow edge-multiplicity.
      * In such cases, if the graph already contains an edge from the specified source to the
-     * specified target, then this method does not change the graph and returns <code>
-     * false</code>. If the edge was added to the graph, returns <code>
-     * true</code>.
+     * specified target, then this method does not change the graph and returns {@code 
+     * false}. If the edge was added to the graph, returns {@code 
+     * true}.
      *
      * <p>
      * The source and target vertices must already be contained in this graph. If they are not found
@@ -198,13 +197,13 @@ public interface Graph<V, E>
      * @param targetVertex target vertex of the edge.
      * @param e edge to be added to this graph.
      *
-     * @return <code>true</code> if this graph did not already contain the specified edge.
+     * @return {@code true} if this graph did not already contain the specified edge.
      *
      * @throws IllegalArgumentException if source or target vertices are not found in the graph.
      * @throws ClassCastException if the specified edge is not assignment compatible with the class
      *         of edges produced by the edge factory of this graph.
-     * @throws NullPointerException if any of the specified vertices is <code>
-     * null</code>.
+     * @throws NullPointerException if any of the specified vertices is {@code 
+     * null}.
      *
      * @see #addEdge(Object, Object)
      * @see #getEdgeSupplier()
@@ -215,16 +214,16 @@ public interface Graph<V, E>
      * Creates a new vertex in this graph and returns it.
      *
      * <p>
-     * This method creates the new vertex <code>v</code> using this graph's vertex supplier (see
-     * {@link #getVertexSupplier()}). For the new vertex to be added <code>v</code> must <i>not</i>
+     * This method creates the new vertex {@code v} using this graph's vertex supplier (see
+     * {@link #getVertexSupplier()}). For the new vertex to be added {@code v} must <i>not</i>
      * be equal to any other vertex in the graph. More formally, the graph must not contain any
-     * vertex <code>v2</code> such that <code>v2.equals(v)</code>. If such <code>
-     * v2</code> is found then the newly created vertex <code>v</code> is abandoned, the method
+     * vertex {@code v2} such that {@code v2.equals(v)}. If such {@code 
+     * v2} is found then the newly created vertex {@code v} is abandoned, the method
      * leaves this graph unchanged and throws an {@link IllegalArgumentException}.
      * 
      * <p>
      * If the underlying graph implementation's {@link #getVertexSupplier()} returns
-     * <code>null</code>, then this method cannot create vertices and throws an
+     * {@code null}, then this method cannot create vertices and throws an
      * {@link UnsupportedOperationException}.
      * 
      * <p>
@@ -246,56 +245,54 @@ public interface Graph<V, E>
 
     /**
      * Adds the specified vertex to this graph if not already present. More formally, adds the
-     * specified vertex, <code>v</code>, to this graph if this graph contains no vertex
-     * <code>u</code> such that <code>
-     * u.equals(v)</code>. If this graph already contains such vertex, the call leaves this graph
-     * unchanged and returns <code>false</code>. In combination with the restriction on
+     * specified vertex, {@code v}, to this graph if this graph contains no vertex
+     * {@code u} such that {@code u.equals(v)}.
+     * If this graph already contains such vertex, the call leaves this graph
+     * unchanged and returns {@code false}. In combination with the restriction on
      * constructors, this ensures that graphs never contain duplicate vertices.
      *
      * @param v vertex to be added to this graph.
      *
-     * @return <code>true</code> if this graph did not already contain the specified vertex.
+     * @return {@code true} if this graph did not already contain the specified vertex.
      *
-     * @throws NullPointerException if the specified vertex is <code>
-     * null</code>.
+     * @throws NullPointerException if the specified vertex is {@code null}.
      */
     boolean addVertex(V v);
 
     /**
-     * Returns <code>true</code> if and only if this graph contains an edge going from the source
+     * Returns {@code true} if and only if this graph contains an edge going from the source
      * vertex to the target vertex. In undirected graphs the same result is obtained when source and
      * target are inverted. If any of the specified vertices does not exist in the graph, or if is
-     * <code>
-     * null</code>, returns <code>false</code>.
+     * {@code null}, returns {@code false}.
      *
      * @param sourceVertex source vertex of the edge.
      * @param targetVertex target vertex of the edge.
      *
-     * @return <code>true</code> if this graph contains the specified edge.
+     * @return {@code true} if this graph contains the specified edge.
      */
     boolean containsEdge(V sourceVertex, V targetVertex);
 
     /**
-     * Returns <code>true</code> if this graph contains the specified edge. More formally, returns
-     * <code>true</code> if and only if this graph contains an edge <code>e2</code> such that
-     * <code>e.equals(e2)</code>. If the specified edge is <code>null</code> returns
-     * <code>false</code>.
+     * Returns {@code true} if this graph contains the specified edge. More formally, returns
+     * {@code true} if and only if this graph contains an edge {@code e2} such that
+     * {@code e.equals(e2)}. If the specified edge is {@code null} returns
+     * {@code false}.
      *
      * @param e edge whose presence in this graph is to be tested.
      *
-     * @return <code>true</code> if this graph contains the specified edge.
+     * @return {@code true} if this graph contains the specified edge.
      */
     boolean containsEdge(E e);
 
     /**
-     * Returns <code>true</code> if this graph contains the specified vertex. More formally, returns
-     * <code>true</code> if and only if this graph contains a vertex <code>u</code> such that
-     * <code>u.equals(v)</code>. If the specified vertex is <code>null</code> returns
-     * <code>false</code>.
+     * Returns {@code true} if this graph contains the specified vertex. More formally, returns
+     * {@code true} if and only if this graph contains a vertex {@code u} such that
+     * {@code u.equals(v)}. If the specified vertex is {@code null} returns
+     * {@code false}.
      *
      * @param v vertex whose presence in this graph is to be tested.
      *
-     * @return <code>true</code> if this graph contains the specified vertex.
+     * @return {@code true} if this graph contains the specified vertex.
      */
     boolean containsVertex(V v);
 
@@ -329,7 +326,7 @@ public interface Graph<V, E>
      * @return the degree of the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      * @throws ArithmeticException if the result overflows an int
      */
     int degreeOf(V vertex);
@@ -342,7 +339,7 @@ public interface Graph<V, E>
      * @return a set of all edges touching the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     Set<E> edgesOf(V vertex);
 
@@ -362,7 +359,7 @@ public interface Graph<V, E>
      * @return the degree of the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      * @throws ArithmeticException if the result overflows an int
      */
     int inDegreeOf(V vertex);
@@ -378,7 +375,7 @@ public interface Graph<V, E>
      * @return a set of all edges incoming into the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     Set<E> incomingEdgesOf(V vertex);
 
@@ -398,7 +395,7 @@ public interface Graph<V, E>
      * @return the degree of the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      * @throws ArithmeticException if the result overflows an int
      */
     int outDegreeOf(V vertex);
@@ -414,7 +411,7 @@ public interface Graph<V, E>
      * @return a set of all edges outgoing from the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     Set<E> outgoingEdgesOf(V vertex);
 
@@ -425,10 +422,9 @@ public interface Graph<V, E>
      *
      * @param edges edges to be removed from this graph.
      *
-     * @return <code>true</code> if this graph changed as a result of the call
+     * @return {@code true} if this graph changed as a result of the call
      *
-     * @throws NullPointerException if the specified edge collection is <code>
-     * null</code>.
+     * @throws NullPointerException if the specified edge collection is {@code null}.
      *
      * @see #removeEdge(Object)
      * @see #containsEdge(Object)
@@ -437,7 +433,7 @@ public interface Graph<V, E>
 
     /**
      * Removes all the edges going from the specified source vertex to the specified target vertex,
-     * and returns a set of all removed edges. Returns <code>null</code> if any of the specified
+     * and returns a set of all removed edges. Returns {@code null} if any of the specified
      * vertices does not exist in the graph. If both vertices exist but no edge is found, returns an
      * empty set. This method will either invoke the {@link #removeEdge(Object)} method, or the
      * {@link #removeEdge(Object, Object)} method.
@@ -445,7 +441,7 @@ public interface Graph<V, E>
      * @param sourceVertex source vertex of the edge.
      * @param targetVertex target vertex of the edge.
      *
-     * @return the removed edges, or <code>null</code> if either vertex is not part of graph
+     * @return the removed edges, or {@code null} if either vertex is not part of graph
      */
     Set<E> removeAllEdges(V sourceVertex, V targetVertex);
 
@@ -456,10 +452,9 @@ public interface Graph<V, E>
      *
      * @param vertices vertices to be removed from this graph.
      *
-     * @return <code>true</code> if this graph changed as a result of the call
+     * @return {@code true} if this graph changed as a result of the call
      *
-     * @throws NullPointerException if the specified vertex collection is <code>
-     * null</code>.
+     * @throws NullPointerException if the specified vertex collection is {@code null}.
      *
      * @see #removeVertex(Object)
      * @see #containsVertex(Object)
@@ -468,49 +463,47 @@ public interface Graph<V, E>
 
     /**
      * Removes an edge going from source vertex to target vertex, if such vertices and such edge
-     * exist in this graph. Returns the edge if removed or <code>null</code> otherwise.
+     * exist in this graph. Returns the edge if removed or {@code null} otherwise.
      *
      * @param sourceVertex source vertex of the edge.
      * @param targetVertex target vertex of the edge.
      *
-     * @return The removed edge, or <code>null</code> if no edge removed.
+     * @return The removed edge, or {@code null} if no edge removed.
      */
     E removeEdge(V sourceVertex, V targetVertex);
 
     /**
      * Removes the specified edge from the graph. Removes the specified edge from this graph if it
-     * is present. More formally, removes an edge <code>
-     * e2</code> such that <code>e2.equals(e)</code>, if the graph contains such edge. Returns
-     * <code>true</code> if the graph contained the specified edge. (The graph will not contain the
-     * specified edge once the call returns).
+     * is present. More formally, removes an edge {@code  e2} such that {@code e2.equals(e)},
+     * if the graph contains such edge. Returns {@code true} if the graph contained
+     * the specified edge. (The graph will not contain the specified edge once the call returns).
      *
      * <p>
-     * If the specified edge is <code>null</code> returns <code>
-     * false</code>.
+     * If the specified edge is {@code null} returns {@code 
+     * false}.
      * </p>
      *
      * @param e edge to be removed from this graph, if present.
      *
-     * @return <code>true</code> if and only if the graph contained the specified edge.
+     * @return {@code true} if and only if the graph contained the specified edge.
      */
     boolean removeEdge(E e);
 
     /**
      * Removes the specified vertex from this graph including all its touching edges if present.
-     * More formally, if the graph contains a vertex <code>
-     * u</code> such that <code>u.equals(v)</code>, the call removes all edges that touch
-     * <code>u</code> and then removes <code>u</code> itself. If no such <code>u</code> is found,
-     * the call leaves the graph unchanged. Returns <code>true</code> if the graph contained the
-     * specified vertex. (The graph will not contain the specified vertex once the call returns).
+     * More formally, if the graph contains a vertex {@code u} such that {@code u.equals(v)},
+     * the call removes all edges that touch {@code u} and then removes {@code u} itself.
+     * If no such {@code u} is found, the call leaves the graph unchanged.
+     * Returns {@code true} if the graph contained the specified vertex.
+     * (The graph will not contain the specified vertex once the call returns).
      *
      * <p>
-     * If the specified vertex is <code>null</code> returns <code>
-     * false</code>.
+     * If the specified vertex is {@code null} returns {@code  false}.
      * </p>
      *
      * @param v vertex to be removed from this graph, if present.
      *
-     * @return <code>true</code> if the graph contained the specified vertex; <code>false</code>
+     * @return {@code true} if the graph contained the specified vertex; {@code false}
      *         otherwise.
      */
     boolean removeVertex(V v);
@@ -585,12 +578,12 @@ public interface Graph<V, E>
     void setEdgeWeight(E e, double weight);
 
     /**
-     * Assigns a weight to an edge between <code>sourceVertex</code> and <code>targetVertex</code>.
-     * If no edge exists between <code>sourceVertex</code> and <code>targetVertex</code> or either
-     * of these vertices is <code>null</code>, a <code>NullPointerException</code> is thrown.
+     * Assigns a weight to an edge between {@code sourceVertex} and {@code targetVertex}.
+     * If no edge exists between {@code sourceVertex} and {@code targetVertex} or either
+     * of these vertices is {@code null}, a {@code NullPointerException} is thrown.
      * <p>
-     * When there exist multiple edges between <code>sourceVertex</code> and
-     * <code>targetVertex</code>, consider using {@link #setEdgeWeight(Object, double)} instead.
+     * When there exist multiple edges between {@code sourceVertex} and
+     * {@code targetVertex}, consider using {@link #setEdgeWeight(Object, double)} instead.
      *
      * @param sourceVertex source vertex of the edge
      * @param targetVertex target vertex of the edge

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphIterables.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphIterables.java
@@ -106,7 +106,7 @@ public interface GraphIterables<V, E>
      * @param vertex input vertex
      * @return an iterable view of the vertices contained in this graph
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     default Iterable<E> edgesOf(V vertex)
     {
@@ -127,7 +127,7 @@ public interface GraphIterables<V, E>
      * @return the degree of the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     default long degreeOf(V vertex)
     {
@@ -147,7 +147,7 @@ public interface GraphIterables<V, E>
      * @param vertex input vertex
      * @return an iterable view of all edges incoming into the specified vertex
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     default Iterable<E> incomingEdgesOf(V vertex)
     {
@@ -170,7 +170,7 @@ public interface GraphIterables<V, E>
      * @return the degree of the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     default long inDegreeOf(V vertex)
     {
@@ -190,7 +190,7 @@ public interface GraphIterables<V, E>
      * @param vertex input vertex
      * @return an iterable view of all edges outgoing from the specified vertex
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     default Iterable<E> outgoingEdgesOf(V vertex)
     {
@@ -213,7 +213,7 @@ public interface GraphIterables<V, E>
      * @return the degree of the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     default long outDegreeOf(V vertex)
     {
@@ -225,7 +225,7 @@ public interface GraphIterables<V, E>
      * vertices exist in this graph. The returned iterators are live views. If the graph is modified
      * while an iteration is in progress, the results of the iteration are undefined.
      * 
-     * If any of the vertices does not exist or is <code>null</code>, returns <code>null</code>. If
+     * If any of the vertices does not exist or is {@code null}, returns {@code null}. If
      * both vertices exist but no edges found, returns an iterable which returns exhausted
      * iterators.
      * 
@@ -240,7 +240,7 @@ public interface GraphIterables<V, E>
      * @return an iterable view of all edges connecting source to target vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     default Iterable<E> allEdges(V sourceVertex, V targetVertex)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphMapping.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphMapping.java
@@ -31,7 +31,7 @@ package org.jgrapht;
 public interface GraphMapping<V, E>
 {
     /**
-     * Gets the mapped value where the key is <code>vertex</code>
+     * Gets the mapped value where the key is {@code vertex}
      *
      * @param vertex vertex in one of the graphs
      * @param forward if true, uses mapping from graph1 to graph2; if false, use mapping from graph2
@@ -42,7 +42,7 @@ public interface GraphMapping<V, E>
     V getVertexCorrespondence(V vertex, boolean forward);
 
     /**
-     * Gets the mapped value where the key is <code>edge</code>
+     * Gets the mapped value where the key is {@code edge}
      *
      * @param edge edge in one of the graphs
      * @param forward if true, uses mapping from graph1 to graph2; if false, use mapping from graph2

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
@@ -51,6 +51,8 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph is empty, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
      */
     public static <V, E> boolean isEmpty(Graph<V, E> graph)
     {
@@ -66,6 +68,8 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if a graph is simple, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
      */
     public static <V, E> boolean isSimple(Graph<V, E> graph)
     {
@@ -98,6 +102,8 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if a graph has self-loops, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
      */
     public static <V, E> boolean hasSelfLoops(Graph<V, E> graph)
     {
@@ -124,6 +130,8 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if a graph has multiple edges, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
      */
     public static <V, E> boolean hasMultipleEdges(Graph<V, E> graph)
     {
@@ -156,6 +164,8 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph is complete, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
      */
     public static <V, E> boolean isComplete(Graph<V, E> graph)
     {
@@ -191,6 +201,9 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph is connected, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
+     * 
      * @see ConnectivityInspector
      */
     public static <V, E> boolean isConnected(Graph<V, E> graph)
@@ -212,6 +225,9 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph is biconnected, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
+     * 
      * @see org.jgrapht.alg.connectivity.BiconnectivityInspector
      */
     public static <V, E> boolean isBiconnected(Graph<V, E> graph)
@@ -231,6 +247,9 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph is weakly connected, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
+     * 
      * @see ConnectivityInspector
      */
     public static <V, E> boolean isWeaklyConnected(Graph<V, E> graph)
@@ -252,6 +271,9 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph is strongly connected, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
+     * 
      * @see KosarajuStrongConnectivityInspector
      */
     public static <V, E> boolean isStronglyConnected(Graph<V, E> graph)
@@ -423,6 +445,9 @@ public abstract class GraphTests
      * @param <E> the graph edge type
      *
      * @return true if the graph is Eulerian, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
+     * 
      * @see HierholzerEulerianCycle#isEulerian(Graph)
      */
     public static <V, E> boolean isEulerian(Graph<V, E> graph)
@@ -440,6 +465,9 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph is chordal, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
+     * 
      * @see ChordalityInspector#isChordal()
      */
     public static <V, E> boolean isChordal(Graph<V, E> graph)
@@ -467,6 +495,9 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph is weakly chordal, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
+     * 
      * @see WeakChordalityInspector#isWeaklyChordal()
      */
     public static <V, E> boolean isWeaklyChordal(Graph<V, E> graph)
@@ -487,6 +518,9 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph meets Ore's condition, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
+     * 
      * @see org.jgrapht.alg.tour.PalmerHamiltonianCycle
      */
     public static <V, E> boolean hasOreProperty(Graph<V, E> graph)
@@ -539,6 +573,8 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph is perfect, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
      */
     public static <V, E> boolean isPerfect(Graph<V, E> graph)
     {
@@ -558,6 +594,9 @@ public abstract class GraphTests
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      * @return true if the graph is planar, false otherwise
+     * 
+     * @throws NullPointerException if graph is {@code null}
+     * 
      * @see PlanarityTestingAlgorithm
      * @see BoyerMyrvoldPlanarityInspector
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphType.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphType.java
@@ -57,61 +57,61 @@ public interface GraphType
     boolean isMixed();
 
     /**
-     * Returns <code>true</code> if and only if multiple (parallel) edges are allowed in this graph.
+     * Returns {@code true} if and only if multiple (parallel) edges are allowed in this graph.
      * The meaning of multiple edges is that there can be many edges going from vertex v1 to vertex
      * v2.
      *
-     * @return <code>true</code> if and only if multiple (parallel) edges are allowed.
+     * @return {@code true} if and only if multiple (parallel) edges are allowed.
      */
     boolean isAllowingMultipleEdges();
 
     /**
-     * Returns <code>true</code> if and only if self-loops are allowed in this graph. A self loop is
+     * Returns {@code true} if and only if self-loops are allowed in this graph. A self loop is
      * an edge that its source and target vertices are the same.
      *
-     * @return <code>true</code> if and only if graph self-loops are allowed.
+     * @return {@code true} if and only if graph self-loops are allowed.
      */
     boolean isAllowingSelfLoops();
 
     /**
-     * Returns <code>true</code> if and only if cycles are allowed in this graph.
+     * Returns {@code true} if and only if cycles are allowed in this graph.
      *
-     * @return <code>true</code> if and only if graph cycles are allowed.
+     * @return {@code true} if and only if graph cycles are allowed.
      */
     boolean isAllowingCycles();
 
     /**
-     * Returns <code>true</code> if and only if the graph supports edge weights.
+     * Returns {@code true} if and only if the graph supports edge weights.
      *
-     * @return <code>true</code> if the graph supports edge weights, <code>false</code> otherwise.
+     * @return {@code true} if the graph supports edge weights, {@code false} otherwise.
      */
     boolean isWeighted();
 
     /**
-     * Returns <code>true</code> if the graph is simple, <code>false</code> otherwise.
+     * Returns {@code true} if the graph is simple, {@code false} otherwise.
      * 
-     * @return <code>true</code> if the graph is simple, <code>false</code> otherwise
+     * @return {@code true} if the graph is simple, {@code false} otherwise
      */
     boolean isSimple();
 
     /**
-     * Returns <code>true</code> if the graph is a pseudograph, <code>false</code> otherwise.
+     * Returns {@code true} if the graph is a pseudograph, {@code false} otherwise.
      * 
-     * @return <code>true</code> if the graph is a pseudograph, <code>false</code> otherwise
+     * @return {@code true} if the graph is a pseudograph, {@code false} otherwise
      */
     boolean isPseudograph();
 
     /**
-     * Returns <code>true</code> if the graph is a multigraph, <code>false</code> otherwise.
+     * Returns {@code true} if the graph is a multigraph, {@code false} otherwise.
      * 
-     * @return <code>true</code> if the graph is a multigraph, <code>false</code> otherwise
+     * @return {@code true} if the graph is a multigraph, {@code false} otherwise
      */
     boolean isMultigraph();
 
     /**
-     * Returns <code>true</code> if the graph is modifiable, <code>false</code> otherwise.
+     * Returns {@code true} if the graph is modifiable, {@code false} otherwise.
      * 
-     * @return <code>true</code> if the graph is modifiable, <code>false</code> otherwise
+     * @return {@code true} if the graph is modifiable, {@code false} otherwise
      */
     boolean isModifiable();
 

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphType.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphType.java
@@ -36,23 +36,23 @@ package org.jgrapht;
 public interface GraphType
 {
     /**
-     * Returns true if all edges of the graph are directed, false otherwise.
+     * Returns {@code true} if all edges of the graph are directed, false otherwise.
      * 
      * @return true if all edges of the graph are directed, false otherwise
      */
     boolean isDirected();
 
     /**
-     * Returns true if all edges of the graph are undirected, false otherwise.
+     * Returns {@code true} if all edges of the graph are undirected, false otherwise.
      * 
-     * @return true if all edges of the graph are undirected, false otherwise
+     * @return {@code true} if all edges of the graph are undirected, false otherwise
      */
     boolean isUndirected();
 
     /**
-     * Returns true if the graph contain both directed and undirected edges, false otherwise.
+     * Returns {@code true} if the graph contain both directed and undirected edges, false otherwise.
      * 
-     * @return true if the graph contain both directed and undirected edges, false otherwise
+     * @return {@code true} if the graph contain both directed and undirected edges, false otherwise
      */
     boolean isMixed();
 

--- a/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
@@ -42,8 +42,7 @@ public abstract class Graphs
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      *
-     * @return The newly created edge if added to the graph, otherwise <code>
-     * null</code>.
+     * @return The newly created edge if added to the graph, otherwise {@code null}.
      * 
      * @throws UnsupportedOperationException if the graph has no edge supplier
      *
@@ -76,8 +75,7 @@ public abstract class Graphs
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      *
-     * @return The newly created edge if added to the graph, otherwise <code>
-     * null</code>.
+     * @return The newly created edge if added to the graph, otherwise {@code null}.
      */
     public static <V, E> E addEdgeWithVertices(Graph<V, E> g, V sourceVertex, V targetVertex)
     {
@@ -96,7 +94,7 @@ public abstract class Graphs
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      *
-     * @return <code>true</code> if the target graph did not already contain the specified edge.
+     * @return {@code true} if the target graph did not already contain the specified edge.
      */
     public static <V,
         E> boolean addEdgeWithVertices(Graph<V, E> targetGraph, Graph<V, E> sourceGraph, E edge)
@@ -122,8 +120,7 @@ public abstract class Graphs
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      *
-     * @return The newly created edge if added to the graph, otherwise <code>
-     * null</code>.
+     * @return The newly created edge if added to the graph, otherwise {@code null}.
      */
     public static <V,
         E> E addEdgeWithVertices(Graph<V, E> g, V sourceVertex, V targetVertex, double weight)
@@ -138,8 +135,8 @@ public abstract class Graphs
      * Adds all the vertices and all the edges of the specified source graph to the specified
      * destination graph. First all vertices of the source graph are added to the destination graph.
      * Then every edge of the source graph is added to the destination graph. This method returns
-     * <code>true</code> if the destination graph has been modified as a result of this operation,
-     * otherwise it returns <code>false</code>.
+     * {@code true} if the destination graph has been modified as a result of this operation,
+     * otherwise it returns {@code false}.
      *
      * <p>
      * The behavior of this operation is undefined if any of the specified graphs is modified while
@@ -151,7 +148,7 @@ public abstract class Graphs
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      *
-     * @return <code>true</code> if and only if the destination graph has been changed as a result
+     * @return {@code true} if and only if the destination graph has been changed as a result
      *         of this operation.
      */
     public static <V,
@@ -206,7 +203,7 @@ public abstract class Graphs
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      *
-     * @return <code>true</code> if this graph changed as a result of the call
+     * @return {@code true} if this graph changed as a result of the call
      */
     public static <V, E> boolean addAllEdges(
         Graph<? super V, ? super E> destination, Graph<V, E> source, Collection<? extends E> edges)
@@ -234,11 +231,10 @@ public abstract class Graphs
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      *
-     * @return <code>true</code> if graph changed as a result of the call
+     * @return {@code true} if graph changed as a result of the call
      *
      * @throws NullPointerException if the specified vertices contains one or more null vertices, or
-     *         if the specified vertex collection is <code>
-     * null</code>.
+     *         if the specified vertex collection is {@code null}.
      *
      * @see Graph#addVertex(Object)
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
@@ -44,6 +44,7 @@ public abstract class Graphs
      *
      * @return The newly created edge if added to the graph, otherwise {@code null}.
      * 
+     * @throws NullPointerException if any one of {@code g}, {@code sourceVertex}, or {@code targetVertex} is {@code null}
      * @throws UnsupportedOperationException if the graph has no edge supplier
      *
      * @see Graph#addEdge(Object, Object)
@@ -76,6 +77,8 @@ public abstract class Graphs
      * @param <E> the graph edge type
      *
      * @return The newly created edge if added to the graph, otherwise {@code null}.
+     * 
+     * @throws NullPointerException if any one of the arguments is {@code null}
      */
     public static <V, E> E addEdgeWithVertices(Graph<V, E> g, V sourceVertex, V targetVertex)
     {
@@ -121,6 +124,8 @@ public abstract class Graphs
      * @param <E> the graph edge type
      *
      * @return The newly created edge if added to the graph, otherwise {@code null}.
+     * 
+     * @throws NullPointerException if any one of {@code g}, {@code sourceVertex}, or {@code targetVertex} is {@code null}
      */
     public static <V,
         E> E addEdgeWithVertices(Graph<V, E> g, V sourceVertex, V targetVertex, double weight)

--- a/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
@@ -233,7 +233,7 @@ public abstract class Graphs
      *
      * @return {@code true} if graph changed as a result of the call
      *
-     * @throws NullPointerException if the specified vertices contains one or more null vertices, or
+     * @throws NullPointerException if the specified vertices contains one or more {@code null} vertices, or
      *         if the specified vertex collection is {@code null}.
      *
      * @see Graph#addVertex(Object)

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/clique/CliqueMinimalSeparatorDecomposition.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/clique/CliqueMinimalSeparatorDecomposition.java
@@ -66,8 +66,7 @@ public class CliqueMinimalSeparatorDecomposition<V, E>
     private LinkedList<V> meo;
 
     /**
-     * List of all vertices that generate a minimal separator of <code>
-     * chordGraph</code>
+     * List of all vertices that generate a minimal separator of {@code chordGraph}
      */
     private List<V> generators;
 
@@ -87,8 +86,8 @@ public class CliqueMinimalSeparatorDecomposition<V, E>
     private Map<Set<V>, Integer> fullComponentCount = new HashMap<>();
 
     /**
-     * Setup a clique minimal separator decomposition on undirected graph <code>
-     * g</code>. Loops and multiple (parallel) edges are removed, i.e. the graph is transformed to a
+     * Setup a clique minimal separator decomposition on undirected graph {@code g}.
+     * Loops and multiple (parallel) edges are removed, i.e. the graph is transformed to a
      * simple graph.
      *
      * @param g The graph to decompose.
@@ -288,7 +287,7 @@ public class CliqueMinimalSeparatorDecomposition<V, E>
     }
 
     /**
-     * Check whether the subgraph of <code>graph</code> induced by the given <code>vertices</code>
+     * Check whether the subgraph of {@code graph} induced by the given {@code vertices}
      * is complete, i.e. a clique.
      *
      * @param graph the graph.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/color/ColorRefinementAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/color/ColorRefinementAlgorithm.java
@@ -26,7 +26,7 @@ import java.util.stream.*;
 
 /**
  * Color refinement algorithm that finds the coarsest stable coloring of a graph based on a given
- * <code>alpha</code> coloring as described in the following
+ * {@code alpha} coloring as described in the following
  * <a href="https://doi.org/10.1007/s00224-016-9686-0">paper</a>: C. Berkholz, P. Bonsma, and M.
  * Grohe. Tight lower and upper bounds for the complexity of canonical colour refinement. Theory of
  * Computing Systems, 60(4), p581--614, 2017.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/BiconnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/BiconnectivityInspector.java
@@ -218,7 +218,7 @@ public class BiconnectivityInspector<V, E>
      * method returns true if and only if the inspected graph is <i>weakly</i> connected. An empty
      * graph is <i>not</i> considered connected.
      *
-     * @return <code>true</code> if and only if inspected graph is connected.
+     * @return {@code true} if and only if inspected graph is connected.
      */
     public boolean isConnected()
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/BlockCutpointGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/BlockCutpointGraph.java
@@ -127,10 +127,10 @@ public class BlockCutpointGraph<V, E>
     }
 
     /**
-     * Returns <code>true</code> if the vertex is a cutpoint, <code>false</code> otherwise.
+     * Returns {@code true} if the vertex is a cutpoint, {@code false} otherwise.
      *
      * @param vertex vertex in the initial graph.
-     * @return <code>true</code> if the vertex is a cutpoint, <code>false</code> otherwise.
+     * @return {@code true} if the vertex is a cutpoint, {@code false} otherwise.
      */
     public boolean isCutpoint(V vertex)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/ConnectivityInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/ConnectivityInspector.java
@@ -77,7 +77,7 @@ public class ConnectivityInspector<V, E>
      * inspected graph is <i>weakly</i> connected. An empty graph is <i>not</i> considered
      * connected.
      *
-     * @return <code>true</code> if and only if inspected graph is connected.
+     * @return {@code true} if and only if inspected graph is connected.
      */
     public boolean isConnected()
     {
@@ -115,13 +115,13 @@ public class ConnectivityInspector<V, E>
     }
 
     /**
-     * Returns a list of <code>Set</code> s, where each set contains all vertices that are in the
+     * Returns a list of {@code Set} s, where each set contains all vertices that are in the
      * same maximally connected component. All graph vertices occur in exactly one set. For more on
      * maximally connected component, see
      * <a href="http://www.nist.gov/dads/HTML/maximallyConnectedComponent.html">
      * http://www.nist.gov/dads/HTML/maximallyConnectedComponent.html</a>.
      *
-     * @return Returns a list of <code>Set</code> s, where each set contains all vertices that are
+     * @return Returns a list of {@code Set} s, where each set contains all vertices that are
      *         in the same maximally connected component.
      */
     public List<Set<V>> connectedSets()
@@ -171,7 +171,7 @@ public class ConnectivityInspector<V, E>
      * @param sourceVertex one end of the path.
      * @param targetVertex another end of the path.
      *
-     * @return <code>true</code> if and only if the source and target vertex are in the same
+     * @return {@code true} if and only if the source and target vertex are in the same
      *         connected component (undirected graph), or in the same weakly connected component
      *         (directed graph).
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/AhujaOrlinSharmaCyclicExchangeLocalAugmentation.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/AhujaOrlinSharmaCyclicExchangeLocalAugmentation.java
@@ -38,7 +38,7 @@ import java.util.*;
  *
  * This algorithm returns the first or the best found negative subset-disjoint cycle. In the case of
  * the first found cycle, the cycle has minimum number of vertices. It may enumerate all paths up to
- * the length given by the parameter <code>lengthBound</code>, i.e the algorithm runs in exponential
+ * the length given by the parameter {@code lengthBound}, i.e the algorithm runs in exponential
  * time.
  *
  * This algorithm is used to detect valid cyclic exchanges in a cyclic exchange neighborhood for the
@@ -227,7 +227,7 @@ public class AhujaOrlinSharmaCyclicExchangeLocalAugmentation<V, E>
     }
 
     /**
-     * Checks whether <code>path</code> dominates the current minimal cost path with the same head,
+     * Checks whether {@code path} dominates the current minimal cost path with the same head,
      * tail and label set in the set of all paths of length k + 1. Thus, dominated paths are
      * eliminated. This is important out of efficiency reasons, otherwise many unnecessary paths may
      * be considered in further calculations.
@@ -235,7 +235,7 @@ public class AhujaOrlinSharmaCyclicExchangeLocalAugmentation<V, E>
      * @param path the currently calculated path
      * @param pathsLengthKplus1 all before calculated paths of length k + 1
      *
-     * @return whether <code>path</code> dominates the current minimal cost path with the same head,
+     * @return whether {@code path} dominates the current minimal cost path with the same head,
      *         tail and label set.
      */
     private boolean checkDominatedPathsOfLengthKplus1(
@@ -251,14 +251,14 @@ public class AhujaOrlinSharmaCyclicExchangeLocalAugmentation<V, E>
     }
 
     /**
-     * Checks whether <code>path</code> is dominated by some path in the previously calculated set
+     * Checks whether {@code path} is dominated by some path in the previously calculated set
      * of paths of length k. This is important out of efficiency reasons, otherwise many unnecessary
      * paths may be considered in further calculations.
      *
      * @param path the currently calculated path
      * @param pathsLengthK all previously calculated paths of length k
      *
-     * @return whether <code>path</code> is dominated by some path in <code>pathsLengthK</code>
+     * @return whether {@code path} is dominated by some path in {@code pathsLengthK}
      */
     private boolean checkDominatedPathsOfLengthK(
         LabeledPath<V> path, Map<PathSetKey<V>, LabeledPath<V>> pathsLengthK)
@@ -281,7 +281,7 @@ public class AhujaOrlinSharmaCyclicExchangeLocalAugmentation<V, E>
 
     /**
      * Adds a path and removes the path, which has the same tail, head and label set, to the data
-     * structure <code>paths</code>, which contains all paths indexed by their head, tail and label
+     * structure {@code paths}, which contains all paths indexed by their head, tail and label
      * set.
      *
      * @param paths the map of paths, which are indexed by head, tail and label set, to add the path

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/BergeGraphInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/BergeGraphInspector.java
@@ -1204,7 +1204,7 @@ public class BergeGraphInspector<V, E>
      * 
      * <p>
      * A certificate can be obtained through the {@link BergeGraphInspector#getCertificate} method,
-     * if <code>computeCertificate</code> is <code>true</code>.
+     * if {@code computeCertificate} is {@code true}.
      * <p>
      * Running this method takes $O(|V|^9)$, and computing the certificate takes $O(|V|^5)$.
      * 
@@ -1261,7 +1261,7 @@ public class BergeGraphInspector<V, E>
      * 
      * <p>
      * This method by default does not compute a certificate. For obtaining a certificate, call
-     * {@link BergeGraphInspector#isBerge} with <code>computeCertificate=true</code>.
+     * {@link BergeGraphInspector#isBerge} with {@code computeCertificate=true}.
      * <p>
      * Running this method takes $O(|V|^9)$.
      * 
@@ -1276,7 +1276,7 @@ public class BergeGraphInspector<V, E>
     /**
      * Returns the certificate in the form of a hole or anti-hole in the inspected graph, when the
      * {@link BergeGraphInspector#isBerge} method is previously called with
-     * <code>computeCertificate=true</code>. Returns null if the inspected graph is perfect.
+     * {@code computeCertificate=true}. Returns null if the inspected graph is perfect.
      *
      * @return a <a href="http://graphclasses.org/smallgraphs.html#holes">hole</a> or
      *         <a href="http://graphclasses.org/smallgraphs.html#antiholes">anti-hole</a> in the

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/DirectedSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/DirectedSimpleCycles.java
@@ -34,7 +34,7 @@ public interface DirectedSimpleCycles<V, E>
     /**
      * Find the simple cycles of the graph.
      *
-     * @return The list of all simple cycles. Possibly empty but never <code>null</code>.
+     * @return The list of all simple cycles. Possibly empty but never {@code null}.
      */
     default List<List<V>> findSimpleCycles()
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
@@ -74,8 +74,7 @@ public class HawickJamesSimpleCycles<V, E>
      *
      * @param graph the DirectedGraph in which to find cycles.
      *
-     * @throws IllegalArgumentException if the graph argument is <code>
-     * null</code>.
+     * @throws IllegalArgumentException if the graph argument is {@code null}.
      */
     public HawickJamesSimpleCycles(Graph<V, E> graph)
         throws IllegalArgumentException

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/JohnsonSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/JohnsonSimpleCycles.java
@@ -64,8 +64,7 @@ public class JohnsonSimpleCycles<V, E>
      *
      * @param graph - the DirectedGraph in which to find cycles.
      *
-     * @throws IllegalArgumentException if the graph argument is <code>
-     * null</code>.
+     * @throws IllegalArgumentException if the graph argument is {@code null}.
      */
     public JohnsonSimpleCycles(Graph<V, E> graph)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/PatonCycleBase.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/PatonCycleBase.java
@@ -53,7 +53,7 @@ public class PatonCycleBase<V, E>
      * Create a cycle base finder for the specified graph.
      *
      * @param graph the input graph
-     * @throws IllegalArgumentException if the graph argument is <code>null</code> or the graph is
+     * @throws IllegalArgumentException if the graph argument is {@code null} or the graph is
      *         not undirected
      */
     public PatonCycleBase(Graph<V, E> graph)

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/SzwarcfiterLauerSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/SzwarcfiterLauerSimpleCycles.java
@@ -67,8 +67,7 @@ public class SzwarcfiterLauerSimpleCycles<V, E>
      *
      * @param graph - the DirectedGraph in which to find cycles.
      *
-     * @throws IllegalArgumentException if the graph argument is <code>
-     * null</code>.
+     * @throws IllegalArgumentException if the graph argument is {@code null}.
      */
     public SzwarcfiterLauerSimpleCycles(Graph<V, E> graph)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/TarjanSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/TarjanSimpleCycles.java
@@ -59,8 +59,7 @@ public class TarjanSimpleCycles<V, E>
      *
      * @param graph - the DirectedGraph in which to find cycles.
      *
-     * @throws IllegalArgumentException if the graph argument is <code>
-     * null</code>.
+     * @throws IllegalArgumentException if the graph argument is {@code null}.
      */
     public TarjanSimpleCycles(Graph<V, E> graph)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/TiernanSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/TiernanSimpleCycles.java
@@ -52,8 +52,7 @@ public class TiernanSimpleCycles<V, E>
      *
      * @param graph - the DirectedGraph in which to find cycles.
      *
-     * @throws IllegalArgumentException if the graph argument is <code>
-     * null</code>.
+     * @throws IllegalArgumentException if the graph argument is {@code null}.
      */
     public TiernanSimpleCycles(Graph<V, E> graph)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
@@ -77,11 +77,10 @@ public final class EdmondsKarpMFImpl<V, E>
     private final ExtensionFactory<AnnotatedFlowEdge> edgeExtensionsFactory;
 
     /**
-     * Constructs <code>MaximumFlow</code> instance to work with <i>a copy of</i>
-     * <code>network</code>. Current source and sink are set to <code>null</code>. If
-     * <code>network</code> is weighted, then capacities are weights, otherwise all capacities are
-     * equal to one. Doubles are compared using <code>
-     * DEFAULT_EPSILON</code> tolerance.
+     * Constructs {@code MaximumFlow} instance to work with <i>a copy of</i>
+     * {@code network}. Current source and sink are set to {@code null}. If
+     * {@code network} is weighted, then capacities are weights, otherwise all capacities are
+     * equal to one. Doubles are compared using {@code DEFAULT_EPSILON} tolerance.
      *
      * @param network network, where maximum flow will be calculated
      */
@@ -91,9 +90,9 @@ public final class EdmondsKarpMFImpl<V, E>
     }
 
     /**
-     * Constructs <code>MaximumFlow</code> instance to work with <i>a copy of</i>
-     * <code>network</code>. Current source and sink are set to <code>null</code>. If
-     * <code>network</code> is weighted, then capacities are weights, otherwise all capacities are
+     * Constructs {@code MaximumFlow} instance to work with <i>a copy of</i>
+     * {@code network}. Current source and sink are set to {@code null}. If
+     * {@code network} is weighted, then capacities are weights, otherwise all capacities are
      * equal to one.
      *
      * @param network network, where maximum flow will be calculated
@@ -120,10 +119,10 @@ public final class EdmondsKarpMFImpl<V, E>
     }
 
     /**
-     * Sets current source to <code>source</code>, current sink to <code>sink</code>, then
-     * calculates maximum flow from <code>source</code> to <code>sink</code>. Note, that
-     * <code>source</code> and <code>sink</code> must be vertices of the <code>
-     * network</code> passed to the constructor, and they must be different.
+     * Sets current source to {@code source}, current sink to {@code sink}, then
+     * calculates maximum flow from {@code source} to {@code sink}. Note, that
+     * {@code source} and {@code sink} must be vertices of the {@code network}
+     * passed to the constructor, and they must be different.
      *
      * @param source source vertex
      * @param sink sink vertex
@@ -138,10 +137,10 @@ public final class EdmondsKarpMFImpl<V, E>
     }
 
     /**
-     * Sets current source to <code>source</code>, current sink to <code>sink</code>, then
-     * calculates maximum flow from <code>source</code> to <code>sink</code>. Note, that
-     * <code>source</code> and <code>sink</code> must be vertices of the <code>
-     * network</code> passed to the constructor, and they must be different. If desired, a flow map
+     * Sets current source to {@code source}, current sink to {@code sink}, then
+     * calculates maximum flow from {@code source} to {@code sink}. Note, that
+     * {@code source} and {@code sink} must be vertices of the {@code network}
+     * passed to the constructor, and they must be different. If desired, a flow map
      * can be queried afterwards; this will not require a new invocation of the algorithm.
      *
      * @param source source vertex

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/EdmondsKarpMFImpl.java
@@ -80,7 +80,7 @@ public final class EdmondsKarpMFImpl<V, E>
      * Constructs {@code MaximumFlow} instance to work with <i>a copy of</i>
      * {@code network}. Current source and sink are set to {@code null}. If
      * {@code network} is weighted, then capacities are weights, otherwise all capacities are
-     * equal to one. Doubles are compared using {@code DEFAULT_EPSILON} tolerance.
+     * equal to one. Doubles are compared using {@link #DEFAULT_EPSILON} tolerance.
      *
      * @param network network, where maximum flow will be calculated
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
@@ -323,8 +323,8 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
     }
 
     /**
-     * Returns current source vertex, or <code>null</code> if there was no <code>
-     * calculateMaximumFlow</code> calls.
+     * Returns current source vertex, or {@code null} if there was no
+     * {@code calculateMaximumFlow} calls.
      *
      * @return current source
      */
@@ -334,8 +334,8 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
     }
 
     /**
-     * Returns current sink vertex, or <code>null</code> if there was no <code>
-     * calculateMaximumFlow</code> calls.
+     * Returns current sink vertex, or {@code null} if there was no
+     * {@code calculateMaximumFlow} calls.
      *
      * @return current sink
      */
@@ -345,8 +345,8 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
     }
 
     /**
-     * Returns maximum flow value, that was calculated during last <code>
-     * calculateMaximumFlow</code> call.
+     * Returns maximum flow value, that was calculated during last
+     * {@code calculateMaximumFlow} call.
      *
      * @return maximum flow value
      */
@@ -356,9 +356,9 @@ public abstract class MaximumFlowAlgorithmBase<V, E>
     }
 
     /**
-     * Returns maximum flow, that was calculated during last <code>
-     * calculateMaximumFlow</code> call, or <code>null</code>, if there was no <code>
-     * calculateMaximumFlow</code> calls.
+     * Returns maximum flow, that was calculated during last
+     * {@code calculateMaximumFlow} call, or {@code null}, if there was no
+     * {@code calculateMaximumFlow} calls.
      *
      * @return <i>read-only</i> mapping from edges to doubles - flow values
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PadbergRaoOddMinimumCutset.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PadbergRaoOddMinimumCutset.java
@@ -113,10 +113,10 @@ public class PadbergRaoOddMinimumCutset<V, E>
      * The original algorithm runs on a compressed Gomory-Hu tree: a cut-tree with the odd vertices
      * as terminal vertices. This tree has $|T|-1$ edges as opposed to $|V|-1$ for a Gomory-Hu tree
      * defined on the input graph $G$. This compression step can however be skipped. If you want to
-     * run the original algorithm in the paper, set the parameter <code>useTreeCompression</code> to
+     * run the original algorithm in the paper, set the parameter {@code useTreeCompression} to
      * true. Alternatively, experiment which setting of this parameter produces the fastest results.
      * Both settings are guaranteed to find the optimal cut. Experiments on random graphs showed
-     * that setting <code>useTreeCompression</code> to false was on average a bit faster.
+     * that setting {@code useTreeCompression} to false was on average a bit faster.
      *
      * @param oddVertices Set of vertices which are labeled 'odd'. Note that the number of vertices
      *        in this set must be even!

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -219,10 +219,10 @@ public class PushRelabelMFImpl<V, E>
     }
 
     /**
-     * Sets current source to <code>source</code>, current sink to <code>sink</code>, then
-     * calculates maximum flow from <code>source</code> to <code>sink</code>. Note, that
-     * <code>source</code> and <code>sink</code> must be vertices of the <code>
-     * network</code> passed to the constructor, and they must be different.
+     * Sets current source to {@code source}, current sink to {@code sink}, then
+     * calculates maximum flow from {@code source} to {@code sink}. Note, that
+     * {@code source} and {@code sink} must be vertices of the {@code network}
+     * passed to the constructor, and they must be different.
      *
      * @param source source vertex
      * @param sink sink vertex

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java
@@ -53,7 +53,7 @@ public interface AStarAdmissibleHeuristic<V>
      *
      * @param graph graph to test heuristic on
      * @param <E> graph edges type
-     * @return true iff the heuristic is consistent wrt the {@code graph}, false otherwise
+     * @return {@code true} iff the heuristic is consistent wrt the {@code graph}, {@code false} otherwise
      */
     default <E> boolean isConsistent(Graph<V, E> graph)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java
@@ -46,7 +46,7 @@ public interface AStarAdmissibleHeuristic<V>
      * to the estimated distance from any neighboring vertex to the goal, plus the step cost of
      * reaching that neighbor. For details, refer to <a href=
      * "https://en.wikipedia.org/wiki/Consistent_heuristic">https://en.wikipedia.org/wiki/Consistent_heuristic</a>.
-     * In short, a heuristic is consistent iff <code>h(u)&le; d(u,v)+h(v)</code>, for every edge
+     * In short, a heuristic is consistent iff {@code h(u)&le; d(u,v)+h(v)}, for every edge
      * $(u,v)$, where $d(u,v)$ is the weight of edge $(u,v)$ and $h(u)$ is the estimated cost to
      * reach the target node from vertex u. Most natural admissible heuristics, such as Manhattan or
      * Euclidean distance, are consistent heuristics.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/CapacitatedSpanningTreeAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/CapacitatedSpanningTreeAlgorithm.java
@@ -59,16 +59,16 @@ public interface CapacitatedSpanningTreeAlgorithm<V, E>
     {
 
         /**
-         * Tests whether <code>cmst</code> is a CMST on <code>graph</code> with root
-         * <code>root</code>, capacity <code>capacity</code> and demand function
-         * <code>demands</code>.
+         * Tests whether {@code cmst} is a CMST on {@code graph} with root
+         * {@code root}, capacity {@code capacity} and demand function
+         * {@code demands}.
          *
          * @param graph the graph
          * @param root the expected root of cmst
          * @param capacity the expected capacity of cmst
          * @param demands the demand function
          *
-         * @return whether <code>cmst</code> is a CMST
+         * @return whether {@code cmst} is a CMST
          */
         boolean isCapacitatedSpanningTree(
             Graph<V, E> graph, V root, double capacity, Map<V, Double> demands);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MaximumFlowAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/MaximumFlowAlgorithm.java
@@ -35,8 +35,8 @@ public interface MaximumFlowAlgorithm<V, E>
 {
 
     /**
-     * Sets current source to <code>source</code>, current sink to <code>sink</code>, then
-     * calculates maximum flow from <code>source</code> to <code>sink</code>. Returns an object
+     * Sets current source to {@code source}, current sink to {@code sink}, then
+     * calculates maximum flow from {@code source} to {@code sink}. Returns an object
      * containing detailed information about the flow.
      *
      * @param source source of the flow inside the network
@@ -47,10 +47,10 @@ public interface MaximumFlowAlgorithm<V, E>
     MaximumFlow<E> getMaximumFlow(V source, V sink);
 
     /**
-     * Sets current source to <code>source</code>, current sink to <code>sink</code>, then
-     * calculates maximum flow from <code>source</code> to <code>sink</code>. Note, that
-     * <code>source</code> and <code>sink</code> must be vertices of the <code>
-     * network</code> passed to the constructor, and they must be different.
+     * Sets current source to {@code source}, current sink to {@code sink}, then
+     * calculates maximum flow from {@code source} to {@code sink}. Note, that
+     * {@code source} and {@code sink} must be vertices of the {@code network}
+     * passed to the constructor, and they must be different.
      *
      * @param source source vertex
      * @param sink sink vertex

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/PartitioningAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/PartitioningAlgorithm.java
@@ -68,7 +68,7 @@ public interface PartitioningAlgorithm<V>
          * @param index index of the partition to return
          * @return the index-th partition
          * @throws IndexOutOfBoundsException if the index is out of range
-         *         (<code>index &lt; 0 || index &gt;= getNumberPartitions()</code>)
+         *         ({@code index < 0 || index >= getNumberPartitions()})
          */
         Set<V> getPartition(int index);
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/StrongConnectivityAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/StrongConnectivityAlgorithm.java
@@ -50,7 +50,7 @@ public interface StrongConnectivityAlgorithm<V, E>
      * Computes a {@link List} of {@link Set}s, where each set contains vertices which together form
      * a strongly connected component within the given graph.
      *
-     * @return <code>List</code> of <code>Set</code> s containing the strongly connected components
+     * @return {@code List} of {@code Set} s containing the strongly connected components
      */
     List<Set<V>> stronglyConnectedSets();
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/ColorRefinementIsomorphismInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/ColorRefinementIsomorphismInspector.java
@@ -79,7 +79,7 @@ public class ColorRefinementIsomorphismInspector<V, E>
 
     /**
      * Constructor for a isomorphism inspector based on color refinement. It checks whether
-     * <code>graph1</code> and <code>graph2</code> are isomorphic.
+     * {@code graph1} and {@code graph2} are isomorphic.
      *
      * @param graph1 the first graph
      * @param graph2 the second graph
@@ -218,7 +218,7 @@ public class ColorRefinementIsomorphismInspector<V, E>
 
     /**
      * Checks whether two coarse colorings are equal. Furthermore, it sets
-     * <code>isColoringDiscrete</code> to true iff the colorings are discrete.
+     * {@code isColoringDiscrete} to true iff the colorings are discrete.
      *
      * @param coloring the coarse coloring of the union graph
      * @return if the given coarse colorings are equal
@@ -346,7 +346,7 @@ public class ColorRefinementIsomorphismInspector<V, E>
 
     /**
      * calculates the graph isomorphism as GraphMapping and assigns it to attribute
-     * <code>isomorphicGraphMapping</code>
+     * {@code isomorphicGraphMapping}
      *
      * @param coloring1 the discrete vertex coloring of graph1
      * @param coloring2 the discrete vertex coloring of graph2
@@ -384,7 +384,7 @@ public class ColorRefinementIsomorphismInspector<V, E>
     }
 
     /**
-     * Calculates and returns a disjoint graph union of <code>graph1</code> and <code>graph2</code>
+     * Calculates and returns a disjoint graph union of {@code graph1} and {@code graph2}
      *
      * @param graph1 the first graph of the disjoint union
      * @param graph2 the second graph of the disjoint union

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/PathValidator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/PathValidator.java
@@ -42,7 +42,7 @@ public interface PathValidator<V, E>
      * @param partialPath the path from source vertex up to the current vertex.
      * @param edge the new edge to be added to the path.
      *
-     * @return <code>true</code> if edge can be added, <code>false</code> otherwise.
+     * @return {@code true} if edge can be added, {@code false} otherwise.
      */
     public boolean isValidPath(GraphPath<V, E> partialPath, E edge);
 }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/AbstractCapacitatedMinimumSpanningTree.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/AbstractCapacitatedMinimumSpanningTree.java
@@ -145,7 +145,7 @@ public abstract class AbstractCapacitatedMinimumSpanningTree<V, E>
 
         /**
          * Constructs a new solution representation for the CMST problem based on
-         * <code>labels</code> and <code>partition</code>. All labels have to be positive.
+         * {@code labels} and {@code partition}. All labels have to be positive.
          *
          * @param labels the labels of the subsets in the partition
          * @param partition the partition map
@@ -197,8 +197,8 @@ public abstract class AbstractCapacitatedMinimumSpanningTree<V, E>
         }
 
         /**
-         * Moves <code>vertex</code> from the subset represented by <code>fromLabel</code> to the
-         * subset represented by <code>toLabel</code>.
+         * Moves {@code vertex} from the subset represented by {@code fromLabel} to the
+         * subset represented by {@code toLabel}.
          *
          * @param vertex the vertex to move
          * @param fromLabel the subset to move the vertex from
@@ -225,8 +225,8 @@ public abstract class AbstractCapacitatedMinimumSpanningTree<V, E>
         }
 
         /**
-         * Moves all vertices in <code>vertices</code> from the subset represented by
-         * <code>fromLabel</code> to the subset represented by <code>toLabel</code>.
+         * Moves all vertices in {@code vertices} from the subset represented by
+         * {@code fromLabel} to the subset represented by {@code toLabel}.
          *
          * @param vertices the vertices to move
          * @param fromLabel the subset to move the vertices from
@@ -259,9 +259,9 @@ public abstract class AbstractCapacitatedMinimumSpanningTree<V, E>
 
         /**
          * Refines the partition by adding new subsets if the designated root has more than one
-         * subtree in the subset <code>label</code> of the partition.
+         * subtree in the subset {@code label} of the partition.
          *
-         * @param vertexSubset the subset represented by <code>label</code>, that is the subset that
+         * @param vertexSubset the subset represented by {@code label}, that is the subset that
          *        has to be refined
          * @param label the label of the subset of the partition that were refined
          *
@@ -357,11 +357,11 @@ public abstract class AbstractCapacitatedMinimumSpanningTree<V, E>
         }
 
         /**
-         * Returns the label of the subset that contains <code>vertex</code>.
+         * Returns the label of the subset that contains {@code vertex}.
          *
          * @param vertex the vertex to return the label from
          *
-         * @return the label of <code>vertex</code>
+         * @return the label of {@code vertex}
          */
         public int getLabel(V vertex)
         {
@@ -379,11 +379,11 @@ public abstract class AbstractCapacitatedMinimumSpanningTree<V, E>
         }
 
         /**
-         * Returns the set of vertices that are in the subset with label <code>label</code>.
+         * Returns the set of vertices that are in the subset with label {@code label}.
          *
          * @param label the label of the subset to return the vertices from
          *
-         * @return the set of vertices that are in the subset with label <code>label</code>
+         * @return the set of vertices that are in the subset with label {@code label}
          */
         public Set<V> getPartitionSet(Integer label)
         {
@@ -392,12 +392,12 @@ public abstract class AbstractCapacitatedMinimumSpanningTree<V, E>
 
         /**
          * Returns the sum of the weights of all vertices that are in the subset with label
-         * <code>label</code>.
+         * {@code label}.
          *
          * @param label the label of the subset to return the weight from
          *
          * @return the sum of the weights of all vertices that are in the subset with label
-         *         <code>label</code>
+         *         {@code label}
          */
         public double getPartitionWeight(Integer label)
         {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/AhujaOrlinSharmaCapacitatedMinimumSpanningTree.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/AhujaOrlinSharmaCapacitatedMinimumSpanningTree.java
@@ -572,13 +572,13 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTree<V, E>
     }
 
     /**
-     * Calculates the subtree of <code>v</code> with respect to the MST given in
-     * <code>partitionSpanningTree</code>.
+     * Calculates the subtree of {@code v} with respect to the MST given in
+     * {@code partitionSpanningTree}.
      *
      * @param v the vertex to calculate the subtree for
      * @param partitionSpanningTree the map from labels to spanning trees of the partition.
-     * @return the subtree of <code>v</code> with respect to the MST given in
-     *         <code>partitionSpanningTree</code>.
+     * @return the subtree of {@code v} with respect to the MST given in
+     *         {@code partitionSpanningTree}.
      */
     private Pair<Set<V>, Double> subtree(
         CapacitatedSpanningTreeSolutionRepresentation currentSolution, Set<V> modifiableSet, V v,
@@ -832,7 +832,7 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTree<V, E>
 
         /**
          * Updates the improvement graph. It updates the vertices and edges in the parts specified
-         * in <code>labelsToUpdate</code>.
+         * in {@code labelsToUpdate}.
          *
          * @param currentSolution the current solution
          * @param subtrees the mapping from vertices to their subtree
@@ -946,17 +946,17 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTree<V, E>
         }
 
         /**
-         * Updates all nodes that correspond to <code>v1</code> and returns if the vertex
-         * <code>v1</code>. That is, all incident edges of <code>v1</code> are removed if
-         * <code>v1</code> is in the tabu list.
+         * Updates all nodes that correspond to {@code v1} and returns if the vertex
+         * {@code v1}. That is, all incident edges of {@code v1} are removed if
+         * {@code v1} is in the tabu list.
          *
          * @param tabuList the tabu list of the current iteration
          * @param v1 the vertex to update the nodes in the improvement graph for
          * @param vertexOfV1Single the node in the improvement graph representing the exchange of
-         *        the vertex <code>v1</code>
+         *        the vertex {@code v1}
          * @param vertexOfV1Subtree the node in the improvement graph representing the exchange of
-         *        the subtree rooted at <code>v1</code>
-         * @return true iff <code>v1</code> is in the tabu list
+         *        the subtree rooted at {@code v1}
+         * @return true iff {@code v1} is in the tabu list
          */
         private boolean updateTabuVertices(
             Set<V> tabuList, V v1, Pair<Integer, ImprovementGraphVertexType> vertexOfV1Single,
@@ -989,9 +989,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTree<V, E>
          *        multi-exchange operation)
          * @param v1 the vertex to update the nodes in the improvement graph for
          * @param vertexOfV1Single the node in the improvement graph representing the exchange of
-         *        the vertex <code>v1</code>
+         *        the vertex {@code v1}
          * @param vertexOfV1Subtree the node in the improvement graph representing the exchange of
-         *        the subtree rooted at <code>v1</code>
+         *        the subtree rooted at {@code v1}
          */
         private void updateOriginNodeConnections(
             CapacitatedSpanningTreeSolutionRepresentation currentSolution,
@@ -1057,8 +1057,8 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTree<V, E>
         }
 
         /**
-         * Updates all edges from <code>vertexOfV1Single</code> to nodes in the subset represented
-         * by <code>label</code>.
+         * Updates all edges from {@code vertexOfV1Single} to nodes in the subset represented
+         * by {@code label}.
          *
          * @param currentSolution the current solution in the iteration
          * @param subtrees the mapping from vertices to their subtree
@@ -1070,7 +1070,7 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTree<V, E>
          * @param pseudoVertex the pseudo vertex representing the subset represented by label
          * @param v1 the vertex to update the nodes in the improvement graph for
          * @param vertexOfV1Single the node in the improvement graph representing the exchange of
-         *        the vertex <code>v1</code>
+         *        the vertex {@code v1}
          */
         private void updateSingleNode(
             CapacitatedSpanningTreeSolutionRepresentation currentSolution,
@@ -1176,9 +1176,9 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTree<V, E>
         }
 
         /**
-         * Updates all edges from <code>vertexOfV1Single</code> to nodes in the subset represented
-         * by <code>label</code>. This method does adds the subtree of v1 to
-         * <code>modifiableSet</code>.
+         * Updates all edges from {@code vertexOfV1Single} to nodes in the subset represented
+         * by {@code label}. This method does adds the subtree of v1 to
+         * {@code modifiableSet}.
          *
          * @param currentSolution the current solution in the iteration
          * @param subtrees the mapping from vertices to their subtree
@@ -1189,7 +1189,7 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTree<V, E>
          * @param pseudoVertex the pseudo vertex representing the subset represented by label
          * @param v1 the vertex to update the nodes in the improvement graph for
          * @param vertexOfV1Subtree the node in the improvement graph representing the exchange of
-         *        the subtree rooted at <code>v1</code>
+         *        the subtree rooted at {@code v1}
          */
         private void updateSubtreeNode(
             CapacitatedSpanningTreeSolutionRepresentation currentSolution,
@@ -1295,19 +1295,19 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTree<V, E>
         }
 
         /**
-         * Adds an edge between <code>v1</code> and <code>v2</code> to the improvement graph if
-         * <code>newCapacity</code> does not exceed the capacity constraint. The weight of the edge
-         * is <code>newCost</code>.
+         * Adds an edge between {@code v1} and {@code v2} to the improvement graph if
+         * {@code newCapacity} does not exceed the capacity constraint. The weight of the edge
+         * is {@code newCost}.
          *
-         * @param v1 start vertex (the vertex or subtree induced by <code>v1</code> that will be
-         *        moved to the subset of <code>v2</code>)
-         * @param v2 end vertex (the vertex or subtree induced by <code>v2</code> that will be
-         *        removed from the subset of <code>v2</code>)
+         * @param v1 start vertex (the vertex or subtree induced by {@code v1} that will be
+         *        moved to the subset of {@code v2})
+         * @param v2 end vertex (the vertex or subtree induced by {@code v2} that will be
+         *        removed from the subset of {@code v2})
          * @param newCapacity the used capacity by adding the vertex or subtree induced by
-         *        <code>v1</code> to the subset of <code>v2</code> and deleting the vertex or
-         *        subtree induced by <code>v2</code>
+         *        {@code v1} to the subset of {@code v2} and deleting the vertex or
+         *        subtree induced by {@code v2}
          * @param newCost the cost of the edge (the cost induced by the operation induced by
-         *        <code>v1</code> and <code>v2</code>)
+         *        {@code v1} and {@code v2})
          */
         public void updateImprovementGraphEdge(
             Pair<Integer, ImprovementGraphVertexType> v1,
@@ -1327,14 +1327,14 @@ public class AhujaOrlinSharmaCapacitatedMinimumSpanningTree<V, E>
 
         /**
          * Calculates the maximum demand over all new subtrees induced by the minimum spanning tree
-         * <code>spanningTree</code>. A spanning tree induces more than one subset in the partition
+         * {@code spanningTree}. A spanning tree induces more than one subset in the partition
          * if the root vertex of the base graph connects more than one subtree of the spanning tree.
          *
-         * @param vertexSubset the vertex subset <code>spanning Tree is defined on</code>
+         * @param vertexSubset the vertex subset {@code spanning Tree is defined on}
          * @param spanningTree the spanning tree
          * @param totalDemand the total demand of the whole spanning tree
          * @return the maximum demand over all new subtrees induced by the minimum spanning tree
-         *         <code>spanningTree</code>
+         *         {@code spanningTree}
          */
         public double calculateMaximumDemandOfSubtrees(
             Set<V> vertexSubset, SpanningTreeAlgorithm.SpanningTree<E> spanningTree,

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/EsauWilliamsCapacitatedMinimumSpanningTree.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/EsauWilliamsCapacitatedMinimumSpanningTree.java
@@ -36,7 +36,7 @@ import java.util.*;
  * School of Management.
  * <p>
  * This version runs in polynomial time dependent on the number of considered operations per
- * iteration <code>numberOfOperationsParameter</code> (denoted by p), such that runs is in $O(|V|^3
+ * iteration {@code numberOfOperationsParameter} (denoted by p), such that runs is in $O(|V|^3
  * + p|V|) = O(|V|^3)$ since $p \leq |V|$.
  * <p>
  * A <a href="https://en.wikipedia.org/wiki/Capacitated_minimum_spanning_tree">Capacitated Minimum
@@ -255,10 +255,10 @@ public class EsauWilliamsCapacitatedMinimumSpanningTree<V, E>
     }
 
     /**
-     * Returns the list of the best options as stored in <code>savings</code>.
+     * Returns the list of the best options as stored in {@code savings}.
      *
      * @param savings the savings calculated in the algorithm (see getSolution())
-     * @return the list of the <code>numberOfOperationsParameter</code> best options
+     * @return the list of the {@code numberOfOperationsParameter} best options
      */
     private LinkedList<V> getListOfBestOptions(Map<V, Double> savings)
     {
@@ -290,8 +290,8 @@ public class EsauWilliamsCapacitatedMinimumSpanningTree<V, E>
     }
 
     /**
-     * Calculates the closest vertex to <code>vertex</code> such that the connection of
-     * <code>vertex</code> to the subtree of the closest vertex does not violate the capacity
+     * Calculates the closest vertex to {@code vertex} such that the connection of
+     * {@code vertex} to the subtree of the closest vertex does not violate the capacity
      * constraint and the savings are positive. Otherwise null is returned.
      *
      * @param vertex the vertex to find a valid closest vertex for

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
@@ -109,14 +109,14 @@ public class VertexDegreeComparator<V, E>
     }
 
     /**
-     * Compare the degrees of <code>v1</code> and <code>v2</code>, taking into account whether
+     * Compare the degrees of {@code v1} and {@code v2}, taking into account whether
      * ascending or descending order is used.
      *
      * @param v1 the first vertex to be compared.
      * @param v2 the second vertex to be compared.
      *
-     * @return -1 if <code>v1</code> comes before <code>v2</code>, +1 if <code>
-     * v1</code> comes after <code>v2</code>, 0 if equal.
+     * @return -1 if {@code v1} comes before {@code v2}, +1 if {@code v1}
+     *         comes after {@code v2}, 0 if equal.
      * @deprecated use {@link VertexDegreeComparator#of(Graph)}
      */
     @Override

--- a/jgrapht-core/src/main/java/org/jgrapht/event/VertexSetListener.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/event/VertexSetListener.java
@@ -22,8 +22,7 @@ import java.util.*;
 /**
  * A listener that is notified when the graph's vertex set changes. It should be used when
  * <i>only</i> notifications on vertex-set changes are of interest. If all graph notifications are
- * of interest better use <code>
- * GraphListener</code>.
+ * of interest better use {@code GraphListener}.
  *
  * @param <V> the graph vertex type
  *

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/ComplementGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/ComplementGraphGenerator.java
@@ -62,7 +62,7 @@ public class ComplementGraphGenerator<V, E>
     /**
      * Complement Graph Generator. If the target graph allows self-loops the complement of $G$ may
      * be defined by adding a self-loop to every vertex that does not have one in $G$. This behavior
-     * can be controlled using the boolean <code>generateSelfLoops</code>.
+     * can be controlled using the boolean {@code generateSelfLoops}.
      *
      * @param graph input graph
      * @param generateSelfLoops indicator whether self loops should be generated. If false, no

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/DirectedScaleFreeGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/DirectedScaleFreeGraphGenerator.java
@@ -171,7 +171,7 @@ public class DirectedScaleFreeGraphGenerator<V, E>
 
     /**
      * Constructs a Generator using a seed for the random number generator and sets the two
-     * relaxation options <code>allowingMultipleEdges</code> and <code>allowingSelfLoops</code>.
+     * relaxation options {@code allowingMultipleEdges} and {@code allowingSelfLoops}.
      * 
      * @param alpha The probability that the new edge is from a new vertex v to an existing vertex
      *        w, where w is chosen according to d_in + delta_in.
@@ -253,7 +253,7 @@ public class DirectedScaleFreeGraphGenerator<V, E>
 
     /**
      * Construct a new generator using the provided random number generator and sets the two
-     * relaxation options <code>allowingMultipleEdges</code> and <code>allowingSelfLoops</code>.
+     * relaxation options {@code allowingMultipleEdges} and {@code allowingSelfLoops}.
      * 
      * @param alpha The probability that the new edge is from a new vertex v to an existing vertex
      *        w, where w is chosen according to d_in + delta_in.

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/GraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/GraphGenerator.java
@@ -51,7 +51,7 @@ public interface GraphGenerator<V, E, T>
      * @throws UnsupportedOperationException if the graph does not have appropriate vertex and edge
      *         suppliers, in order to be able to create new vertices and edges. Methods
      *         {@link Graph#getEdgeSupplier()} and {@link Graph#getVertexSupplier()} must not return
-     *         <code>null</code>.
+     *         {@code null}.
      */
     void generateGraph(Graph<V, E> target, Map<String, T> resultMap);
 

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/ScaleFreeGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/ScaleFreeGraphGenerator.java
@@ -76,7 +76,7 @@ public class ScaleFreeGraphGenerator<V, E>
     }
 
     /**
-     * Generates scale-free network with <code>size</code> passed to the constructor.
+     * Generates scale-free network with {@code size} passed to the constructor.
      *
      * @param target receives the generated edges and vertices; if this is non-empty on entry, the
      *        result will be a disconnected graph since generated elements will not be connected to

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/WheelGraphGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/WheelGraphGenerator.java
@@ -61,7 +61,7 @@ public class WheelGraphGenerator<V, E>
      * Construct a new WheelGraphGenerator.
      *
      * @param size number of vertices to be generated.
-     * @param inwardSpokes if <code>true</code> and graph is directed, spokes are oriented from rim
+     * @param inwardSpokes if {@code true} and graph is directed, spokes are oriented from rim
      *        to hub; else from hub to rim.
      *
      * @throws IllegalArgumentException in case the number of vertices is negative

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -161,9 +161,9 @@ public abstract class AbstractBaseGraph<V, E>
      * <p>
      * In contrast with the {@link Supplier} interface, the edge supplier has the additional
      * requirement that a new and distinct result is returned every time it is invoked. More
-     * specifically for a new edge to be added in a graph <code>e</code> must <i>not</i> be equal to
+     * specifically for a new edge to be added in a graph {@code e} must <i>not</i> be equal to
      * any other edge in the graph (even if the graph allows edge-multiplicity). More formally, the
-     * graph must not contain any edge <code>e2</code> such that <code>e2.equals(e)</code>.
+     * graph must not contain any edge {@code e2} such that {@code e2.equals(e)}.
      * 
      * @param edgeSupplier the edge supplier
      */
@@ -189,9 +189,9 @@ public abstract class AbstractBaseGraph<V, E>
      * <p>
      * In contrast with the {@link Supplier} interface, the vertex supplier has the additional
      * requirement that a new and distinct result is returned every time it is invoked. More
-     * specifically for a new vertex to be added in a graph <code>v</code> must <i>not</i> be equal
+     * specifically for a new vertex to be added in a graph {@code v} must <i>not</i> be equal
      * to any other vertex in the graph. More formally, the graph must not contain any vertex
-     * <code>v2</code> such that <code>v2.equals(v)</code>.
+     * {@code v2} such that {@code v2.equals(v)}.
      * 
      * <p>
      * Care must also be taken when interchanging calls to methods {@link Graph#addVertex(Object)}

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractGraph.java
@@ -23,7 +23,7 @@ import org.jgrapht.util.*;
 import java.util.*;
 
 /**
- * A skeletal implementation of the <code>Graph</code> interface, to minimize the effort required to
+ * A skeletal implementation of the {@code Graph} interface, to minimize the effort required to
  * implement graph interfaces. This implementation is applicable to both: directed graphs and
  * undirected graphs.
  *
@@ -115,9 +115,9 @@ public abstract class AbstractGraph<V, E>
      *
      * @param v vertex
      *
-     * @return <code>true</code> if this assertion holds.
+     * @return {@code true} if this assertion holds.
      *
-     * @throws NullPointerException if specified vertex is <code>null</code>.
+     * @throws NullPointerException if specified vertex is {@code null}.
      * @throws IllegalArgumentException if specified vertex does not exist in this graph.
      */
     protected boolean assertVertexExist(V v)
@@ -138,7 +138,7 @@ public abstract class AbstractGraph<V, E>
      *
      * @param edges edges to be removed from this graph.
      *
-     * @return <code>true</code> if this graph changed as a result of the call.
+     * @return {@code true} if this graph changed as a result of the call.
      *
      * @see Graph#removeEdge(Object)
      * @see Graph#containsEdge(Object)
@@ -237,13 +237,13 @@ public abstract class AbstractGraph<V, E>
     }
 
     /**
-     * Indicates whether some other object is "equal to" this graph. Returns <code>true</code> if
+     * Indicates whether some other object is "equal to" this graph. Returns {@code true} if
      * the given object is also a graph, the two graphs are instances of the same graph class, have
      * identical vertices and edges sets with the same weights.
      *
      * @param obj object to be compared for equality with this graph
      *
-     * @return <code>true</code> if the specified object is equal to this graph
+     * @return {@code true} if the specified object is equal to this graph
      *
      * @see Object#equals(Object)
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsSubgraph.java
@@ -30,7 +30,7 @@ import java.util.stream.*;
  * base graph. More formally, a subgraph G(V,E) that is based on a base graph Gb(Vb,Eb) satisfies
  * the following <b><i>subgraph property</i></b>: V is a subset of Vb and E is a subset of Eb. Other
  * than this property, a subgraph is a graph with any respect and fully complies with the
- * <code>Graph</code> interface.
+ * {@code Graph} interface.
  *
  * <p>
  * If the base graph is a {@link org.jgrapht.ListenableGraph}, the subgraph listens on the base
@@ -61,8 +61,8 @@ import java.util.stream.*;
  * value-equal) to their respective ones in the base graph. Previous versions of this class enforced
  * such identity, at a severe performance cost. Currently it is no longer enforced. If you want to
  * achieve a "live-window" functionality, your safest tactics would be to NOT override the
- * <code>equals()</code> methods of your vertices and edges. If you use a class that has already
- * overridden the <code>equals()</code> method, such as <code>String</code>, then you can use a
+ * {@code equals()} methods of your vertices and edges. If you use a class that has already
+ * overridden the {@code equals()} method, such as {@code String}, then you can use a
  * wrapper around it, or else use it directly but exercise a great care to avoid having
  * different-but-equal instances in the subgraph and the base graph.
  * </p>
@@ -113,9 +113,9 @@ public class AsSubgraph<V, E>
      * Creates a new subgraph.
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     * @param vertexSubset vertices to include in the subgraph. If {@code null} then all
      *        vertices are included.
-     * @param edgeSubset edges to in include in the subgraph. If <code>null</code> then all the
+     * @param edgeSubset edges to in include in the subgraph. If {@code null} then all the
      *        edges whose vertices found in the graph are included.
      */
     public AsSubgraph(Graph<V, E> base, Set<? extends V> vertexSubset, Set<? extends E> edgeSubset)
@@ -139,7 +139,7 @@ public class AsSubgraph<V, E>
      * identical to the call Subgraph(base, vertexSubset, null).
      *
      * @param base the base (backing) graph on which the subgraph will be based.
-     * @param vertexSubset vertices to include in the subgraph. If <code>null</code> then all
+     * @param vertexSubset vertices to include in the subgraph. If {@code null} then all
      *        vertices are included.
      */
     public AsSubgraph(Graph<V, E> base, Set<? extends V> vertexSubset)
@@ -278,8 +278,7 @@ public class AsSubgraph<V, E>
      *
      * @param v the vertex to be added.
      *
-     * @return <code>true</code> if the vertex was added, otherwise <code>
-     * false</code>.
+     * @return {@code true} if the vertex was added, otherwise {@code false}.
      *
      * @throws NullPointerException if v is null
      * @throws IllegalArgumentException if the base graph does not contain the vertex

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsSubgraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsSubgraph.java
@@ -280,7 +280,7 @@ public class AsSubgraph<V, E>
      *
      * @return {@code true} if the vertex was added, otherwise {@code false}.
      *
-     * @throws NullPointerException if v is null
+     * @throws NullPointerException if v is {@code null}
      * @throws IllegalArgumentException if the base graph does not contain the vertex
      *
      * @see AsSubgraph

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUndirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUndirectedGraph.java
@@ -30,7 +30,7 @@ import java.util.*;
  * <a href="http://mathworld.wolfram.com/OrientedGraph.html">oriented graph</a>, then the view will
  * be a simple graph; otherwise, it will be a multigraph. Query operations on this graph "read
  * through" to the backing graph. Attempts to add edges will result in an
- * <code>UnsupportedOperationException</code>, but vertex addition/removal and edge removal are all
+ * {@code UnsupportedOperationException}, but vertex addition/removal and edge removal are all
  * supported (and immediately reflected in the backing graph).
  *
  * <p>
@@ -41,7 +41,7 @@ import java.util.*;
  *
  * <p>
  * This graph does <i>not</i> pass the hashCode and equals operations through to the backing graph,
- * but relies on <code>Object</code>'s <code>equals</code> and <code>hashCode</code> methods. This
+ * but relies on {@code Object}'s {@code equals} and {@code hashCode} methods. This
  * graph will be serializable if the backing graph is serializable.
  * </p>
  *

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUndirectedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUndirectedGraph.java
@@ -30,7 +30,7 @@ import java.util.*;
  * <a href="http://mathworld.wolfram.com/OrientedGraph.html">oriented graph</a>, then the view will
  * be a simple graph; otherwise, it will be a multigraph. Query operations on this graph "read
  * through" to the backing graph. Attempts to add edges will result in an
- * {@code UnsupportedOperationException}, but vertex addition/removal and edge removal are all
+ * {@link UnsupportedOperationException}, but vertex addition/removal and edge removal are all
  * supported (and immediately reflected in the backing graph).
  *
  * <p>

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnmodifiableGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnmodifiableGraph.java
@@ -26,7 +26,7 @@ import java.util.*;
  * An unmodifiable view of the backing graph specified in the constructor. This graph allows modules
  * to provide users with "read-only" access to internal graphs. Query operations on this graph "read
  * through" to the backing graph, and attempts to modify this graph result in an
- * {@code UnsupportedOperationException}.
+ * {@link UnsupportedOperationException}.
  *
  * <p>
  * This graph does <i>not</i> pass the hashCode and equals operations through to the backing graph,

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnmodifiableGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnmodifiableGraph.java
@@ -25,12 +25,12 @@ import java.util.*;
 /**
  * An unmodifiable view of the backing graph specified in the constructor. This graph allows modules
  * to provide users with "read-only" access to internal graphs. Query operations on this graph "read
- * through" to the backing graph, and attempts to modify this graph result in an <code>
- * UnsupportedOperationException</code>.
+ * through" to the backing graph, and attempts to modify this graph result in an
+ * {@code UnsupportedOperationException}.
  *
  * <p>
  * This graph does <i>not</i> pass the hashCode and equals operations through to the backing graph,
- * but relies on <code>Object</code>'s <code>equals</code> and <code>hashCode</code> methods. This
+ * but relies on {@code Object}'s {@code equals} and {@code hashCode} methods. This
  * graph will be serializable if the backing graph is serializable.
  * </p>
  *

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedGraph.java
@@ -26,10 +26,10 @@ import java.util.*;
  * Provides an unweighted view on a graph.
  *
  * Algorithms designed for unweighted graphs should also work on weighted graphs. This class
- * emulates an unweighted graph based on a weighted one by returning {@code Graph.DEFAULT_EDGE_WEIGHT}
+ * emulates an unweighted graph based on a weighted one by returning {@link Graph#DEFAULT_EDGE_WEIGHT}
  * for each edge weight. The underlying weighted graph is provided at the constructor.
  * Modifying operations (adding/removing vertexes/edges) are also passed through to the underlying
- * weighted graph. As edge weight, Graph.DEFAULT_EDGE_WEIGHT is used. Setting an edge weight is not
+ * weighted graph. As edge weight, {@link Graph#DEFAULT_EDGE_WEIGHT} is used. Setting an edge weight is not
  * supported. The edges are not modified. So, if an edge is asked for, the one from the underlying
  * weighted graph is returned. In case the underlying graph is serializable, this one is
  * serializable, too.
@@ -49,7 +49,7 @@ public class AsUnweightedGraph<V, E>
      * Constructor for AsUnweightedGraph.
      *
      * @param g the backing directed graph over which an undirected view is to be created.
-     * @throws NullPointerException if the graph is null
+     * @throws NullPointerException if the graph is {@link null}
      */
     public AsUnweightedGraph(Graph<V, E> g)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsUnweightedGraph.java
@@ -26,8 +26,8 @@ import java.util.*;
  * Provides an unweighted view on a graph.
  *
  * Algorithms designed for unweighted graphs should also work on weighted graphs. This class
- * emulates an unweighted graph based on a weighted one by returning <code>Graph.DEFAULT_EDGE_WEIGHT
- * </code> for each edge weight. The underlying weighted graph is provided at the constructor.
+ * emulates an unweighted graph based on a weighted one by returning {@code Graph.DEFAULT_EDGE_WEIGHT}
+ * for each edge weight. The underlying weighted graph is provided at the constructor.
  * Modifying operations (adding/removing vertexes/edges) are also passed through to the underlying
  * weighted graph. As edge weight, Graph.DEFAULT_EDGE_WEIGHT is used. Setting an edge weight is not
  * supported. The edges are not modified. So, if an edge is asked for, the one from the underlying

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
@@ -25,7 +25,7 @@ import java.util.function.*;
 
 /**
  * Provides a weighted view of a graph. The class stores edge weights internally.
- * All @link{getEdgeWeight} calls are handled by this view; all other graph operations are
+ * All {@link #getEdgeWeight()} calls are handled by this view; all other graph operations are
  * propagated to the graph backing this view.
  *
  * <p>
@@ -43,11 +43,11 @@ import java.util.function.*;
  * </ol>
  * In the first way, the map is used to lookup edge weights. In the second way, a function is
  * provided to calculate the weight of an edge. If the map does not contain a particular edge, or
- * the function does not provide a weight for a particular edge, the @link{getEdgeWeight} call is
+ * the function does not provide a weight for a particular edge, the {@link #getEdgeWeight(Object)} call is
  * propagated to the backing graph.
  *
- * Finally, the view provides a @link{setEdgeWeight} method. This method behaves differently
- * depending on how the view is constructed. See @link{setEdgeWeight} for details.
+ * Finally, the view provides a {@link #setEdgeWeight(Object, double)} method. This method behaves differently
+ * depending on how the view is constructed. See {@link #setEdgeWeight(Object, double)} for details.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
@@ -65,8 +65,8 @@ public class AsWeightedGraph<V, E>
 
     /**
      * Constructor for AsWeightedGraph where the weights are provided through a map. Invocations of
-     * the @link{setEdgeWeight} method will update the map. Moreover, calls to @link{setEdgeWeight}
-     * are propagated to the underlying graph.
+     * the {@link #setEdgeWeight(Object, double)} method will update the map. Moreover, calls to
+     * {@link #setEdgeWeight(Object, double)} are propagated to the underlying graph.
      *
      * @param graph the backing graph over which a weighted view is to be created.
      * @param weights the map containing the edge weights.
@@ -106,10 +106,10 @@ public class AsWeightedGraph<V, E>
      * the weight of an edge is queried, the weight function is invoked. If
      * {@code cacheWeights} is set to {@code true}, the weight of an edge returned by the
      * {@code weightFunction} after its first invocation is stored in a map. The weight of an
-     * edge returned by subsequent calls to @link{getEdgeWeight} for the same edge will then be
+     * edge returned by subsequent calls to {@link #getEdgeWeight(Object)} for the same edge will then be
      * retrieved directly from the map, instead of re-invoking the weight function. If
      * {@code cacheWeights} is set to {@code false}, each invocation of
-     * the @link{getEdgeWeight} method will invoke the weight function. Caching the edge weights is
+     * the {@link #getEdgeWeight(Object)} method will invoke the weight function. Caching the edge weights is
      * particularly useful when pre-computing all edge weights is expensive and it is expected that
      * the weights of only a subset of all edges will be queried.
      *
@@ -118,7 +118,7 @@ public class AsWeightedGraph<V, E>
      * @param cacheWeights if set to {@code true}, weights are cached once computed by the
      *        weight function
      * @param writeWeightsThrough if set to {@code true}, the weight set directly by
-     *        the @link{setEdgeWeight} method will be propagated to the backing graph.
+     *        the {@link #setEdgeWeight(Object, double)} method will be propagated to the backing graph.
      * @throws NullPointerException if the graph or the weight function is null
      * @throws IllegalArgumentException if {@code writeWeightsThrough} is set to true and
      *         {@code graph} is not a weighted graph
@@ -139,7 +139,7 @@ public class AsWeightedGraph<V, E>
 
     /**
      * Returns the weight assigned to a given edge. If weights are provided through a map, first a
-     * map lookup is performed. If the edge is not found, the @link{getEdgeWeight} method of the
+     * map lookup is performed. If the edge is not found, the {@link #getEdgeWeight(Object)} method of the
      * underlying graph is invoked instead. If, on the other hand, the weights are provided through
      * a function, this method will first attempt to lookup the weight of an edge in the cache (that
      * is, if {@code cacheWeights} is set to {@code true} in the constructor). If caching

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
@@ -84,10 +84,10 @@ public class AsWeightedGraph<V, E>
      * @param graph the backing graph over which an weighted view is to be created
      * @param weights the map containing the edge weights
      * @param writeWeightsThrough if set to true, the weights will get propagated to the backing
-     *        graph in the <code>setEdgeWeight()</code> method.
+     *        graph in the {@code setEdgeWeight()} method.
      * @throws NullPointerException if the graph or the weights are null
-     * @throws IllegalArgumentException if <code>writeWeightsThrough</code> is set to true and
-     *         <code>graph</code> is not a weighted graph
+     * @throws IllegalArgumentException if {@code writeWeightsThrough} is set to true and
+     *         {@code graph} is not a weighted graph
      */
     public AsWeightedGraph(Graph<V, E> graph, Map<E, Double> weights, boolean writeWeightsThrough)
     {
@@ -104,24 +104,24 @@ public class AsWeightedGraph<V, E>
     /**
      * Constructor for AsWeightedGraph which uses a weight function to compute edge weights. When
      * the weight of an edge is queried, the weight function is invoked. If
-     * <code>cacheWeights</code> is set to <code>true</code>, the weight of an edge returned by the
-     * <code>weightFunction</code> after its first invocation is stored in a map. The weight of an
+     * {@code cacheWeights} is set to {@code true}, the weight of an edge returned by the
+     * {@code weightFunction} after its first invocation is stored in a map. The weight of an
      * edge returned by subsequent calls to @link{getEdgeWeight} for the same edge will then be
      * retrieved directly from the map, instead of re-invoking the weight function. If
-     * <code>cacheWeights</code> is set to <code>false</code>, each invocation of
+     * {@code cacheWeights} is set to {@code false}, each invocation of
      * the @link{getEdgeWeight} method will invoke the weight function. Caching the edge weights is
      * particularly useful when pre-computing all edge weights is expensive and it is expected that
      * the weights of only a subset of all edges will be queried.
      *
      * @param graph the backing graph over which an weighted view is to be created
      * @param weightFunction function which maps an edge to a weight
-     * @param cacheWeights if set to <code>true</code>, weights are cached once computed by the
+     * @param cacheWeights if set to {@code true}, weights are cached once computed by the
      *        weight function
-     * @param writeWeightsThrough if set to <code>true</code>, the weight set directly by
+     * @param writeWeightsThrough if set to {@code true}, the weight set directly by
      *        the @link{setEdgeWeight} method will be propagated to the backing graph.
      * @throws NullPointerException if the graph or the weight function is null
-     * @throws IllegalArgumentException if <code>writeWeightsThrough</code> is set to true and
-     *         <code>graph</code> is not a weighted graph
+     * @throws IllegalArgumentException if {@code writeWeightsThrough} is set to true and
+     *         {@code graph} is not a weighted graph
      */
     public AsWeightedGraph(
         Graph<V, E> graph, Function<E, Double> weightFunction, boolean cacheWeights,
@@ -142,7 +142,7 @@ public class AsWeightedGraph<V, E>
      * map lookup is performed. If the edge is not found, the @link{getEdgeWeight} method of the
      * underlying graph is invoked instead. If, on the other hand, the weights are provided through
      * a function, this method will first attempt to lookup the weight of an edge in the cache (that
-     * is, if <code>cacheWeights</code> is set to <code>true</code> in the constructor). If caching
+     * is, if {@code cacheWeights} is set to {@code true} in the constructor). If caching
      * was disabled, or the edge could not be found in the cache, the weight function is invoked. If
      * the function does not provide a weight for a given edge, the call is again propagated to the
      * underlying graph.
@@ -172,9 +172,9 @@ public class AsWeightedGraph<V, E>
     }
 
     /**
-     * Assigns a weight to an edge. If <code>writeWeightsThrough</code> is set to <code>true</code>,
+     * Assigns a weight to an edge. If {@code writeWeightsThrough} is set to {@code true},
      * the same weight is set in the backing graph. If this class was constructed using a weight
-     * function, it only makes sense to invoke this method when <code>cacheWeights</code> is set to
+     * function, it only makes sense to invoke this method when {@code cacheWeights} is set to
      * true. This method can then be used to preset weights in the cache, or to overwrite existing
      * values.
      *

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
@@ -119,7 +119,7 @@ public class AsWeightedGraph<V, E>
      *        weight function
      * @param writeWeightsThrough if set to {@code true}, the weight set directly by
      *        the {@link #setEdgeWeight(Object, double)} method will be propagated to the backing graph.
-     * @throws NullPointerException if the graph or the weight function is null
+     * @throws NullPointerException if the graph or the weight function is {@link null}
      * @throws IllegalArgumentException if {@code writeWeightsThrough} is set to true and
      *         {@code graph} is not a weighted graph
      */
@@ -149,7 +149,7 @@ public class AsWeightedGraph<V, E>
      *
      * @param e edge of interest
      * @return the edge weight
-     * @throws NullPointerException if the edge is null
+     * @throws NullPointerException if the edge is {@link null}
      */
     @Override
     public double getEdgeWeight(E e)

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphMapping.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphMapping.java
@@ -22,10 +22,9 @@ import org.jgrapht.*;
 import java.util.*;
 
 /**
- * Implementation of the GraphMapping interface. The performance of <code>
- * getVertex/EdgeCorrespondence</code> is based on the performance of the concrete Map class which
- * is passed in the constructor. For example, using {@link HashMap} will provide expected $O(1)$
- * performance.
+ * Implementation of the GraphMapping interface. The performance of {@code  getVertex/EdgeCorrespondence}
+ * is based on the performance of the concrete Map class which is passed in the constructor. For example,
+ * using {@link HashMap} will provide expected $O(1)$ performance.
  *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultListenableGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultListenableGraph.java
@@ -25,13 +25,13 @@ import java.util.*;
 
 /**
  * A graph backed by the the graph specified at the constructor, which can be listened by
- * <code>GraphListener</code> s and by <code>
- * VertexSetListener</code> s. Operations on this graph "pass through" to the to the backing graph.
+ * {@code GraphListener} s and by {@code  VertexSetListener} s. Operations on this graph
+ * "pass through" to the to the backing graph.
  * Any modification made to this graph or the backing graph is reflected by the other.
  *
  * <p>
  * This graph does <i>not</i> pass the hashCode and equals operations through to the backing graph,
- * but relies on <code>Object</code>'s <code>equals</code> and <code>hashCode</code> methods.
+ * but relies on {@code Object}'s {@code equals} and {@code hashCode} methods.
  * </p>
  *
  * @param <V> the graph vertex type
@@ -64,8 +64,8 @@ public class DefaultListenableGraph<V, E>
     }
 
     /**
-     * Creates a new listenable graph. If the <code>reuseEvents</code> flag is set to
-     * <code>true</code> this class will reuse previously fired events and will not create a new
+     * Creates a new listenable graph. If the {@code reuseEvents} flag is set to
+     * {@code true} this class will reuse previously fired events and will not create a new
      * object for each event. This option increases performance but should be used with care,
      * especially in multithreaded environment.
      *
@@ -89,7 +89,7 @@ public class DefaultListenableGraph<V, E>
     }
 
     /**
-     * If the <code>reuseEvents</code> flag is set to <code>true</code> this class will reuse
+     * If the {@code reuseEvents} flag is set to {@code true} this class will reuse
      * previously fired events and will not create a new object for each event. This option
      * increases performance but should be used with care, especially in multithreaded environment.
      *
@@ -102,12 +102,12 @@ public class DefaultListenableGraph<V, E>
     }
 
     /**
-     * Tests whether the <code>reuseEvents</code> flag is set. If the flag is set to
-     * <code>true</code> this class will reuse previously fired events and will not create a new
+     * Tests whether the {@code reuseEvents} flag is set. If the flag is set to
+     * {@code true} this class will reuse previously fired events and will not create a new
      * object for each event. This option increases performance but should be used with care,
      * especially in multithreaded environment.
      *
-     * @return the value of the <code>reuseEvents</code> flag.
+     * @return the value of the {@code reuseEvents} flag.
      */
     public boolean isReuseEvents()
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/GraphDelegator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/GraphDelegator.java
@@ -30,7 +30,7 @@ import java.util.function.*;
  *
  * <p>
  * This graph does <i>not</i> pass the hashCode and equals operations through to the backing graph,
- * but relies on <code>Object</code>'s <code>equals</code> and <code>hashCode</code> methods.
+ * but relies on {@code Object}'s {@code equals} and {@code hashCode} methods.
  * </p>
  *
  * <p>

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/concurrent/AsSynchronizedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/concurrent/AsSynchronizedGraph.java
@@ -41,10 +41,10 @@ import java.util.stream.*;
  *
  * <p>
  * For all methods returning a Set, the Graph guarantees that all operations on the returned Set do
- * not affect the backing Graph. For <code>edgeSet</code> and <code>vertexSet</code> methods, the
+ * not affect the backing Graph. For {@code edgeSet} and {@code vertexSet} methods, the
  * returned Set is backed by the underlying graph, but when a traversal over the set is started via
  * a method such as iterator(), a snapshot of the underlying Set is copied for iteration purposes.
- * For <code>edgesOf</code>, <code>incomingEdgesOf</code> and <code>outgoingEdgesOf</code> methods,
+ * For {@code edgesOf}, {@code incomingEdgesOf} and {@code outgoingEdgesOf} methods,
  * the returned Set is a unmodifiable copy of the result produced by the underlying Graph. Users can
  * control whether those copies should be cached; caching may significantly increase memory
  * requirements. If users decide to cache those copies and the backing graph's changes don't affect
@@ -555,10 +555,10 @@ public class AsSynchronizedGraph<V, E>
     }
 
     /**
-     * Return whether the graph uses cache for <code>edgesOf</code>, <code>incomingEdgesOf</code>
-     * and <code>outgoingEdgesOf</code> methods.
+     * Return whether the graph uses cache for {@code edgesOf}, {@code incomingEdgesOf}
+     * and {@code outgoingEdgesOf} methods.
      * 
-     * @return <code>true</code> if cache is in use, <code>false</code> if cache is not in use.
+     * @return {@code true} if cache is in use, {@code false} if cache is not in use.
      */
     public boolean isCacheEnabled()
     {
@@ -573,7 +573,7 @@ public class AsSynchronizedGraph<V, E>
     /**
      * Return whether copyless mode is used for collection-returning methods.
      * 
-     * @return <code>true</code> if the graph uses copyless mode, <code>false</code> otherwise
+     * @return {@code true} if the graph uses copyless mode, {@code false} otherwise
      */
     public boolean isCopyless()
     {
@@ -581,10 +581,10 @@ public class AsSynchronizedGraph<V, E>
     }
 
     /**
-     * Set the cache strategy for <code>edgesOf</code>, <code>incomingEdgesOf</code> and
-     * <code>outgoingEdgesOf</code> methods.
+     * Set the cache strategy for {@code edgesOf}, {@code incomingEdgesOf} and
+     * {@code outgoingEdgesOf} methods.
      *
-     * @param cacheEnabled a flag whether to use cache for those methods, if <code>true</code>,
+     * @param cacheEnabled a flag whether to use cache for those methods, if {@code true},
      *        cache will be used for those methods, otherwise cache will not be used.
      * @return the AsSynchronizedGraph
      */
@@ -665,7 +665,7 @@ public class AsSynchronizedGraph<V, E>
     /**
      * Return whether fair mode is used for synchronizing access to this graph.
      * 
-     * @return <code>true</code> if the graph uses fair mode, <code>false</code> if non-fair mode
+     * @return {@code true} if the graph uses fair mode, {@code false} if non-fair mode
      */
     public boolean isFair()
     {
@@ -746,7 +746,7 @@ public class AsSynchronizedGraph<V, E>
         /**
          * Return whether copyless mode is used for iteration.
          * 
-         * @return <code>true</code> if the set uses copyless mode, <code>false</code> otherwise
+         * @return {@code true} if the set uses copyless mode, {@code false} otherwise
          */
         public boolean isCopyless()
         {
@@ -928,9 +928,9 @@ public class AsSynchronizedGraph<V, E>
         }
 
         /**
-         * Creates a <Code>Spliterator</code> over the elements in the set's unmodifiable copy.
+         * Creates a {@code Spliterator} over the elements in the set's unmodifiable copy.
          *
-         * @return a <code>Spliterator</code> over the elements in the backing set's unmodifiable
+         * @return a {@code Spliterator} over the elements in the backing set's unmodifiable
          *         copy.
          */
         @Override
@@ -940,10 +940,10 @@ public class AsSynchronizedGraph<V, E>
         }
 
         /**
-         * Return a sequential <code>Stream</code> with the backing set's unmodifiable copy as its
+         * Return a sequential {@code Stream} with the backing set's unmodifiable copy as its
          * source.
          * 
-         * @return a sequential <code>Stream</code> with the backing set's unmodifiable copy as its
+         * @return a sequential {@code Stream} with the backing set's unmodifiable copy as its
          *         source.
          */
         @Override
@@ -953,10 +953,10 @@ public class AsSynchronizedGraph<V, E>
         }
 
         /**
-         * Return a possibly parallel <code>Stream</code> with the backing set's unmodifiable copy
+         * Return a possibly parallel {@code Stream} with the backing set's unmodifiable copy
          * as its source.
          * 
-         * @return a possibly parallel <code>Stream</code> with the backing set's unmodifiable copy
+         * @return a possibly parallel {@code Stream} with the backing set's unmodifiable copy
          *         as its source.
          */
         @Override
@@ -969,7 +969,7 @@ public class AsSynchronizedGraph<V, E>
          * Compares the specified object with this set for equality.
          * 
          * @param o object to be compared for equality with this set.
-         * @return <code>true</code> if o and this set are the same object or o is equal to the
+         * @return {@code true} if o and this set are the same object or o is equal to the
          *         backing object, false otherwise.
          */
         @Override
@@ -1056,8 +1056,8 @@ public class AsSynchronizedGraph<V, E>
     }
 
     /**
-     * An interface for cache strategy of AsSynchronizedGraph's <code>edgesOf</code>,
-     * <code>incomingEdgesOf</code> and <code>outgoingEdgesOf</code> methods.
+     * An interface for cache strategy of AsSynchronizedGraph's {@code edgesOf},
+     * {@code incomingEdgesOf} and {@code outgoingEdgesOf} methods.
      */
     private interface CacheStrategy<V, E>
     {
@@ -1104,17 +1104,17 @@ public class AsSynchronizedGraph<V, E>
         boolean removeVertex(V v);
 
         /**
-         * Return whether the graph uses cache for <code>edgesOf</code>,
-         * <code>incomingEdgesOf</code> and <code>outgoingEdgesOf</code> methods.
+         * Return whether the graph uses cache for {@code edgesOf},
+         * {@code incomingEdgesOf} and {@code outgoingEdgesOf} methods.
          * 
-         * @return <code>true</code> if cache is in use, <code>false</code> if cache is not in use.
+         * @return {@code true} if cache is in use, {@code false} if cache is not in use.
          */
         boolean isCacheEnabled();
     }
 
     /**
-     * Don't use cache for AsSynchronizedGraph's <code>edgesOf</code>, <code>incomingEdgesOf</code>
-     * and <code>outgoingEdgesOf</code> methods.
+     * Don't use cache for AsSynchronizedGraph's {@code edgesOf}, {@code incomingEdgesOf}
+     * and {@code outgoingEdgesOf} methods.
      */
     private class NoCache
         implements CacheStrategy<V, E>, Serializable
@@ -1204,7 +1204,7 @@ public class AsSynchronizedGraph<V, E>
     }
 
     /**
-     * Disable cache as per <code>NoCache</code>, and also don't produce copies; instead, just
+     * Disable cache as per {@code NoCache}, and also don't produce copies; instead, just
      * directly return the results from the underlying graph. This requires the caller to explicitly
      * synchronize iterations over these collections.
      */
@@ -1242,8 +1242,8 @@ public class AsSynchronizedGraph<V, E>
     }
 
     /**
-     * Use cache for AsSynchronizedGraph's <code>edgesOf</code>, <code>incomingEdgesOf</code> and
-     * <code>outgoingEdgesOf</code> methods.
+     * Use cache for AsSynchronizedGraph's {@code edgesOf}, {@code incomingEdgesOf} and
+     * {@code outgoingEdgesOf} methods.
      */
     private class CacheAccess
         implements CacheStrategy<V, E>, Serializable
@@ -1457,7 +1457,7 @@ public class AsSynchronizedGraph<V, E>
         /**
          * Return whether a cache will be used for the synchronized graph being built.
          *
-         * @return <code>true</code> if cache will be used, <code>false</code> if cache will not be
+         * @return {@code true} if cache will be used, {@code false} if cache will not be
          *         used
          */
         public boolean isCacheEnable()
@@ -1490,7 +1490,7 @@ public class AsSynchronizedGraph<V, E>
         /**
          * Return whether copyless mode will be used for the synchronized graph being built.
          *
-         * @return <code>true</code> if constructed as copyless, <code>false</code> otherwise
+         * @return {@code true} if constructed as copyless, {@code false} otherwise
          */
         public boolean isCopyless()
         {
@@ -1522,7 +1522,7 @@ public class AsSynchronizedGraph<V, E>
         /**
          * Return whether fair mode will be used for the synchronized graph being built.
          *
-         * @return <code>true</code> if constructed as fair mode, <code>false</code> if non-fair
+         * @return {@code true} if constructed as fair mode, {@code false} if non-fair
          */
         public boolean isFair()
         {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/Specifics.java
@@ -48,8 +48,8 @@ public interface Specifics<V, E>
 
     /**
      * Returns a set of all edges connecting source vertex to target vertex if such vertices exist
-     * in this graph. If any of the vertices does not exist or is <code>null</code>, returns
-     * <code>null</code>. If both vertices exist but no edges found, returns an empty set.
+     * in this graph. If any of the vertices does not exist or is {@code null}, returns
+     * {@code null}. If both vertices exist but no edges found, returns an empty set.
      *
      * @param sourceVertex source vertex of the edge.
      * @param targetVertex target vertex of the edge.
@@ -60,8 +60,8 @@ public interface Specifics<V, E>
 
     /**
      * Returns an edge connecting source vertex to target vertex if such vertices and such edge
-     * exist in this graph. Otherwise returns <code>
-     * null</code>. If any of the specified vertices is <code>null</code> returns <code>null</code>
+     * exist in this graph. Otherwise returns {@code null}.
+     * If any of the specified vertices is {@code null} returns {@code null}
      *
      * <p>
      * In undirected graphs, the returned edge may have its source and target vertices in the

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/AbstractGraphIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/AbstractGraphIterator.java
@@ -75,7 +75,7 @@ public abstract class AbstractGraphIterator<V, E>
      * Sets the cross component traversal flag - indicates whether to traverse the graph across
      * connected components.
      *
-     * @param crossComponentTraversal if <code>true</code> traverses across connected components.
+     * @param crossComponentTraversal if {@code true} traverses across connected components.
      */
     public void setCrossComponentTraversal(boolean crossComponentTraversal)
     {
@@ -85,8 +85,8 @@ public abstract class AbstractGraphIterator<V, E>
     /**
      * Test whether this iterator is set to traverse the graph across connected components.
      *
-     * @return <code>true</code> if traverses across connected components, otherwise
-     *         <code>false</code>.
+     * @return {@code true} if traverses across connected components, otherwise
+     *         {@code false}.
      */
     @Override
     public boolean isCrossComponentTraversal()

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/BreadthFirstIterator.java
@@ -52,7 +52,7 @@ public class BreadthFirstIterator<V, E>
     /**
      * Creates a new breadth-first iterator for the specified graph. Iteration will start at the
      * specified start vertex and will be limited to the connected component that includes that
-     * vertex. If the specified start vertex is <code>null</code>, iteration will start at an
+     * vertex. If the specified start vertex is {@code null}, iteration will start at an
      * arbitrary vertex and will not be limited, that is, will be able to traverse all the graph.
      *
      * @param g the graph to be iterated.
@@ -66,7 +66,7 @@ public class BreadthFirstIterator<V, E>
     /**
      * Creates a new breadth-first iterator for the specified graph. Iteration will start at the
      * specified start vertices and will be limited to the connected component that includes those
-     * vertices. If the specified start vertices is <code>null</code>, iteration will start at an
+     * vertices. If the specified start vertices is {@code null}, iteration will start at an
      * arbitrary vertex and will not be limited, that is, will be able to traverse all the graph.
      *
      * @param g the graph to be iterated.

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/ClosestFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/ClosestFirstIterator.java
@@ -60,7 +60,7 @@ public class ClosestFirstIterator<V, E>
     /**
      * Creates a new closest-first iterator for the specified graph. Iteration will start at the
      * specified start vertex and will be limited to the connected component that includes that
-     * vertex. If the specified start vertex is <code>null</code>, iteration will start at an
+     * vertex. If the specified start vertex is {@code null}, iteration will start at an
      * arbitrary vertex and will not be limited, that is, will be able to traverse all the graph.
      *
      * @param g the graph to be iterated.
@@ -91,8 +91,7 @@ public class ClosestFirstIterator<V, E>
      * Creates a new radius-bounded closest-first iterator for the specified graph. Iteration will
      * start at the specified start vertex and will be limited to the subset of the connected
      * component which includes that vertex and is reachable via paths of weighted length less than
-     * or equal to the specified radius. The specified start vertex may not be <code>
-     * null</code>.
+     * or equal to the specified radius. The specified start vertex may not be {@code null}.
      *
      * @param g the graph to be iterated.
      * @param startVertex the vertex iteration to be started.
@@ -110,8 +109,8 @@ public class ClosestFirstIterator<V, E>
      * Creates a new radius-bounded closest-first iterator for the specified graph. Iteration will
      * start at the specified start vertex and will be limited to the subset of the connected
      * component which includes that vertex and is reachable via paths of weighted length less than
-     * or equal to the specified radius. The specified start vertex may not be <code>
-     * null</code>. This algorithm will use the heap supplied by the {@code heapSupplier}.
+     * or equal to the specified radius. The specified start vertex may not be {@code null}.
+     * This algorithm will use the heap supplied by the {@code heapSupplier}.
      *
      * @param g the graph to be iterated.
      * @param startVertex the vertex iteration to be started.
@@ -132,7 +131,7 @@ public class ClosestFirstIterator<V, E>
      * Creates a new radius-bounded closest-first iterator for the specified graph. Iteration will
      * start at the specified start vertices and will be limited to the subset of the graph
      * reachable from those vertices via paths of weighted length less than or equal to the
-     * specified radius. The specified collection of start vertices may not be <code>null</code>.
+     * specified radius. The specified collection of start vertices may not be {@code null}.
      * Iteration order is based on minimum distance from any of the start vertices, regardless of
      * the order in which the start vertices are supplied. Because of this, the entire traversal is
      * treated as if it were over a single connected component with respect to events fired.
@@ -151,7 +150,7 @@ public class ClosestFirstIterator<V, E>
      * Creates a new radius-bounded closest-first iterator for the specified graph. Iteration will
      * start at the specified start vertices and will be limited to the subset of the graph
      * reachable from those vertices via paths of weighted length less than or equal to the
-     * specified radius. The specified collection of start vertices may not be <code>null</code>.
+     * specified radius. The specified collection of start vertices may not be {@code null}.
      * Iteration order is based on minimum distance from any of the start vertices, regardless of
      * the order in which the start vertices are supplied. Because of this, the entire traversal is
      * treated as if it were over a single connected component with respect to events fired. This

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
@@ -83,14 +83,14 @@ public abstract class CrossComponentIterator<V, E, D>
 
     /**
      * Creates a new iterator for the specified graph. Iteration will start at the specified start
-     * vertex. If the specified start vertex is <code>
-     * null</code>, Iteration will start at an arbitrary graph vertex.
+     * vertex. If the specified start vertex is {@code null},
+     * Iteration will start at an arbitrary graph vertex.
      *
      * @param g the graph to be iterated.
      * @param startVertex the vertex iteration to be started.
      *
-     * @throws IllegalArgumentException if <code>g==null</code> or does not contain
-     *         <code>startVertex</code>
+     * @throws IllegalArgumentException if {@code g==null} or does not contain
+     *         {@code startVertex}
      */
     public CrossComponentIterator(Graph<V, E> g, V startVertex)
     {
@@ -99,14 +99,14 @@ public abstract class CrossComponentIterator<V, E, D>
 
     /**
      * Creates a new iterator for the specified graph. Iteration will start at the specified start
-     * vertices. If the specified start vertices is <code>
-     * null</code>, Iteration will start at an arbitrary graph vertex.
+     * vertices. If the specified start vertices is {@code null},
+     * Iteration will start at an arbitrary graph vertex.
      *
      * @param g the graph to be iterated.
      * @param startVertices the vertices iteration to be started.
      *
-     * @throws IllegalArgumentException if <code>g==null</code> or does not contain
-     *         <code>startVertex</code>
+     * @throws IllegalArgumentException if {@code g==null} or does not contain
+     *         {@code startVertex}
      */
     public CrossComponentIterator(Graph<V, E> g, Iterable<V> startVertices)
     {
@@ -218,11 +218,11 @@ public abstract class CrossComponentIterator<V, E, D>
     }
 
     /**
-     * Returns <code>true</code> if there are no more uniterated vertices in the currently iterated
-     * connected component; <code>false</code> otherwise.
+     * Returns {@code true} if there are no more uniterated vertices in the currently iterated
+     * connected component; {@code false} otherwise.
      *
-     * @return <code>true</code> if there are no more uniterated vertices in the currently iterated
-     *         connected component; <code>false</code> otherwise.
+     * @return {@code true} if there are no more uniterated vertices in the currently iterated
+     *         connected component; {@code false} otherwise.
      */
     protected abstract boolean isConnectedComponentExhausted();
 
@@ -236,7 +236,7 @@ public abstract class CrossComponentIterator<V, E, D>
     protected abstract void encounterVertex(V vertex, E edge);
 
     /**
-     * Returns the vertex to be returned in the following call to the iterator <code>next</code>
+     * Returns the vertex to be returned in the following call to the iterator {@code next}
      * method.
      *
      * @return the next vertex to be returned by this iterator.
@@ -248,10 +248,9 @@ public abstract class CrossComponentIterator<V, E, D>
      *
      * @param vertex a vertex which has already been seen.
      *
-     * @return data associated with the seen vertex or <code>null</code> if no data was associated
-     *         with the vertex. A <code>null</code> return can also indicate that the vertex was
-     *         explicitly associated with <code>
-     * null</code>.
+     * @return data associated with the seen vertex or {@code null} if no data was associated
+     *         with the vertex. A {@code null} return can also indicate that the vertex was
+     *         explicitly associated with {@code null}.
      */
     protected D getSeenData(V vertex)
     {
@@ -263,7 +262,7 @@ public abstract class CrossComponentIterator<V, E, D>
      *
      * @param vertex vertex in question
      *
-     * @return <code>true</code> if vertex has already been seen
+     * @return {@code true} if vertex has already been seen
      */
     protected boolean isSeenVertex(V vertex)
     {
@@ -284,10 +283,10 @@ public abstract class CrossComponentIterator<V, E, D>
      * @param vertex a vertex which has been seen.
      * @param data data to be associated with the seen vertex.
      *
-     * @return previous value associated with specified vertex or <code>
-     * null</code> if no data was associated with the vertex. A <code>
-     * null</code> return can also indicate that the vertex was explicitly associated with
-     *         <code>null</code>.
+     * @return previous value associated with specified vertex or {@code null}
+     *         if no data was associated with the vertex. A {@code null} return
+     *         can also indicate that the vertex was explicitly associated with
+     *         {@code null}.
      */
     protected D putSeenData(V vertex, D data)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/DepthFirstIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/DepthFirstIterator.java
@@ -82,7 +82,7 @@ public class DepthFirstIterator<V, E>
     /**
      * Creates a new depth-first iterator for the specified graph. Iteration will start at the
      * specified start vertex and will be limited to the connected component that includes that
-     * vertex. If the specified start vertex is <code>null</code>, iteration will start at an
+     * vertex. If the specified start vertex is {@code null}, iteration will start at an
      * arbitrary vertex and will not be limited, that is, will be able to traverse all the graph.
      *
      * @param g the graph to be iterated.
@@ -96,7 +96,7 @@ public class DepthFirstIterator<V, E>
     /**
      * Creates a new depth-first iterator for the specified graph. Iteration will start at the
      * specified start vertices and will be limited to the connected component that includes those
-     * vertices. If the specified start vertices is <code>null</code>, iteration will start at an
+     * vertices. If the specified start vertices is {@code null}, iteration will start at an
      * arbitrary vertex and will not be limited, that is, will be able to traverse all the graph.
      *
      * @param g the graph to be iterated.

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/GraphIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/GraphIterator.java
@@ -35,26 +35,26 @@ public interface GraphIterator<V, E>
     /**
      * Test whether this iterator is set to traverse the graph across connected components.
      *
-     * @return <code>true</code> if traverses across connected components, otherwise
-     *         <code>false</code>.
+     * @return {@code true} if traverses across connected components, otherwise
+     *         {@code false}.
      */
     boolean isCrossComponentTraversal();
 
     /**
-     * Tests whether the <code>reuseEvents</code> flag is set. If the flag is set to
-     * <code>true</code> this class will reuse previously fired events and will not create a new
+     * Tests whether the {@code reuseEvents} flag is set. If the flag is set to
+     * {@code true} this class will reuse previously fired events and will not create a new
      * object for each event. This option increases performance but should be used with care,
      * especially in multithreaded environment.
      *
-     * @return the value of the <code>reuseEvents</code> flag.
+     * @return the value of the {@code reuseEvents} flag.
      */
     boolean isReuseEvents();
 
     /**
-     * Sets a value the <code>reuseEvents</code> flag. If the <code>
-     * reuseEvents</code> flag is set to <code>true</code> this class will reuse previously fired
-     * events and will not create a new object for each event. This option increases performance but
-     * should be used with care, especially in multithreaded environment.
+     * Sets a value the {@code reuseEvents} flag. If the {@code reuseEvents} flag is set to
+     * {@code true} this class will reuse previously fired events and will not create a new
+     * object for each event. This option increases performance but should be used with care,
+     * especially in multithreaded environment.
      *
      * @param reuseEvents whether to reuse previously fired event objects instead of creating a new
      *        event object for each event.

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/TopologicalOrderIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/TopologicalOrderIterator.java
@@ -26,8 +26,8 @@ import java.util.*;
  * A topological ordering iterator for a directed acyclic graph.
  * 
  * <p>
- * A topological order is a permutation <code>p</code> of the vertices of a graph such that an edge
- * <code>(i,j)</code> implies that <code>i</code> appears before <code>j</code> in <code>p</code>.
+ * A topological order is a permutation {@code p} of the vertices of a graph such that an edge
+ * {@code (i,j)} implies that {@code i} appears before {@code j} in {@code p}.
  * For more information see
  * <a href="https://en.wikipedia.org/wiki/Topological_sorting">wikipedia</a> or
  * <a href="http://mathworld.wolfram.com/TopologicalSort.html">wolfram</a>.

--- a/jgrapht-core/src/main/java/org/jgrapht/util/ArrayUnenforcedSet.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/ArrayUnenforcedSet.java
@@ -51,7 +51,7 @@ public class ArrayUnenforcedSet<E>
      * Constructs a set containing the elements of the specified collection.
      *
      * @param c the collection whose elements are to be placed into this set
-     * @throws NullPointerException if the specified collection is null
+     * @throws NullPointerException if the specified collection is {@code null}
      */
     public ArrayUnenforcedSet(Collection<? extends E> c)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/util/CollectionUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/CollectionUtil.java
@@ -64,7 +64,7 @@ public class CollectionUtil
      *
      * @param <K> the type of keys in the returned {@code LinkedHashMap}
      * @param <V> the type of values in the returned {@code LinkedHashMap}
-     * @param expectedSize of mappings that will be put into the returned {@code LinkedHashMap}
+     * @param expectedSize expected size of mappings that will be put into the returned {@code LinkedHashMap}
      * @return an empty {@code LinkedHashMap} with sufficient capacity to hold expectedSize mappings
      * @see HashMap
      */
@@ -83,7 +83,7 @@ public class CollectionUtil
      * </p>
      *
      * @param <E> the type of elements in the returned {@code HashSet}
-     * @param expectedSize of elements that will be add to the returned {@code HashSet}
+     * @param expectedSize expected number of elements that will be add to the returned {@code HashSet}
      * @return an empty {@code HashSet} with sufficient capacity to hold expectedSize elements
      * @see HashMap
      */
@@ -102,7 +102,7 @@ public class CollectionUtil
      * </p>
      *
      * @param <E> the type of elements in the returned {@code LinkedHashSet}
-     * @param expectedSize of elements that will be add to the returned {@code LinkedHashSet}
+     * @param expectedSize expected number of elements that will be add to the returned {@code LinkedHashSet}
      * @return an empty {@code LinkedHashSet} with sufficient capacity to hold expectedSize elements
      * @see HashMap
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/util/ModifiableInteger.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/ModifiableInteger.java
@@ -18,14 +18,14 @@
 package org.jgrapht.util;
 
 /**
- * The <code>ModifiableInteger</code> class wraps a value of the primitive type <code>int</code> in
+ * The {@code ModifiableInteger} class wraps a value of the primitive type {@code int} in
  * an object, similarly to {@link java.lang.Integer}. An object of type
- * <code>ModifiableInteger</code> contains a single field whose type is <code>int</code>.
+ * {@code ModifiableInteger} contains a single field whose type is {@code int}.
  *
  * <p>
- * Unlike <code>java.lang.Integer</code>, the int value which the ModifiableInteger represents can
+ * Unlike {@code java.lang.Integer}, the int value which the ModifiableInteger represents can
  * be modified. It becomes useful when used together with the collection framework. For example, if
- * you want to have a {@link java.util.List} of counters. You could use <code>Integer</code> but
+ * you want to have a {@link java.util.List} of counters. You could use {@code Integer} but
  * that would have became wasteful and inefficient if you frequently had to update the counters.
  * </p>
  *
@@ -33,7 +33,7 @@ package org.jgrapht.util;
  * WARNING: Because instances of this class are mutable, great care must be exercised if used as
  * keys of a {@link java.util.Map} or as values in a {@link java.util.Set} in a manner that affects
  * equals comparisons while the instances are keys in the map (or values in the set). For more see
- * documentation of <code>Map</code> and <code>Set</code>.
+ * documentation of {@code Map} and {@code Set}.
  * </p>
  *
  * @author Barak Naveh
@@ -45,7 +45,7 @@ public class ModifiableInteger
     private static final long serialVersionUID = 3618698612851422261L;
 
     /**
-     * The int value represented by this <code>ModifiableInteger</code>.
+     * The int value represented by this {@code ModifiableInteger}.
      */
     public int value;
 
@@ -65,11 +65,10 @@ public class ModifiableInteger
     }
 
     /**
-     * Constructs a newly allocated <code>ModifiableInteger</code> object that represents the
-     * specified <code>int</code> value.
+     * Constructs a newly allocated {@code ModifiableInteger} object that represents the
+     * specified {@code int} value.
      *
-     * @param value the value to be represented by the <code>
-     * ModifiableInteger</code> object.
+     * @param value the value to be represented by the {@code ModifiableInteger} object.
      */
     public ModifiableInteger(int value)
     {
@@ -114,16 +113,16 @@ public class ModifiableInteger
     }
 
     /**
-     * Compares two <code>ModifiableInteger</code> objects numerically.
+     * Compares two {@code ModifiableInteger} objects numerically.
      *
-     * @param anotherInteger the <code>ModifiableInteger</code> to be compared.
+     * @param anotherInteger the {@code ModifiableInteger} to be compared.
      *
-     * @return the value <code>0</code> if this <code>ModifiableInteger</code> is equal to the
-     *         argument <code>ModifiableInteger</code>; a value less than <code>0</code> if this
-     *         <code>ModifiableInteger</code> is numerically less than the argument
-     *         <code>ModifiableInteger</code>; and a value greater than <code>0</code> if this
-     *         <code>ModifiableInteger</code> is numerically greater than the argument
-     *         <code>ModifiableInteger</code> (signed comparison).
+     * @return the value {@code 0} if this {@code ModifiableInteger} is equal to the
+     *         argument {@code ModifiableInteger}; a value less than {@code 0} if this
+     *         {@code ModifiableInteger} is numerically less than the argument
+     *         {@code ModifiableInteger}; and a value greater than {@code 0} if this
+     *         {@code ModifiableInteger} is numerically greater than the argument
+     *         {@code ModifiableInteger} (signed comparison).
      */
     @Override
     public int compareTo(ModifiableInteger anotherInteger)
@@ -144,14 +143,14 @@ public class ModifiableInteger
     }
 
     /**
-     * Compares this object to the specified object. The result is <code>
-     * true</code> if and only if the argument is not <code>null</code> and is an
-     * <code>ModifiableInteger</code> object that contains the same <code>
-     * int</code> value as this object.
+     * Compares this object to the specified object. The result is {@code 
+     * true} if and only if the argument is not {@code null} and is an
+     * {@code ModifiableInteger} object that contains the same {@code 
+     * int} value as this object.
      *
      * @param o the object to compare with.
      *
-     * @return <code>true</code> if the objects are the same; <code>false</code> otherwise.
+     * @return {@code true} if the objects are the same; {@code false} otherwise.
      */
     @Override
     public boolean equals(Object o)
@@ -173,10 +172,10 @@ public class ModifiableInteger
     }
 
     /**
-     * Returns a hash code for this <code>ModifiableInteger</code>.
+     * Returns a hash code for this {@code ModifiableInteger}.
      *
-     * @return a hash code value for this object, equal to the primitive <code>
-     * int</code> value represented by this <code>ModifiableInteger</code> object.
+     * @return a hash code value for this object, equal to the primitive {@code 
+     * int} value represented by this {@code ModifiableInteger} object.
      */
     @Override
     public int hashCode()
@@ -203,10 +202,10 @@ public class ModifiableInteger
     }
 
     /**
-     * Returns an <code>Integer</code> object representing this <code>
-     * ModifiableInteger</code>'s value.
+     * Returns an {@code Integer} object representing this {@code 
+     * ModifiableInteger}'s value.
      *
-     * @return an <code>Integer</code> representation of the value of this object.
+     * @return an {@code Integer} representation of the value of this object.
      */
     public Integer toInteger()
     {
@@ -214,8 +213,8 @@ public class ModifiableInteger
     }
 
     /**
-     * Returns a <code>String</code> object representing this <code>
-     * ModifiableInteger</code>'s value. The value is converted to signed decimal representation and
+     * Returns a {@code String} object representing this {@code 
+     * ModifiableInteger}'s value. The value is converted to signed decimal representation and
      * returned as a string, exactly as if the integer value were given as an argument to the
      * {@link java.lang.Integer#toString(int)} method.
      *

--- a/jgrapht-core/src/main/java/org/jgrapht/util/ModifiableInteger.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/ModifiableInteger.java
@@ -23,7 +23,7 @@ package org.jgrapht.util;
  * {@code ModifiableInteger} contains a single field whose type is {@code int}.
  *
  * <p>
- * Unlike {@code java.lang.Integer}, the int value which the ModifiableInteger represents can
+ * Unlike {@code java.lang.Integer}, the {@code int} value which the ModifiableInteger represents can
  * be modified. It becomes useful when used together with the collection framework. For example, if
  * you want to have a {@link java.util.List} of counters. You could use {@code Integer} but
  * that would have became wasteful and inefficient if you frequently had to update the counters.

--- a/jgrapht-core/src/main/java/org/jgrapht/util/PrefetchIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/PrefetchIterator.java
@@ -20,12 +20,12 @@ package org.jgrapht.util;
 import java.util.*;
 
 /**
- * Utility class to help implement an iterator/enumerator in which the hasNext() method needs to
+ * Utility class to help implement an iterator/enumerator in which the {@link #hasNext()} method needs to
  * calculate the next elements ahead of time.
  *
  * <p>
  * Many classes which implement an iterator face a common problem: if there is no easy way to
- * calculate hasNext() other than to call getNext(), then they save the result for fetching in the
+ * calculate {@link #hasNext()} other than to call getNext(), then they save the result for fetching in the
  * next call to getNext(). This utility helps in doing just that.
  *
  * <p>
@@ -158,11 +158,12 @@ public class PrefetchIterator<E>
 
     /**
      * Tests whether the enumeration started as an empty one. It does not matter if it
-     * hasMoreElements() now, only at initialization time. Efficiency: if nextElements(),
-     * hasMoreElements() were never used, it activates the hasMoreElements() once. Else it is
-     * immediately(O(1))
+     * {@link #hasMoreElements()} now, only at initialization time.
      * 
-     * @return true if the enumeration started as an empty one, false otherwise.
+     * <p>Efficiency: if {@link #nextElements()}, {@link #hasMoreElements()} were never used,
+     * it activates the {@link #hasMoreElements()} once. Else it is immediately $(O(1))$
+     * 
+     * @return {@link true} if the enumeration started as an empty one, {@link false} otherwise.
      */
     public boolean isEnumerationStartedEmpty()
     {

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/JGraphXAdapter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/JGraphXAdapter.java
@@ -82,9 +82,11 @@ public class JGraphXAdapter<V, E>
     /**
      * Constructs and draws a new ListenableGraph. If the graph changes through the ListenableGraph,
      * the JGraphXAdapter will automatically add/remove the new edge/vertex as it implements the
-     * GraphListener interface. Throws a IllegalArgumentException if the graph is null.
+     * GraphListener interface. 
      *
      * @param graph casted to graph
+     * 
+     * @throws IllegalArgumentException if the graph is null.
      */
     public JGraphXAdapter(ListenableGraph<V, E> graph)
     {
@@ -97,10 +99,11 @@ public class JGraphXAdapter<V, E>
     /**
      * Constructs and draws a new mxGraph from a JGraphT graph. Changes on the JGraphT graph will
      * not edit this mxGraph any further; use the constructor with the ListenableGraph parameter
-     * instead or use this graph as a normal mxGraph. Throws an IllegalArgumentException if the
-     * parameter is null.
+     * instead or use this graph as a normal mxGraph.
      *
      * @param graph is a graph
+     * 
+     * @throws IllegalArgumentException if the parameter is null
      */
     public JGraphXAdapter(Graph<V, E> graph)
     {

--- a/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseGraphAdapter.java
+++ b/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseGraphAdapter.java
@@ -117,9 +117,9 @@ public abstract class BaseGraphAdapter<V, G extends com.google.common.graph.Grap
      * <p>
      * In contrast with the {@link Supplier} interface, the vertex supplier has the additional
      * requirement that a new and distinct result is returned every time it is invoked. More
-     * specifically for a new vertex to be added in a graph <code>v</code> must <i>not</i> be equal
+     * specifically for a new vertex to be added in a graph {@code v} must <i>not</i> be equal
      * to any other vertex in the graph. More formally, the graph must not contain any vertex
-     * <code>v2</code> such that <code>v2.equals(v)</code>.
+     * {@code v2} such that {@code v2.equals(v)}.
      * 
      * @param vertexSupplier the vertex supplier
      */
@@ -145,9 +145,9 @@ public abstract class BaseGraphAdapter<V, G extends com.google.common.graph.Grap
      * <p>
      * In contrast with the {@link Supplier} interface, the edge supplier has the additional
      * requirement that a new and distinct result is returned every time it is invoked. More
-     * specifically for a new edge to be added in a graph <code>e</code> must <i>not</i> be equal to
+     * specifically for a new edge to be added in a graph {@code e} must <i>not</i> be equal to
      * any other edge in the graph (even if the graph allows edge-multiplicity). More formally, the
-     * graph must not contain any edge <code>e2</code> such that <code>e2.equals(e)</code>.
+     * graph must not contain any edge {@code e2} such that {@code e2.equals(e)}.
      * 
      * @param edgeSupplier the edge supplier
      */

--- a/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseNetworkAdapter.java
+++ b/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseNetworkAdapter.java
@@ -114,9 +114,9 @@ public abstract class BaseNetworkAdapter<V, E, N extends Network<V, E>>
      * <p>
      * In contrast with the {@link Supplier} interface, the vertex supplier has the additional
      * requirement that a new and distinct result is returned every time it is invoked. More
-     * specifically for a new vertex to be added in a graph <code>v</code> must <i>not</i> be equal
+     * specifically for a new vertex to be added in a graph {@code v} must <i>not</i> be equal
      * to any other vertex in the graph. More formally, the graph must not contain any vertex
-     * <code>v2</code> such that <code>v2.equals(v)</code>.
+     * {@code v2} such that {@code v2.equals(v)}.
      * 
      * @param vertexSupplier the vertex supplier
      */
@@ -142,9 +142,9 @@ public abstract class BaseNetworkAdapter<V, E, N extends Network<V, E>>
      * <p>
      * In contrast with the {@link Supplier} interface, the edge supplier has the additional
      * requirement that a new and distinct result is returned every time it is invoked. More
-     * specifically for a new edge to be added in a graph <code>e</code> must <i>not</i> be equal to
+     * specifically for a new edge to be added in a graph {@code e} must <i>not</i> be equal to
      * any other edge in the graph (even if the graph allows edge-multiplicity). More formally, the
-     * graph must not contain any edge <code>e2</code> such that <code>e2.equals(e)</code>.
+     * graph must not contain any edge {@code e2} such that {@code e2.equals(e)}.
      * 
      * @param edgeSupplier the edge supplier
      */

--- a/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseValueGraphAdapter.java
+++ b/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseValueGraphAdapter.java
@@ -126,9 +126,9 @@ public abstract class BaseValueGraphAdapter<V, W, VG extends ValueGraph<V, W>>
      * <p>
      * In contrast with the {@link Supplier} interface, the vertex supplier has the additional
      * requirement that a new and distinct result is returned every time it is invoked. More
-     * specifically for a new vertex to be added in a graph <code>v</code> must <i>not</i> be equal
+     * specifically for a new vertex to be added in a graph {@code v} must <i>not</i> be equal
      * to any other vertex in the graph. More formally, the graph must not contain any vertex
-     * <code>v2</code> such that <code>v2.equals(v)</code>.
+     * {@code v2} such that {@code v2.equals(v)}.
      * 
      * @param vertexSupplier the vertex supplier
      */
@@ -154,9 +154,9 @@ public abstract class BaseValueGraphAdapter<V, W, VG extends ValueGraph<V, W>>
      * <p>
      * In contrast with the {@link Supplier} interface, the edge supplier has the additional
      * requirement that a new and distinct result is returned every time it is invoked. More
-     * specifically for a new edge to be added in a graph <code>e</code> must <i>not</i> be equal to
+     * specifically for a new edge to be added in a graph {@code e} must <i>not</i> be equal to
      * any other edge in the graph (even if the graph allows edge-multiplicity). More formally, the
-     * graph must not contain any edge <code>e2</code> such that <code>e2.equals(e)</code>.
+     * graph must not contain any edge {@code e2} such that {@code e2.equals(e)}.
      * 
      * @param edgeSupplier the edge supplier
      */

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTExporter.java
@@ -248,7 +248,7 @@ public class DOTExporter<V, E>
      * <li>an HTML string (<...>).
      * </ul>
      *
-     * @throws ExportException if the given <code>vertexIDProvider</code> didn't generate a valid
+     * @throws ExportException if the given {@code vertexIDProvider} didn't generate a valid
      *         vertex ID.
      */
     private String getVertexID(V v)

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTUtils.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTUtils.java
@@ -48,7 +48,7 @@ class DOTUtils
      *
      * @param idCandidate the ID candidate.
      *
-     * @return <code>true</code> if it is valid; <code>false</code> otherwise.
+     * @return {@code true} if it is valid; {@code false} otherwise.
      */
     static boolean isValidID(String idCandidate)
     {

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/graph6/Graph6Sparse6EventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/graph6/Graph6Sparse6EventDrivenImporter.java
@@ -39,13 +39,13 @@ import java.io.*;
  * Note that a g6/s6 string may contain backslashes '\'. Thus, escaping is required. E.g.
  * 
  * <pre>
- * <code>":?@MnDA\oi"</code>
+ * {@code ":?@MnDA\oi"}
  * </pre>
  * 
  * may result in undefined behavior. This should have been:
  * 
  * <pre>
- * <code>":?@MnDA\\oi"</code>
+ * {@code ":?@MnDA\\oi"}
  * </pre>
  *
  * @author Joris Kinable

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/graph6/Graph6Sparse6Importer.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/graph6/Graph6Sparse6Importer.java
@@ -42,13 +42,13 @@ import java.util.function.*;
  * Note that a g6/s6 string may contain backslashes '\'. Thus, escaping is required. E.g.
  * 
  * <pre>
- * <code>":?@MnDA\oi"</code>
+ * {@code ":?@MnDA\oi"}
  * </pre>
  * 
  * may result in undefined behavior. This should have been:
  * 
  * <pre>
- * <code>":?@MnDA\\oi"</code>
+ * {@code ":?@MnDA\\oi"}
  * </pre>
  *
  * <p>

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/json/JSONExporter.java
@@ -37,9 +37,9 @@ import org.jgrapht.nio.IntegerIdProvider;
  * <p>
  * The output is one object which contains:
  * <ul>
- * <li>A member named <code>nodes</code> whose value is an array of nodes.
- * <li>A member named <code>edges</code> whose value is an array of edges.
- * <li>Two members named <code>creator</code> and <code>version</code> for metadata.
+ * <li>A member named {@code nodes} whose value is an array of nodes.
+ * <li>A member named {@code edges} whose value is an array of edges.
+ * <li>Two members named {@code creator} and {@code version} for metadata.
  * </ul>
  * 
  * <p>

--- a/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/sparse/specifics/SparseGraphSpecifics.java
+++ b/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/sparse/specifics/SparseGraphSpecifics.java
@@ -44,14 +44,14 @@ public interface SparseGraphSpecifics
     long verticesCount();
 
     /**
-     * Returns <code>true</code> if this graph contains the specified edge. More formally, returns
-     * <code>true</code> if and only if this graph contains an edge <code>e2</code> such that
-     * <code>e.equals(e2)</code>. If the specified edge is <code>null</code> returns
-     * <code>false</code>.
+     * Returns {@code true} if this graph contains the specified edge. More formally, returns
+     * {@code true} if and only if this graph contains an edge {@code e2} such that
+     * {@code e.equals(e2)}. If the specified edge is {@code null} returns
+     * {@code false}.
      *
      * @param e edge whose presence in this graph is to be tested.
      *
-     * @return <code>true</code> if this graph contains the specified edge.
+     * @return {@code true} if this graph contains the specified edge.
      */
     default boolean containsEdge(Integer e)
     {
@@ -59,14 +59,14 @@ public interface SparseGraphSpecifics
     }
 
     /**
-     * Returns <code>true</code> if this graph contains the specified vertex. More formally, returns
-     * <code>true</code> if and only if this graph contains a vertex <code>u</code> such that
-     * <code>u.equals(v)</code>. If the specified vertex is <code>null</code> returns
-     * <code>false</code>.
+     * Returns {@code true} if this graph contains the specified vertex. More formally, returns
+     * {@code true} if and only if this graph contains a vertex {@code u} such that
+     * {@code u.equals(v)}. If the specified vertex is {@code null} returns
+     * {@code false}.
      *
      * @param v vertex whose presence in this graph is to be tested.
      *
-     * @return <code>true</code> if this graph contains the specified vertex.
+     * @return {@code true} if this graph contains the specified vertex.
      */
     default boolean containsVertex(Integer v)
     {
@@ -110,7 +110,7 @@ public interface SparseGraphSpecifics
      * @return the degree of the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      * @throws ArithmeticException if the result overflows an int
      */
     long degreeOf(Integer vertex);
@@ -123,7 +123,7 @@ public interface SparseGraphSpecifics
      * @return a set of all edges touching the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     Set<Integer> edgesOf(Integer vertex);
 
@@ -143,7 +143,7 @@ public interface SparseGraphSpecifics
      * @return the degree of the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      * @throws ArithmeticException if the result overflows an int
      */
     long inDegreeOf(Integer vertex);
@@ -159,7 +159,7 @@ public interface SparseGraphSpecifics
      * @return a set of all edges incoming into the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     Set<Integer> incomingEdgesOf(Integer vertex);
 
@@ -179,7 +179,7 @@ public interface SparseGraphSpecifics
      * @return the degree of the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      * @throws ArithmeticException if the result overflows an int
      */
     long outDegreeOf(Integer vertex);
@@ -195,7 +195,7 @@ public interface SparseGraphSpecifics
      * @return a set of all edges outgoing from the specified vertex.
      *
      * @throws IllegalArgumentException if vertex is not found in the graph.
-     * @throws NullPointerException if vertex is <code>null</code>.
+     * @throws NullPointerException if vertex is {@code null}.
      */
     Set<Integer> outgoingEdgesOf(Integer vertex);
 
@@ -278,8 +278,8 @@ public interface SparseGraphSpecifics
 
     /**
      * Returns an edge connecting source vertex to target vertex if such vertices and such edge
-     * exist in this graph. Otherwise returns <code>
-     * null</code>. If any of the specified vertices is <code>null</code> returns <code>null</code>
+     * exist in this graph. Otherwise returns {@code null}. If any of the specified vertices is
+     * {@code null} returns {@code null}
      *
      * <p>
      * In undirected graphs, the returned edge may have its source and target vertices in the
@@ -295,8 +295,8 @@ public interface SparseGraphSpecifics
 
     /**
      * Returns a set of all edges connecting source vertex to target vertex if such vertices exist
-     * in this graph. If any of the vertices does not exist or is <code>null</code>, returns
-     * <code>null</code>. If both vertices exist but no edges found, returns an empty set.
+     * in this graph. If any of the vertices does not exist or is {@code null}, returns
+     * {@code null}. If both vertices exist but no edges found, returns an empty set.
      *
      * <p>
      * In undirected graphs, some of the returned edges may have their source and target vertices in
@@ -314,7 +314,7 @@ public interface SparseGraphSpecifics
      * Ensures that the specified vertex exists in this graph, or else throws exception.
      *
      * @param v vertex
-     * @return <code>true</code> if this assertion holds.
+     * @return {@code true} if this assertion holds.
      * @throws IllegalArgumentException if specified vertex does not exist in this graph.
      */
     default boolean assertVertexExist(Integer v)
@@ -330,7 +330,7 @@ public interface SparseGraphSpecifics
      * Ensures that the specified edge exists in this graph, or else throws exception.
      *
      * @param e edge
-     * @return <code>true</code> if this assertion holds.
+     * @return {@code true} if this assertion holds.
      * @throws IllegalArgumentException if specified edge does not exist in this graph.
      */
     default boolean assertEdgeExist(Integer e)

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/AbstractSuccinctGraph.java
@@ -76,7 +76,7 @@ public abstract class AbstractSuccinctGraph<E>
      * Ensures that the specified vertex exists in this graph, or else throws exception.
      *
      * @param v vertex
-     * @return <code>true</code> if this assertion holds.
+     * @return {@code true} if this assertion holds.
      * @throws IllegalArgumentException if specified vertex does not exist in this graph.
      */
     @Override

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java
@@ -341,7 +341,7 @@ public class SuccinctIntDirectedGraph
      * Ensures that the specified edge exists in this graph, or else throws exception.
      *
      * @param e edge
-     * @return <code>true</code> if this assertion holds.
+     * @return {@code true} if this assertion holds.
      * @throws IllegalArgumentException if specified edge does not exist in this graph.
      */
     protected boolean assertEdgeExist(final Integer e)

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntUndirectedGraph.java
@@ -224,7 +224,7 @@ public class SuccinctIntUndirectedGraph
      * Ensures that the specified edge exists in this graph, or else throws exception.
      *
      * @param e edge
-     * @return <code>true</code> if this assertion holds.
+     * @return {@code true} if this assertion holds.
      * @throws IllegalArgumentException if specified edge does not exist in this graph.
      */
     protected boolean assertEdgeExist(final Integer e)


### PR DESCRIPTION
This PR adds Javadoc maintenance commits. Changes include:

- Replacing `<code></code>` HTML snippets with `{@code }` snippets.
- Surrounding `true`s and `false`s with `{@code }` (formatting / readability)
- Fixing broken Javadoc syntax for `{@link }`
- Mentioning undocumented conditions where exceptions could be thrown
  - Fixes #1118

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] <s>I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)</s>
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
