### PR TITLE
Restore Deque Interface in DoublyLinkedList

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -1347,6 +1347,100 @@ public class DoublyLinkedList<E>
     }
 
     /**
+     * A wrapper for {@link NodeIterator} that disallows modification
+     * of the underlying list. All getter methods forward the call
+     * to the wrapped iterator.
+     * 
+     * @since 1.5.3
+     */
+    private static class UnmodifiableNodeIterator<E> implements NodeIterator<E> {
+        private NodeIterator<E> orig;
+
+        UnmodifiableNodeIterator(NodeIterator<E> original) {
+            this.orig = original;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return orig.hasNext();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ListNode<E> nextNode() {
+            return orig.nextNode();
+        }
+
+        /**
+         * Returns the wrapped node iterator.
+         * @return the wrapped node iterator
+         */
+        NodeIterator<E> getWrapped() {
+            return orig;
+        }
+    }
+
+
+    /**
+     * A wrapper for {@link ListNodeIterator} that disallows modification
+     * of the underlying list. All setter methods throw
+     * {@link UnsupportedOperationException} and all getter methods
+     * forward the call to the wrapped iterator.
+     * 
+     * @since 1.5.3
+     */
+    private static class UnmodifiableListNodeIterator<E> extends UnmodifiableNodeIterator<E> implements ListNodeIterator<E> {
+
+        UnmodifiableListNodeIterator(ListNodeIterator<E> original) {
+            super(original);
+        }
+
+        @Override
+        public boolean hasPrevious() {
+            return getWrapped().hasPrevious();
+        }
+
+        @Override
+        public int nextIndex() {
+            return getWrapped().nextIndex();
+        }
+
+        @Override
+        public int previousIndex() {
+            return getWrapped().previousIndex();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void set(E e) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void add(E e) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ListNode<E> previousNode() {
+            return getWrapped().previousNode();
+        }
+
+        @Override
+        ListNodeIterator<E> getWrapped() {
+            return (ListNodeIterator<E>) super.getWrapped();
+        }
+    }
+
+    /**
      * Returns a {@link NodeIterator} that iterates in reverse order, assuming the cursor of the
      * specified {@link ListNodeIterator} is behind the tail of the list.
      */
@@ -1848,6 +1942,26 @@ public class DoublyLinkedList<E>
         public void prepend(DoublyLinkedList<E> movedList)
         {
             throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public NodeIterator<E> circularIterator(E firstElement) {
+            return new UnmodifiableNodeIterator<>(super.circularIterator(firstElement));
+        }
+
+        @Override
+        public NodeIterator<E> reverseCircularIterator(E firstElement) {
+            return new UnmodifiableNodeIterator<>(super.reverseCircularIterator(firstElement));
+        }
+
+        @Override
+        public ListNodeIterator<E> listIterator(int index) {
+            return new UnmodifiableListNodeIterator<>(super.listIterator(index));
+        }
+
+        @Override
+        public ListNodeIterator<E> listIterator(E element) {
+            return new UnmodifiableListNodeIterator<>(super.listIterator(element));
         }
 
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -1614,12 +1614,12 @@ public class DoublyLinkedList<E>
         }
 
         @Override
-        protected void setNext(ListNode<V> next) {
+        void setNext(ListNode<V> next) {
             this.next = next;
         }
 
         @Override
-        protected void setPrev(ListNode<V> prev) {
+        void setPrev(ListNode<V> prev) {
             this.prev = prev;
         }
 
@@ -1659,7 +1659,7 @@ public class DoublyLinkedList<E>
          * @throws UnsupportedOperationException always
          */
         @Override
-        protected void setNext(ListNode<V> next) {
+        void setNext(ListNode<V> next) {
             throw new UnsupportedOperationException();
         }
 
@@ -1667,7 +1667,7 @@ public class DoublyLinkedList<E>
          * @throws UnsupportedOperationException always
          */
         @Override
-        protected void setPrev(ListNode<V> prev) {
+        void setPrev(ListNode<V> prev) {
             throw new UnsupportedOperationException();
         }
 
@@ -1675,7 +1675,7 @@ public class DoublyLinkedList<E>
          * @throws UnsupportedOperationException always
          */
         @Override
-        protected void setList(DoublyLinkedList<V> list) {
+        void setList(DoublyLinkedList<V> list) {
             throw new UnsupportedOperationException();
         }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -61,7 +61,7 @@ public class DoublyLinkedList<E>
     implements Deque<E>
 {
     /** The first element of the list, {@code null} if this list is empty. */
-    private AbstractListNode<E> head = null;
+    private ListNode<E> head = null;
     private int size;
 
     /**
@@ -71,7 +71,7 @@ public class DoublyLinkedList<E>
      * 
      * @since 1.5.3
      */
-    AbstractListNode<E> head()
+    ListNode<E> head()
     {
         return this.head;
     }
@@ -81,7 +81,7 @@ public class DoublyLinkedList<E>
      * 
      * @return the last element of the list
      */
-    AbstractListNode<E> tail()
+    ListNode<E> tail()
     {
         return head.getPrev();
     }
@@ -111,9 +111,9 @@ public class DoublyLinkedList<E>
     public void clear()
     {
         if (!isEmpty()) {
-            AbstractListNode<E> node = head;
+            ListNode<E> node = head;
             do {
-                AbstractListNode<E> next = node.getNext();
+                ListNode<E> next = node.getNext();
                 boolean removed = removeListNode(node); // clears all links of removed node
                 assert removed;
                 node = next;
@@ -137,7 +137,7 @@ public class DoublyLinkedList<E>
      * @throws IllegalArgumentException if {@code node} is already contained in this or another
      *         {@code DoublyLinkedList}
      */
-    private void addListNode(AbstractListNode<E> node)
+    private void addListNode(ListNode<E> node)
     { // call this before any modification of this list is done
         if (node.getList() != null) {
             String list = (node.getList() == this) ? "this" : "other";
@@ -151,8 +151,8 @@ public class DoublyLinkedList<E>
 
     /**
      * Atomically moves all {@link ListNode ListNodes} from {@code list} to this list as if each
-     * node was removed with {@link #removeListNode(AbstractListNode)} from {@code list} and
-     * subsequently added to this list by {@link #addListNode(AbstractListNode)}.
+     * node was removed with {@link #removeListNode(ListNode)} from {@code list} and
+     * subsequently added to this list by {@link #addListNode(ListNode)}.
      */
     private void moveAllListNodes(DoublyLinkedList<E> list)
     { // call this before any modification of this list is done
@@ -160,7 +160,7 @@ public class DoublyLinkedList<E>
         for (ListNodeIteratorImpl it = list.new ListNodeIteratorImpl(0); it.hasNext();) {
             ListNode<E> node = it.nextNode();
             assert node.getList() == list;
-            ((AbstractListNode<E>) node).setList(this);
+            node.setList(this);
         }
         size += list.size;
         list.size = 0;
@@ -180,7 +180,7 @@ public class DoublyLinkedList<E>
      * @param node the node to remove from this list
      * @return true if {@code node} was removed from this list, else false
      */
-    private boolean removeListNode(AbstractListNode<E> node)
+    private boolean removeListNode(ListNode<E> node)
     { // call this before any modification of this list is done
         if (node.list == this) {
 
@@ -196,20 +196,20 @@ public class DoublyLinkedList<E>
     }
 
     /**
-     * Establishes the links between the given {@link AbstractListNode nodes} in such a way that the
+     * Establishes the links between the given {@link ListNode nodes} in such a way that the
      * {@code predecessor} is linked before the {@code successor}.
      * 
      * @param predecessor the first node linked before the other
      * @param successor the second node linked after the other
      */
-    private void link(AbstractListNode<E> predecessor, AbstractListNode<E> successor)
+    private void link(ListNode<E> predecessor, ListNode<E> successor)
     {
         predecessor.setNext(successor);
         successor.setPrev(predecessor);
     }
 
     /** Insert non null {@code node} before non null {@code successor} into the list. */
-    private void linkBefore(AbstractListNode<E> node, AbstractListNode<E> successor)
+    private void linkBefore(ListNode<E> node, ListNode<E> successor)
     {
         addListNode(node);
         link(successor.getPrev(), node);
@@ -217,7 +217,7 @@ public class DoublyLinkedList<E>
     }
 
     /** Insert non null {@code node} as last node into the list. */
-    private void linkLast(AbstractListNode<E> node)
+    private void linkLast(ListNode<E> node)
     {
         if (isEmpty()) { // node will be the first and only one
             addListNode(node);
@@ -238,9 +238,9 @@ public class DoublyLinkedList<E>
         if (previousSize == 0) {
             head = list.head; // head and tail already linked together
         } else {
-            AbstractListNode<E> refNode = index == previousSize ? head() : getNodeAt(index);
+            ListNode<E> refNode = index == previousSize ? head() : getNodeAt(index);
 
-            AbstractListNode<E> listTail = list.tail();
+            ListNode<E> listTail = list.tail();
             link(refNode.getPrev(), list.head); // changes list.tail()
             link(listTail, refNode);
 
@@ -253,10 +253,10 @@ public class DoublyLinkedList<E>
     }
 
     /** Remove the non null {@code node} from the list. */
-    private boolean unlink(AbstractListNode<E> node)
+    private boolean unlink(ListNode<E> node)
     {
-        AbstractListNode<E> prev = node.getPrev();
-        AbstractListNode<E> next = node.getNext();
+        ListNode<E> prev = node.getPrev();
+        ListNode<E> next = node.getNext();
         if (removeListNode(node)) { // clears prev and next of node
             if (size == 0) {
                 head = null;
@@ -297,14 +297,13 @@ public class DoublyLinkedList<E>
      */
     public void addNode(int index, ListNode<E> node)
     {
-        AbstractListNode<E> nodeImpl = (AbstractListNode<E>) node;
         if (index == size) { // also true if this is empty
-            linkLast(nodeImpl);
+            linkLast(node);
         } else {
-            AbstractListNode<E> successor = index == 0 ? head : getNodeAt(index);
-            linkBefore(nodeImpl, successor);
+            ListNode<E> successor = index == 0 ? head : getNodeAt(index);
+            linkBefore(node, successor);
             if (head == successor) {
-                head = nodeImpl;
+                head = node;
             }
         }
     }
@@ -359,11 +358,9 @@ public class DoublyLinkedList<E>
         if (successor.getList() != this) {
             throw new IllegalArgumentException("Node <" + successor + "> not in this list");
         }
-        AbstractListNode<E> successorImpl = (AbstractListNode<E>) successor;
-        AbstractListNode<E> nodeImpl = (AbstractListNode<E>) node;
-        linkBefore(nodeImpl, successorImpl);
-        if (head == successorImpl) {
-            head = nodeImpl;
+        linkBefore(node, successor);
+        if (head == successor) {
+            head = node;
         }
     }
 
@@ -425,12 +422,12 @@ public class DoublyLinkedList<E>
      * @throws IndexOutOfBoundsException if the index is out of range
      *         ({@code index < 0 || index >= size()})
      */
-    private AbstractListNode<E> getNodeAt(int index)
+    private ListNode<E> getNodeAt(int index)
     {
         if (index < 0 || size <= index) {
             throw new IndexOutOfBoundsException("Index: " + index);
         }
-        AbstractListNode<E> node;
+        ListNode<E> node;
         if (index < size / 2) {
             node = head();
             for (int i = 0; i < index; i++) {
@@ -508,7 +505,7 @@ public class DoublyLinkedList<E>
      */
     public boolean removeNode(ListNode<E> node)
     {
-        return unlink((AbstractListNode<E>) node);
+        return unlink(node);
     }
 
     /**
@@ -910,10 +907,10 @@ public class DoublyLinkedList<E>
         if (size < 2) {
             return;
         }
-        AbstractListNode<E> newHead = tail();
-        AbstractListNode<E> current = head();
+        ListNode<E> newHead = tail();
+        ListNode<E> current = head();
         do {
-            AbstractListNode<E> next = current.getNext();
+            ListNode<E> next = current.getNext();
 
             current.setNext(current.getPrev());
             current.setPrev(next);
@@ -1482,28 +1479,38 @@ public class DoublyLinkedList<E>
      * 
      * @param <V> the type of the element stored in this node
      */
-    public interface ListNode<V>
+    public abstract static class ListNode<V>
     {
+
+        /** The list that this node is a member of. */
+        private DoublyLinkedList<V> list;
+
+        /**
+         * Constructs a new {@code ListNode}.
+         */
+        ListNode() {
+        }
+
         /**
          * Returns the immutable value this {@code ListNode} contains.
          *
          * @return the value this list node contains
          */
-        V getValue();
+        public abstract V getValue();
 
         /**
          * Returns the next node in the list structure with respect to this node
          *
          * @return the next node in the list structure with respect to this node
          */
-        ListNode<V> getNext();
+        public abstract ListNode<V> getNext();
 
         /**
          * Returns the previous node in the list structure with respect to this node
          *
          * @return the previous node in the list structure with respect to this node
          */
-        ListNode<V> getPrev();
+        public abstract ListNode<V> getPrev();
 
         /**
          * Returns the list that this node is a member of.
@@ -1512,44 +1519,8 @@ public class DoublyLinkedList<E>
          * 
          * @since 1.5.3
          */
-        DoublyLinkedList<V> getList();
-    }
-
-    /**
-     * A skeletal implementation of a {@code ListNode}.
-     * 
-     * @since 1.5.3
-     */
-    protected abstract static class AbstractListNode<V> implements ListNode<V> {
-
-        /** The list that this node is a member of. */
-        private DoublyLinkedList<V> list;
-        /** The value stored by this node. */
-        private final V value;
-
-        /**
-         * Constructs a new {@code AbstractListNode} with the specified value;
-         * 
-         * @param value the value to be stored
-         */
-        AbstractListNode(V value) {
-            this.value = value;
-        }
-
-        @Override
-        public abstract AbstractListNode<V> getNext();
-
-        @Override
-        public abstract AbstractListNode<V> getPrev();
-
-        @Override
         public DoublyLinkedList<V> getList() {
             return this.list;
-        }
-
-        @Override
-        public final V getValue() {
-            return value;
         }
 
         /**
@@ -1559,7 +1530,7 @@ public class DoublyLinkedList<E>
          * 
          * @throws UnsupportedOperationException if this node does not support modification
          */
-        abstract void setNext(AbstractListNode<V> next);
+        abstract void setNext(ListNode<V> next);
 
         /**
          * Sets the previous node to the specified node.
@@ -1568,7 +1539,7 @@ public class DoublyLinkedList<E>
          * 
          * @throws UnsupportedOperationException if this node does not support modification
          */
-        abstract void setPrev(AbstractListNode<V> prev);
+        abstract void setPrev(ListNode<V> prev);
 
         /**
          * Sets the list that this node belongs to.
@@ -1601,10 +1572,13 @@ public class DoublyLinkedList<E>
      * The default {@link ListNode} implementation that enables checks and enforcement of a single
      * container list policy.
      */
-    private static class ListNodeImpl<V> extends AbstractListNode<V>
+    private static class ListNodeImpl<V> extends ListNode<V>
     {
-        private AbstractListNode<V> next = null;
-        private AbstractListNode<V> prev = null;
+        /** The value stored by this node. */
+        private final V value;
+
+        private ListNode<V> next = null;
+        private ListNode<V> prev = null;
 
         /**
          * Creates new list node
@@ -1613,14 +1587,14 @@ public class DoublyLinkedList<E>
          */
         ListNodeImpl(V value)
         {
-            super(value);
+            this.value = value;
         }
 
         /**
          * {@inheritDoc}
          */
         @Override
-        public AbstractListNode<V> getNext()
+        public ListNode<V> getNext()
         {
             return next;
         }
@@ -1629,18 +1603,23 @@ public class DoublyLinkedList<E>
          * {@inheritDoc}
          */
         @Override
-        public AbstractListNode<V> getPrev()
+        public ListNode<V> getPrev()
         {
             return prev;
         }
 
         @Override
-        protected void setNext(AbstractListNode<V> next) {
+        public final V getValue() {
+            return value;
+        }
+
+        @Override
+        protected void setNext(ListNode<V> next) {
             this.next = next;
         }
 
         @Override
-        protected void setPrev(AbstractListNode<V> prev) {
+        protected void setPrev(ListNode<V> prev) {
             this.prev = prev;
         }
 
@@ -1651,11 +1630,10 @@ public class DoublyLinkedList<E>
      * 
      * @since 1.5.3
      */
-    private static class ReversedListNode<V> extends AbstractListNode<V> {
+    private static class ReversedListNode<V> extends ListNode<V> {
         private final ListNode<V> wrapped;
 
         ReversedListNode(ListNode<V> node, DoublyLinkedList<V> list) {
-            super(node.getValue());
             this.wrapped = node;
             super.setList(list);
         }
@@ -1672,11 +1650,16 @@ public class DoublyLinkedList<E>
             return new ReversedListNode<>(wrapped.getNext(), this.getList());
         }
 
+        @Override
+        public final V getValue() {
+            return wrapped.getValue();
+        }
+
         /**
          * @throws UnsupportedOperationException always
          */
         @Override
-        protected void setNext(AbstractListNode<V> next) {
+        protected void setNext(ListNode<V> next) {
             throw new UnsupportedOperationException();
         }
 
@@ -1684,7 +1667,7 @@ public class DoublyLinkedList<E>
          * @throws UnsupportedOperationException always
          */
         @Override
-        protected void setPrev(AbstractListNode<V> prev) {
+        protected void setPrev(ListNode<V> prev) {
             throw new UnsupportedOperationException();
         }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -1532,6 +1532,11 @@ public class DoublyLinkedList<E>
         @Override
         public abstract AbstractListNode<V> getPrev();
 
+        @Override
+        public DoublyLinkedList<V> getList() {
+            return this.list;
+        }
+
         /**
          * Sets the next node to the specified node.
          * 
@@ -1549,11 +1554,6 @@ public class DoublyLinkedList<E>
          * @throws UnsupportedOperationException if this node does not support modification
          */
         protected abstract void setPrev(AbstractListNode<V> prev);
-
-        @Override
-        public DoublyLinkedList<V> getList() {
-            return this.list;
-        }
 
         /**
          * Sets the list that this node belongs to.

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -58,6 +58,7 @@ import java.util.function.*;
  */
 public class DoublyLinkedList<E>
     extends AbstractSequentialList<E>
+    implements Deque<E>
 {
     /** The first element of the list, {@code null} if this list is empty. */
     private ListNodeImpl<E> head = null;
@@ -651,28 +652,48 @@ public class DoublyLinkedList<E>
 
     // Deque methods
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void addFirst(E e)
     {
         addElementFirst(e);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void addLast(E e)
     {
         addElementLast(e);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean offerFirst(E e)
     {
         addElementFirst(e);
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean offerLast(E e)
     {
         addElementLast(e);
         return true;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E removeFirst()
     {
         if (isEmpty()) {
@@ -684,6 +705,10 @@ public class DoublyLinkedList<E>
         return node.getValue();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E removeLast()
     {
         if (isEmpty()) {
@@ -695,6 +720,10 @@ public class DoublyLinkedList<E>
         return node.getValue();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E pollFirst()
     {
         if (isEmpty()) {
@@ -705,6 +734,10 @@ public class DoublyLinkedList<E>
         return node.getValue();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E pollLast()
     {
         if (isEmpty()) {
@@ -715,26 +748,46 @@ public class DoublyLinkedList<E>
         return node.getValue();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E getFirst()
     {
         return getFirstNode().getValue();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E getLast()
     {
         return getLastNode().getValue();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E peekFirst()
     {
         return isEmpty() ? null : getFirst();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E peekLast()
     {
         return isEmpty() ? null : getLast();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean removeFirstOccurrence(Object o)
     {
         ListNode<E> node = nodeOf(o);
@@ -745,6 +798,10 @@ public class DoublyLinkedList<E>
         return false;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean removeLastOccurrence(Object o)
     {
         ListNode<E> node = lastNodeOf(o);
@@ -757,26 +814,46 @@ public class DoublyLinkedList<E>
 
     // Queue methods
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean offer(E e)
     {
         return offerLast(e);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E remove()
     {
         return removeFirst();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E poll()
     {
         return pollFirst();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E element()
     {
         return getFirst();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E peek()
     {
         return peekFirst();
@@ -784,11 +861,19 @@ public class DoublyLinkedList<E>
 
     // Stack methods
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void push(E e)
     {
         addFirst(e);
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public E pop()
     {
         return removeFirst();
@@ -918,6 +1003,10 @@ public class DoublyLinkedList<E>
         return reverseIterator(new ListNodeIteratorImpl(size, startNode.next));
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public NodeIterator<E> descendingIterator()
     {
         return reverseIterator(listIterator(size));

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -1818,6 +1818,15 @@ public class DoublyLinkedList<E>
          * @throws UnsupportedOperationException always
          */
         @Override
+        public void invert()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
         public void moveFrom(int index, DoublyLinkedList<E> movedList)
         {
             throw new UnsupportedOperationException();

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -1037,7 +1037,7 @@ public class DoublyLinkedList<E>
         if (startNode == null) {
             throw new NoSuchElementException();
         }
-        return reverseIterator(new ListNodeIteratorImpl(size, startNode.getNext()));
+        return reverseIterator(new ListNodeIteratorImpl(size(), startNode.getNext()));
     }
 
     /**
@@ -1046,7 +1046,7 @@ public class DoublyLinkedList<E>
     @Override
     public NodeIterator<E> descendingIterator()
     {
-        return reverseIterator(listIterator(size));
+        return reverseIterator(listIterator(size()));
     }
 
     /**
@@ -1965,6 +1965,11 @@ public class DoublyLinkedList<E>
         @Override
         public NodeIterator<E> reverseCircularIterator(E firstElement) {
             return new UnmodifiableNodeIterator<>(super.reverseCircularIterator(firstElement));
+        }
+
+        @Override
+        public NodeIterator<E> descendingIterator() {
+            return super.descendingIterator();
         }
 
         @Override

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -933,6 +933,8 @@ public class DoublyLinkedList<E>
      * 
      * <p>The returned view is unmodifiable, i.e., any method that
      * attempts to modify the returned view throws an {@link UnsupportedOperationException}.
+     * The behavior of the view is not defined if the original list is modified after
+     * the creation of the view.
      * 
      * @return a reverse-ordered view of this {@code DoublyLinkedList}
      * 

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -61,7 +61,7 @@ public class DoublyLinkedList<E>
     implements Deque<E>
 {
     /** The first element of the list, {@code null} if this list is empty. */
-    private ListNodeImpl<E> head = null;
+    private AbstractListNode<E> head = null;
     private int size;
 
     /**
@@ -111,9 +111,9 @@ public class DoublyLinkedList<E>
     public void clear()
     {
         if (!isEmpty()) {
-            ListNodeImpl<E> node = head;
+            AbstractListNode<E> node = head;
             do {
-                ListNodeImpl<E> next = node.next;
+                AbstractListNode<E> next = node.getNext();
                 boolean removed = removeListNode(node); // clears all links of removed node
                 assert removed;
                 node = next;
@@ -137,14 +137,14 @@ public class DoublyLinkedList<E>
      * @throws IllegalArgumentException if {@code node} is already contained in this or another
      *         {@code DoublyLinkedList}
      */
-    private void addListNode(ListNodeImpl<E> node)
+    private void addListNode(AbstractListNode<E> node)
     { // call this before any modification of this list is done
-        if (node.list != null) {
-            String list = (node.list == this) ? "this" : "other";
+        if (node.getList() != null) {
+            String list = (node.getList() == this) ? "this" : "other";
             throw new IllegalArgumentException(
                 "Node <" + node + "> already contained in " + list + " list");
         }
-        node.list = this;
+        node.setList(this);
         size++;
         modCount++;
     }
@@ -160,7 +160,7 @@ public class DoublyLinkedList<E>
         for (ListNodeIteratorImpl it = list.new ListNodeIteratorImpl(0); it.hasNext();) {
             ListNode<E> node = it.nextNode();
             assert node.getList() == list;
-            ((ListNodeImpl<E>) node).list = this;
+            ((AbstractListNode<E>) node).setList(this);
         }
         size += list.size;
         list.size = 0;
@@ -180,13 +180,13 @@ public class DoublyLinkedList<E>
      * @param node the node to remove from this list
      * @return true if {@code node} was removed from this list, else false
      */
-    private boolean removeListNode(ListNodeImpl<E> node)
+    private boolean removeListNode(AbstractListNode<E> node)
     { // call this before any modification of this list is done
         if (node.list == this) {
 
             node.list = null;
-            node.next = null;
-            node.prev = null;
+            node.setNext(null);
+            node.setPrev(null);
 
             size--;
             modCount++;
@@ -202,22 +202,22 @@ public class DoublyLinkedList<E>
      * @param predecessor the first node linked before the other
      * @param successor the second node linked after the other
      */
-    private void link(ListNodeImpl<E> predecessor, ListNodeImpl<E> successor)
+    private void link(AbstractListNode<E> predecessor, AbstractListNode<E> successor)
     {
-        predecessor.next = successor;
-        successor.prev = predecessor;
+        predecessor.setNext(successor);
+        successor.setPrev(predecessor);
     }
 
     /** Insert non null {@code node} before non null {@code successor} into the list. */
-    private void linkBefore(ListNodeImpl<E> node, ListNodeImpl<E> successor)
+    private void linkBefore(AbstractListNode<E> node, AbstractListNode<E> successor)
     {
         addListNode(node);
-        link(successor.prev, node);
+        link(successor.getPrev(), node);
         link(node, successor);
     }
 
     /** Insert non null {@code node} as last node into the list. */
-    private void linkLast(ListNodeImpl<E> node)
+    private void linkLast(AbstractListNode<E> node)
     {
         if (isEmpty()) { // node will be the first and only one
             addListNode(node);
@@ -238,10 +238,10 @@ public class DoublyLinkedList<E>
         if (previousSize == 0) {
             head = list.head; // head and tail already linked together
         } else {
-            ListNodeImpl<E> refNode = (ListNodeImpl<E>) ((index == previousSize) ? head() : getNodeAt(index));
+            AbstractListNode<E> refNode = (AbstractListNode<E>) ((index == previousSize) ? head() : getNodeAt(index));
 
-            ListNodeImpl<E> listTail = (ListNodeImpl<E>) list.tail();
-            link(refNode.prev, list.head); // changes list.tail()
+            AbstractListNode<E> listTail = (AbstractListNode<E>) list.tail();
+            link(refNode.getPrev(), list.head); // changes list.tail()
             link(listTail, refNode);
 
             if (index == 0) {
@@ -253,10 +253,10 @@ public class DoublyLinkedList<E>
     }
 
     /** Remove the non null {@code node} from the list. */
-    private boolean unlink(ListNodeImpl<E> node)
+    private boolean unlink(AbstractListNode<E> node)
     {
-        ListNodeImpl<E> prev = node.prev;
-        ListNodeImpl<E> next = node.next;
+        AbstractListNode<E> prev = node.getPrev();
+        AbstractListNode<E> next = node.getNext();
         if (removeListNode(node)) { // clears prev and next of node
             if (size == 0) {
                 head = null;
@@ -297,11 +297,11 @@ public class DoublyLinkedList<E>
      */
     public void addNode(int index, ListNode<E> node)
     {
-        ListNodeImpl<E> nodeImpl = (ListNodeImpl<E>) node;
+        AbstractListNode<E> nodeImpl = (AbstractListNode<E>) node;
         if (index == size) { // also true if this is empty
             linkLast(nodeImpl);
         } else {
-            ListNodeImpl<E> successor = (ListNodeImpl<E>) (index == 0 ? head : getNodeAt(index));
+            AbstractListNode<E> successor = index == 0 ? head : (AbstractListNode<E>) getNodeAt(index);
             linkBefore(nodeImpl, successor);
             if (head == successor) {
                 head = nodeImpl;
@@ -359,7 +359,7 @@ public class DoublyLinkedList<E>
         ListNodeImpl<E> successorImpl = (ListNodeImpl<E>) successor;
         ListNodeImpl<E> nodeImpl = (ListNodeImpl<E>) node;
 
-        if (successorImpl.list != this) {
+        if (successorImpl.getList() != this) {
             throw new IllegalArgumentException("Node <" + successorImpl + "> not in this list");
         }
         linkBefore(nodeImpl, successorImpl);
@@ -911,13 +911,13 @@ public class DoublyLinkedList<E>
         if (size < 2) {
             return;
         }
-        ListNodeImpl<E> newHead = (ListNodeImpl<E>) tail();
-        ListNodeImpl<E> current = (ListNodeImpl<E>) head();
+        AbstractListNode<E> newHead = (AbstractListNode<E>) tail();
+        AbstractListNode<E> current = (AbstractListNode<E>) head();
         do {
-            ListNodeImpl<E> next = current.next;
+            AbstractListNode<E> next = current.getNext();
 
-            current.next = current.prev;
-            current.prev = next;
+            current.setNext(current.getPrev());
+            current.setPrev(next);
 
             current = next;
         } while (current != head);
@@ -1515,16 +1515,74 @@ public class DoublyLinkedList<E>
     }
 
     /**
+     * An abstract implementation of a {@code ListNode}. All {@code ListNode}
+     * 
+     * @since 1.5.3
+     */
+    protected abstract static class AbstractListNode<V> implements ListNode<V> {
+
+        /** The list that this node is a member of. */
+        private DoublyLinkedList<V> list;
+
+        @Override
+        public abstract AbstractListNode<V> getNext();
+
+        @Override
+        public abstract AbstractListNode<V> getPrev();
+
+        /**
+         * Sets the next node to the specified node.
+         * 
+         * @param next the next node
+         */
+        protected abstract void setNext(AbstractListNode<V> next);
+
+        /**
+         * Sets the previous node to the specified node.
+         * 
+         * @param prev the previous node
+         */
+        protected abstract void setPrev(AbstractListNode<V> prev);
+
+        @Override
+        public DoublyLinkedList<V> getList() {
+            return this.list;
+        }
+
+        /**
+         * Sets the list that this node belongs to.
+         * 
+         * @param list the list to consist of this node
+         */
+        protected void setList(DoublyLinkedList<V> list) {
+            this.list = list;
+        }
+
+        /**
+         * Returns the string representation of this list node.
+         * 
+         * @return the string representation of this list node
+         */
+        @Override
+        public String toString()
+        {
+            if (getList() == null) {
+                return " - " + getValue() + " - "; // not in a list
+            } else {
+                return getPrev().getValue() + " -> " + getValue() + " -> " + getNext().getValue();
+            }
+        }
+    }
+
+    /**
      * The default {@link ListNode} implementation that enables checks and enforcement of a single
      * container list policy.
      */
-    private static class ListNodeImpl<V>
-        implements ListNode<V>
+    private static class ListNodeImpl<V> extends AbstractListNode<V>
     {
         private final V value;
-        private DoublyLinkedList<V> list = null;
-        private ListNodeImpl<V> next = null;
-        private ListNodeImpl<V> prev = null;
+        private AbstractListNode<V> next = null;
+        private AbstractListNode<V> prev = null;
 
         /**
          * Creates new list node
@@ -1540,19 +1598,6 @@ public class DoublyLinkedList<E>
          * {@inheritDoc}
          */
         @Override
-        public String toString()
-        {
-            if (list == null) {
-                return " - " + value + " - "; // not in a list
-            } else {
-                return prev.value + " -> " + value + " -> " + next.value;
-            }
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
         public V getValue()
         {
             return value;
@@ -1562,7 +1607,7 @@ public class DoublyLinkedList<E>
          * {@inheritDoc}
          */
         @Override
-        public ListNodeImpl<V> getNext()
+        public AbstractListNode<V> getNext()
         {
             return next;
         }
@@ -1571,19 +1616,21 @@ public class DoublyLinkedList<E>
          * {@inheritDoc}
          */
         @Override
-        public ListNodeImpl<V> getPrev()
+        public AbstractListNode<V> getPrev()
         {
             return prev;
         }
 
-        /**
-         * @since 1.5.3
-         */
         @Override
-        public DoublyLinkedList<V> getList()
-        {
-            return list;
+        protected void setNext(AbstractListNode<V> next) {
+            this.next = next;
         }
+
+        @Override
+        protected void setPrev(AbstractListNode<V> prev) {
+            this.prev = prev;
+        }
+
     }
 
     /**
@@ -1591,13 +1638,12 @@ public class DoublyLinkedList<E>
      * 
      * @since 1.5.3
      */
-    private static class ReversedListNode<V> implements ListNode<V> {
+    private static class ReversedListNode<V> extends AbstractListNode<V> {
         private final ListNode<V> wrapped;
-        private DoublyLinkedList<V> list = null;
 
         ReversedListNode(ListNode<V> node, DoublyLinkedList<V> list) {
             this.wrapped = node;
-            this.list = list;
+            super.setList(list);
         }
         
         @Override
@@ -1607,31 +1653,39 @@ public class DoublyLinkedList<E>
         }
 
         @Override
-        public ListNode<V> getNext()
+        public ReversedListNode<V> getNext()
         {
-            return new ReversedListNode<>(wrapped.getPrev(), this.list);
+            return new ReversedListNode<>(wrapped.getPrev(), this.getList());
         }
 
         @Override
-        public ListNode<V> getPrev()
+        public ReversedListNode<V> getPrev()
         {
-            return new ReversedListNode<>(wrapped.getNext(), this.list);
+            return new ReversedListNode<>(wrapped.getNext(), this.getList());
         }
 
+        /**
+         * @throws UnsupportedOperationException always
+         */
         @Override
-        public DoublyLinkedList<V> getList()
-        {
-            return list;
+        protected void setNext(AbstractListNode<V> next) {
+            throw new UnsupportedOperationException();
         }
 
+        /**
+         * @throws UnsupportedOperationException always
+         */
         @Override
-        public String toString()
-        {
-            if (list == null) {
-                return " - " + getValue() + " - "; // not in a list
-            } else {
-                return getPrev().getValue() + " -> " + getValue() + " -> " + getNext().getValue();
-            }
+        protected void setPrev(AbstractListNode<V> prev) {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        protected void setList(DoublyLinkedList<V> list) {
+            throw new UnsupportedOperationException();
         }
 
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -1525,6 +1525,17 @@ public class DoublyLinkedList<E>
 
         /** The list that this node is a member of. */
         private DoublyLinkedList<V> list;
+        /** The value stored by this node. */
+        private final V value;
+
+        /**
+         * Constructs a new {@code AbstractListNode} with the specified value;
+         * 
+         * @param value the value to be stored
+         */
+        AbstractListNode(V value) {
+            this.value = value;
+        }
 
         @Override
         public abstract AbstractListNode<V> getNext();
@@ -1535,6 +1546,11 @@ public class DoublyLinkedList<E>
         @Override
         public DoublyLinkedList<V> getList() {
             return this.list;
+        }
+
+        @Override
+        public final V getValue() {
+            return value;
         }
 
         /**
@@ -1588,7 +1604,6 @@ public class DoublyLinkedList<E>
      */
     private static class ListNodeImpl<V> extends AbstractListNode<V>
     {
-        private final V value;
         private AbstractListNode<V> next = null;
         private AbstractListNode<V> prev = null;
 
@@ -1599,16 +1614,7 @@ public class DoublyLinkedList<E>
          */
         ListNodeImpl(V value)
         {
-            this.value = value;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public V getValue()
-        {
-            return value;
+            super(value);
         }
 
         /**
@@ -1650,14 +1656,9 @@ public class DoublyLinkedList<E>
         private final ListNode<V> wrapped;
 
         ReversedListNode(ListNode<V> node, DoublyLinkedList<V> list) {
+            super(node.getValue());
             this.wrapped = node;
             super.setList(list);
-        }
-        
-        @Override
-        public V getValue()
-        {
-            return wrapped.getValue();
         }
 
         @Override

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -1517,7 +1517,7 @@ public class DoublyLinkedList<E>
     }
 
     /**
-     * An abstract implementation of a {@code ListNode}. All {@code ListNode}
+     * A skeletal implementation of a {@code ListNode}.
      * 
      * @since 1.5.3
      */
@@ -1536,6 +1536,8 @@ public class DoublyLinkedList<E>
          * Sets the next node to the specified node.
          * 
          * @param next the next node
+         * 
+         * @throws UnsupportedOperationException if this node does not support modification
          */
         protected abstract void setNext(AbstractListNode<V> next);
 
@@ -1543,6 +1545,8 @@ public class DoublyLinkedList<E>
          * Sets the previous node to the specified node.
          * 
          * @param prev the previous node
+         * 
+         * @throws UnsupportedOperationException if this node does not support modification
          */
         protected abstract void setPrev(AbstractListNode<V> prev);
 
@@ -1555,6 +1559,8 @@ public class DoublyLinkedList<E>
          * Sets the list that this node belongs to.
          * 
          * @param list the list to consist of this node
+         * 
+         * @throws UnsupportedOperationException if this node does not support modification
          */
         protected void setList(DoublyLinkedList<V> list) {
             this.list = list;

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -71,7 +71,7 @@ public class DoublyLinkedList<E>
      * 
      * @since 1.5.3
      */
-    ListNode<E> head()
+    AbstractListNode<E> head()
     {
         return this.head;
     }
@@ -81,7 +81,7 @@ public class DoublyLinkedList<E>
      * 
      * @return the last element of the list
      */
-    ListNode<E> tail()
+    AbstractListNode<E> tail()
     {
         return head.getPrev();
     }
@@ -151,8 +151,8 @@ public class DoublyLinkedList<E>
 
     /**
      * Atomically moves all {@link ListNode ListNodes} from {@code list} to this list as if each
-     * node was removed with {@link #removeListNode(ListNodeImpl)} from {@code list} and
-     * subsequently added to this list by {@link #addListNode(ListNodeImpl)}.
+     * node was removed with {@link #removeListNode(AbstractListNode)} from {@code list} and
+     * subsequently added to this list by {@link #addListNode(AbstractListNode)}.
      */
     private void moveAllListNodes(DoublyLinkedList<E> list)
     { // call this before any modification of this list is done
@@ -196,7 +196,7 @@ public class DoublyLinkedList<E>
     }
 
     /**
-     * Establishes the links between the given {@link ListNodeImpl nodes} in such a way that the
+     * Establishes the links between the given {@link AbstractListNode nodes} in such a way that the
      * {@code predecessor} is linked before the {@code successor}.
      * 
      * @param predecessor the first node linked before the other
@@ -238,9 +238,9 @@ public class DoublyLinkedList<E>
         if (previousSize == 0) {
             head = list.head; // head and tail already linked together
         } else {
-            AbstractListNode<E> refNode = (AbstractListNode<E>) ((index == previousSize) ? head() : getNodeAt(index));
+            AbstractListNode<E> refNode = index == previousSize ? head() : getNodeAt(index);
 
-            AbstractListNode<E> listTail = (AbstractListNode<E>) list.tail();
+            AbstractListNode<E> listTail = list.tail();
             link(refNode.getPrev(), list.head); // changes list.tail()
             link(listTail, refNode);
 
@@ -301,7 +301,7 @@ public class DoublyLinkedList<E>
         if (index == size) { // also true if this is empty
             linkLast(nodeImpl);
         } else {
-            AbstractListNode<E> successor = index == 0 ? head : (AbstractListNode<E>) getNodeAt(index);
+            AbstractListNode<E> successor = index == 0 ? head : getNodeAt(index);
             linkBefore(nodeImpl, successor);
             if (head == successor) {
                 head = nodeImpl;
@@ -356,12 +356,11 @@ public class DoublyLinkedList<E>
      */
     public void addNodeBefore(ListNode<E> node, ListNode<E> successor)
     {
-        ListNodeImpl<E> successorImpl = (ListNodeImpl<E>) successor;
-        ListNodeImpl<E> nodeImpl = (ListNodeImpl<E>) node;
-
-        if (successorImpl.getList() != this) {
-            throw new IllegalArgumentException("Node <" + successorImpl + "> not in this list");
+        if (successor.getList() != this) {
+            throw new IllegalArgumentException("Node <" + successor + "> not in this list");
         }
+        AbstractListNode<E> successorImpl = (AbstractListNode<E>) successor;
+        AbstractListNode<E> nodeImpl = (AbstractListNode<E>) node;
         linkBefore(nodeImpl, successorImpl);
         if (head == successorImpl) {
             head = nodeImpl;
@@ -419,19 +418,19 @@ public class DoublyLinkedList<E>
     }
 
     /**
-     * Returns the {@link ListNodeImpl node} at the specified position in this list.
+     * Returns the {@link ListNode node} at the specified position in this list.
      * 
      * @param index index of the {@code ListNodeImpl} to return
      * @return the {@code ListNode} at the specified position in this list
      * @throws IndexOutOfBoundsException if the index is out of range
      *         ({@code index < 0 || index >= size()})
      */
-    private ListNode<E> getNodeAt(int index)
+    private AbstractListNode<E> getNodeAt(int index)
     {
         if (index < 0 || size <= index) {
             throw new IndexOutOfBoundsException("Index: " + index);
         }
-        ListNode<E> node;
+        AbstractListNode<E> node;
         if (index < size / 2) {
             node = head();
             for (int i = 0; i < index; i++) {
@@ -509,7 +508,7 @@ public class DoublyLinkedList<E>
      */
     public boolean removeNode(ListNode<E> node)
     {
-        return unlink((ListNodeImpl<E>) node);
+        return unlink((AbstractListNode<E>) node);
     }
 
     /**
@@ -911,8 +910,8 @@ public class DoublyLinkedList<E>
         if (size < 2) {
             return;
         }
-        AbstractListNode<E> newHead = (AbstractListNode<E>) tail();
-        AbstractListNode<E> current = (AbstractListNode<E>) head();
+        AbstractListNode<E> newHead = tail();
+        AbstractListNode<E> current = head();
         do {
             AbstractListNode<E> next = current.getNext();
 
@@ -1306,9 +1305,9 @@ public class DoublyLinkedList<E>
             boolean wasLast = last == tail();
             removeNode(last);
             if (wasLast) { // or the sole node
-                last = (ListNodeImpl<E>) addElementLast(e);
+                last = addElementLast(e);
             } else {
-                last = (ListNodeImpl<E>) addElementBeforeNode(nextNode, e);
+                last = addElementBeforeNode(nextNode, e);
             }
             expectedModCount += 2; // because of unlink and add
         }
@@ -1721,13 +1720,13 @@ public class DoublyLinkedList<E>
         }
 
         @Override
-        ListNode<E> head()
+        ReversedListNode<E> head()
         {
             return new ReversedListNode<>(orig.tail(), this);
         }
 
         @Override
-        ListNode<E> tail()
+        ReversedListNode<E> tail()
         {
             return new ReversedListNode<>(orig.head(), this);
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -1560,7 +1560,7 @@ public class DoublyLinkedList<E>
          * 
          * @throws UnsupportedOperationException if this node does not support modification
          */
-        protected abstract void setNext(AbstractListNode<V> next);
+        abstract void setNext(AbstractListNode<V> next);
 
         /**
          * Sets the previous node to the specified node.
@@ -1569,7 +1569,7 @@ public class DoublyLinkedList<E>
          * 
          * @throws UnsupportedOperationException if this node does not support modification
          */
-        protected abstract void setPrev(AbstractListNode<V> prev);
+        abstract void setPrev(AbstractListNode<V> prev);
 
         /**
          * Sets the list that this node belongs to.
@@ -1578,7 +1578,7 @@ public class DoublyLinkedList<E>
          * 
          * @throws UnsupportedOperationException if this node does not support modification
          */
-        protected void setList(DoublyLinkedList<V> list) {
+        void setList(DoublyLinkedList<V> list) {
             this.list = list;
         }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -1722,10 +1722,28 @@ public class DoublyLinkedList<E>
             throw new UnsupportedOperationException();
         }
 
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void addNodeBefore(ListNode<E> node, ListNode<E> successor)
+        {
+            throw new UnsupportedOperationException();
+        }
+
         @Override
         public ListNode<E> getNode(int index)
         {
             return new ReversedListNode<>(orig.getNodeAt(size() - (1 + index)), this);
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public boolean removeNode(ListNode<E> node)
+        {
+            throw new UnsupportedOperationException();
         }
 
         /**

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -1415,11 +1415,6 @@ public class DoublyLinkedList<E>
         }
 
         @Override
-        public void remove() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
         public void set(E e) {
             throw new UnsupportedOperationException();
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -940,202 +940,7 @@ public class DoublyLinkedList<E>
      * @since 1.5.3
      */
     public DoublyLinkedList<E> reversed() {
-        final DoublyLinkedList<E> orig = this;
-        return new DoublyLinkedList<E>() {
-
-            @Override
-            ListNode<E> head()
-            {
-                return new ReversedListNode<>(orig.tail(), this);
-            }
-
-            @Override
-            ListNode<E> tail()
-            {
-                return new ReversedListNode<>(orig.head(), this);
-            }
-
-            @Override
-            public boolean isEmpty()
-            {
-                return orig.isEmpty();
-            }
-
-            @Override
-            public int size()
-            {
-                return orig.size();
-            }
-
-            @Override
-            public void clear()
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void addNode(int index, ListNode<E> node)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void addNodeFirst(ListNode<E> node)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void addNodeLast(ListNode<E> node)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public ListNode<E> getNode(int index)
-            {
-                return new ReversedListNode<>(orig.getNodeAt(size() - (1 + index)), this);
-            }
-
-            @Override
-            public ListNode<E> addElementFirst(E element)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public ListNode<E> addElementLast(E element)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public ListNode<E> addElementBeforeNode(ListNode<E> successor, E element)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void add(int index, E element)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public E remove(int index)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void addFirst(E e)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void addLast(E e)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean offerFirst(E e)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean offerLast(E e)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public E removeFirst()
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public E removeLast()
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public E pollFirst()
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public E pollLast()
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean removeFirstOccurrence(Object o)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean removeLastOccurrence(Object o)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean offer(E e)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public boolean remove(Object o)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public E poll()
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void push(E e)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public E pop()
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void moveFrom(int index, DoublyLinkedList<E> movedList)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void append(DoublyLinkedList<E> movedList)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void prepend(DoublyLinkedList<E> movedList)
-            {
-                throw new UnsupportedOperationException();
-            }
-
-        };
+        return new ReversedDoublyLinkedListView<>(this);
     }
 
     /**
@@ -1738,6 +1543,302 @@ public class DoublyLinkedList<E>
             } else {
                 return getPrev().getValue() + " -> " + getValue() + " -> " + getNext().getValue();
             }
+        }
+
+    }
+
+    /**
+     * A reversed view of a {@link DoublyLinkedList}. This view is unmodifiable.
+     * 
+     * @since 1.5.3
+     */
+    private static class ReversedDoublyLinkedListView<E> extends DoublyLinkedList<E> {
+
+        /** Reference to the original list. */
+        private final DoublyLinkedList<E> orig;
+
+        /**
+         * Constructs a new reversed view of the specified {@code DoublyLinkedList}.
+         * 
+         * @param orig the original list
+         * 
+         * @throws NullPointerException if argument is {@code null}
+         */
+        ReversedDoublyLinkedListView(DoublyLinkedList<E> orig) {
+            this.orig = Objects.requireNonNull(orig);
+        }
+
+        @Override
+        ListNode<E> head()
+        {
+            return new ReversedListNode<>(orig.tail(), this);
+        }
+
+        @Override
+        ListNode<E> tail()
+        {
+            return new ReversedListNode<>(orig.head(), this);
+        }
+
+        @Override
+        public boolean isEmpty()
+        {
+            return orig.isEmpty();
+        }
+
+        @Override
+        public int size()
+        {
+            return orig.size();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void clear()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void addNode(int index, ListNode<E> node)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void addNodeFirst(ListNode<E> node)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void addNodeLast(ListNode<E> node)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public ListNode<E> getNode(int index)
+        {
+            return new ReversedListNode<>(orig.getNodeAt(size() - (1 + index)), this);
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public ListNode<E> addElementFirst(E element)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public ListNode<E> addElementLast(E element)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public ListNode<E> addElementBeforeNode(ListNode<E> successor, E element)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void add(int index, E element)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public E remove(int index)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void addFirst(E e)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void addLast(E e)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public boolean offerFirst(E e)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public boolean offerLast(E e)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public E removeFirst()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public E removeLast()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public E pollFirst()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public E pollLast()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public boolean removeFirstOccurrence(Object o)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public boolean removeLastOccurrence(Object o)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public boolean offer(E e)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public boolean remove(Object o)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public E poll()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void push(E e)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public E pop()
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void moveFrom(int index, DoublyLinkedList<E> movedList)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void append(DoublyLinkedList<E> movedList)
+        {
+            throw new UnsupportedOperationException();
+        }
+
+        /**
+         * @throws UnsupportedOperationException always
+         */
+        @Override
+        public void prepend(DoublyLinkedList<E> movedList)
+        {
+            throw new UnsupportedOperationException();
         }
 
     }

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -1188,7 +1188,7 @@ public class DoublyLinkedList<E>
             if (startIndex == size()) {
                 this.next = isEmpty() ? null : head();
             } else {
-                this.next = getNodeAt(startIndex);
+                this.next = getNode(startIndex);
             }
         }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
@@ -1932,7 +1932,7 @@ public class DoublyLinkedListTest
 
             while (expectedIterator.hasNext()) {
                 assertEquals(expectedIterator.next(), revDescendingNodeIterator.next());
-                assertTrue(expectedIterator.hasNext() & revDescendingNodeIterator.hasNext());
+                assertEquals(expectedIterator.hasNext(), revDescendingNodeIterator.hasNext());
             }
         }
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
@@ -1925,7 +1925,6 @@ public class DoublyLinkedListTest
             }
         }
 
-        @Disabled // temporary
         @Test
         public void testDescendingIterator() {
             NodeIterator<Integer> expectedIterator = list.iterator();

--- a/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
@@ -1909,6 +1909,31 @@ public class DoublyLinkedListTest
                 ListNode<Integer> node = iterator.nextNode();
                 assertSame(reversedList, node.getList());
                 assertEquals(expected--, node.getValue());
+                assertThrows(UnsupportedOperationException.class, () -> iterator.remove());
+            }
+        }
+
+        @Test
+        public void testListNodeIterator() {
+            ListNodeIterator<Integer> iterator = reversedList.listIterator();
+            int expected = 4;
+            while (iterator.hasNext()) {
+                ListNode<Integer> node = iterator.nextNode();
+                assertSame(reversedList, node.getList());
+                assertEquals(expected--, node.getValue());
+                assertThrows(UnsupportedOperationException.class, () -> iterator.add(6));
+            }
+        }
+
+        @Disabled // temporary
+        @Test
+        public void testDescendingIterator() {
+            NodeIterator<Integer> expectedIterator = list.iterator();
+            NodeIterator<Integer> revDescendingNodeIterator = reversedList.descendingIterator();
+
+            while (expectedIterator.hasNext()) {
+                assertEquals(expectedIterator.next(), revDescendingNodeIterator.next());
+                assertTrue(expectedIterator.hasNext() & revDescendingNodeIterator.hasNext());
             }
         }
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
@@ -18,6 +18,7 @@
 package org.jgrapht.util;
 
 import org.jgrapht.util.DoublyLinkedList.*;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
 
@@ -1812,6 +1813,106 @@ public class DoublyLinkedListTest
         assertThrows(IllegalStateException.class, () -> listIterator.set("another"));
     }
 
+    /**
+     * Tests for {@link DoublyLinkedList.ReversedDoublyLinkedListView}.
+     * 
+     * @since 1.5.3
+     */
+    @DisplayName("Reversed view tests")
+    @Nested
+    class ReversedDoublyLinkedListViewTest {
+        
+        private DoublyLinkedList<Integer> list;
+        private DoublyLinkedList<Integer> reversedList;
+        private List<Integer> expected;
+
+        @BeforeEach
+        public void setup() {
+            expected = List.of(0, 1, 2, 3, 4);
+            list = createDoublyLinkedList(expected);
+            reversedList = list.reversed();
+        }
+
+        @Test
+        public void testHead() {
+            ListNode<Integer> revHead = reversedList.head();
+            assertSame(reversedList, revHead.getList());
+            assertEquals(4, revHead.getValue());
+        }
+
+        @Test
+        public void testTail() {
+            ListNode<Integer> revTail = reversedList.tail();
+            assertSame(reversedList, revTail.getList());
+            assertEquals(0, revTail.getValue());
+        }
+
+        @Test
+        public void testEmpty() {
+            assertFalse(reversedList.isEmpty());
+            assertTrue(new DoublyLinkedList<Object>().reversed().isEmpty());
+        }
+
+        @Test
+        public void testSize() {
+            assertEquals(5, reversedList.size());
+            assertEquals(0, new DoublyLinkedList<Object>().reversed().size());
+        }
+
+        @Test
+        public void testModification() {
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.clear());
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.addNode(0, createFreeListNode(5)));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.addNodeFirst(createFreeListNode(5)));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.addNodeLast(createFreeListNode(-1)));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.addNodeBefore(createFreeListNode(5), reversedList.getNode(0)));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.removeNode(reversedList.getNode(0)));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.addElementFirst(5));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.addElementLast(-1));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.addElementBeforeNode(reversedList.getNode(0), 5));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.add(0, 5));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.remove(0));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.addFirst(5));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.addLast(-1));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.offerFirst(4));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.offerLast(3));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.removeFirst());
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.removeLast());
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.pollFirst());
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.pollLast());
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.removeFirstOccurrence(2));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.removeLastOccurrence(1));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.offer(5));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.remove(1));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.poll());
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.push(5));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.pop());
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.invert());
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.moveFrom(0, list));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.append(list));
+            assertThrows(UnsupportedOperationException.class, () -> reversedList.prepend(list));
+        }
+
+        @Test
+        public void testGets() {
+            for (int i = 0; i < expected.size(); i++) {
+                assertEquals(i, reversedList.getNode(reversedList.size() - (1 + i)).getValue());
+                assertEquals(i, reversedList.get(reversedList.size() - (1 + i)));
+            }
+        }
+
+        @Test
+        public void testNodeIterator() {
+            NodeIterator<Integer> iterator = reversedList.iterator();
+            int expected = 4;
+            while (iterator.hasNext()) {
+                ListNode<Integer> node = iterator.nextNode();
+                assertSame(reversedList, node.getList());
+                assertEquals(expected--, node.getValue());
+            }
+        }
+    }
+
     // utility methods
 
     private static <E> DoublyLinkedList<E> createDoublyLinkedList(Collection<E> content)
@@ -1839,12 +1940,12 @@ public class DoublyLinkedListTest
     }
 
     /** Returns a {@link ListNode} contained in no {@link DoublyLinkedList}. */
-    private static ListNode<String> createFreeListNode(String element)
+    private static <E> ListNode<E> createFreeListNode(E element)
     {
 
-        DoublyLinkedList<String> list = createDoublyLinkedList(Collections.singletonList(element));
+        DoublyLinkedList<E> list = createDoublyLinkedList(Collections.singletonList(element));
 
-        ListNode<String> node = list.getNode(0);
+        ListNode<E> node = list.getNode(0);
         list.removeNode(node);
         return node;
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
@@ -1814,6 +1814,18 @@ public class DoublyLinkedListTest
     }
 
     /**
+     * Tests that {@code DoublyLinkedList} implements both {@code java.util.List} and {@code java.util.Deque} interfaces.
+     * 
+     * @since 1.5.3
+     */
+    @Test
+    public void testInheritance() {
+        DoublyLinkedList<?> list = new DoublyLinkedList<>();
+        assertInstanceOf(List.class, list);
+        assertInstanceOf(Deque.class, list);
+    }
+
+    /**
      * Tests for {@link DoublyLinkedList.ReversedDoublyLinkedListView}.
      * 
      * @since 1.5.3

--- a/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/util/DoublyLinkedListTest.java
@@ -1820,7 +1820,7 @@ public class DoublyLinkedListTest
      */
     @DisplayName("Reversed view tests")
     @Nested
-    class ReversedDoublyLinkedListViewTest {
+    public class ReversedDoublyLinkedListViewTest {
         
         private DoublyLinkedList<Integer> list;
         private DoublyLinkedList<Integer> reversedList;
@@ -1939,7 +1939,7 @@ public class DoublyLinkedListTest
 
     // utility methods
 
-    private static <E> DoublyLinkedList<E> createDoublyLinkedList(Collection<E> content)
+    static <E> DoublyLinkedList<E> createDoublyLinkedList(Collection<E> content)
     {
         DoublyLinkedList<E> list = new DoublyLinkedList<>();
         for (E element : content) {
@@ -1964,7 +1964,7 @@ public class DoublyLinkedListTest
     }
 
     /** Returns a {@link ListNode} contained in no {@link DoublyLinkedList}. */
-    private static <E> ListNode<E> createFreeListNode(E element)
+    static <E> ListNode<E> createFreeListNode(E element)
     {
 
         DoublyLinkedList<E> list = createDoublyLinkedList(Collections.singletonList(element));


### PR DESCRIPTION
_Resolves #1154_

This PR:
- Restores `java.util.Deque` interface in `DoublyLinkedList`, i.e., reverts #1159
- Implements `DoublyLinkedList.reversed()`, as specified by [`java.util.SequencedCollection`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/util/SequencedCollection.html) in Java 21 API. This includes:
  - Changing inheritance hierarchy of `ListNode`
    - Adding a `ReversedListNode` class as a subclass of `ListNode`
  - Adding `ListNode.getList()` method
  - Adding `ReversedDoublyLinkedListView` class
  - Adding `DoublyLinkedList.head()` (as counterpart of `DoublyLinkedList.tail()`)
  - Changing visibility of `DoublyLinkedList.tail()` to package private (originally private)

The reversed view returned by `DoublyLinkedList.reversed()`, as implemented by this PR, is unmodifiable. This is to avoid headaches with data inconsistencies, although making the modifications "write through" to the original list should be doable. For a similar reason, the behavior of the view is explicitly undefined if the original list is modified after the creation of the view.

Note that this PR's goal is compatibility across versions.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
