### PR TITLE
Fix Javadoc warnings

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AsWeightedGraph.java
@@ -119,7 +119,7 @@ public class AsWeightedGraph<V, E>
      *        weight function
      * @param writeWeightsThrough if set to {@code true}, the weight set directly by
      *        the {@link #setEdgeWeight(Object, double)} method will be propagated to the backing graph.
-     * @throws NullPointerException if the graph or the weight function is {@link null}
+     * @throws NullPointerException if the graph or the weight function is {@code null}
      * @throws IllegalArgumentException if {@code writeWeightsThrough} is set to true and
      *         {@code graph} is not a weighted graph
      */
@@ -149,7 +149,7 @@ public class AsWeightedGraph<V, E>
      *
      * @param e edge of interest
      * @return the edge weight
-     * @throws NullPointerException if the edge is {@link null}
+     * @throws NullPointerException if the edge is {@code null}
      */
     @Override
     public double getEdgeWeight(E e)

--- a/jgrapht-core/src/main/java/org/jgrapht/util/PrefetchIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/PrefetchIterator.java
@@ -163,7 +163,7 @@ public class PrefetchIterator<E>
      * <p>Efficiency: if {@link #nextElement()}, {@link #hasMoreElements()} were never used,
      * it activates the {@link #hasMoreElements()} once. Else it is immediately $(O(1))$
      * 
-     * @return {@link true} if the enumeration started as an empty one, {@link false} otherwise.
+     * @return {@code true} if the enumeration started as an empty one, {@code false} otherwise.
      */
     public boolean isEnumerationStartedEmpty()
     {


### PR DESCRIPTION
This PR fixes Javadoc syntax regressions (introduced in #1168) that cause _warnings_ during Javadoc generation.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] <s>I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)</s>
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
