### PR TITLE
Avoid unused pathVertices rebuild in AllDirectedPaths non-simple mode

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
@@ -221,7 +221,7 @@ public class AllDirectedPaths<V, E>
          * edges whose minimum distances is small enough.
          */
         List<GraphPath<V, E>> completePaths = new ArrayList<>();
-        Deque<List<E>> incompletePaths = new LinkedList<>();
+        Deque<List<E>> incompletePaths = new ArrayDeque<>();
 
         // Input sanity checking
         if (maxPathLength != null && maxPathLength < 0) {
@@ -271,10 +271,17 @@ public class AllDirectedPaths<V, E>
             E leafEdge = incompletePath.get(lengthSoFar - 1);
             V leafNode = graph.getEdgeTarget(leafEdge);
 
-            Set<V> pathVertices = new HashSet<>();
-            for (E pathEdge : incompletePath) {
-                pathVertices.add(graph.getEdgeSource(pathEdge));
-                pathVertices.add(graph.getEdgeTarget(pathEdge));
+            // pathVertices is only consulted by the simple-path filter below;
+            // building it in non-simple mode is wasted work proportional to path length.
+            Set<V> pathVertices;
+            if (simplePathsOnly) {
+                pathVertices = new HashSet<>();
+                for (E pathEdge : incompletePath) {
+                    pathVertices.add(graph.getEdgeSource(pathEdge));
+                    pathVertices.add(graph.getEdgeTarget(pathEdge));
+                }
+            } else {
+                pathVertices = null;
             }
 
             for (E outEdge : graph.outgoingEdgesOf(leafNode)) {


### PR DESCRIPTION
## Summary

In `AllDirectedPaths.generatePaths` the per-pop `pathVertices` `HashSet` is
only consulted by the simple-path self-intersection filter

```java
if (simplePathsOnly && pathVertices.contains(graph.getEdgeTarget(outEdge))) {
    continue;
}
```

but it was rebuilt unconditionally on every iteration of the main loop,
including in non-simple-paths mode (`simplePathsOnly=false`, the only mode
allowed alongside cyclic search). This PR guards the rebuild behind the
`simplePathsOnly` check, so the set is only constructed when it has a
reader. The downstream test short-circuits, so the field is only
dereferenced when populated — keeping the change purely a performance
refactor with no behavioral difference.

This also switches the `incompletePaths` queue from `LinkedList` to
`ArrayDeque` to remove the per-node linked-list overhead; the queue is
only used through the `Deque` interface (`poll` / `addFirst` / `add` /
`isEmpty`), which `ArrayDeque` supports identically with better
allocation behavior.

This removes avoidable `O(path length)` work per popped partial path when
`simplePathsOnly=false`.

## Benchmark

Cyclic grid `n × n` with self-loops on every vertex, source = corner,
target = center, simple-paths mode off, JVM 21.0.9, mean wall-clock per
`getAllPaths` call over 20 reps after 3 warm-up calls:

| n  | maxLen | paths produced | master | this PR | speed-up |
|----|--------|----------------|--------|---------|----------|
| 8  | 10     | 3 850          | 4.45 ms | 6.75 ms | 0.66× ⚠ |
| 8  | 12     | 50 050         | 24.22 ms | 9.38 ms | 2.6× |
| 10 | 12     | 19 656         | 11.78 ms | 4.17 ms | 2.8× |
| 12 | 12     | 924            | 0.92 ms | 0.44 ms | 2.1× |

Caveats: single JVM run, no JMH/forks. The first row is the cold-JIT cell
(it is the first benchmark to exercise the non-simple-mode branch on
this run); the remaining hot-JIT rows all land in the 2–3× range.

## Tests

No new tests — the change is a pure refactor of an existing code path
already covered by `AllDirectedPathsTest`. In particular,
`testCycleBehavior` exercises both `simplePathsOnly=true` and
`simplePathsOnly=false` on a cyclic toy graph with `maxPathLength=8` and
verifies the produced path counts (7 simple, 13 non-simple) match the
expected enumeration.

## Test plan

- [x] `mvn -pl jgrapht-core -Dtest=AllDirectedPathsTest test` — 9/9 PASS
- [x] `mvn -pl jgrapht-core test` — 6875/6875 PASS, 15 unrelated upstream skips
- [x] `mvn -pl jgrapht-core checkstyle:check -P checkstyle` — 0 violations
- [x] `mvn -pl jgrapht-core javadoc:javadoc` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)