### PR TITLE
Prune source-unreachable branches in AllDirectedPaths preprocessing

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
@@ -116,9 +116,14 @@ public class AllDirectedPaths<V, E>
             return Collections.emptyList();
         }
 
-        // Decorate the edges with the minimum path lengths through them
-        Map<E, Integer> edgeMinDistancesFromTargets =
-            edgeMinDistancesBackwards(targetVertices, maxPathLength);
+        // Decorate the edges with the minimum path lengths through them.
+        // Sandwich pruning: only retain edges whose source vertex is also forward-reachable from
+        // some source within the remaining budget, so that the edge can actually lie on a
+        // sources -> targets path of length at most maxPathLength.
+        Map<V, Integer> vertexMinDistancesFromSources =
+            vertexMinDistancesForwards(sourceVertices, maxPathLength);
+        Map<E, Integer> edgeMinDistancesFromTargets = edgeMinDistancesBackwards(
+            targetVertices, vertexMinDistancesFromSources, maxPathLength);
 
         // Generate all the paths
 
@@ -128,16 +133,34 @@ public class AllDirectedPaths<V, E>
     }
 
     /**
-     * Compute the minimum number of edges in a path to the targets through each edge, so long as it
-     * is not greater than a bound.
+     * Compute the minimum number of edges in a path to the targets through each edge, so long as
+     * it is not greater than a bound and the edge can lie on at least one path of length at most
+     * {@code maxPathLength} from some source vertex to some target vertex.
+     *
+     * <p>
+     * The sandwich condition is enforced via {@code vertexMinDistancesFromSources}: an edge
+     * {@code (u, v)} is retained only when {@code u} is forward-reachable from some source and
+     * {@code dF(u) + (1 + dB(v)) <= maxPathLength} (when bounded), where {@code dF(u)} is the
+     * forward BFS distance from the source set to {@code u} and {@code 1 + dB(v)} is the backward
+     * BFS distance to a target through this edge. Edges that fail the sandwich cannot appear on
+     * any feasible source -> target path and would therefore never be traversed by the forward
+     * enumeration in {@link #generatePaths}; dropping them keeps the decoration map smaller and
+     * avoids continuing the backward walk through unreachable parts of the graph.
+     * </p>
      *
      * @param targetVertices the target vertices
+     * @param vertexMinDistancesFromSources forward BFS distances from the source set, computed
+     *        with the same {@code maxPathLength} bound; vertices not in the map are not
+     *        forward-reachable within that bound
      * @param maxPathLength maximum number of edges to allow in a path (if null, all edges will be
      *        considered, which may be expensive)
      *
-     * @return the minimum number of edges in a path from each edge to the targets, encoded in a Map
+     * @return the minimum number of edges in a path from each edge to the targets, encoded in a
+     *         Map
      */
-    private Map<E, Integer> edgeMinDistancesBackwards(Set<V> targetVertices, Integer maxPathLength)
+    private Map<E, Integer> edgeMinDistancesBackwards(
+        Set<V> targetVertices, Map<V, Integer> vertexMinDistancesFromSources,
+        Integer maxPathLength)
     {
         /*
          * We walk backwards through the network from the target vertices, marking edges and
@@ -157,10 +180,13 @@ public class AllDirectedPaths<V, E>
             }
         }
 
-        // Bootstrap the process with the target vertices
+        // Bootstrap the process with target vertices that are forward-reachable from some source.
+        // Targets that no source can reach cannot anchor a feasible path, so we skip them.
         for (V target : targetVertices) {
-            vertexMinDistances.put(target, 0);
-            verticesToProcess.add(target);
+            if (vertexMinDistancesFromSources.containsKey(target)) {
+                vertexMinDistances.put(target, 0);
+                verticesToProcess.add(target);
+            }
         }
 
         // Work through the node queue. When it's empty, we're done!
@@ -172,6 +198,20 @@ public class AllDirectedPaths<V, E>
             // Check whether the incoming edges of this node are correctly
             // decorated
             for (E edge : graph.incomingEdgesOf(vertex)) {
+                V edgeSource = graph.getEdgeSource(edge);
+
+                // Sandwich prune: drop edges whose source side is not reachable from the source
+                // set, or whose total forward + backward length already exceeds the budget.
+                Integer forwardOfSource = vertexMinDistancesFromSources.get(edgeSource);
+                if (forwardOfSource == null) {
+                    continue;
+                }
+                if (maxPathLength != null
+                    && forwardOfSource + childDistance > maxPathLength)
+                {
+                    continue;
+                }
+
                 // Mark the edge if needed
                 if (!edgeMinDistances.containsKey(edge)
                     || (edgeMinDistances.get(edge) > childDistance))
@@ -180,7 +220,6 @@ public class AllDirectedPaths<V, E>
                 }
 
                 // Mark the edge's source vertex if needed
-                V edgeSource = graph.getEdgeSource(edge);
                 if (!vertexMinDistances.containsKey(edgeSource)
                     || (vertexMinDistances.get(edgeSource) > childDistance))
                 {
@@ -195,6 +234,51 @@ public class AllDirectedPaths<V, E>
 
         assert verticesToProcess.isEmpty();
         return edgeMinDistances;
+    }
+
+    /**
+     * Compute the minimum number of edges in a forward BFS from the source vertices, capped at
+     * {@code maxPathLength} when given. Used together with
+     * {@link #edgeMinDistancesBackwards(Set, Map, Integer)} to apply sandwich-style pruning of the
+     * edge decoration map.
+     *
+     * @param sourceVertices the source vertices
+     * @param maxPathLength maximum number of forward edges to expand (if null, the BFS is
+     *        unrestricted)
+     *
+     * @return for every vertex reachable from {@code sourceVertices} within {@code maxPathLength}
+     *         edges, its minimum forward distance from the source set
+     */
+    private Map<V, Integer> vertexMinDistancesForwards(
+        Set<V> sourceVertices, Integer maxPathLength)
+    {
+        Map<V, Integer> vertexMinDistances = new HashMap<>();
+        Queue<V> verticesToProcess = new ArrayDeque<>();
+
+        for (V source : sourceVertices) {
+            if (!vertexMinDistances.containsKey(source)) {
+                vertexMinDistances.put(source, 0);
+                verticesToProcess.add(source);
+            }
+        }
+
+        for (V vertex; (vertex = verticesToProcess.poll()) != null;) {
+            int currentDistance = vertexMinDistances.get(vertex);
+            if (maxPathLength != null && currentDistance >= maxPathLength) {
+                continue;
+            }
+            int childDistance = currentDistance + 1;
+
+            for (E edge : graph.outgoingEdgesOf(vertex)) {
+                V child = graph.getEdgeTarget(edge);
+                if (!vertexMinDistances.containsKey(child)) {
+                    vertexMinDistances.put(child, childDistance);
+                    verticesToProcess.add(child);
+                }
+            }
+        }
+
+        return vertexMinDistances;
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/AllDirectedPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/AllDirectedPathsTest.java
@@ -223,6 +223,39 @@ public class AllDirectedPathsTest
     }
 
     @Test
+    public void testTargetReachableButSourceUnreachableBranchIsIgnored()
+    {
+        // Sandwich-prune sanity check: a vertex that can reach the target but is not
+        // reachable from any source must not appear on any returned path, and must not
+        // cause the algorithm to spend time relaxing it.
+        DefaultDirectedGraph<String, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("S");
+        graph.addVertex("A");
+        graph.addVertex("T");
+        graph.addEdge("S", "A");
+        graph.addEdge("A", "T");
+
+        // Dead source-side branch: U and V can reach T (U -> T) but no edge from S
+        // ever leads into U or V.
+        graph.addVertex("U");
+        graph.addVertex("V");
+        graph.addEdge("U", "T");
+        graph.addEdge("V", "U");
+
+        AllDirectedPaths<String, DefaultEdge> alg = new AllDirectedPaths<>(graph);
+
+        List<GraphPath<String, DefaultEdge>> simplePaths = alg.getAllPaths("S", "T", true, 5);
+        assertEquals(1, simplePaths.size());
+        assertEquals(Arrays.asList("S", "A", "T"), simplePaths.get(0).getVertexList());
+
+        List<GraphPath<String, DefaultEdge>> nonSimplePaths = alg.getAllPaths(
+            Collections.singleton("S"), Collections.singleton("T"), false, 5);
+        assertEquals(1, nonSimplePaths.size());
+        assertEquals(Arrays.asList("S", "A", "T"), nonSimplePaths.get(0).getVertexList());
+    }
+
+    @Test
     public void testZeroLengthPaths()
     {
         // Verify fix for https://github.com/jgrapht/jgrapht/issues/640.


### PR DESCRIPTION
## Summary

The existing `AllDirectedPaths.edgeMinDistancesBackwards` walks backward
from the targets and decorates every edge whose head is backward-reachable
to a target within `maxPathLength` edges. This includes edges whose tail
is **not** forward-reachable from any source within the budget, even
though such edges cannot lie on any feasible source → target path and the
forward enumeration in `generatePaths` will never traverse them.

This PR adds a forward BFS from `sourceVertices`
(`vertexMinDistancesForwards`) and threads its result into
`edgeMinDistancesBackwards`. For each candidate edge `(u, v)` the backward
sweep now requires both:

1. `forwardMin(u)` is defined — `u` is reachable from some source within
   the budget — and
2. when bounded, `forwardMin(u) + (1 + backwardMin(v)) ≤ maxPathLength`.

These are necessary and sufficient conditions for the edge to lie on at
least one feasible `s → t` path of length at most `maxPathLength`, so the
prune preserves exactness of the path enumeration. As a side effect the
backward BFS no longer descends into source-disconnected regions of the
graph.

The backward queue is also bootstrapped only with targets that are
themselves forward-reachable from some source — a target no source can
reach cannot anchor any path. The zero-length / source==target trivial
path branch in `generatePaths` is unaffected since that path is generated
independently of the backward sweep.

## Benchmark

Forward chain of 20 vertices `0 → 1 → … → 19 = T`, plus an N-vertex
source-disconnected garden whose every vertex has an edge into `T` (and
internal forward edges between consecutive garden vertices). Simple-paths
mode, `maxLen = 25`, JVM 21.0.9, mean wall-clock per `getAllPaths` call
over 200 reps after 3 warm-up calls:

| garden | master | this PR | speed-up |
|--------|--------|---------|----------|
| 1 000  | 0.235 ms | 0.107 ms | 2.2× |
| 3 000  | 0.483 ms | 0.068 ms | 7.1× |
| 6 000  | 0.700 ms | 0.107 ms | 6.5× |
| 10 000 | 1.316 ms | 0.179 ms | 7.4× |

Master runs grow linearly with garden size because the backward cone
contains the whole garden; this PR stays nearly flat because the garden
is pruned up-front. Caveats: single JVM run, no JMH/forks.

## Tests

Adds a focused regression test
`testTargetReachableButSourceUnreachableBranchIsIgnored` that builds a
graph with a dead source-side branch (`U → T`, `V → U` with no edge from
`S` into `U` or `V`) and verifies both simple-only and non-simple modes
return only the legitimate `S → A → T` path.

## Test plan

- [x] `mvn -pl jgrapht-core -Dtest=AllDirectedPathsTest test` — 10/10 PASS (9 existing + 1 new)
- [x] `mvn -pl jgrapht-core test` — 6876/6876 PASS, 15 unrelated upstream skips
- [x] `mvn -pl jgrapht-core checkstyle:check -P checkstyle` — 0 violations
- [x] `mvn -pl jgrapht-core javadoc:javadoc` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)