### PR TITLE
Fix Suurballe's modifiedWeight calculation

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/SuurballeKDisjointShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/SuurballeKDisjointShortestPaths.java
@@ -34,11 +34,11 @@
  */
 package org.jgrapht.alg.shortestpath;
 
+import java.math.*;
+import java.util.*;
+
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
-
-import java.math.BigDecimal;
-import java.util.*;
 
 /**
  * An implementation of Suurballe algorithm for finding K edge-<em>disjoint</em> shortest paths. The
@@ -89,8 +89,10 @@ public class SuurballeKDisjointShortestPaths<V, E>
         for (E edge : this.workingGraph.edgeSet()) {
             V source = workingGraph.getEdgeSource(edge);
             V target = workingGraph.getEdgeTarget(edge);
-            double modifiedWeight = calculateModifiedWeight(this.workingGraph.getEdgeWeight(edge),
-                    singleSourcePaths.getWeight(source), singleSourcePaths.getWeight(target));
+
+            double modifiedWeight = calculateModifiedWeight(
+                this.workingGraph.getEdgeWeight(edge), singleSourcePaths.getWeight(source),
+                singleSourcePaths.getWeight(target));
 
             this.workingGraph.setEdgeWeight(edge, modifiedWeight);
         }
@@ -122,19 +124,21 @@ public class SuurballeKDisjointShortestPaths<V, E>
         return singleSourcePaths.getPath(endVertex);
     }
 
-    private double calculateModifiedWeight(double edgeWeight, double sourcePathWeight, double targetPathWeight) 
+    private double calculateModifiedWeight(
+        double edgeWeight, double sourcePathWeight, double targetPathWeight)
     {
-        if (sourcePathWeight == Double.POSITIVE_INFINITY && targetPathWeight == Double.POSITIVE_INFINITY) {
+        if (sourcePathWeight == Double.POSITIVE_INFINITY
+            && targetPathWeight == Double.POSITIVE_INFINITY)
+        {
             return Double.NaN;
         } else if (sourcePathWeight == Double.POSITIVE_INFINITY) {
             return Double.POSITIVE_INFINITY;
         } else if (targetPathWeight == Double.POSITIVE_INFINITY) {
             return Double.NEGATIVE_INFINITY;
         } else {
-            return BigDecimal.valueOf(edgeWeight)
-                    .subtract(BigDecimal.valueOf(targetPathWeight))
-                    .add(BigDecimal.valueOf(sourcePathWeight))
-                    .doubleValue();
+            return BigDecimal
+                .valueOf(edgeWeight).subtract(BigDecimal.valueOf(targetPathWeight))
+                .add(BigDecimal.valueOf(sourcePathWeight)).doubleValue();
         }
     }
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/SuurballeKDisjointShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/SuurballeKDisjointShortestPaths.java
@@ -37,6 +37,7 @@ package org.jgrapht.alg.shortestpath;
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
 
+import java.math.BigDecimal;
 import java.util.*;
 
 /**
@@ -88,8 +89,8 @@ public class SuurballeKDisjointShortestPaths<V, E>
         for (E edge : this.workingGraph.edgeSet()) {
             V source = workingGraph.getEdgeSource(edge);
             V target = workingGraph.getEdgeTarget(edge);
-            double modifiedWeight = this.workingGraph.getEdgeWeight(edge)
-                - singleSourcePaths.getWeight(target) + singleSourcePaths.getWeight(source);
+            double modifiedWeight = calculateModifiedWeight(this.workingGraph.getEdgeWeight(edge),
+                    singleSourcePaths.getWeight(source), singleSourcePaths.getWeight(target));
 
             this.workingGraph.setEdgeWeight(edge, modifiedWeight);
         }
@@ -119,6 +120,22 @@ public class SuurballeKDisjointShortestPaths<V, E>
         this.singleSourcePaths =
             new DijkstraShortestPath<>(this.workingGraph).getPaths(startVertex);
         return singleSourcePaths.getPath(endVertex);
+    }
+
+    private double calculateModifiedWeight(double edgeWeight, double sourcePathWeight, double targetPathWeight) 
+    {
+        if (sourcePathWeight == Double.POSITIVE_INFINITY && targetPathWeight == Double.POSITIVE_INFINITY) {
+            return Double.NaN;
+        } else if (sourcePathWeight == Double.POSITIVE_INFINITY) {
+            return Double.POSITIVE_INFINITY;
+        } else if (targetPathWeight == Double.POSITIVE_INFINITY) {
+            return Double.NEGATIVE_INFINITY;
+        } else {
+            return BigDecimal.valueOf(edgeWeight)
+                    .subtract(BigDecimal.valueOf(targetPathWeight))
+                    .add(BigDecimal.valueOf(sourcePathWeight))
+                    .doubleValue();
+        }
     }
 
 }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/SuurballeKDisjointShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/SuurballeKDisjointShortestPathsTest.java
@@ -17,8 +17,14 @@
  */
 package org.jgrapht.alg.shortestpath;
 
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.*;
+
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
+import org.jgrapht.graph.*;
+import org.junit.jupiter.api.*;
 
 /**
  * 
@@ -35,4 +41,42 @@ public class SuurballeKDisjointShortestPathsTest
     {
         return new SuurballeKDisjointShortestPaths<>(graph);
     }
+
+    @Test
+    public void testTwoDisjointPathsInGraphContainingFractionalDoublelEdgeWeight()
+    {
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        graph.addVertex(2);
+        graph.addVertex(3);
+
+        DefaultWeightedEdge e12 = graph.addEdge(1, 2);
+        DefaultWeightedEdge e13 = graph.addEdge(1, 3);
+        DefaultWeightedEdge e23 = graph.addEdge(2, 3);
+
+        graph.setEdgeWeight(e12, 1.0);
+        graph.setEdgeWeight(e13, 2.0);
+        graph.setEdgeWeight(e23, 0.9);
+
+        SuurballeKDisjointShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new SuurballeKDisjointShortestPaths<Integer, DefaultWeightedEdge>(graph);
+
+        List<GraphPath<Integer, DefaultWeightedEdge>> pathList = alg.getPaths(1, 3, 2);
+
+        assertEquals(2, pathList.size());
+
+        GraphPath<Integer, DefaultWeightedEdge> expectedP1 =
+            new GraphWalk<>(graph, Arrays.asList(1, 2, 3), 1);
+        assertEquals(expectedP1, pathList.get(0));
+        assertEquals(2, pathList.get(0).getLength());
+        assertEquals(1.9, pathList.get(0).getWeight(), 0.0);
+
+        GraphPath<Integer, DefaultWeightedEdge> expectedP2 =
+            new GraphWalk<>(graph, Arrays.asList(1, 3), 2);
+        assertEquals(expectedP2, pathList.get(1));
+        assertEquals(1, pathList.get(1).getLength());
+        assertEquals(2.0, pathList.get(1).getWeight(), 0.0);
+    }
+
 }


### PR DESCRIPTION
We have found that the use of doubles in the calculation of the modified edge weights can lead to floating point precision errors. 

e.g. `0.9 - 1.9 + 1.0` returns `1.1102230246251565E-16` instead of `0.0`

where:
- `0.9` is the weight of the current edge
- `1.9` is the weight of the path until the target of the current edge 
- `1.0` is the weight of the path until the source of the current edge 

Further down on line `101` where the zero weight check is done is where the algorithm falls over.

I expect that if the weights used were whole numbers the calculation would work fine, however, the implementation implies that `double` fractional numbers are supported.

The proposed fix uses `BigDecimal` to get a more precise calculation of the weights which works ok in our use case.

For scenarios where vertices that have not been reached and would have an edge weight of infinity, it would still return the expected infinity or `NaN` the initial calculation would have resulted in.

<!-- describe the changes you have made here: what, why, …
     Link issues by using the following pattern: [#333](https://github.com/jgrapht/jgrapht/issues/333).
     The title of the PR must not reference an issue, because GitHub does not support autolinking there. -->

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [ ] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
