### PR TITLE
Add Missing License Headers

### DIFF
--- a/etc/checkstyle_suppressions.xml
+++ b/etc/checkstyle_suppressions.xml
@@ -5,9 +5,6 @@
     "https://checkstyle.org/dtds/suppressions_1_2.dtd">
 
 <suppressions>
-    <!-- Ignore header checks for package-info.java files -->
-    <suppress files="package-info\.java" checks="Header" />
-
     <!-- Suppression of Javadoc related checks for test files -->
     <suppress files="[/\\]src[/\\]test[/\\].*" checks="JavadocMethod" />
     <suppress files="[/\\]src[/\\]test[/\\].*" checks="JavadocType" />

--- a/etc/jgrapht_checks.xml
+++ b/etc/jgrapht_checks.xml
@@ -4,6 +4,9 @@
         "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
+    <module name="BeforeExecutionExclusionFileFilter">
+        <property name="fileNamePattern" value="module\-info\.java$" />
+    </module>
     <module name="SuppressionFilter">
         <property name="file" value="etc/checkstyle_suppressions.xml" />
     </module>

--- a/etc/jgrapht_checks.xml
+++ b/etc/jgrapht_checks.xml
@@ -4,9 +4,6 @@
         "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <module name="Checker">
-    <module name="BeforeExecutionExclusionFileFilter">
-        <property name="fileNamePattern" value="module\-info\.java$" />
-    </module>
     <module name="SuppressionFilter">
         <property name="file" value="etc/checkstyle_suppressions.xml" />
     </module>

--- a/jgrapht-core/src/main/java/module-info.java
+++ b/jgrapht-core/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Defines the core APIs of the JGraphT library.
  * 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/clique/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/clique/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2017-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Clique related algorithms.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/clustering/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/clustering/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Graph clustering algorithms.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/color/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/color/package-info.java
@@ -1,3 +1,22 @@
+/*
+ * (C) Copyright 2017-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
+
 /**
  * Graph coloring algorithms.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Joris Kinable and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms dealing with various connectivity aspects of a graph.
  *

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2016-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms related to graph cycles.
  * 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Alexandru Valeanu and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms for computing decompositions.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/densesubgraph/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/densesubgraph/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Andre Immig and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms for computing maximum density subgraphs.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/drawing/model/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/drawing/model/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Graph Drawing Basic Types and Models.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/drawing/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/drawing/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Graph Drawing.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/mincost/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Timofey Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms for minimum cost flow
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2016-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Flow related algorithms.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/independentset/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/independentset/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Joris Kinable and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms for <a href="http://mathworld.wolfram.com/IndependentVertexSet.html">Independent
  * Set</a> in a graph.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/interfaces/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2016-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithm related interfaces.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2016-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms for (sub)graph isomorphism.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/lca/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/lca/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Alexandru Valeanu and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms for computing lowest common ancestors in graphs.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/linkprediction/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/linkprediction/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms for link prediction
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/matching/blossom/v5/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/matching/blossom/v5/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Timofey Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Package for Kolmogorov's Blossom V algorithm
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/matching/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/matching/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2016-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms for the computation of matchings.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms provided with <b>JGraphT</b>.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/partition/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/partition/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Alexandru Valeanu and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithm for computing partitions.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/planar/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/planar/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Timofey Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms for testing planarity of the graphs
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/scoring/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2017-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Vertex and/or edge scoring algorithms.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2017-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Shortest-path related algorithms.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/similarity/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/similarity/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Semen Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Algorithms for computing graph similarity metrics.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/spanning/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2016-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Spanning tree and spanner algorithms.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2017-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Graph tours related algorithms.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/transform/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/transform/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Joris Kinable and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Package for graph transformers
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/extension/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/extension/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Utility classes for managing extensions/encapsulations.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Utilities used by JGraphT algorithms.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Vertex cover algorithms.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/util/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/vertexcover/util/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Utilities for vertex cover algorithms.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/event/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/event/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Event classes and listener interfaces, used to provide a change notification mechanism on graph
  * modification events.

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/netgen/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/netgen/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Timofey Chudakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Network generator components
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Generators for graphs of various topologies.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/builder/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/builder/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Various builder for graphs.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/concurrent/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/concurrent/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by CHEN Kui and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Implementations of various concurrent graph structures.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Implementations of various graphs.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/specifics/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Implementations of specifics for various graph types.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2016-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * The front-end API's interfaces and classes, including {@link org.jgrapht.Graph}.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Graph traversal means.
  */

--- a/jgrapht-core/src/main/java/org/jgrapht/util/package-info.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Non-graph-specific data structures, algorithms, and utilities used by <b>JGraphT</b>.
  */

--- a/jgrapht-core/src/test/java/org/jgrapht/graph/AsUnweightedGraphTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/graph/AsUnweightedGraphTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright 2018, by Lukas Harzenetter and Contributors.
+ * (C) Copyright 2018-2024, by Lukas Harzenetter and Contributors.
  *
  * JGraphT : a free Java graph-theory library
  *

--- a/jgrapht-demo/src/main/java/module-info.java
+++ b/jgrapht-demo/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Provides demo applications of the JGraphT library.
  * 

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/package-info.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Demo programs that help to get started with <b>JGraphT</b>.
  */

--- a/jgrapht-ext/src/main/java/module-info.java
+++ b/jgrapht-ext/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Provides adaptors for the JGraphT graphs to be used
  * with external libraries.

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/package-info.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Extensions and integration means to other products.
  */

--- a/jgrapht-guava/src/main/java/module-info.java
+++ b/jgrapht-guava/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Provides adaptors for the Google Guava graphs to be used with the
  * JGraphT library.

--- a/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/package-info.java
+++ b/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * <a href="https://jgrapht.org/guide/UserOverview#guava-graph-adapter">Guava adapters</a> allow you
  * to <a href="https://jgrapht.org/guide/GuavaAdapter">run JGraphT algorithms directly against

--- a/jgrapht-io/src/main/java/module-info.java
+++ b/jgrapht-io/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Provides I/O extensions for the JGraphT library.
  * 

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/csv/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/csv/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * CSV importers/exporters
  */

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dimacs/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * DIMACS Challenges importers/exporters
  */

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * DOT importers/exporters
  */

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/gexf/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/gexf/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Graph Exchange XML Format (GEXF) importers/exporters.
  * 

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/gml/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/gml/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * GML importers/exporters
  */

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/graph6/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/graph6/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Graph6, sparse6 and digraph6 importers/exporters
  */

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/graphml/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/graphml/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * GraphML importers/exporters
  */

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/json/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/json/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Json importers/exporters
  */

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/lemon/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/lemon/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Lemon input/output.
  */

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/matrix/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/matrix/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Matrix input/output
  */

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Importers/Exporters for various graph formats.
  */

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/package-info.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/tsplib/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Hannes Wellmann and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * TSPLIB95 importers/exporters
  */

--- a/jgrapht-opt/src/main/java/module-info.java
+++ b/jgrapht-opt/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Provides specialized graph implementations.
  * 

--- a/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/fastutil/package-info.java
+++ b/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/fastutil/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2018-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Specialized graph implementations using the FastUtil library 
  */

--- a/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/sparse/package-info.java
+++ b/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/sparse/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2019-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Specialized graph implementations using sparse matrix representations.
  */

--- a/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/sparse/specifics/package-info.java
+++ b/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/sparse/specifics/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2021-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Implementations of different sparse graphs with different tradeoffs.
  */

--- a/jgrapht-unimi-dsi/src/main/java/module-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/module-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Provides graph implementations using succinct data structures.
  * 

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2021-2024, by Sebastiano Vigna and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Immutable graphs stored using <a href="http://sux4j.di.unimi.it/">Sux4J</a>'s quasi-succinct data
  * structures.

--- a/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/package-info.java
+++ b/jgrapht-unimi-dsi/src/main/java/org/jgrapht/webgraph/package-info.java
@@ -1,3 +1,21 @@
+/*
+ * (C) Copyright 2020-2024, by Sebastiano Vigna and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+
 /**
  * Adapters for graphs stored using
  * <a href="http://webgraph.di.unimi.it/">WebGraph</a>'s compressed and succinct


### PR DESCRIPTION
> Regarding the question of adding the license headers to the -info.java files, yes, that would be a good as a separate PR. If you do that, be sure to remove the exclusions in etc/jgrapht_checks.xml and etc/checkstyle_suppressions.xml.
> 
> _Originally posted by @jsichi in https://github.com/jgrapht/jgrapht/pull/1213#issuecomment-2046654962_

This PR adds the missing license headers to the `module-info.java` and `package-info.java` files and updates the Checkstyle rule accordingly.

The added license headers respect (or at least try to respect) the original authorships of the files, i.e., the year that the file was added and the original author's name are included, not my name and 2024.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] <s>I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)</s>
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
