### PR TITLE
Update Maven Configurations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -373,7 +373,7 @@
                         <additionalJOption>--allow-script-in-comments</additionalJOption>
                         <doclint>none</doclint>
                         <source>11</source>
-                        <header>&lt;script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS-MML_HTMLorMML,https://jgrapht.org/mathjax/mathjaxConfig.js"&gt;&lt;/script&gt;
+                        <header>&lt;script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS-MML_HTMLorMML,https://jgrapht.org/mathjax/mathjaxConfig.js"&gt;&lt;/script&gt;
                         &lt;img src="https://github.com/jgrapht/jgrapht/blob/master/etc/logo/jgrapht-logo-transparent-cropped-javadocheader.png?raw=true" style="height:55px;"&gt;
                         </header>
                         <doctitle>${project.name} ${project.version} API

--- a/pom.xml
+++ b/pom.xml
@@ -379,7 +379,6 @@
                         <doctitle>${project.name} ${project.version} API
                         &lt;img src="https://github.com/jgrapht/jgrapht/blob/master/etc/logo/jgrapht-logo-transparent-cropped.png?raw=true" style="height:100px;float:right" &gt;
                         </doctitle>
-                        <detectJavaApiLink>false</detectJavaApiLink> <!-- Temporary fix for https://stackoverflow.com/questions/58836862/jdk-11-and-javadoc -->
                         <notimestamp>true</notimestamp>
                         <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
                     </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
         <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
         <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
-        <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
         <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
@@ -274,7 +273,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>${maven-failsafe-plugin.version}</version>
+                    <version>${maven-surefire-plugin.version}</version>
                     <configuration>
                         <properties>
                             <configurationParameters>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <fastutil.version>8.5.12</fastutil.version>
         <guava.version>32.1.1-jre</guava.version>
         <hamcrest.version>2.2</hamcrest.version>
+        <java.version>11</java.version>
         <jgraphx.version>4.2.2</jgraphx.version>
         <jheaps.version>0.14</jheaps.version>
         <jmh.version>1.37</jmh.version>
@@ -238,7 +239,7 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
-                        <release>11</release>
+                        <release>${java.version}</release>
                         <compilerArgs>
                             <arg>--add-modules</arg>
                                 <arg>java.xml</arg>
@@ -371,7 +372,7 @@
                         <windowtitle>JGraphT : a free Java graph library</windowtitle>
                         <additionalJOption>--allow-script-in-comments</additionalJOption>
                         <doclint>none</doclint>
-                        <source>11</source>
+                        <source>${java.version}</source>
                         <header>&lt;script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.9/MathJax.js?config=TeX-AMS-MML_HTMLorMML,https://jgrapht.org/mathjax/mathjaxConfig.js"&gt;&lt;/script&gt;
                         &lt;img src="https://github.com/jgrapht/jgrapht/blob/master/etc/logo/jgrapht-logo-transparent-cropped-javadocheader.png?raw=true" style="height:55px;"&gt;
                         </header>


### PR DESCRIPTION
This PR:

- Updates the link for loading MathJax in Javadoc  
  The old link was using `v2.7.1`, this PR bumps up to `v2.7.9`. Includes patches for CVE-2018-1999024 (fixed in MathJax `v2.7.4`).
- Tells Maven to use the same versioning key for Surefire and Failsafe (to keep dependency versions consistent)
- Removes the Java API detection suppression in Javadoc (first added by bafb5a1)  
  The underlying cause was resolved in the upstream dependencies few versions ago, and the version JGraphT uses for build is no longer affected.
- Adds `java.version` property in pom (to keep compile and javadoc plugins consistent and free of hard-coded Java version)

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] <s>I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)</s>
- [ ] <s>I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)</s>
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
