### PR TITLE
Optimize BaseManyToManyShortestPaths.getPaths(V) to run one source search

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseManyToManyShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BaseManyToManyShortestPaths.java
@@ -72,6 +72,16 @@ abstract class BaseManyToManyShortestPaths<V, E> implements ManyToManyShortestPa
 
     /**
      * {@inheritDoc}
+     *
+     * <p>
+     * Implementation note: in this many-to-many setting, a call to {@code getPaths(source)} is
+     * resolved by running a single shortest-paths search from {@code source} that settles every
+     * vertex reachable in the graph, instead of issuing one separate {@code getPath(source, v)}
+     * call per vertex of the graph. The latter would invoke the underlying
+     * {@link #getManyToManyPaths(Set, Set)} once per target vertex and re-run Dijkstra from
+     * {@code source} each time, turning a single-source query into {@code |V|} single-source
+     * queries from the same source.
+     * </p>
      */
     @Override
     public SingleSourcePaths<V, E> getPaths(V source)
@@ -79,12 +89,7 @@ abstract class BaseManyToManyShortestPaths<V, E> implements ManyToManyShortestPa
         if (!graph.containsVertex(source)) {
             throw new IllegalArgumentException("graph must contain the source vertex");
         }
-
-        Map<V, GraphPath<V, E>> paths = new HashMap<>();
-        for (V v : graph.vertexSet()) {
-            paths.put(v, getPath(source, v));
-        }
-        return new ListSingleSourcePathsImpl<>(graph, source, paths);
+        return getShortestPathsTree(graph, source, graph.vertexSet());
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPathsTest.java
@@ -17,10 +17,14 @@
  */
 package org.jgrapht.alg.shortestpath;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
+import org.jgrapht.alg.interfaces.ShortestPathAlgorithm.SingleSourcePaths;
 import org.jgrapht.graph.*;
 import org.junit.jupiter.api.*;
 
@@ -90,6 +94,67 @@ public class DijkstraManyToManyShortestPathsTest extends BaseManyToManyShortestP
     public void testOnRandomGraphs()
     {
         super.testOnRandomGraphs(100, 20, new int[][] { { 50, 30 }, { 40, 40 }, { 30, 50 } }, 50);
+    }
+
+    @Test
+    public void testGetPathsSingleSourceMatchesDijkstra()
+    {
+        // The inherited getPaths(V) was previously implemented by issuing one
+        // getPath(source, v) per vertex of the graph, which re-ran Dijkstra |V| times from the
+        // same source. The optimized implementation runs a single shortest-paths search from
+        // source instead. This test pins that result against a fresh DijkstraShortestPath as the
+        // ground-truth oracle, and additionally verifies the unreachable-vertex contract.
+
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        graph.addVertex(2);
+        graph.addVertex(3);
+        graph.addVertex(4);
+        graph.addVertex(5);
+        graph.setEdgeWeight(graph.addEdge(1, 2), 1.5);
+        graph.setEdgeWeight(graph.addEdge(2, 3), 2.0);
+        graph.setEdgeWeight(graph.addEdge(1, 3), 5.0);
+        graph.setEdgeWeight(graph.addEdge(3, 4), 1.0);
+        // vertex 5 is intentionally isolated: unreachable from 1 in the directed graph
+
+        DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new DijkstraManyToManyShortestPaths<>(graph);
+        DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
+            new DijkstraShortestPath<>(graph);
+        SingleSourcePaths<Integer, DefaultWeightedEdge> oraclePaths = oracle.getPaths(1);
+
+        SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(1);
+        assertEquals(graph, paths.getGraph());
+        assertEquals(Integer.valueOf(1), paths.getSourceVertex());
+
+        // Source vertex itself
+        assertEquals(0d, paths.getWeight(1), 1e-12);
+        assertNotNull(paths.getPath(1));
+        assertEquals(0, paths.getPath(1).getLength());
+
+        // Reachable targets
+        for (Integer target : new Integer[] { 2, 3, 4 }) {
+            assertEquals(oraclePaths.getWeight(target), paths.getWeight(target), 1e-12);
+            assertEquals(
+                oraclePaths.getPath(target).getVertexList(),
+                paths.getPath(target).getVertexList());
+        }
+
+        // Unreachable target (5): SingleSourcePaths contract is null path / +Inf weight
+        assertNull(paths.getPath(5));
+        assertEquals(Double.POSITIVE_INFINITY, paths.getWeight(5), 0d);
+    }
+
+    @Test
+    public void testGetPathsRejectsVertexNotInGraph()
+    {
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new DijkstraManyToManyShortestPaths<>(graph);
+        assertThrows(IllegalArgumentException.class, () -> alg.getPaths(42));
     }
 
     @Override


### PR DESCRIPTION
## Summary

`BaseManyToManyShortestPaths.getPaths(V source)` (inherited by
`DijkstraManyToManyShortestPaths`, `CHManyToManyShortestPaths`, and
`DefaultManyToManyShortestPaths`) was implemented as

```java
Map<V, GraphPath<V, E>> paths = new HashMap<>();
for (V v : graph.vertexSet()) {
    paths.put(v, getPath(source, v));
}
return new ListSingleSourcePathsImpl<>(graph, source, paths);
```

Each `getPath(source, v)` call dispatches through the contract method
`getManyToManyPaths(Collections.singleton(source), Collections.singleton(v))`
which, in `DijkstraManyToManyShortestPaths`, runs a fresh
`DijkstraClosestFirstIterator` from `source`. So a single call to
`getPaths(source)` ran `|V|` separate Dijkstras from the same source, turning
what should be a single `O(V log V + E)` query into
`O(|V| · (V log V + E))`.

This PR replaces the loop with a single call to the existing helper

```java
return getShortestPathsTree(graph, source, graph.vertexSet());
```

which returns a `TreeSingleSourcePathsImpl<V, E>`. Both
`ListSingleSourcePathsImpl` and `TreeSingleSourcePathsImpl` honor the same
`SingleSourcePaths` contract on the externally-visible methods (`getGraph`,
`getSourceVertex`, `getWeight(target)`, `getPath(target)`), including the
unreachable-target case (null path, `+∞` weight) and the source==target
case (singleton walk, weight 0). The change is therefore a pure performance
fix with no behavioral difference for any caller using only the
`SingleSourcePaths` interface.

## Benchmark

Random directed weighted graph, average out-degree 5, JVM 21.0.9, mean
wall-clock per `getPaths(0)` call over 20 reps after 3 warm-up calls:

| `\|V\|` | master | this PR | speed-up |
|------|--------|---------|----------|
| 50   | 0.83 ms | 0.27 ms | 3.1× |
| 100  | 1.97 ms | 0.08 ms | 25.9× |
| 200  | 3.90 ms | 0.18 ms | 21.8× |
| 400  | 16.17 ms | 0.55 ms | 29.2× |

Caveats: single JVM run, no JMH/forks. The `V=50` row is depressed by JIT
warm-up — that cell ran first.

## Tests

Adds two regression tests on `DijkstraManyToManyShortestPathsTest`:

- `testGetPathsSingleSourceMatchesDijkstra` — pins the new implementation
  against a fresh `DijkstraShortestPath` oracle on a small directed
  weighted graph, including a deliberately isolated unreachable vertex to
  lock in the null-path / `+∞`-weight contract.
- `testGetPathsRejectsVertexNotInGraph` — keeps the precondition that the
  source must be a vertex of the graph.

## Test plan

- [x] `mvn -pl jgrapht-core -Dtest=DijkstraManyToManyShortestPathsTest test` — 12/12 PASS (10 existing + 2 new)
- [x] `mvn -pl jgrapht-core test` — 6877/6877 PASS, 15 unrelated upstream skips
- [x] `mvn -pl jgrapht-core checkstyle:check -P checkstyle` — 0 violations
- [x] `mvn -pl jgrapht-core javadoc:javadoc` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)