### PR TITLE
J21warningfixes

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/GraphMetrics.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphMetrics.java
@@ -33,6 +33,10 @@ import java.util.stream.*;
 public abstract class GraphMetrics
 {
 
+    private GraphMetrics()
+    {
+    }
+
     /**
      * Compute the <a href="http://mathworld.wolfram.com/GraphDiameter.html">diameter</a> of the
      * graph. The diameter of a graph is defined as $\max_{v\in V}\epsilon(v)$, where $\epsilon(v)$

--- a/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/GraphTests.java
@@ -36,6 +36,10 @@ import java.util.stream.*;
  */
 public abstract class GraphTests
 {
+    private GraphTests()
+    {
+    }
+
     private static final String GRAPH_CANNOT_BE_NULL = "Graph cannot be null";
     private static final String GRAPH_MUST_BE_DIRECTED_OR_UNDIRECTED =
         "Graph must be directed or undirected";

--- a/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/Graphs.java
@@ -31,6 +31,10 @@ import java.util.function.*;
 public abstract class Graphs
 {
 
+    private Graphs()
+    {
+    }
+
     /**
      * Creates a new edge and adds it to the specified graph similarly to the
      * {@link Graph#addEdge(Object, Object)} method.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/StoerWagnerMinimumCut.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/StoerWagnerMinimumCut.java
@@ -50,6 +50,7 @@ public class StoerWagnerMinimumCut<V, E>
      * @throws IllegalArgumentException if a negative weight edge is found
      * @throws IllegalArgumentException if graph has less than 2 vertices
      */
+    @SuppressWarnings("this-escape")
     public StoerWagnerMinimumCut(Graph<V, E> graph)
     {
         GraphTests.requireUndirected(graph, "Graph must be undirected");

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/centers/CentersLocationAlgorithmBase.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/centers/CentersLocationAlgorithmBase.java
@@ -37,6 +37,13 @@ public abstract class CentersLocationAlgorithmBase<V, E> implements CentersLocat
 {
 
     /**
+     * Constructs a new centers location algorithm base.
+     */
+    public CentersLocationAlgorithmBase()
+    {
+    }
+
+    /**
      * Checks that graph is undirected, complete, and non-empty
      *
      * @param graph the graph

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/BlockCutpointGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/connectivity/BlockCutpointGraph.java
@@ -66,6 +66,7 @@ public class BlockCutpointGraph<V, E> extends SimpleGraph<Graph<V, E>, DefaultEd
      *
      * @param graph the input graph
      */
+    @SuppressWarnings("this-escape")
     public BlockCutpointGraph(Graph<V, E> graph)
     {
         super(DefaultEdge.class);

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/AhujaOrlinSharmaCyclicExchangeLocalAugmentation.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/AhujaOrlinSharmaCyclicExchangeLocalAugmentation.java
@@ -437,6 +437,7 @@ public class AhujaOrlinSharmaCyclicExchangeLocalAugmentation<V, E>
             return Objects.hash(this.head, this.tail, this.labels);
         }
 
+        @SuppressWarnings("rawtypes")
         @Override
         public boolean equals(Object o)
         {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/BergeGraphInspector.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/BergeGraphInspector.java
@@ -63,6 +63,13 @@ import java.util.stream.*;
 public class BergeGraphInspector<V, E>
 {
 
+    /**
+     * Constructs a new Berge graph inspector.
+     */
+    public BergeGraphInspector()
+    {
+    }
+
     private GraphPath<V, E> certificate = null;
     private boolean certify = false;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChinesePostman.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/ChinesePostman.java
@@ -68,6 +68,13 @@ public class ChinesePostman<V, E>
 {
 
     /**
+     * Constructs a new Chinese Postman solver.
+     */
+    public ChinesePostman()
+    {
+    }
+
+    /**
      * Solves the Chinese Postman Problem on the given graph. For Undirected graph, this
      * implementation uses the @{@link KolmogorovWeightedPerfectMatching} matching algorithm; for
      * directed graphs, @{@link KuhnMunkresMinimalWeightBipartitePerfectMatching} is used instead.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/Cycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/Cycles.java
@@ -30,6 +30,10 @@ import java.util.*;
 public abstract class Cycles
 {
 
+    private Cycles()
+    {
+    }
+
     /**
      * Transform a simple cycle from an edge set representation to a graph path. A simple cycle
      * contains vertices with degrees either zero or two. This method treats directed graphs as

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HawickJamesSimpleCycles.java
@@ -89,7 +89,7 @@ public class HawickJamesSimpleCycles<V, E> implements DirectedSimpleCycles<V, E>
         blocked = new boolean[nVertices];
         stack = new ArrayDeque<>(nVertices);
 
-        b = new ArrayList[nVertices];
+        b = (List<Integer>[]) new List<?>[nVertices];
         for (int i = 0; i < nVertices; i++) {
             b[i] = new ArrayList<>();
         }

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HierholzerEulerianCycle.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/cycle/HierholzerEulerianCycle.java
@@ -46,6 +46,13 @@ import java.util.*;
  */
 public class HierholzerEulerianCycle<V, E> implements EulerianCycleAlgorithm<V, E>
 {
+    /**
+     * Constructs a new Hierholzer Eulerian cycle algorithm.
+     */
+    public HierholzerEulerianCycle()
+    {
+    }
+
     /*
      * The input graph.
      */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/HeavyPathDecomposition.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/decomposition/HeavyPathDecomposition.java
@@ -354,6 +354,13 @@ public class HeavyPathDecomposition<V, E> implements TreeToPathDecompositionAlgo
     public class InternalState
     {
         /**
+         * Constructs a new internal state.
+         */
+        public InternalState()
+        {
+        }
+
+        /**
          * Returns the parent of vertex $v$ in the internal DFS tree/forest. If the vertex $v$ has
          * not been explored or it is the root of its tree, $null$ will be returned.
          *

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/densesubgraph/GoldbergMaximumDensitySubgraphAlgorithmBase.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/densesubgraph/GoldbergMaximumDensitySubgraphAlgorithmBase.java
@@ -117,6 +117,7 @@ public abstract class GoldbergMaximumDensitySubgraphAlgorithmBase<V, E> implemen
      * @param epsilon to use for internal computation
      * @param algFactory function to construct the subalgorithm
      */
+    @SuppressWarnings("this-escape")
     public GoldbergMaximumDensitySubgraphAlgorithmBase(
         Graph<V, E> graph, V s, V t, boolean checkWeights, double epsilon,
         Function<Graph<V, DefaultWeightedEdge>, MinimumSTCutAlgorithm<V, DefaultWeightedEdge>> algFactory)

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/drawing/model/Boxes.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/drawing/model/Boxes.java
@@ -28,6 +28,10 @@ import java.util.*;
  */
 public abstract class Boxes
 {
+    private Boxes()
+    {
+    }
+
     /**
      * Test whether a box contains a point.
      *

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/drawing/model/Points.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/drawing/model/Points.java
@@ -28,6 +28,10 @@ import java.util.function.*;
  */
 public abstract class Points
 {
+    private Points()
+    {
+    }
+
     private static final ToleranceDoubleComparator TOLERANCE_DOUBLE_COMPARATOR =
         new ToleranceDoubleComparator(1e-9);
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/DinicMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/DinicMFImpl.java
@@ -245,8 +245,15 @@ public class DinicMFImpl<V, E> extends MaximumFlowAlgorithmBase<V, E>
     /**
      * Extension for vertex class.
      */
-    class VertexExtension extends VertexExtensionBase
+    public class VertexExtension extends VertexExtensionBase
     {
+        /**
+         * Constructs a new vertex extension.
+         */
+        public VertexExtension()
+        {
+            super();
+        }
 
         /**
          * Stores index of the first unexplored edge from current vertex.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/MaximumFlowAlgorithmBase.java
@@ -247,8 +247,15 @@ public abstract class MaximumFlowAlgorithmBase<V, E> implements MaximumFlowAlgor
         return maxFlow;
     }
 
-    class VertexExtensionBase implements Extension
+    public class VertexExtensionBase implements Extension
     {
+        /**
+         * Constructs a new vertex extension base.
+         */
+        public VertexExtensionBase()
+        {
+        }
+
         private final List<AnnotatedFlowEdge> outgoing = new ArrayList<>();
 
         V prototype;
@@ -261,8 +268,15 @@ public abstract class MaximumFlowAlgorithmBase<V, E> implements MaximumFlowAlgor
         }
     }
 
-    class AnnotatedFlowEdge implements Extension
+    public class AnnotatedFlowEdge implements Extension
     {
+        /**
+         * Constructs a new annotated flow edge.
+         */
+        public AnnotatedFlowEdge()
+        {
+        }
+
         /* Edge source */
         private VertexExtensionBase source;
         /* Edge target */

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/flow/PushRelabelMFImpl.java
@@ -526,6 +526,14 @@ public class PushRelabelMFImpl<V, E> extends MaximumFlowAlgorithmBase<V, E>
      */
     public class VertexExtension extends VertexExtensionBase
     {
+        /**
+         * Constructs a new vertex extension.
+         */
+        public VertexExtension()
+        {
+            super();
+        }
+
         private int id;
         private int height; // also called label (or distance label) in some papers
         private boolean active;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/GraphOrdering.java
@@ -31,7 +31,7 @@ import java.util.*;
  * @param <E> the type of the edges
  */
 
-final class GraphOrdering<V, E>
+public final class GraphOrdering<V, E>
 {
     private final Graph<V, E> graph;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2GraphMappingIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2GraphMappingIterator.java
@@ -28,7 +28,7 @@ import java.util.*;
  * @param <V> the type of the vertices
  * @param <E> the type of the edges
  */
-class VF2GraphMappingIterator<V, E> extends VF2MappingIterator<V, E>
+public class VF2GraphMappingIterator<V, E> extends VF2MappingIterator<V, E>
 {
     /**
      * @param ordering1

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2SubgraphMappingIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/isomorphism/VF2SubgraphMappingIterator.java
@@ -28,7 +28,7 @@ import java.util.*;
  * @param <V> the type of the vertices
  * @param <E> the type of the edges
  */
-class VF2SubgraphMappingIterator<V, E> extends VF2MappingIterator<V, E>
+public class VF2SubgraphMappingIterator<V, E> extends VF2MappingIterator<V, E>
 {
     public VF2SubgraphMappingIterator(
         GraphOrdering<V, E> ordering1, GraphOrdering<V, E> ordering2,

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/matching/blossom/v5/KolmogorovWeightedPerfectMatching.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/matching/blossom/v5/KolmogorovWeightedPerfectMatching.java
@@ -881,6 +881,13 @@ public class KolmogorovWeightedPerfectMatching<V, E> implements MatchingAlgorith
     public static class Statistics
     {
         /**
+         * Constructs a new statistics instance.
+         */
+        public Statistics()
+        {
+        }
+
+        /**
          * Number of shrink operations
          */
         int shrinkNum = 0;

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseBidirectionalShortestPathAlgorithm.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseBidirectionalShortestPathAlgorithm.java
@@ -102,7 +102,7 @@ public abstract class BaseBidirectionalShortestPathAlgorithm<V, E> extends BaseS
      * @param <V> vertices type
      * @param <E> edges type
      */
-    abstract static class BaseSearchFrontier<V, E>
+    public abstract static class BaseSearchFrontier<V, E>
     {
         /**
          * Frontier`s graph.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/ChristofidesThreeHalvesApproxMetricTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/ChristofidesThreeHalvesApproxMetricTSP.java
@@ -75,6 +75,12 @@ import java.util.stream.*;
  */
 public class ChristofidesThreeHalvesApproxMetricTSP<V, E> extends HamiltonianCycleAlgorithmBase<V, E>
 {
+    /**
+     * Constructs a new instance.
+     */
+    public ChristofidesThreeHalvesApproxMetricTSP()
+    {
+    }
 
     /**
      * Computes a $3/2$-approximate tour.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/GreedyHeuristicTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/GreedyHeuristicTSP.java
@@ -60,6 +60,12 @@ import java.util.stream.*;
  */
 public class GreedyHeuristicTSP<V, E> extends HamiltonianCycleAlgorithmBase<V, E>
 {
+    /**
+     * Constructs a new instance.
+     */
+    public GreedyHeuristicTSP()
+    {
+    }
 
     /**
      * Computes a tour using the greedy heuristic.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/HamiltonianCycleAlgorithmBase.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/HamiltonianCycleAlgorithmBase.java
@@ -39,6 +39,12 @@ import java.util.*;
  */
 public abstract class HamiltonianCycleAlgorithmBase<V, E> implements HamiltonianCycleAlgorithm<V, E>
 {
+    /**
+     * Constructs a new Hamiltonian cycle algorithm base.
+     */
+    public HamiltonianCycleAlgorithmBase()
+    {
+    }
 
     /**
      * Transform from a List representation to a graph path.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/HeldKarpTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/HeldKarpTSP.java
@@ -50,6 +50,12 @@ import java.util.*;
  */
 public class HeldKarpTSP<V, E> extends HamiltonianCycleAlgorithmBase<V, E>
 {
+    /**
+     * Constructs a new instance.
+     */
+    public HeldKarpTSP()
+    {
+    }
 
     private double memo(int previousNode, int state, double[][] c, double[][] w)
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/PalmerHamiltonianCycle.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/PalmerHamiltonianCycle.java
@@ -66,6 +66,12 @@ import static org.jgrapht.util.ArrayUtil.*;
  */
 public class PalmerHamiltonianCycle<V, E> extends HamiltonianCycleAlgorithmBase<V, E>
 {
+    /**
+     * Constructs a new instance.
+     */
+    public PalmerHamiltonianCycle()
+    {
+    }
 
     /**
      * Computes a Hamiltonian tour.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoApproxMetricTSP.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/tour/TwoApproxMetricTSP.java
@@ -51,6 +51,12 @@ import java.util.*;
  */
 public class TwoApproxMetricTSP<V, E> extends HamiltonianCycleAlgorithmBase<V, E>
 {
+    /**
+     * Constructs a new instance.
+     */
+    public TwoApproxMetricTSP()
+    {
+    }
 
     /**
      * Computes a 2-approximate tour.

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/VertexDegreeComparator.java
@@ -37,6 +37,10 @@ import java.util.*;
  */
 public abstract class VertexDegreeComparator<V, E> implements Comparator<V>
 {
+    private VertexDegreeComparator()
+    {
+    }
+
     /**
      * Returns a {@link Comparator} that compares vertices by their degrees in the specified graph.
      * <p>

--- a/jgrapht-core/src/main/java/org/jgrapht/event/TraversalListenerAdapter.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/event/TraversalListenerAdapter.java
@@ -29,6 +29,13 @@ package org.jgrapht.event;
 public class TraversalListenerAdapter<V, E> implements TraversalListener<V, E>
 {
     /**
+     * Constructs a new traversal listener adapter.
+     */
+    public TraversalListenerAdapter()
+    {
+    }
+
+    /**
      * @see TraversalListener#connectedComponentFinished(ConnectedComponentTraversalEvent)
      */
     @Override

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/SimpleWeightedBipartiteGraphMatrixGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/SimpleWeightedBipartiteGraphMatrixGenerator.java
@@ -29,6 +29,13 @@ import java.util.*;
  */
 public class SimpleWeightedBipartiteGraphMatrixGenerator<V, E> implements GraphGenerator<V, E, V>
 {
+    /**
+     * Constructs a new simple weighted bipartite graph matrix generator.
+     */
+    public SimpleWeightedBipartiteGraphMatrixGenerator()
+    {
+    }
+
     protected List<V> first;
     protected List<V> second;
     protected double[][] weights;

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/SimpleWeightedGraphMatrixGenerator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/SimpleWeightedGraphMatrixGenerator.java
@@ -29,6 +29,13 @@ import java.util.*;
  */
 public class SimpleWeightedGraphMatrixGenerator<V, E> implements GraphGenerator<V, E, V>
 {
+    /**
+     * Constructs a new simple weighted graph matrix generator.
+     */
+    public SimpleWeightedGraphMatrixGenerator()
+    {
+    }
+
     protected List<V> vertices;
     protected double[][] weights;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/generate/netgen/NetworkGeneratorConfigBuilder.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/generate/netgen/NetworkGeneratorConfigBuilder.java
@@ -29,6 +29,13 @@ package org.jgrapht.generate.netgen;
  */
 public class NetworkGeneratorConfigBuilder
 {
+    /**
+     * Constructs a new network generator config builder.
+     */
+    public NetworkGeneratorConfigBuilder()
+    {
+    }
+
     int nodeNum = 0;
     int arcNum = 0;
     int sourceNum = 0;

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/AbstractBaseGraph.java
@@ -113,6 +113,7 @@ public abstract class AbstractBaseGraph<V, E> extends AbstractGraph<V, E> implem
      * @throws NullPointerException if either one of {@code type} or {@code graphSpecificsStragegy}
      *         is {@code null}, or if {@code graphSpecificsStragegy} generates {@code null}
      */
+    @SuppressWarnings("this-escape")
     protected AbstractBaseGraph(
         Supplier<V> vertexSupplier, Supplier<E> edgeSupplier, GraphType type,
         GraphSpecificsStrategy<V, E> graphSpecificsStrategy)

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultEdge.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultEdge.java
@@ -29,6 +29,13 @@ public class DefaultEdge extends IntrusiveEdge
     private static final long serialVersionUID = 3258408452177932855L;
 
     /**
+     * Constructs a new edge.
+     */
+    public DefaultEdge()
+    {
+    }
+
+    /**
      * Retrieves the source of this edge. This is protected, for use by subclasses only (e.g. for
      * implementing toString).
      *

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultGraphSpecificsStrategy.java
@@ -42,6 +42,13 @@ public class DefaultGraphSpecificsStrategy<V, E> implements GraphSpecificsStrate
 {
     private static final long serialVersionUID = 7615319421753562075L;
 
+    /**
+     * Constructs a new default graph specifics strategy.
+     */
+    public DefaultGraphSpecificsStrategy()
+    {
+    }
+
     @Override
     public Function<GraphType, IntrusiveEdgesSpecifics<V, E>> getIntrusiveEdgesSpecificsFactory()
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultWeightedEdge.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/DefaultWeightedEdge.java
@@ -28,6 +28,13 @@ public class DefaultWeightedEdge extends IntrusiveWeightedEdge
     private static final long serialVersionUID = -3259071493169286685L;
 
     /**
+     * Constructs a new weighted edge.
+     */
+    public DefaultWeightedEdge()
+    {
+    }
+
+    /**
      * Retrieves the source of this edge. This is protected, for use by subclasses only (e.g. for
      * implementing toString).
      *

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/FastLookupGraphSpecificsStrategy.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/FastLookupGraphSpecificsStrategy.java
@@ -42,6 +42,13 @@ public class FastLookupGraphSpecificsStrategy<V, E> implements GraphSpecificsStr
 {
     private static final long serialVersionUID = -5490869870275054280L;
 
+    /**
+     * Constructs a new fast lookup graph specifics strategy.
+     */
+    public FastLookupGraphSpecificsStrategy()
+    {
+    }
+
     @Override
     public Function<GraphType, IntrusiveEdgesSpecifics<V, E>> getIntrusiveEdgesSpecificsFactory()
     {

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/IntrusiveEdge.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/IntrusiveEdge.java
@@ -25,9 +25,16 @@ import java.io.*;
  *
  * @author John V. Sichi
  */
-class IntrusiveEdge implements Cloneable, Serializable
+public class IntrusiveEdge implements Cloneable, Serializable
 {
     private static final long serialVersionUID = 3258408452177932855L;
+
+    /**
+     * Constructs a new intrusive edge.
+     */
+    public IntrusiveEdge()
+    {
+    }
 
     Object source;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/graph/IntrusiveWeightedEdge.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/graph/IntrusiveWeightedEdge.java
@@ -26,9 +26,16 @@ import org.jgrapht.*;
  *
  * @author Dimitrios Michail
  */
-class IntrusiveWeightedEdge extends IntrusiveEdge
+public class IntrusiveWeightedEdge extends IntrusiveEdge
 {
     private static final long serialVersionUID = 2890534758523920741L;
+
+    /**
+     * Constructs a new intrusive weighted edge.
+     */
+    public IntrusiveWeightedEdge()
+    {
+    }
 
     double weight = Graph.DEFAULT_EDGE_WEIGHT;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/AbstractGraphIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/AbstractGraphIterator.java
@@ -228,7 +228,7 @@ public abstract class AbstractGraphIterator<V, E> implements GraphIterator<V, E>
      *
      * @author Barak Naveh
      */
-    static class FlyweightEdgeEvent<E> extends EdgeTraversalEvent<E>
+    public static class FlyweightEdgeEvent<E> extends EdgeTraversalEvent<E>
     {
         private static final long serialVersionUID = 4051327833765000755L;
 
@@ -259,7 +259,7 @@ public abstract class AbstractGraphIterator<V, E> implements GraphIterator<V, E>
      *
      * @author Barak Naveh
      */
-    static class FlyweightVertexEvent<V> extends VertexTraversalEvent<V>
+    public static class FlyweightVertexEvent<V> extends VertexTraversalEvent<V>
     {
         private static final long serialVersionUID = 3834024753848399924L;
 

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/AbstractGraphIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/AbstractGraphIterator.java
@@ -226,6 +226,7 @@ public abstract class AbstractGraphIterator<V, E> implements GraphIterator<V, E>
     /**
      * A reusable edge event.
      *
+     * @param <E> the graph edge type
      * @author Barak Naveh
      */
     public static class FlyweightEdgeEvent<E> extends EdgeTraversalEvent<E>
@@ -257,6 +258,7 @@ public abstract class AbstractGraphIterator<V, E> implements GraphIterator<V, E>
     /**
      * A reusable vertex event.
      *
+     * @param <V> the graph vertex type
      * @author Barak Naveh
      */
     public static class FlyweightVertexEvent<V> extends VertexTraversalEvent<V>

--- a/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/traverse/CrossComponentIterator.java
@@ -77,6 +77,7 @@ public abstract class CrossComponentIterator<V, E, D> extends AbstractGraphItera
      *
      * @throws NullPointerException if argument is {@code null}
      */
+    @SuppressWarnings("this-escape")
     public CrossComponentIterator(Graph<V, E> g)
     {
         this(g, (V) null);
@@ -93,6 +94,7 @@ public abstract class CrossComponentIterator<V, E, D> extends AbstractGraphItera
      * @throws IllegalArgumentException if {@code g} does not contain {@code startVertex}
      * @throws NullPointerException if {@code g} is {@code null}
      */
+    @SuppressWarnings("this-escape")
     public CrossComponentIterator(Graph<V, E> g, V startVertex)
     {
         this(g, startVertex == null ? null : Collections.singletonList(startVertex));
@@ -110,6 +112,7 @@ public abstract class CrossComponentIterator<V, E, D> extends AbstractGraphItera
      *         vertex of {@code g}
      * @throws NullPointerException if {@code g} is {@code null}
      */
+    @SuppressWarnings("this-escape")
     public CrossComponentIterator(Graph<V, E> g, Iterable<V> startVertices)
     {
         super(g);

--- a/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/DoublyLinkedList.java
@@ -58,6 +58,13 @@ import java.util.function.*;
  */
 public class DoublyLinkedList<E> extends AbstractSequentialList<E> implements Deque<E>
 {
+    /**
+     * Constructs an empty doubly linked list.
+     */
+    public DoublyLinkedList()
+    {
+    }
+
     /** The first element of the list, {@code null} if this list is empty. */
     private ListNode<E> head = null;
     private int size;

--- a/jgrapht-core/src/main/java/org/jgrapht/util/MathUtil.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/util/MathUtil.java
@@ -25,6 +25,10 @@ package org.jgrapht.util;
 public class MathUtil
 {
 
+    private MathUtil()
+    {
+    }
+
     /**
      * Calculate the factorial of $n$.
      *

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/CompleteGraphDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/CompleteGraphDemo.java
@@ -37,6 +37,10 @@ import java.util.function.*;
 // @example:class:begin
 public final class CompleteGraphDemo
 {
+    private CompleteGraphDemo()
+    {
+    }
+
     // number of vertices
     private static final int SIZE = 10;
 

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/DependencyDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/DependencyDemo.java
@@ -31,6 +31,9 @@ import java.util.*;
  **/
 public class DependencyDemo
 {
+    private DependencyDemo()
+    {
+    }
 
     /**
      * Test creating a directed graph, checking it for cycles and either outputting cycles detected

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/DirectedGraphDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/DirectedGraphDemo.java
@@ -42,6 +42,10 @@ import java.util.*;
  */
 public class DirectedGraphDemo
 {
+    private DirectedGraphDemo()
+    {
+    }
+
     /**
      * The starting point for the demo.
      *

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphBuilderDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphBuilderDemo.java
@@ -28,6 +28,10 @@ import org.jgrapht.graph.builder.*;
  */
 public final class GraphBuilderDemo
 {
+    private GraphBuilderDemo()
+    {
+    }
+
     /**
      * Main demo entry point.
      *

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/GraphMLDemo.java
@@ -40,6 +40,10 @@ import java.util.function.*;
  */
 public final class GraphMLDemo
 {
+    private GraphMLDemo()
+    {
+    }
+
     // number of vertices
     private static final int SIZE = 6;
 

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/JGraphXAdapterDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/JGraphXAdapterDemo.java
@@ -29,53 +29,39 @@ import javax.swing.*;
 import java.awt.*;
 
 /**
- * A demo applet that shows how to use JGraphX to visualize JGraphT graphs. Applet based on
- * JGraphAdapterDemo.
+ * A demo that shows how to use JGraphX to visualize JGraphT graphs.
  *
  */
-public class JGraphXAdapterDemo extends JApplet
+public final class JGraphXAdapterDemo
 {
-    private static final long serialVersionUID = 2202072534703043194L;
-
     private static final Dimension DEFAULT_SIZE = new Dimension(530, 320);
 
-    private JGraphXAdapter<String, DefaultEdge> jgxAdapter;
+    private JGraphXAdapterDemo()
+    {
+    }
 
     /**
-     * An alternative starting point for this demo, to also allow running this applet as an
-     * application.
+     * The starting point for the demo.
      *
      * @param args command line arguments
      */
     public static void main(String[] args)
-    {
-        JGraphXAdapterDemo applet = new JGraphXAdapterDemo();
-        applet.init();
-
-        JFrame frame = new JFrame();
-        frame.getContentPane().add(applet);
-        frame.setTitle("JGraphT Adapter to JGraphX Demo");
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-        frame.pack();
-        frame.setVisible(true);
-    }
-
-    @Override
-    public void init()
     {
         // create a JGraphT graph
         ListenableGraph<String, DefaultEdge> g =
             new DefaultListenableGraph<>(new DefaultDirectedGraph<>(DefaultEdge.class));
 
         // create a visualization using JGraph, via an adapter
-        jgxAdapter = new JGraphXAdapter<>(g);
+        JGraphXAdapter<String, DefaultEdge> jgxAdapter = new JGraphXAdapter<>(g);
 
-        setPreferredSize(DEFAULT_SIZE);
+        JFrame frame = new JFrame("JGraphT Adapter to JGraphX Demo");
+        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+        frame.setPreferredSize(DEFAULT_SIZE);
+
         mxGraphComponent component = new mxGraphComponent(jgxAdapter);
         component.setConnectable(false);
         component.getGraph().setAllowDanglingEdges(false);
-        getContentPane().add(component);
-        resize(DEFAULT_SIZE);
+        frame.getContentPane().add(component);
 
         String v1 = "v1";
         String v2 = "v2";
@@ -104,7 +90,9 @@ public class JGraphXAdapterDemo extends JApplet
         layout.setMoveCircle(true);
 
         layout.execute(jgxAdapter.getDefaultParent());
-        // that's all there is to it!...
+
+        frame.pack();
+        frame.setVisible(true);
     }
 }
 // @example:full:end

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/KnightTour.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/KnightTour.java
@@ -24,7 +24,7 @@ import java.util.*;
 /**
  * Class that represents container for knight's tour.
  */
-class KnightTour
+public class KnightTour
 {
 
     /**
@@ -42,7 +42,7 @@ class KnightTour
      * @param <E> type of a value storing in a node.
      */
 
-    class DoublyLinkedList<E>
+    public class DoublyLinkedList<E>
     {
 
         /**
@@ -170,7 +170,7 @@ class KnightTour
      *
      */
 
-    static class Node<E>
+    public static class Node<E>
     {
 
         /**

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/KnightTour.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/KnightTour.java
@@ -1,0 +1,341 @@
+/*
+ * (C) Copyright 2018-2026, by Kirill Vishnyakov and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.demo;
+
+import org.jgrapht.alg.util.*;
+
+import java.util.*;
+
+/**
+ * Class that represents container for knight's tour.
+ */
+class KnightTour
+{
+
+    /**
+     * Enum type that represents two knight's tour types: closed and open.
+     */
+    enum TourType
+    {
+        CLOSED,
+        OPEN
+    }
+
+    /**
+     * Implementation of a doubly linked list data structure that is being used for storing a tour.
+     *
+     * @param <E> type of a value storing in a node.
+     */
+
+    class DoublyLinkedList<E>
+    {
+
+        /**
+         * Pointer to the head of the list.
+         */
+
+        private Node<E> head;
+
+        /**
+         * Pointer to the tail of the list.
+         */
+
+        private Node<E> tail;
+
+        /**
+         * Pointer to the start node. Start node is the node from which we start any traversal
+         * operation on the list.
+         */
+
+        private Node<E> startNode;
+
+        /**
+         * Size of the list.
+         */
+
+        private int size;
+
+        public DoublyLinkedList()
+        {
+            head = null;
+            tail = null;
+            startNode = null;
+            size = 0;
+        }
+
+        public int getSize()
+        {
+            return size;
+        }
+
+        public boolean isEmpty()
+        {
+            return head == null;
+        }
+
+        /**
+         * Adds element to the end of the list.
+         *
+         * @param element we want to add.
+         */
+
+        public void add(E element)
+        {
+            Node<E> node = new Node<>(element);
+            size++;
+            if (isEmpty()) {
+                node.next = null;
+                node.prev = null;
+                head = node;
+                tail = node;
+                return;
+            }
+            tail.next = node;
+            node.prev = tail;
+            node.next = null;
+            tail = node;
+        }
+
+        /**
+         * Removes tail element.
+         */
+
+        public void remove()
+        {
+            if (isEmpty()) {
+                throw new IndexOutOfBoundsException("The list is empty!");
+            }
+            size--;
+            if (tail.prev == null) {
+                head = null;
+                tail = null;
+                return;
+            }
+            tail = tail.prev;
+            tail.next = null;
+        }
+
+        public Node<E> getHead()
+        {
+            return head;
+        }
+
+        public Node<E> getTail()
+        {
+            return tail;
+        }
+
+        public void clear()
+        {
+            head = null;
+            tail = null;
+            size = 0;
+        }
+
+        public void setStartNode(Node<E> startNode)
+        {
+            this.startNode = startNode;
+        }
+
+        public Node<E> getStartNode()
+        {
+            return startNode;
+        }
+
+        public void setSize(int i)
+        {
+            size = i;
+        }
+    }
+
+    /**
+     * Static class that represents a node.
+     *
+     * @param <E> type of the value stored in the node.
+     *
+     */
+
+    static class Node<E>
+    {
+
+        /**
+         * Pointer to the next node.
+         */
+
+        private Node<E> next;
+
+        /**
+         * Pointer to the previous node.
+         */
+
+        private Node<E> prev;
+
+        /**
+         * Value that is being stored in the node.
+         */
+
+        private E value;
+
+        /**
+         * Boolean flag that is being used in traversal function, such as toList. True if the node
+         * was visited, otherwise false.
+         */
+
+        private boolean visited = false;
+
+        public Node(E value)
+        {
+            this.value = value;
+        }
+
+        public Node()
+        {
+        }
+
+        public boolean isVisited()
+        {
+            return !visited;
+        }
+
+        public void setVisited(boolean visited)
+        {
+            this.visited = visited;
+        }
+
+        public E getValue()
+        {
+            return value;
+        }
+
+        public Node<E> getNext()
+        {
+            return next;
+        }
+
+        public Node<E> getPrev()
+        {
+            return prev;
+        }
+
+        public void setPrev(Node<E> prev)
+        {
+            this.prev = prev;
+        }
+
+        public void setNext(Node<E> next)
+        {
+            this.next = next;
+        }
+    }
+
+    /**
+     * Doubly linked list that stores nodes in order of their appearance in the knight's tour.
+     */
+
+    private final DoublyLinkedList<Pair<Integer, Integer>> list;
+
+    /*
+     * Let's call each of the following 8 cells structured:
+     *
+     * (enumeration starts with 0 to make the relation between cells and indices in structured array
+     * more clear)
+     *
+     * 0). (2, 0); 1). (0, 1); 2). (n - 1, 0); 3). (n - 2, 2); 4). (1, m - 3); 5). (0, m - 1); 6).
+     * (n - 1, m - 2); 7). (n - 3, m - 1);
+     *
+     * ######################################### #**0***********************************2#
+     * #1**************************************# #*************************************3*#
+     * #***************************************# #***************************************#
+     * #***************************************# #***************************************#
+     * #***************************************# #***************************************#
+     * #***************************************# #***************************************#
+     * #***************************************# #***************************************#
+     * #***************************************# #*4*************************************#
+     * #**************************************6# #5***********************************7**#
+     * #########################################
+     *
+     * Structured cells are needed in the the merging procedure in the Parberry's algorithm.
+     */
+
+    /**
+     * ArrayList that stores pointers on the structured cells.
+     */
+
+    private final ArrayList<KnightTour.Node<Pair<Integer, Integer>>> structured;
+
+    /**
+     * Used in toList function.
+     */
+
+    private List<Pair<Integer, Integer>> arrayList;
+
+    /**
+     * Constructor of knight's tour container.
+     */
+
+    public KnightTour()
+    {
+        structured = new ArrayList<>(Collections.nCopies(8, new KnightTour.Node<>()));
+        list = new DoublyLinkedList<>();
+        arrayList = null;
+    }
+
+    /**
+     * Converts knight's tour represented as DoublyLinkedList to ArrayList.
+     *
+     * @return ArrayList that contains knight's tour.
+     */
+
+    public List<Pair<Integer, Integer>> toList()
+    {
+        if (arrayList != null) {
+            return arrayList;
+        }
+
+        Node<Pair<Integer, Integer>> startNode = list.getStartNode();
+        startNode.setVisited(true);
+        arrayList = new ArrayList<>();
+        arrayList.add(startNode.getValue());
+
+        /*
+         * Traverse of the list.
+         */
+
+        while (startNode.getNext().isVisited() || startNode.getPrev().isVisited()) {
+            if (startNode.getNext().isVisited())
+                startNode = startNode.getNext();
+            else {
+                startNode = startNode.getPrev();
+            }
+            arrayList.add(startNode.getValue());
+            startNode.setVisited(true);
+        }
+
+        return arrayList;
+    }
+
+    public DoublyLinkedList<Pair<Integer, Integer>> getList()
+    {
+        return list;
+    }
+
+    public ArrayList<Node<Pair<Integer, Integer>>> getStructured()
+    {
+        return structured;
+    }
+}

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/LabeledEdges.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/LabeledEdges.java
@@ -30,6 +30,10 @@ import java.util.*;
  */
 public class LabeledEdges
 {
+    private LabeledEdges()
+    {
+    }
+
     private static final String FRIEND = "friend";
     private static final String ENEMY = "enemy";
 

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/ParberryKnightTour.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/ParberryKnightTour.java
@@ -144,7 +144,7 @@ public class ParberryKnightTour
 
         if (Math.max(nDim, mDim) <= 12) {
             return new WarnsdorffRuleKnightTourHeuristic(nDim, mDim)
-                .getTour(TourType.CLOSED, true, start.getFirst(), start.getSecond());
+                .getTour(KnightTour.TourType.CLOSED, true, start.getFirst(), start.getSecond());
         }
 
         /*

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/PerformanceDemo.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/PerformanceDemo.java
@@ -42,6 +42,10 @@ import java.util.*;
  */
 public final class PerformanceDemo
 {
+    private PerformanceDemo()
+    {
+    }
+
     /**
      * The starting point for the demo.
      *

--- a/jgrapht-demo/src/main/java/org/jgrapht/demo/WarnsdorffRuleKnightTourHeuristic.java
+++ b/jgrapht-demo/src/main/java/org/jgrapht/demo/WarnsdorffRuleKnightTourHeuristic.java
@@ -22,327 +22,6 @@ import org.jgrapht.alg.util.*;
 import java.util.*;
 
 /**
- * Enum type that represents two knight's tour types: closed and open.
- */
-
-enum TourType
-{
-    CLOSED,
-    OPEN
-}
-
-/**
- * Class that represents container for knight's tour.
- */
-
-class KnightTour
-{
-
-    /**
-     * Implementation of a doubly linked list data structure that is being used for storing a tour.
-     *
-     * @param <E> type of a value storing in a node.
-     */
-
-    class DoublyLinkedList<E>
-    {
-
-        /**
-         * Pointer to the head of the list.
-         */
-
-        private Node<E> head;
-
-        /**
-         * Pointer to the tail of the list.
-         */
-
-        private Node<E> tail;
-
-        /**
-         * Pointer to the start node. Start node is the node from which we start any traversal
-         * operation on the list.
-         */
-
-        private Node<E> startNode;
-
-        /**
-         * Size of the list.
-         */
-
-        private int size;
-
-        public DoublyLinkedList()
-        {
-            head = null;
-            tail = null;
-            startNode = null;
-            size = 0;
-        }
-
-        public int getSize()
-        {
-            return size;
-        }
-
-        public boolean isEmpty()
-        {
-            return head == null;
-        }
-
-        /**
-         * Adds element to the end of the list.
-         *
-         * @param element we want to add.
-         */
-
-        public void add(E element)
-        {
-            Node<E> node = new Node<>(element);
-            size++;
-            if (isEmpty()) {
-                node.next = null;
-                node.prev = null;
-                head = node;
-                tail = node;
-                return;
-            }
-            tail.next = node;
-            node.prev = tail;
-            node.next = null;
-            tail = node;
-        }
-
-        /**
-         * Removes tail element.
-         */
-
-        public void remove()
-        {
-            if (isEmpty()) {
-                throw new IndexOutOfBoundsException("The list is empty!");
-            }
-            size--;
-            if (tail.prev == null) {
-                head = null;
-                tail = null;
-                return;
-            }
-            tail = tail.prev;
-            tail.next = null;
-        }
-
-        public Node<E> getHead()
-        {
-            return head;
-        }
-
-        public Node<E> getTail()
-        {
-            return tail;
-        }
-
-        public void clear()
-        {
-            head = null;
-            tail = null;
-            size = 0;
-        }
-
-        public void setStartNode(Node<E> startNode)
-        {
-            this.startNode = startNode;
-        }
-
-        public Node<E> getStartNode()
-        {
-            return startNode;
-        }
-
-        public void setSize(int i)
-        {
-            size = i;
-        }
-    }
-
-    /**
-     * Static class that represents a node.
-     *
-     * @param <E> type of the value stored in the node.
-     *
-     */
-
-    static class Node<E>
-    {
-
-        /**
-         * Pointer to the next node.
-         */
-
-        private Node<E> next;
-
-        /**
-         * Pointer to the previous node.
-         */
-
-        private Node<E> prev;
-
-        /**
-         * Value that is being stored in the node.
-         */
-
-        private E value;
-
-        /**
-         * Boolean flag that is being used in traversal function, such as toList. True if the node
-         * was visited, otherwise false.
-         */
-
-        private boolean visited = false;
-
-        public Node(E value)
-        {
-            this.value = value;
-        }
-
-        public Node()
-        {
-        }
-
-        public boolean isVisited()
-        {
-            return !visited;
-        }
-
-        public void setVisited(boolean visited)
-        {
-            this.visited = visited;
-        }
-
-        public E getValue()
-        {
-            return value;
-        }
-
-        public Node<E> getNext()
-        {
-            return next;
-        }
-
-        public Node<E> getPrev()
-        {
-            return prev;
-        }
-
-        public void setPrev(Node<E> prev)
-        {
-            this.prev = prev;
-        }
-
-        public void setNext(Node<E> next)
-        {
-            this.next = next;
-        }
-    }
-
-    /**
-     * Doubly linked list that stores nodes in order of their appearance in the knight's tour.
-     */
-
-    private final DoublyLinkedList<Pair<Integer, Integer>> list;
-
-    /*
-     * Let's call each of the following 8 cells structured:
-     *
-     * (enumeration starts with 0 to make the relation between cells and indices in structured array
-     * more clear)
-     *
-     * 0). (2, 0); 1). (0, 1); 2). (n - 1, 0); 3). (n - 2, 2); 4). (1, m - 3); 5). (0, m - 1); 6).
-     * (n - 1, m - 2); 7). (n - 3, m - 1);
-     *
-     * ######################################### #**0***********************************2#
-     * #1**************************************# #*************************************3*#
-     * #***************************************# #***************************************#
-     * #***************************************# #***************************************#
-     * #***************************************# #***************************************#
-     * #***************************************# #***************************************#
-     * #***************************************# #***************************************#
-     * #***************************************# #*4*************************************#
-     * #**************************************6# #5***********************************7**#
-     * #########################################
-     *
-     * Structured cells are needed in the the merging procedure in the Parberry's algorithm.
-     */
-
-    /**
-     * ArrayList that stores pointers on the structured cells.
-     */
-
-    private final ArrayList<KnightTour.Node<Pair<Integer, Integer>>> structured;
-
-    /**
-     * Used in toList function.
-     */
-
-    private List<Pair<Integer, Integer>> arrayList;
-
-    /**
-     * Constructor of knight's tour container.
-     */
-
-    public KnightTour()
-    {
-        structured = new ArrayList<>(Collections.nCopies(8, new KnightTour.Node<>()));
-        list = new DoublyLinkedList<>();
-        arrayList = null;
-    }
-
-    /**
-     * Converts knight's tour represented as DoublyLinkedList to ArrayList.
-     *
-     * @return ArrayList that contains knight's tour.
-     */
-
-    public List<Pair<Integer, Integer>> toList()
-    {
-        if (arrayList != null) {
-            return arrayList;
-        }
-
-        Node<Pair<Integer, Integer>> startNode = list.getStartNode();
-        startNode.setVisited(true);
-        arrayList = new ArrayList<>();
-        arrayList.add(startNode.getValue());
-
-        /*
-         * Traverse of the list.
-         */
-
-        while (startNode.getNext().isVisited() || startNode.getPrev().isVisited()) {
-            if (startNode.getNext().isVisited())
-                startNode = startNode.getNext();
-            else {
-                startNode = startNode.getPrev();
-            }
-            arrayList.add(startNode.getValue());
-            startNode.setVisited(true);
-        }
-
-        return arrayList;
-    }
-
-    public DoublyLinkedList<Pair<Integer, Integer>> getList()
-    {
-        return list;
-    }
-
-    public ArrayList<Node<Pair<Integer, Integer>>> getStructured()
-    {
-        return structured;
-    }
-}
-
-/**
  * Implementation of {@literal <a href =
  *  "https://en.wikipedia.org/wiki/Knight%27s_tour#Warnsdorf's_rule">}Warnsdorff's
  * rule{@literal </a>} - heuristic for finding a knight's tour on chessboards.
@@ -558,9 +237,9 @@ public class WarnsdorffRuleKnightTourHeuristic
      * @return true, if the found tour satisfies the required invariants, otherwise false.
      */
 
-    private boolean checkType(int startX, int startY, int endX, int endY, TourType type)
+    private boolean checkType(int startX, int startY, int endX, int endY, KnightTour.TourType type)
     {
-        if (type == TourType.CLOSED) {
+        if (type == KnightTour.TourType.CLOSED) {
             return Math.abs(startX - endX) == 1 && Math.abs(startY - endY) == 2
                 || Math.abs(startX - endX) == 2 && Math.abs(startY - endY) == 1;
         }
@@ -636,7 +315,7 @@ public class WarnsdorffRuleKnightTourHeuristic
      * @return true if the tour exists, otherwise false.
      */
 
-    private boolean checkExistence(TourType type)
+    private boolean checkExistence(KnightTour.TourType type)
     {
         int newN = Math.min(n, m);
         int newM = Math.max(n, m);
@@ -649,7 +328,7 @@ public class WarnsdorffRuleKnightTourHeuristic
          * 4, 6, 8.
          */
 
-        if (type == TourType.CLOSED) {
+        if (type == KnightTour.TourType.CLOSED) {
             return !((newN % 2 == 1 && newM % 2 == 1) || newN == 1 || newN == 2 || newN == 4
                 || (newN == 3 && (newM == 4 || newM == 6 || newM == 8)));
         }
@@ -713,7 +392,7 @@ public class WarnsdorffRuleKnightTourHeuristic
      * @return knight's tour.
      */
 
-    public KnightTour getTour(TourType type, boolean structured, int shiftX, int shiftY)
+    public KnightTour getTour(KnightTour.TourType type, boolean structured, int shiftX, int shiftY)
     {
 
         if (shiftX < 0 || shiftY < 0) {

--- a/jgrapht-demo/src/test/java/org/jgrapht/demo/WarnsdorffRuleKnightTourHeuristicTest.java
+++ b/jgrapht-demo/src/test/java/org/jgrapht/demo/WarnsdorffRuleKnightTourHeuristicTest.java
@@ -150,10 +150,10 @@ public class WarnsdorffRuleKnightTourHeuristicTest
     }
 
     private void checkCorrectness(
-        List<Pair<Integer, Integer>> tour, TourType type, int n, int m, int shiftX, int shiftY,
+        List<Pair<Integer, Integer>> tour, KnightTour.TourType type, int n, int m, int shiftX, int shiftY,
         boolean structured)
     {
-        if (type == TourType.CLOSED) {
+        if (type == KnightTour.TourType.CLOSED) {
             assertTrue(checkClosed(tour.get(0), tour.get(tour.size() - 1)));
         } else {
             assertTrue(checkOpen(tour.get(0), tour.get(tour.size() - 1)));
@@ -167,104 +167,104 @@ public class WarnsdorffRuleKnightTourHeuristicTest
     public void warnsdorff8x8OpenWithShift()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(8);
-        container = solver.getTour(TourType.OPEN, false, 10, 143);
-        checkCorrectness(container.toList(), TourType.OPEN, 8, 8, 10, 143, false);
+        container = solver.getTour(KnightTour.TourType.OPEN, false, 10, 143);
+        checkCorrectness(container.toList(), KnightTour.TourType.OPEN, 8, 8, 10, 143, false);
     }
 
     @Test
     public void warnsdorff10x10Open()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(10);
-        container = solver.getTour(TourType.OPEN, false, 0, 0);
-        checkCorrectness(container.toList(), TourType.OPEN, 10, 10, 0, 0, false);
+        container = solver.getTour(KnightTour.TourType.OPEN, false, 0, 0);
+        checkCorrectness(container.toList(), KnightTour.TourType.OPEN, 10, 10, 0, 0, false);
     }
 
     @Test
     public void warnsdorff37x10Open()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(37, 10);
-        container = solver.getTour(TourType.OPEN, false, 0, 0);
-        checkCorrectness(container.toList(), TourType.OPEN, 37, 10, 0, 0, false);
+        container = solver.getTour(KnightTour.TourType.OPEN, false, 0, 0);
+        checkCorrectness(container.toList(), KnightTour.TourType.OPEN, 37, 10, 0, 0, false);
     }
 
     @Test
     public void warnsdorff41x41Open()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(41, 41);
-        container = solver.getTour(TourType.OPEN, false, 0, 0);
-        checkCorrectness(container.toList(), TourType.OPEN, 41, 41, 0, 0, false);
+        container = solver.getTour(KnightTour.TourType.OPEN, false, 0, 0);
+        checkCorrectness(container.toList(), KnightTour.TourType.OPEN, 41, 41, 0, 0, false);
     }
 
     @Test
     public void warnsdorff41x41OpenStructured()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(41, 41);
-        container = solver.getTour(TourType.OPEN, true, 0, 0);
-        checkCorrectness(container.toList(), TourType.OPEN, 41, 41, 0, 0, true);
+        container = solver.getTour(KnightTour.TourType.OPEN, true, 0, 0);
+        checkCorrectness(container.toList(), KnightTour.TourType.OPEN, 41, 41, 0, 0, true);
     }
 
     @Test
     public void warnsdorff10x10Closed()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(10);
-        container = solver.getTour(TourType.CLOSED, false, 0, 0);
-        checkCorrectness(container.toList(), TourType.CLOSED, 10, 10, 0, 0, false);
+        container = solver.getTour(KnightTour.TourType.CLOSED, false, 0, 0);
+        checkCorrectness(container.toList(), KnightTour.TourType.CLOSED, 10, 10, 0, 0, false);
     }
 
     @Test
     public void warnsdorff34x34ClosedWithShift()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(34);
-        container = solver.getTour(TourType.CLOSED, false, 20, 89);
-        checkCorrectness(container.toList(), TourType.CLOSED, 34, 34, 20, 89, false);
+        container = solver.getTour(KnightTour.TourType.CLOSED, false, 20, 89);
+        checkCorrectness(container.toList(), KnightTour.TourType.CLOSED, 34, 34, 20, 89, false);
     }
 
     @Test
     public void warnsdorff63x23OpenStructured()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(63, 23);
-        container = solver.getTour(TourType.OPEN, true, 0, 0);
-        checkCorrectness(container.toList(), TourType.OPEN, 63, 23, 0, 0, true);
+        container = solver.getTour(KnightTour.TourType.OPEN, true, 0, 0);
+        checkCorrectness(container.toList(), KnightTour.TourType.OPEN, 63, 23, 0, 0, true);
     }
 
     @Test
     public void warnsdorff49x34Closed()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(49, 34);
-        container = solver.getTour(TourType.CLOSED, false, 0, 0);
-        checkCorrectness(container.toList(), TourType.CLOSED, 49, 34, 0, 0, false);
+        container = solver.getTour(KnightTour.TourType.CLOSED, false, 0, 0);
+        checkCorrectness(container.toList(), KnightTour.TourType.CLOSED, 49, 34, 0, 0, false);
     }
 
     @Test
     public void warnsdorff34x34ClosedStructuredWithShift()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(34);
-        container = solver.getTour(TourType.CLOSED, true, 20, 89);
-        checkCorrectness(container.toList(), TourType.CLOSED, 34, 34, 20, 89, true);
+        container = solver.getTour(KnightTour.TourType.CLOSED, true, 20, 89);
+        checkCorrectness(container.toList(), KnightTour.TourType.CLOSED, 34, 34, 20, 89, true);
     }
 
     @Test
     public void warnsdorff18x34ClosedStructuredWithShift()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(18, 34);
-        container = solver.getTour(TourType.CLOSED, true, 7, 7);
-        checkCorrectness(container.toList(), TourType.CLOSED, 18, 34, 7, 7, true);
+        container = solver.getTour(KnightTour.TourType.CLOSED, true, 7, 7);
+        checkCorrectness(container.toList(), KnightTour.TourType.CLOSED, 18, 34, 7, 7, true);
     }
 
     @Test
     public void warnsdorff42x42ClosedStructured()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(42, 42);
-        container = solver.getTour(TourType.CLOSED, true, 0, 0);
-        checkCorrectness(container.toList(), TourType.CLOSED, 42, 42, 0, 0, true);
+        container = solver.getTour(KnightTour.TourType.CLOSED, true, 0, 0);
+        checkCorrectness(container.toList(), KnightTour.TourType.CLOSED, 42, 42, 0, 0, true);
     }
 
     @Test
     public void warnsdorff40x20OpenStructured()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(40, 20);
-        container = solver.getTour(TourType.OPEN, true, 0, 0);
-        checkCorrectness(container.toList(), TourType.OPEN, 40, 20, 0, 0, true);
+        container = solver.getTour(KnightTour.TourType.OPEN, true, 0, 0);
+        checkCorrectness(container.toList(), KnightTour.TourType.OPEN, 40, 20, 0, 0, true);
     }
 
     @Test
@@ -272,7 +272,7 @@ public class WarnsdorffRuleKnightTourHeuristicTest
     {
         assertThrows(IllegalArgumentException.class, () -> {
             solver = new WarnsdorffRuleKnightTourHeuristic(2, 200);
-            container = solver.getTour(TourType.OPEN, false, 0, 0);
+            container = solver.getTour(KnightTour.TourType.OPEN, false, 0, 0);
         });
     }
 
@@ -281,7 +281,7 @@ public class WarnsdorffRuleKnightTourHeuristicTest
     {
         assertThrows(IllegalArgumentException.class, () -> {
             solver = new WarnsdorffRuleKnightTourHeuristic(5, 3);
-            container = solver.getTour(TourType.OPEN, false, 0, 0);
+            container = solver.getTour(KnightTour.TourType.OPEN, false, 0, 0);
         });
     }
 
@@ -290,7 +290,7 @@ public class WarnsdorffRuleKnightTourHeuristicTest
     {
         assertThrows(IllegalArgumentException.class, () -> {
             solver = new WarnsdorffRuleKnightTourHeuristic(3, 6);
-            container = solver.getTour(TourType.OPEN, false, 0, 0);
+            container = solver.getTour(KnightTour.TourType.OPEN, false, 0, 0);
         });
     }
 
@@ -299,7 +299,7 @@ public class WarnsdorffRuleKnightTourHeuristicTest
     {
         assertThrows(IllegalArgumentException.class, () -> {
             solver = new WarnsdorffRuleKnightTourHeuristic(4, 4);
-            container = solver.getTour(TourType.OPEN, false, 0, 0);
+            container = solver.getTour(KnightTour.TourType.OPEN, false, 0, 0);
         });
     }
 
@@ -308,7 +308,7 @@ public class WarnsdorffRuleKnightTourHeuristicTest
     {
         assertThrows(IllegalArgumentException.class, () -> {
             solver = new WarnsdorffRuleKnightTourHeuristic(31, 31);
-            container = solver.getTour(TourType.CLOSED, false, 0, 0);
+            container = solver.getTour(KnightTour.TourType.CLOSED, false, 0, 0);
         });
     }
 
@@ -317,7 +317,7 @@ public class WarnsdorffRuleKnightTourHeuristicTest
     {
         assertThrows(IllegalArgumentException.class, () -> {
             solver = new WarnsdorffRuleKnightTourHeuristic(4, 6);
-            container = solver.getTour(TourType.CLOSED, false, 0, 0);
+            container = solver.getTour(KnightTour.TourType.CLOSED, false, 0, 0);
         });
     }
 
@@ -325,8 +325,8 @@ public class WarnsdorffRuleKnightTourHeuristicTest
     public void warnsdorffOpenNonStructured4x6()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(4, 6);
-        container = solver.getTour(TourType.OPEN, false, 0, 0);
-        checkCorrectness(container.toList(), TourType.OPEN, 4, 6, 0, 0, false);
+        container = solver.getTour(KnightTour.TourType.OPEN, false, 0, 0);
+        checkCorrectness(container.toList(), KnightTour.TourType.OPEN, 4, 6, 0, 0, false);
     }
 
     @Test
@@ -362,7 +362,7 @@ public class WarnsdorffRuleKnightTourHeuristicTest
     public void warnsdorffDoubleInvocationToArrayList()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(49, 34);
-        container = solver.getTour(TourType.CLOSED, false, 0, 0);
+        container = solver.getTour(KnightTour.TourType.CLOSED, false, 0, 0);
         List<Pair<Integer, Integer>> arr1 = container.toList();
         List<Pair<Integer, Integer>> arr2 = container.toList();
         assertEquals(arr1.size(), arr2.size());
@@ -372,11 +372,11 @@ public class WarnsdorffRuleKnightTourHeuristicTest
     public void warnsdorffDoubleInvocationToArrayListAndgetTour()
     {
         solver = new WarnsdorffRuleKnightTourHeuristic(40, 40);
-        container = solver.getTour(TourType.CLOSED, false, 0, 0);
+        container = solver.getTour(KnightTour.TourType.CLOSED, false, 0, 0);
         List<Pair<Integer, Integer>> arr1 = container.toList();
         List<Pair<Integer, Integer>> arr2 = container.toList();
         assertEquals(arr1.size(), arr2.size());
-        container = solver.getTour(TourType.OPEN, true, 10, 10);
+        container = solver.getTour(KnightTour.TourType.OPEN, true, 10, 10);
         arr1 = container.toList();
         arr2 = container.toList();
         assertEquals(arr1.size(), arr2.size());

--- a/jgrapht-ext/src/main/java/org/jgrapht/ext/JGraphXAdapter.java
+++ b/jgrapht-ext/src/main/java/org/jgrapht/ext/JGraphXAdapter.java
@@ -86,6 +86,7 @@ public class JGraphXAdapter<V, E> extends mxGraph implements GraphListener<V, E>
      *
      * @throws IllegalArgumentException if the graph is null.
      */
+    @SuppressWarnings("this-escape")
     public JGraphXAdapter(ListenableGraph<V, E> graph)
     {
         // call normal constructor with graph class
@@ -103,6 +104,7 @@ public class JGraphXAdapter<V, E> extends mxGraph implements GraphListener<V, E>
      *
      * @throws IllegalArgumentException if the parameter is null
      */
+    @SuppressWarnings("this-escape")
     public JGraphXAdapter(Graph<V, E> graph)
     {
         super();

--- a/jgrapht-guava/pom.xml
+++ b/jgrapht-guava/pom.xml
@@ -58,10 +58,6 @@
                     <artifactId>jsr305</artifactId>
                 </exclusion>
                 <exclusion>
-                    <groupId>com.google.errorprone</groupId>
-                    <artifactId>error_prone_annotations</artifactId>
-                </exclusion>
-                <exclusion>
                     <groupId>com.google.j2objc</groupId>
                     <artifactId>j2objc-annotations</artifactId>
                 </exclusion>

--- a/jgrapht-guava/src/main/java/module-info.java
+++ b/jgrapht-guava/src/main/java/module-info.java
@@ -28,5 +28,5 @@ module org.jgrapht.guava
 
     requires transitive org.jgrapht.core;
     requires transitive com.google.common;
-    requires transitive org.jheaps;
+    requires org.jheaps;
 }

--- a/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseGraphAdapter.java
+++ b/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseGraphAdapter.java
@@ -97,6 +97,7 @@ public abstract class BaseGraphAdapter<V, G extends com.google.common.graph.Grap
      * @throws NullPointerException if either one of {@code graph} or {@code vertexOrderMethod} is
      *         {@code null}
      */
+    @SuppressWarnings("this-escape")
     public BaseGraphAdapter(
         G graph, Supplier<V> vertexSupplier, Supplier<EndpointPair<V>> edgeSupplier,
         ElementOrderMethod<V> vertexOrderMethod)

--- a/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseNetworkAdapter.java
+++ b/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseNetworkAdapter.java
@@ -91,6 +91,7 @@ public abstract class BaseNetworkAdapter<V, E, N extends Network<V, E>> extends 
      * @throws NullPointerException if either one of {@code network} or {@code vertexOrderMethod} is
      *         {@code null}
      */
+    @SuppressWarnings("this-escape")
     public BaseNetworkAdapter(
         N network, Supplier<V> vertexSupplier, Supplier<E> edgeSupplier,
         ElementOrderMethod<V> vertexOrderMethod)

--- a/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseValueGraphAdapter.java
+++ b/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/BaseValueGraphAdapter.java
@@ -106,6 +106,7 @@ public abstract class BaseValueGraphAdapter<V, W, VG extends ValueGraph<V, W>> e
      * @throws NullPointerException if any one of {@code valueGraph}, {@code valueConverter}, or
      *         {@code vertexOrderMethod} is {@code null}
      */
+    @SuppressWarnings("this-escape")
     public BaseValueGraphAdapter(
         VG valueGraph, ToDoubleFunction<W> valueConverter, Supplier<V> vertexSupplier,
         Supplier<EndpointPair<V>> edgeSupplier, ElementOrderMethod<V> vertexOrderMethod)

--- a/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/ElementOrder.java
+++ b/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/ElementOrder.java
@@ -33,7 +33,7 @@ import java.util.Map;
  *
  * @author Dimitrios Michail
  */
-class ElementOrder<V> implements Serializable
+public class ElementOrder<V> implements Serializable
 {
     private static final long serialVersionUID = -3732847114940656189L;
 

--- a/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/ElementOrder.java
+++ b/jgrapht-guava/src/main/java/org/jgrapht/graph/guava/ElementOrder.java
@@ -32,6 +32,7 @@ import java.util.Map;
  * internal state. Construction of elements is performed in a lazy manner.
  *
  * @author Dimitrios Michail
+ * @param <V> the element type
  */
 public class ElementOrder<V> implements Serializable
 {

--- a/jgrapht-io/src/main/java/module-info.java
+++ b/jgrapht-io/src/main/java/module-info.java
@@ -39,5 +39,5 @@ module org.jgrapht.io
     requires transitive org.jgrapht.core;
     requires transitive org.apache.commons.text;
     requires transitive java.xml;
-    requires transitive org.antlr.antlr4.runtime;
+    requires org.antlr.antlr4.runtime;
 }

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/gexf/GEXFExporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/gexf/GEXFExporter.java
@@ -140,7 +140,7 @@ public class GEXFExporter<V, E> extends BaseExporter<V, E> implements GraphExpor
         this.parameters = new HashSet<>();
 
         // enable meta by default
-        this.setParameter(Parameter.EXPORT_META, true);
+        this.parameters.add(Parameter.EXPORT_META);
     }
 
     /**

--- a/jgrapht-io/src/main/java/org/jgrapht/nio/graph6/Graph6Sparse6Exporter.java
+++ b/jgrapht-io/src/main/java/org/jgrapht/nio/graph6/Graph6Sparse6Exporter.java
@@ -221,7 +221,7 @@ public class Graph6Sparse6Exporter<V, E> implements GraphExporter<V, E>
         if (bitIndex == 6)
             writeByte();
         if (bit)
-            currentByte |= 1 << (5 - bitIndex);
+            currentByte = (byte) (currentByte | (1 << (5 - bitIndex)));
         bitIndex++;
     }
 

--- a/jgrapht-opt/src/main/java/module-info.java
+++ b/jgrapht-opt/src/main/java/module-info.java
@@ -25,7 +25,8 @@ module org.jgrapht.opt
 {
     exports org.jgrapht.opt.graph.fastutil;
     exports org.jgrapht.opt.graph.sparse;
+    exports org.jgrapht.opt.graph.sparse.specifics;
 
     requires transitive org.jgrapht.core;
-    requires transitive it.unimi.dsi.fastutil;
+    requires it.unimi.dsi.fastutil;
 }

--- a/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/fastutil/FastutilFastLookupGSS.java
+++ b/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/fastutil/FastutilFastLookupGSS.java
@@ -43,6 +43,13 @@ public class FastutilFastLookupGSS<V, E> implements GraphSpecificsStrategy<V, E>
 {
     private static final long serialVersionUID = -1335362823522091418L;
 
+    /**
+     * Constructs a new fast lookup graph specifics strategy.
+     */
+    public FastutilFastLookupGSS()
+    {
+    }
+
     @Override
     public BiFunction<Graph<V, E>, GraphType, Specifics<V, E>> getSpecificsFactory()
     {

--- a/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/fastutil/FastutilFastLookupIntVertexGSS.java
+++ b/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/fastutil/FastutilFastLookupIntVertexGSS.java
@@ -44,6 +44,13 @@ public class FastutilFastLookupIntVertexGSS<E> implements GraphSpecificsStrategy
 {
     private static final long serialVersionUID = 6098261533235930603L;
 
+    /**
+     * Constructs a new fast lookup integer vertex graph specifics strategy.
+     */
+    public FastutilFastLookupIntVertexGSS()
+    {
+    }
+
     @Override
     public BiFunction<Graph<Integer, E>, GraphType, Specifics<Integer, E>> getSpecificsFactory()
     {

--- a/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/fastutil/FastutilGSS.java
+++ b/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/fastutil/FastutilGSS.java
@@ -43,6 +43,13 @@ public class FastutilGSS<V, E> implements GraphSpecificsStrategy<V, E>
 {
     private static final long serialVersionUID = -4319431062943632549L;
 
+    /**
+     * Constructs a new graph specifics strategy.
+     */
+    public FastutilGSS()
+    {
+    }
+
     @Override
     public BiFunction<Graph<V, E>, GraphType, Specifics<V, E>> getSpecificsFactory()
     {

--- a/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/fastutil/FastutilIntVertexGSS.java
+++ b/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/fastutil/FastutilIntVertexGSS.java
@@ -38,6 +38,13 @@ public class FastutilIntVertexGSS<E> implements GraphSpecificsStrategy<Integer, 
 {
     private static final long serialVersionUID = 803286406699705306L;
 
+    /**
+     * Constructs a new integer vertex graph specifics strategy.
+     */
+    public FastutilIntVertexGSS()
+    {
+    }
+
     @Override
     public BiFunction<Graph<Integer, E>, GraphType, Specifics<Integer, E>> getSpecificsFactory()
     {

--- a/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/sparse/specifics/CSRBooleanMatrix.java
+++ b/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/sparse/specifics/CSRBooleanMatrix.java
@@ -30,7 +30,7 @@ import java.util.*;
  *
  * @author Dimitrios Michail
  */
-class CSRBooleanMatrix implements Serializable
+public class CSRBooleanMatrix implements Serializable
 {
     private static final long serialVersionUID = -8639339411487665967L;
 

--- a/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/sparse/specifics/IncomingNoReindexSparseDirectedSpecifics.java
+++ b/jgrapht-opt/src/main/java/org/jgrapht/opt/graph/sparse/specifics/IncomingNoReindexSparseDirectedSpecifics.java
@@ -50,6 +50,7 @@ public class IncomingNoReindexSparseDirectedSpecifics extends NoIncomingNoReinde
      * @param lazyIncomingEdges whether to lazily support incoming edge traversals, only if actually
      *        needed by the user
      */
+    @SuppressWarnings("this-escape")
     public IncomingNoReindexSparseDirectedSpecifics(
         int numVertices, int numEdges, Supplier<Stream<Pair<Integer, Integer>>> edges,
         boolean lazyIncomingEdges)


### PR DESCRIPTION

This PR fixes 80+ warnings thrown by the compiler when issuing `mvn compile`. Some were newly introduced due to the switch to Java 21, but most of them were old, nagging pains. In some occasions the warning is legit and we fix it. In other cases we simply cannot fix it, so it gets suppressed. 
Sadly, there is still a 100 or so warnings left, which can be categorized as follows:

## Unfixible automatic module warnings

There are 13 warnings like this:
> [WARNING] /home/ANT.AMAZON.COM/kinable/workspace/research/external/jgrapht/jgrapht/jgrapht-unimi-dsi/src/main/java/module-info.java:[36,35] requires transitive directive for an automatic module

Issue:
Java's module system (JPMS) requires every library to declare a stable module name via a module-info.java file. Libraries that don't have one 
are treated as "automatic modules" whose names are inferred from the jar filename — an unstable convention that could change between releases. 
When your code declares a dependency on one of these libraries (e.g., Guava, ANTLR, fastutil), the compiler warns that you're building your module 
graph on top of an unstable name. You can't simply remove dependencies you rely on, so the dependency must be transitive. The proper fix is for each upstream library to add a module-info.java to their jar.

Dependencies that lack a module-info.java:
jheaps, apfloat, ANTLR, fastutil, JGraphX, Guava, webgraph, webgraph-big, dsiutils, sux4j.

Unless these dependencies add a module-info.java on their end, this is not going to be fixed.


## Serializable warnings
There are 98 warnings like this: 
> [WARNING] /home/ANT.AMAZON.COM/kinable/workspace/research/external/jgrapht/jgrapht/jgrapht-unimi-dsi/src/main/java/org/jgrapht/sux4j/SuccinctIntDirectedGraph.java:[441,52] non-transient instance field of a serializable class declared with a non-serializable type

Issue: 
Non-serializable generic fields in Serializable classes. Example: `Graph<V,E> implements Serializable` but `V` and `E` have no Serializable bound. 

This issue seems to appear in both our own classes as well as in some of our dependencies.

There seem to be 3 solutions:
1. Tighten bounds (`<V extends Serializable>`). This would work, but would make this jgrapht render this version non-backward compatible as we suddenly impose additional restrictions on the input
2. Remove serialize alltogether. Sounds like a bad idea.
3. @SuppressWarnings("serial"). Ostrich approach: prevent the warning from being printed
4. Do nothing, just live with the warning.

## Other issues that were fixed:

**Missing explicit constructors** — Java's module system warns when a public class in an exported package has no explicit constructor, since the compiler-generated default constructor is unintentionally exposed to module clients. Fixed by adding private constructors to utility classes (static-only) and public constructors to instantiable classes.

**Not accessible to module clients** — Package-private classes or inner classes used in public method signatures. Module clients can see the method but can't access the type. Fixed by making these types public.

**Unexported package** — The specifics package in jgrapht-opt was used in public API but not declared in module-info.java. Fixed by adding exports org.jgrapht.opt.graph.sparse.specifics.

**This-escape in constructors** — Java 21 warns when a constructor calls a virtual method on this before the object is fully initialized, since a subclass override could run on a half-constructed object. Each case was inspected individually; all were intentional design patterns (factory callbacks, graph population during construction, abstract method calls) that can't be refactored without breaking the API. Fixed with @SuppressWarnings("this-escape") on the constructor. 

**Raw types** — Two cases of generic type erasure. HawickJamesSimpleCycles used new ArrayList[n] (unavoidable raw array creation, fixed with (List<Integer>[]) new List<?>[n] under existing @SuppressWarnings("unchecked")). PathSetKey.equals() used raw instanceof (unavoidable in generic equals, suppressed with @SuppressWarnings("rawtypes")).

**Missing errorprone annotations** — Guava's compiled bytecode references @Immutable and @DoNotMock from error_prone_annotations, but jgrapht-guava excluded that jar from Guava's dependencies. The compiler couldn't resolve the annotations. Fixed by removing the exclusion.

## NOTE
There is some weird stuff. For instance:

BEFORE: `static class FlyweightEdgeEvent<E> extends EdgeTraversalEvent<E>`
AFTER: `public static class FlyweightEdgeEvent<E> extends EdgeTraversalEvent<E>`

FlyweightEdgeEvent was static class (package-private). It's used in public method signatures inside AbstractGraphIterator: the fireEdgeTraversed and fireEdgeFinished methods create and pass these events to listeners. Because the class was package-private but appeared in public API, the module system warned: "clients can see the method but can't access the type." Making it public was the fix to align the access modifier with its actual visibility. It can't be private because it's returned/passed to code outside the class (the traversal listener API). Arguably a better fix would have been to change the public methods to not expose this type, but that would be violate our backward compatible requirements.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
