### PR TITLE
CI: Use correct context property

### DIFF
--- a/.github/workflows/master-workflow.yaml
+++ b/.github/workflows/master-workflow.yaml
@@ -44,7 +44,7 @@ jobs:
   snapshot-publish:
     name: Publish Snapshot
     needs: build
-    if: github.action_repository == 'jgrapht/jgrapht'
+    if: github.repository == 'jgrapht/jgrapht'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
A quick regression patch for #1181

This PR fixes the "snapshot not publishing" issue (regression introduced by #1181 - see <https://github.com/jgrapht/jgrapht/actions/runs/7443751444/job/20249318986>).

Ref: [GitHub Docs: Contexts#`github` context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] <s>I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)</s>
- [ ] <s>I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)</s>
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)

----

Side note:

https://github.com/jgrapht/jgrapht/blob/64c6cf7ffdb9f6a6ef5a1972e6653e7757beb440/.github/workflows/master-workflow.yaml#L47

What this line does is blocking all CI workflows being run to _not_ attempt to publish snapshot versions (because making it run on forks results in failures due to absence of secret values, which really is irrelevant to the test results).