### PR TITLE
Document that PathValidator::isValidPath might be called on empty paths

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/PathValidator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/PathValidator.java
@@ -39,8 +39,10 @@ public interface PathValidator<V, E>
     /**
      * Checks if an edge can be added to a previous path element.
      *
-     * @param partialPath the path from source vertex up to the current vertex.
-     * @param edge the new edge to be added to the path.
+     * @param partialPath the path from source vertex up to the current vertex. Note that 
+     *                    {@code partialPath} can be an empty walk when checking whether a
+     *                    single edge is a valid path.
+     * @param edge        the new edge to be added to the path.
      *
      * @return {@code true} if edge can be added, {@code false} otherwise.
      */


### PR DESCRIPTION
Explicitly mention that the argument `partialPath` of `PathValidator::isValidPath` might be an empty path with both source and target vertices equal to `null`. This happens in `AllDirectedPaths`.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ ] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
