### PR TITLE
Javadoc Maintenance: Cleanup 2

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java
@@ -46,7 +46,7 @@ public interface AStarAdmissibleHeuristic<V>
      * to the estimated distance from any neighboring vertex to the goal, plus the step cost of
      * reaching that neighbor. For details, refer to <a href=
      * "https://en.wikipedia.org/wiki/Consistent_heuristic">https://en.wikipedia.org/wiki/Consistent_heuristic</a>.
-     * In short, a heuristic is consistent iff {@code h(u) < d(u,v)+h(v)}, for every edge
+     * In short, a heuristic is consistent iff $h(u) \le d(u,v)+h(v)$, for every edge
      * $(u,v)$, where $d(u,v)$ is the weight of edge $(u,v)$ and $h(u)$ is the estimated cost to
      * reach the target node from vertex u. Most natural admissible heuristics, such as Manhattan or
      * Euclidean distance, are consistent heuristics.


### PR DESCRIPTION
Yet another follow-up for #1168 and #1179, caused by human error (sigh):

https://github.com/jgrapht/jgrapht/blob/644a438692e256580aeb533e839963c49ca1e5a6/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java#L49
https://github.com/jgrapht/jgrapht/blob/381a5957835bce9430435fa1644b74190e5a4cdd/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/AStarAdmissibleHeuristic.java#L49

`&le;` translates to `<=` in HTML, but #1179 replaced it with `<` (without equal sign). This caused a regression in documentation, and this PR fixes it.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] <s>I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)</s>
- [ ] <s>I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)</s>
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
