### PR TITLE
TransitiveReduction should remove edge present in the original graph

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/TransitiveReduction.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/TransitiveReduction.java
@@ -160,6 +160,14 @@ public class TransitiveReduction
             originalMatrix[i1].set(i2);
         }
 
+        // Keep a copy of the original adjacency before it is overwritten by
+        // transformToPathMatrix, so the final removal loop can skip (i,j) pairs
+        // that were never edges in the first place.
+        final BitSet[] originalMatrixCopy = new BitSet[n];
+        for (int i = 0; i < n; i++) {
+            originalMatrixCopy[i] = (BitSet) originalMatrix[i].clone();
+        }
+
         // create path matrix from original matrix
         final BitSet[] pathMatrix = originalMatrix;
 
@@ -170,13 +178,14 @@ public class TransitiveReduction
 
         transitiveReduction(transitivelyReducedMatrix);
 
-        // remove edges from the DirectedGraph which are not in the reduced
-        // matrix
+        // Remove edges that existed in the original graph but were eliminated
+        // by the reduction.
         for (int i = 0; i < n; i++) {
-            for (int j = 0; j < n; j++) {
+            // for each index in the original graph
+            for (int j = originalMatrixCopy[i].nextSetBit(0); j >= 0; j = originalMatrixCopy[i].nextSetBit(j + 1)) {
+                // if it has been eliminated
                 if (!transitivelyReducedMatrix[i].get(j)) {
-                    directedGraph
-                        .removeEdge(directedGraph.getEdge(vertices.get(i), vertices.get(j)));
+                    directedGraph.removeEdge(directedGraph.getEdge(vertices.get(i), vertices.get(j)));
                 }
             }
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/TransitiveReduction.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/TransitiveReduction.java
@@ -73,11 +73,7 @@ public class TransitiveReduction
                     continue;
                 }
                 if (matrix[j].get(i)) {
-                    for (int k = 0; k < matrix.length; k++) {
-                        if (!matrix[j].get(k) && matrix[i].get(k)) {
-                            matrix[j].set(k);
-                        }
-                    }
+                    matrix[j].or(matrix[i]);
                 }
             }
         }
@@ -99,11 +95,7 @@ public class TransitiveReduction
         for (int j = 0; j < pathMatrix.length; j++) {
             for (int i = 0; i < pathMatrix.length; i++) {
                 if (pathMatrix[i].get(j)) {
-                    for (int k = 0; k < pathMatrix.length; k++) {
-                        if (pathMatrix[j].get(k)) {
-                            pathMatrix[i].set(k, false);
-                        }
-                    }
+                    pathMatrix[i].andNot(pathMatrix[j]);
                 }
             }
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/TransitiveReduction.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/TransitiveReduction.java
@@ -74,8 +74,8 @@ public class TransitiveReduction
                 }
                 if (matrix[j].get(i)) {
                     for (int k = 0; k < matrix.length; k++) {
-                        if (!matrix[j].get(k)) {
-                            matrix[j].set(k, matrix[i].get(k));
+                        if (!matrix[j].get(k) && matrix[i].get(k)) {
+                            matrix[j].set(k);
                         }
                     }
                 }


### PR DESCRIPTION
I observed some slowness in a project using JGraphtT around `TransitiveReduction`.

One unexpected slowness was many `hashCode/equals` tests over a Graph expected to have a small number of edges to be removed. Looking at the code, it appears the edge-removal phase considers many edges which are not present in the original graph.

Calling `directedGraph.removeEdge` on irrelevant edge is even more a penalty as Edge/Vertex are based on objects with a slow `hashCode/Object`.

Analyzing performances spotted an improvent in the hot-loop in `transformToPathMatrix`, which brings substantial improvment.

---

I used JMH to check the results, focusing on the case of a Graph already reduced (to highlight the cost of irrelevant edges):

```
Benchmark                                                    (nodeCount)  Mode  Cnt     Score     Error  Units
BenchmarkTransitiveReduction.reduceChain_LocalDate_original          100  avgt    3     1.604 ±   1.430  ms/op
BenchmarkTransitiveReduction.reduceChain_LocalDate_original          500  avgt    3   239.993 ±  18.605  ms/op
BenchmarkTransitiveReduction.reduceChain_LocalDate_original         1000  avgt    3  1616.833 ± 800.575  ms/op
BenchmarkTransitiveReduction.reduceChain_LocalDate_v2                100  avgt    3     1.156 ±   0.503  ms/op
BenchmarkTransitiveReduction.reduceChain_LocalDate_v2                500  avgt    3   127.707 ±  66.585  ms/op
BenchmarkTransitiveReduction.reduceChain_LocalDate_v2               1000  avgt    3   668.310 ± 126.608  ms/op
BenchmarkTransitiveReduction.reduceChain_original                    100  avgt    3     1.630 ±   0.716  ms/op
BenchmarkTransitiveReduction.reduceChain_original                    500  avgt    3   274.276 ± 122.897  ms/op
BenchmarkTransitiveReduction.reduceChain_original                   1000  avgt    3  1868.536 ± 410.533  ms/op
BenchmarkTransitiveReduction.reduceChain_v2                          100  avgt    3     1.251 ±   0.430  ms/op
BenchmarkTransitiveReduction.reduceChain_v2                          500  avgt    3   127.719 ±  74.185  ms/op
BenchmarkTransitiveReduction.reduceChain_v2                         1000  avgt    3   645.697 ± 177.486  ms/op
```
```
package eu.solven.adhoc.engine.tabular.splitter;

import java.time.LocalDate;
import java.util.concurrent.TimeUnit;

import eu.solven.adhoc.jgrapht.alg.TransitiveReductionV2;
import org.jgrapht.alg.TransitiveReduction;
import org.jgrapht.graph.DefaultEdge;
import org.jgrapht.graph.SimpleDirectedGraph;
import org.openjdk.jmh.annotations.Benchmark;
import org.openjdk.jmh.annotations.BenchmarkMode;
import org.openjdk.jmh.annotations.Fork;
import org.openjdk.jmh.annotations.Measurement;
import org.openjdk.jmh.annotations.Mode;
import org.openjdk.jmh.annotations.OutputTimeUnit;
import org.openjdk.jmh.annotations.Param;
import org.openjdk.jmh.annotations.Scope;
import org.openjdk.jmh.annotations.State;
import org.openjdk.jmh.annotations.Warmup;


/**
 * Benchmarks {@link TransitiveReductionV2} on a simple linear chain a₀ → a₁ → … → aₙ.
 *
 * <p>
 * A chain is the worst case for the naïve O(n²) removal loop: after path-matrix expansion every
 * node can reach every later node, so the reduced matrix has exactly n-1 set bits while the naïve
 * loop calls {@code getEdge} for O(n²) pairs. The optimised loop iterates only the original edges
 * and therefore does O(n) work here.
 * </p>
 */
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.MILLISECONDS)
@State(Scope.Thread)
@Warmup(iterations = 3, time = 2)
@Measurement(iterations = 3, time = 2)
@Fork(1)
public class BenchmarkTransitiveReduction {

	@Param({ "100", "500", "1000" })
	int nodeCount;

	/**
	 * Builds a fresh linear-chain graph for each invocation so that each benchmark call starts from
	 * the same state.
	 */
	private SimpleDirectedGraph<Integer, DefaultEdge> buildChain() {
		SimpleDirectedGraph<Integer, DefaultEdge> graph =
				new SimpleDirectedGraph<>(DefaultEdge.class);
		for (int i = 0; i < nodeCount; i++) {
			graph.addVertex(i);
		}
		for (int i = 0; i < nodeCount - 1; i++) {
			graph.addEdge(i, i + 1);
		}
		return graph;
	}

	private SimpleDirectedGraph<LocalDate, DefaultEdge> buildChain_LocalDate() {
		SimpleDirectedGraph<LocalDate, DefaultEdge> graph =
				new SimpleDirectedGraph<>(DefaultEdge.class);
		for (int i = 0; i < nodeCount; i++) {
			graph.addVertex(LocalDate.of(i,1,1));
		}
		for (int i = 0; i < nodeCount - 1; i++) {
			graph.addEdge(LocalDate.of(i,1,1), LocalDate.of(i+1,1,1));
		}
		return graph;
	}

	/**
	 * Measures end-to-end {@link TransitiveReductionV2#reduce} time on a linear chain. The chain has
	 * n-1 edges; after reduction it still has n-1 edges (every hop is necessary), so the benchmark
	 * exercises the full algorithm without removing a single edge — stressing the removal-loop scan
	 * cost rather than actual graph mutations.
	 */
	@Benchmark
	public int reduceChain_v2() {
		SimpleDirectedGraph<?, DefaultEdge> graph = buildChain();
		TransitiveReductionV2.INSTANCE.reduce(graph);
		return graph.edgeSet().size();
	}

	@Benchmark
	public int reduceChain_LocalDate_v2() {
		SimpleDirectedGraph<?, DefaultEdge> graph = buildChain_LocalDate();
		TransitiveReductionV2.INSTANCE.reduce(graph);
		return graph.edgeSet().size();
	}

	/**
	 * Same scenario using the original {@link TransitiveReduction} implementation, as a baseline for
	 * comparison against {@link #reduceChain_v2()}.
	 */
	@Benchmark
	public int reduceChain_original() {
		SimpleDirectedGraph<?, DefaultEdge> graph = buildChain();
		TransitiveReduction.INSTANCE.reduce(graph);
		return graph.edgeSet().size();
	}

	@Benchmark
	public int reduceChain_LocalDate_original() {
		SimpleDirectedGraph<?, DefaultEdge> graph = buildChain_LocalDate();
		TransitiveReduction.INSTANCE.reduce(graph);
		return graph.edgeSet().size();
	}
}
```

----

- [X] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [X] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [X] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [X] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [X] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [X] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [X] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
