### PR TITLE
Terminate BFSShortestPath#getPath when target vertex is found

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BFSShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BFSShortestPath.java
@@ -58,6 +58,19 @@ public class BFSShortestPath<V, E>
     @Override
     public SingleSourcePaths<V, E> getPaths(V source)
     {
+        return getPaths(source, null);
+    }
+
+    /**
+     * Compute all shortest paths from single source vertex if no sink provided.
+     * If sink provided, will compute shortest path from source vertex to target vertex.
+     * @param source - The source vertex.
+     * @param sink - Optional, the target vertex.
+     * @return - The shortest paths if no sink provided.
+     * Returns the shortest path between source and sink if sink is provided.
+     */
+    private SingleSourcePaths<V, E> getPaths(V source, V sink)
+    {
         if (!graph.containsVertex(source)) {
             throw new IllegalArgumentException(GRAPH_MUST_CONTAIN_THE_SOURCE_VERTEX);
         }
@@ -87,6 +100,14 @@ public class BFSShortestPath<V, E>
                     double newDist = distanceAndPredecessorMap.get(v).getFirst() + 1.0;
                     distanceAndPredecessorMap.put(u, Pair.of(newDist, e));
                 }
+
+                /*
+                 * Break the loop if target vertex is found.
+                 */
+                if(u.equals(sink)) {
+                    queue.clear();
+                    break;
+                }
             }
         }
 
@@ -104,16 +125,16 @@ public class BFSShortestPath<V, E>
         if (!graph.containsVertex(sink)) {
             throw new IllegalArgumentException(GRAPH_MUST_CONTAIN_THE_SINK_VERTEX);
         }
-        return getPaths(source).getPath(sink);
+        return getPaths(source, sink).getPath(sink);
     }
 
     /**
      * Find a path between two vertices.
-     * 
+     *
      * @param graph the graph to be searched
      * @param source the vertex at which the path should start
      * @param sink the vertex at which the path should end
-     * 
+     *
      * @param <V> the graph vertex type
      * @param <E> the graph edge type
      *


### PR DESCRIPTION
Fixes [#1158](https://github.com/jgrapht/jgrapht/issues/1158).

Overloaded the BFSShortestPath#getPaths  function to accept target vertex. Added logic to terminate the loop if target vertex is found. No extra test cases added as BFSShortestPath#getPath test case was already present in BFSShortestPathTest.java. I could see improvement of 43 times in the benchmarking tests for BFSShortestPath#getPath.


----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [not applicable] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
