### PR TITLE
Upgrade to Java 21

### DIFF
--- a/.github/workflows/PR-workflow.yaml
+++ b/.github/workflows/PR-workflow.yaml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ${{ matrix.os.tag }}
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Build with Maven

--- a/.github/workflows/master-workflow.yaml
+++ b/.github/workflows/master-workflow.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
 
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - run: |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Please address all contributions, suggestions, and inquiries to the [user mailin
 
 ## Introduction
 
-JGraphT is a free Java class library that provides mathematical graph-theory objects and algorithms. It runs on Java 2 Platform (requires JDK 11 or later starting with JGraphT 1.5.0).
+JGraphT is a free Java class library that provides mathematical graph-theory objects and algorithms. It runs on Java 2 Platform (requires JDK 21 or later starting with JGraphT 1.6.0).
 
 JGraphT may be used under the terms of either the
 
@@ -150,7 +150,7 @@ A local copy of the Javadoc HTML files is included in the distribution. The late
 
 ## Dependencies
 
-- JGraphT requires JDK 11 or later to build starting with version 1.5.0.
+- JGraphT requires JDK 21 or later to build starting with version 1.6.0.
 - [JHeaps](https://www.jheaps.org/) is a library with priority queues. JHeaps is licensed under the terms of the Apache License, Version 2.0.
 - [JUnit](https://www.junit.org) is a unit testing framework. You need JUnit only if you want to run the unit tests.  JUnit is licensed under the terms of the Eclipse Public License - v 2.0. The JUnit tests included with JGraphT have been created using JUnit 5.
 - [XMLUnit](https://www.xmlunit.org/) extends JUnit with XML capabilities. You need XMLUnit only if you want to run the unit tests.  XMLUnit is licensed under the terms of the BSD License.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ A local copy of the Javadoc HTML files is included in the distribution. The late
 
 - JGraphT requires JDK 21 or later to build starting with version 1.6.0.
 - [JHeaps](https://www.jheaps.org/) is a library with priority queues. JHeaps is licensed under the terms of the Apache License, Version 2.0.
-- [JUnit](https://www.junit.org) is a unit testing framework. You need JUnit only if you want to run the unit tests.  JUnit is licensed under the terms of the Eclipse Public License - v 2.0. The JUnit tests included with JGraphT have been created using JUnit 5.
+- [JUnit](https://www.junit.org) is a unit testing framework. You need JUnit only if you want to run the unit tests.  JUnit is licensed under the terms of the Eclipse Public License - v 2.0. The JUnit tests included with JGraphT have been created using JUnit 6.
 - [XMLUnit](https://www.xmlunit.org/) extends JUnit with XML capabilities. You need XMLUnit only if you want to run the unit tests.  XMLUnit is licensed under the terms of the BSD License.
 - [JGraphX](https://github.com/jgraph/jgraphx) is a graph visualizations and editing component (the successor to the older JGraph library). You need JGraphX only if you want to use the JGraphXAdapter to visualize the JGraphT graph interactively via JGraphX. JGraphX is licensed under the terms of the BSD license.
 - [ANTLR](https://www.antlr.org) is a parser generator.  It is used for reading text files containing graph representations, and is only required by the jgrapht-io module.  ANTLR v4 is licensed under the terms of the [BSD license](https://www.antlr.org/license.html).

--- a/jgrapht-core/src/main/java/org/jgrapht/util/PrefetchIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/PrefetchIterator.java
@@ -49,7 +49,7 @@ import java.util.*;
  *                  if (counter &lt;= 100)
  *                      throw new NoSuchElementException();
  *                  else
- *                      return new Integer(counter);
+ *                      return Integer.valueOf(counter);
  *              }
  *
  *          });

--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,7 @@
         <jgraphx.version>4.2.2</jgraphx.version>
         <jheaps.version>0.14</jheaps.version>
         <jmh.version>1.37</jmh.version>
-        <junit.version>5.11.4</junit.version>
-        <junit.platform.version>1.11.4</junit.platform.version>
+        <junit.version>6.0.0</junit.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
         <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
         <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
@@ -223,7 +222,7 @@
             <dependency>
                 <groupId>org.junit.platform</groupId>
                 <artifactId>junit-platform-suite</artifactId>
-                <version>${junit.platform.version}</version>
+                <version>${junit.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -8,11 +8,6 @@
     <version>1.6.0-SNAPSHOT</version>
     <description>A Java class library for graph-theory data structures and algorithms.</description>
     <url>http://www.jgrapht.org</url>
-    <parent>
-        <groupId>org.sonatype.oss</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>7</version>
-    </parent>
     <licenses>
         <license>
             <name>GNU Lesser General Public License Version 2.1, February 1999</name>
@@ -79,12 +74,12 @@
         <fastutil.version>8.5.18</fastutil.version>
         <guava.version>33.3.1-jre</guava.version>
         <hamcrest.version>3.0</hamcrest.version>
-        <java.version>11</java.version>
+        <java.version>21</java.version>
         <jgraphx.version>4.2.2</jgraphx.version>
         <jheaps.version>0.14</jheaps.version>
         <jmh.version>1.37</jmh.version>
-        <junit.version>5.10.1</junit.version>
-        <junit.platform.version>1.10.1</junit.platform.version>
+        <junit.version>5.11.4</junit.version>
+        <junit.platform.version>1.11.4</junit.platform.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
         <maven-assembly-plugin.version>3.8.0</maven-assembly-plugin.version>
         <maven-bundle-plugin.version>5.1.9</maven-bundle-plugin.version>
@@ -249,10 +244,6 @@
                     <version>${maven-compiler-plugin.version}</version>
                     <configuration>
                         <release>${java.version}</release>
-                        <compilerArgs>
-                            <arg>--add-modules</arg>
-                                <arg>java.xml</arg>
-                        </compilerArgs>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Upgraded from java 11 to java 21
Upgraded junit from v5 to v6

This is a minimal PR. I would recommend some follow-up PRs:
- some code modernization/scrubbing taking advantage of newer java features
- `mvn compile` spits out some warnings which already existed before but should probably be cleaned up

Note: it seems that no additional code changes are needed to bump java from 21 to 25, so this could be considered.

----

- [x ] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x ] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [ x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x ] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [ x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [ x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [ x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
