### PR TITLE
<fix>: resolve the unexpected behavior of DOTImporter.

### DIFF
--- a/jgrapht-io/src/main/antlr4/org/jgrapht/nio/dot/DOT.g4
+++ b/jgrapht-io/src/main/antlr4/org/jgrapht/nio/dot/DOT.g4
@@ -137,12 +137,11 @@ SCharSequence
    : SChar+
    ;
 
+
 fragment
 SChar
-   : ~["\\]
-   | '\\' ["\\]
-   | '\\\n'
-   | '\\\r\n'  
+   : ~["]
+   | '\\"' 
    ;
 
 fragment

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTEventDrivenImporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTEventDrivenImporter.java
@@ -78,10 +78,7 @@ public class DOTEventDrivenImporter
     {
         super();
         Map<CharSequence, CharSequence> lookupMap = new HashMap<>();
-        lookupMap.put("\\\\", "\\");
         lookupMap.put("\\\"", "\"");
-        lookupMap.put("\\'", "'");
-        lookupMap.put("\\", "");
         unescapeId = new AggregateTranslator(new LookupTranslator(lookupMap));
 
         this.notifyVertexAttributesOutOfOrder = notifyVertexAttributesOutOfOrder;

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/dot/DOTImporter2Test.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/dot/DOTImporter2Test.java
@@ -678,9 +678,36 @@ public class DOTImporter2Test
             "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\"?>",
             attrs.get("6").get("name").getValue());
         assertEquals("<h2>name \u2705</h2>", attrs.get("7").get("name").getValue());
-        assertEquals("two\nlines", attrs.get("8").get("name").getValue());
+        assertEquals("two\\\nlines", attrs.get("8").get("name").getValue());
         assertEquals("", attrs.get("9").get("name").getValue());
-        assertEquals("\\\\\\\\", attrs.get("10").get("name").getValue());
+        assertEquals("\\\\\\\\\\\\\\\\", attrs.get("10").get("name").getValue());
+    }
+
+    @Test
+    public void testUnescape2() {
+        String input = "digraph G {" + NL + 
+                        "  a [ label=\" /\\\\n \"];" + NL + 
+                        "  b [ label=\"\\\"Test\\\"\"];"  + NL + 
+                        "  a -> b; " + NL + 
+                        "}";
+        Map<String, Map<String, Attribute>> attrs = new HashMap<>();
+        DOTImporter<String, DefaultEdge> importer = new DOTImporter<>();
+        importer.addVertexAttributeConsumer((p, a) -> {
+            Map<String, Attribute> map = attrs.get(p.getFirst());
+            if (map == null) {
+                map = new HashMap<>();
+                attrs.put(p.getFirst(), map);
+            }
+            map.put(p.getSecond(), a);
+        });
+
+        DirectedMultigraph<String, DefaultEdge> result = new DirectedMultigraph<>(
+            SupplierUtil.createStringSupplier(), SupplierUtil.DEFAULT_EDGE_SUPPLIER, false);
+        importer.importGraph(result, new StringReader(input));
+        assertEquals("a", attrs.get("0").get("ID").getValue());
+        assertEquals(" /\\\\n ", attrs.get("0").get("label").getValue());
+        assertEquals("b", attrs.get("1").get("ID").getValue());
+        assertEquals("\"Test\"", attrs.get("1").get("label").getValue());
     }
 
     @Test


### PR DESCRIPTION
Resolve the issue [#1228](https://github.com/jgrapht/jgrapht/issues/1228)

To avoid the unexpected behavior of DOTImpoter, I modify the parsing rules for DOT language according to https://graphviz.org/doc/info/lang.html. In summary, I modify three files:
1. Modify the DOT.g4 to enable JGraphT identify legal text in DOT language which is omitted in current verion of JGraphT.
2. Modify the DOTEventDerivenImporter to update the lookupMap rule to parse corresponding element.
3. Add a unit test for these modifications.

Because the modification of the source code does not involve the addition/deletion/modification on the level of class/method, I just update the codes instead of use _Deprecation policy_.

Since there is no added class or method, It seems that there is no need to modify the document.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [ ] ~~I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)~~
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
