### PR TITLE
Add subgraph support in DOT export

### DIFF
--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTExporter.java
@@ -164,6 +164,13 @@ public class DOTExporter<V, E>
         out.flush();
     }
 
+    /**
+     * Export a subgraph into DOT format
+     *
+     * @param out the writer to which the graph to be exported
+     * @param subgraphName the name of the subgraph
+     * @param subgraph the subgraph to be exported
+     */
     private void writeSubgraph(PrintWriter out, String subgraphName, DOTSubgraph<V, E> subgraph) {
         out.println(INDENT + "subgraph " + subgraphName + " {");
         renderSubgraphAttributes(out, subgraphName, subgraph);

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTSubgraph.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/dot/DOTSubgraph.java
@@ -20,7 +20,7 @@ package org.jgrapht.nio.dot;
 import org.jgrapht.graph.AsSubgraph;
 import org.jgrapht.nio.Attribute;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
 
@@ -28,6 +28,22 @@ import java.util.Set;
  * A DOTSubgraph is a container class for a subgraph and its attributes. It may be used in DOT export and can be
  * parametrized to export or not vertices and/or edges.
  *
+ * <p>
+ *     For example, for a subgraph named "subg" with DefaultEdges (1, 2) and (2, 3) between Integer vertices 1, 2, and 3,
+ *     with the subgraph attribute {@code pencolor} set to {@code transparent}, and the cluster attribute {@code shape}
+ *     set to {@code point}, the DOT export of the subgraph will be:
+ * </p>
+ * <pre>
+ *     subgraph subg {
+ *         subg [ shape="point" ]
+ *         pencolor=transparent;
+ *         1;
+ *         2;
+ *         3;
+ *         1 -- 2;
+ *         2 -- 3;
+ *     }
+ * </pre>
  * @param <V> the vertex type
  * @param <E> the edge type
  *
@@ -43,43 +59,120 @@ public class DOTSubgraph<V, E> {
     private final boolean exportVertices;
     private final boolean exportEdges;
 
+    /**
+     * Constructs a new DOTSubgraph with specified subgraph, attributes, and export options.
+     *
+     * @param subgraph the subgraph to be exported
+     * @param subgraphAttributes attributes for the subgraph
+     * @param clusterAttributes attributes for the cluster
+     * @param exportVertices whether to export vertices
+     * @param exportEdges whether to export edges
+     */
     public DOTSubgraph(AsSubgraph<V, E> subgraph, Map<String, Attribute> subgraphAttributes, Map<String, Attribute> clusterAttributes,
                        boolean exportVertices, boolean exportEdges) {
         this.subgraph = subgraph;
-        this.subgraphAttributes = new HashMap<>(subgraphAttributes);
-        this.clusterAttributes = new HashMap<>(clusterAttributes);
+        this.subgraphAttributes = new LinkedHashMap<>(subgraphAttributes);
+        this.clusterAttributes = new LinkedHashMap<>(clusterAttributes);
         this.exportVertices = exportVertices;
         this.exportEdges = exportEdges;
     }
 
+    /**
+     * Constructs a new DOTSubgraph with specified subgraph, attributes.
+     *
+     * @param subgraph the subgraph to be exported
+     * @param subgraphAttributes attributes for the subgraph
+     * @param clusterAttributes attributes for the cluster
+     */
     public DOTSubgraph(AsSubgraph<V, E> subgraph, Map<String, Attribute> subgraphAttributes, Map<String, Attribute> clusterAttributes) {
         this(subgraph, subgraphAttributes, clusterAttributes, true, true);
     }
 
+    /**
+     * Get the subgraph.
+     *
+     * @return the subgraph
+     */
     public AsSubgraph<V, E> getSubgraph() {
         return subgraph;
     }
 
+    /**
+     * Get the subgraph attributes in a preserved order.
+     *
+     * @return the subgraph attributes.
+     */
     public Map<String, Attribute> getSubgraphAttributes() {
         return subgraphAttributes;
     }
 
+    /**
+     * Get the cluster attributes in a preserved order.
+     *
+     * @return the cluster attributes.
+     */
     public Map<String, Attribute> getClusterAttributes() {
         return clusterAttributes;
     }
 
+    /**
+     * Get the vertices of the subgraph.
+     *
+     * @return the vertices of the subgraph
+     */
     public Set<V> vertexSet() {
         return subgraph.vertexSet();
     }
 
+    /**
+     * Get the edges of the subgraph.
+     *
+     * @return the edges of the subgraph
+     */
     public Set<E> edgeSet() {
         return subgraph.edgeSet();
     }
 
+    /**
+     * Whether to export the subgraph vertices in the DOT export.
+     * <p>
+     *     If {@code true}, vertices will be included in the DOT export by writing their identifiers one by one on successive
+     *     lines, with the same formalism as the main graph's vertices.
+     * </p>
+     *
+     * <p>
+     *     For example, for a subgraph with DefaultEdges (1, 2) and (2, 3) between Integer vertices 1, 2, and 3, the
+     *     DOT export of the vertices will be:
+     *     <pre>
+     *         1;
+     *         2;
+     *         3;
+     *     </pre>
+     * </p>
+     *
+     * @return {@code true} if vertices should be exported, {@code false} otherwise.
+     */
     public boolean isExportVertices() {
         return exportVertices;
     }
 
+    /**
+     * Whether to export the subgraph edges in the DOT export.
+     * <p>
+     *     If {@code true}, edges will be included in the DOT export by writing the identifiers of their respective source
+     *     and target vertices on successive lines, with the same formalism as the main graph's edges.
+     * </p>
+     *
+     * <p>
+     *     For example, for a subgraph with DefaultEdges (1, 2) and (2, 3) between Integer vertices 1, 2, and 3, the
+     *     DOT export of the edges will be:
+     *     <pre>
+     *         1 -- 2;
+     *         2 -- 3;
+     *     </pre>
+     * </p>
+     * @return {@code true} if edges should be exported, {@code false} otherwise.
+     */
     public boolean isExportEdges() {
         return exportEdges;
     }

--- a/jgrapht-io/src/test/java/org/jgrapht/nio/dot/DOTExporterTest.java
+++ b/jgrapht-io/src/test/java/org/jgrapht/nio/dot/DOTExporterTest.java
@@ -235,8 +235,10 @@ public class DOTExporterTest
         AsSubgraph<Integer, DefaultEdge> sg = new AsSubgraph<>(g, vertices, edges);
         Map<String, Attribute> subgraphAttributes = Map.of(
             "pencolor", DefaultAttribute.createAttribute("transparent"));
-        Map<String, Attribute> clusterAttributes = Map.of(
-            "style", DefaultAttribute.createAttribute("invis"));
+        Map<String, Attribute> clusterAttributes = new LinkedHashMap<>();
+        clusterAttributes.put("label", DefaultAttribute.createAttribute(""));
+        clusterAttributes.put("shape", DefaultAttribute.createAttribute("point"));
+        clusterAttributes.put("style", DefaultAttribute.createAttribute("invis"));
         DOTSubgraph<Integer, DefaultEdge> dotSubgraph = new DOTSubgraph<>(sg, subgraphAttributes, clusterAttributes);
         Map<String, DOTSubgraph<Integer, DefaultEdge>> subgraphs = Map.of("subg", dotSubgraph);
 
@@ -260,7 +262,7 @@ public class DOTExporterTest
             "  4 -- 5;",
             "  5 -- 2;",
             "  subgraph subg {",
-            "    subg [ style=\"invis\" ];",
+            "    subg [ label=\"\" shape=\"point\" style=\"invis\" ];",
             "    pencolor=transparent;",
             "    1;",
             "    2;",


### PR DESCRIPTION
The goal of this PR is to add the support of subgraphs in DOT export.
Since cluster attributes and subgraph attributes are used only for DOT export, and since users could want to export or not subgraph vertices and/or edges, I created a specific class (`DOTSubgraph.java`) to contain all that information for each subgraph the user wants to export.

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
