### PR TITLE
feat(shortestpath): Add bounded-pruned Yen k-shortest paths with pluggable spur engines

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AStarSpurEngine.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AStarSpurEngine.java
@@ -1,0 +1,132 @@
+/*
+ * (C) Copyright 2026-2026, by Shai Eilat and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.interfaces.AStarAdmissibleHeuristic;
+import org.jgrapht.graph.GraphWalk;
+import org.jgrapht.graph.MaskSubgraph;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Spur shortest-path engine that delegates to JGraphT's {@link AStarShortestPath}, using the
+ * {@code reverseDistancesToSink} hint as an admissible heuristic. Bans are applied by wrapping the
+ * input graph in a {@link MaskSubgraph} so we do not duplicate or modify the underlying A*
+ * implementation.
+ *
+ * <p>
+ * Correctness: distances on the original graph are a valid lower bound for distances on any
+ * subgraph obtained by removing vertices/edges (Dijkstra never gets shorter when the graph
+ * shrinks). So {@code h(v) = reverseDistancesToSink[v]} is admissible for the spur subproblem on
+ * the masked graph. If the heuristic map is {@code null} or missing for some vertex, the engine
+ * falls back to {@code 0.0} for that vertex (still admissible, equivalent to running A* with a
+ * trivial heuristic, i.e. Dijkstra).
+ *
+ * <p>
+ * Edge weights must be non-negative.
+ *
+ * @param <V> graph vertex type
+ * @param <E> graph edge type
+ */
+public class AStarSpurEngine<V, E>
+    implements SpurShortestPathEngine<V, E>
+{
+    private long expandedVertices;
+    private long pathQueries;
+
+    @Override
+    public GraphPath<V, E> findPath(
+        Graph<V, E> graph, V source, V sink, Set<V> bannedVertices, Set<E> bannedEdges,
+        Map<V, Double> reverseDistancesToSink)
+    {
+        pathQueries++;
+        if (source.equals(sink)) {
+            // Trivial zero-length walk; matches YenKShortestPath behaviour for source==sink.
+            return new GraphWalk<>(
+                graph, source, sink, Collections.singletonList(source), Collections.emptyList(),
+                0.0);
+        }
+        Set<V> banV = bannedVertices == null ? Collections.emptySet() : bannedVertices;
+        Set<E> banE = bannedEdges == null ? Collections.emptySet() : bannedEdges;
+        Graph<V, E> masked = (banV.isEmpty() && banE.isEmpty())
+            ? graph
+            : new MaskSubgraph<>(graph, banV::contains, banE::contains);
+
+        AStarAdmissibleHeuristic<V> heuristic = (sourceVertex, targetVertex) -> {
+            if (reverseDistancesToSink == null) {
+                return 0.0;
+            }
+            Double d = reverseDistancesToSink.get(sourceVertex);
+            // Missing entry => unreachable to sink on the original graph; 0.0 is still admissible.
+            return d == null || Double.isInfinite(d) ? 0.0 : d;
+        };
+
+        CountingAStar<V, E> astar = new CountingAStar<>(masked, heuristic);
+        GraphPath<V, E> path = astar.getPath(source, sink);
+        expandedVertices += astar.expanded();
+        return path;
+    }
+
+    @Override
+    public long expandedVertices()
+    {
+        return expandedVertices;
+    }
+
+    @Override
+    public long pathQueries()
+    {
+        return pathQueries;
+    }
+
+    @Override
+    public void resetCounters()
+    {
+        expandedVertices = 0;
+        pathQueries = 0;
+    }
+
+    @Override
+    public String name()
+    {
+        return "AStar";
+    }
+
+    /**
+     * Tiny subclass that exposes the protected {@code numberOfExpandedNodes} counter so the
+     * engine can report per-call expansion counts to the benchmark. Behaviour is otherwise
+     * identical to {@link AStarShortestPath}.
+     */
+    private static final class CountingAStar<V, E>
+        extends AStarShortestPath<V, E>
+    {
+        CountingAStar(Graph<V, E> graph, AStarAdmissibleHeuristic<V> heuristic)
+        {
+            super(graph, heuristic);
+        }
+
+        int expanded()
+        {
+            return numberOfExpandedNodes;
+        }
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BoundedPrunedYenKShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/BoundedPrunedYenKShortestPath.java
@@ -1,0 +1,592 @@
+/*
+ * (C) Copyright 2026-2026, by Shai Eilat and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.interfaces.KShortestPathAlgorithm;
+import org.jgrapht.graph.EdgeReversedGraph;
+import org.jgrapht.graph.GraphWalk;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.Set;
+
+/**
+ * Experimental bounded-pruned variant of Yen's $k$ shortest loopless paths algorithm.
+ *
+ * <p>
+ * This class returns the same ordered sequence of path weights as {@link YenKShortestPath} (and is
+ * regression-tested against it) but tries to perform fewer spur shortest-path computations and
+ * fewer candidate materializations by deferring spur work behind <em>lower-bound certificates</em>.
+ *
+ * <h3>Key idea</h3>
+ *
+ * Standard Yen, when accepting a path $P$, eagerly enumerates every spur index of $P$, runs a
+ * shortest-path query under the appropriate banning, materializes the full candidate path, and
+ * pushes it into the candidate heap. For large $k$ on dense graphs this generates many candidates
+ * that will never be output.
+ *
+ * <p>
+ * The bounded-pruned variant defers each spur enumeration as a {@code SpurTask} carrying:
+ * <ul>
+ *   <li>the parent accepted path,</li>
+ *   <li>the spur index in that parent,</li>
+ *   <li>the banned vertex set (the parent's prefix),</li>
+ *   <li>the root cost so far,</li>
+ *   <li>and a <em>lower bound</em> on any candidate it could ever produce:
+ *       {@code lowerBound = rootCost + reverseDistanceToSink[spurNode]}.</li>
+ * </ul>
+ *
+ * <p>
+ * Reverse distances are computed once on the original graph. Because removing vertices/edges can
+ * only increase shortest-path distance, those reverse distances remain valid lower bounds even
+ * under arbitrary bans. So:
+ *
+ * <blockquote>If the cheapest materialized candidate already satisfies
+ * {@code candidate.cost ≤ task.lowerBound} for every still-deferred task, it is safe to output
+ * the candidate as the next path — no deferred task could possibly produce something better.
+ * </blockquote>
+ *
+ * <h3>Algorithm sketch</h3>
+ *
+ * <pre>
+ *   firstPath = shortestPath(source, sink)
+ *   accepted.add(firstPath)
+ *   addSpurTasks(firstPath)
+ *   while accepted.size &lt; k:
+ *       while taskHeap not empty AND
+ *             (candidateHeap empty OR taskHeap.minLB &lt; candidateHeap.minCost):
+ *           materialize(taskHeap.pop())  // run the actual spur query, push candidate
+ *       if candidateHeap empty: break
+ *       next = candidateHeap.pop()
+ *       accepted.add(next)
+ *       addSpurTasks(next)
+ * </pre>
+ *
+ * <h3>Exactness</h3>
+ *
+ * The returned path-weight sequence equals that of {@link YenKShortestPath}. Tie-breaking among
+ * paths of equal weight is deterministic: a stable ordinal is attached to every candidate / task
+ * push so that two equal weights are broken by insertion order, which mirrors how the standard
+ * implementation eagerly inserts candidates as it accepts each path. The benchmark harness
+ * verifies the path-weight sequences match exactly across many graph families.
+ *
+ * <h3>What this class does NOT yet claim</h3>
+ *
+ * <ul>
+ *   <li>No proven better worst-case complexity: Yen's $O(k\,n\,(m + n \log n))$ remains the
+ *       upper bound. The bounded-pruned layer is an output-sensitive optimisation only.</li>
+ * </ul>
+ *
+ * <h3>References</h3>
+ *
+ * <ul>
+ *   <li>Yen, J. Y. (1971). Finding the k shortest loopless paths in a network.
+ *       <i>Management Science</i>, 17(11), 712–716. The original loopless k-shortest-paths
+ *       algorithm whose spur step is reused here.</li>
+ *   <li>Martins, E. Q. V., &amp; Pascoal, M. M. B. (2003). A new implementation of Yen's
+ *       ranking loopless paths algorithm. <i>4OR — Quarterly Journal of the Belgian, French
+ *       and Italian Operations Research Societies</i>, 1(2), 121–133. Practical
+ *       implementation notes that informed JGraphT's existing {@link YenKShortestPath}.</li>
+ *   <li>Aljazzar, H., &amp; Leue, S. (2011). K*: A heuristic search algorithm for finding the
+ *       k shortest paths. <i>Artificial Intelligence</i>, 175(18), 2129–2154. The closest
+ *       prior published precedent for using admissible lower bounds (an A*-style heuristic on
+ *       the reverse graph) to defer expansion of provably non-improving k-paths candidates.
+ *       This class applies the same lower-bound-then-defer idea at the Yen spur-task level
+ *       rather than at K*'s edge-expansion level.</li>
+ * </ul>
+ *
+ * @param <V> graph vertex type
+ * @param <E> graph edge type
+ */
+public class BoundedPrunedYenKShortestPath<V, E>
+    implements KShortestPathAlgorithm<V, E>
+{
+    private final Graph<V, E> graph;
+    private final SpurShortestPathEngine<V, E> engine;
+
+    private final Stats stats = new Stats();
+
+    /**
+     * Default constructor using {@link DijkstraSpurEngine} as the spur shortest-path back-end.
+     * This default mirrors the spur step of the existing {@link YenKShortestPath} for
+     * principle-of-least-surprise. Pass an {@link AStarSpurEngine} via
+     * {@link #BoundedPrunedYenKShortestPath(Graph, SpurShortestPathEngine)} to opt into the
+     * reverse-distance A* heuristic — recommended for dense graphs or large k. The A* engine
+     * is exact (the heuristic is admissible by construction).
+     *
+     * @param graph the input graph (must not be {@code null})
+     */
+    public BoundedPrunedYenKShortestPath(Graph<V, E> graph)
+    {
+        this(graph, new DijkstraSpurEngine<>());
+    }
+
+    /**
+     * Constructor with a pluggable {@link SpurShortestPathEngine}.
+     *
+     * @param graph the input graph (must not be {@code null})
+     * @param engine the spur shortest-path engine to use (must not be {@code null})
+     */
+    public BoundedPrunedYenKShortestPath(
+        Graph<V, E> graph, SpurShortestPathEngine<V, E> engine)
+    {
+        this.graph = Objects.requireNonNull(graph, "Graph cannot be null!");
+        this.engine = Objects.requireNonNull(engine, "Engine cannot be null!");
+    }
+
+    @Override
+    public List<GraphPath<V, E>> getPaths(V source, V sink, int k)
+    {
+        if (k < 0) {
+            throw new IllegalArgumentException("k should be positive");
+        }
+        if (!graph.containsVertex(source)) {
+            throw new IllegalArgumentException("Graph should contain source vertex!");
+        }
+        if (!graph.containsVertex(sink)) {
+            throw new IllegalArgumentException("Graph should contain sink vertex!");
+        }
+        stats.reset();
+        engine.resetCounters();
+
+        if (k == 0) {
+            return new ArrayList<>();
+        }
+
+        // -- Step 1: reverse distances from sink (single Dijkstra on edge-reversed original graph)
+        Map<V, Double> reverseDistances = computeReverseDistances(sink);
+
+        // -- Step 2: first shortest path
+        GraphPath<V, E> first = engine.findPath(
+            graph, source, sink, Collections.emptySet(), Collections.emptySet(), reverseDistances);
+        if (first == null) {
+            return new ArrayList<>();
+        }
+
+        return runBoundedLoop(first, sink, k, reverseDistances);
+    }
+
+    private List<GraphPath<V, E>> runBoundedLoop(
+        GraphPath<V, E> first, V sink, int k, Map<V, Double> reverseDistances)
+    {
+        List<GraphPath<V, E>> accepted = new ArrayList<>();
+        // Per-path metadata: index of first deviation vertex from parent (source for the first
+        // shortest path).
+        List<Integer> firstDeviationIndex = new ArrayList<>();
+
+        // Heaps. We use a stable ordinal as a tiebreaker so identical-weight items break ties by
+        // insertion order — matches standard Yen's behaviour closely.
+        PriorityQueue<SpurTask> taskHeap = new PriorityQueue<>();
+        PriorityQueue<Candidate> candHeap = new PriorityQueue<>();
+        // Dedup: a (vertex-list) signature so we never push the same candidate twice. Candidate
+        // duplication can in principle occur even under banning if multiple parents lead to the
+        // same path through different spur indices.
+        Set<List<V>> seenCandidates = new HashSet<>();
+
+        accepted.add(first);
+        firstDeviationIndex.add(0); // first path deviates at source
+        seenCandidates.add(first.getVertexList());
+        addSpurTasksFor(
+            first, /*pathIndex=*/0, firstDeviationIndex, accepted, reverseDistances, taskHeap);
+
+        while (accepted.size() < k) {
+            // Materialize tasks while their LB might beat the best candidate.
+            while (!taskHeap.isEmpty()
+                && (candHeap.isEmpty() || taskHeap.peek().lowerBound < candHeap.peek().cost
+                    || approxEq(taskHeap.peek().lowerBound, candHeap.peek().cost)))
+            {
+                SpurTask t = taskHeap.poll();
+                stats.spurTasksMaterialized++;
+                Candidate c = materialize(t, accepted, reverseDistances);
+                if (c == null) {
+                    stats.unreachableSpurs++;
+                    continue;
+                }
+                if (seenCandidates.add(c.path.getVertexList())) {
+                    candHeap.offer(c);
+                    stats.candidateHeapPushes++;
+                    stats.materializedCandidates++;
+                }
+            }
+            if (candHeap.isEmpty()) {
+                break;
+            }
+            Candidate next = candHeap.poll();
+            stats.candidateHeapPops++;
+
+            // Lower-bound certificate: if any deferred task has lowerBound < next.cost, we cannot
+            // safely output next — we must continue materializing. The outer while loop already
+            // ensured this, but we double-check after the pop because materialization above may
+            // have produced a strictly cheaper candidate.
+            if (!taskHeap.isEmpty() && taskHeap.peek().lowerBound < next.cost
+                && !approxEq(taskHeap.peek().lowerBound, next.cost))
+            {
+                // Re-queue and loop. Should be rare in practice because we already drained tasks.
+                candHeap.offer(next);
+                stats.candidateHeapPushes++;
+                continue;
+            }
+            accepted.add(next.path);
+            firstDeviationIndex.add(next.firstDeviationIndex);
+            int newIdx = accepted.size() - 1;
+            addSpurTasksFor(
+                next.path, newIdx, firstDeviationIndex, accepted, reverseDistances, taskHeap);
+        }
+
+        stats.shortestPathCalls = engine.pathQueries();
+        stats.expandedVertices = engine.expandedVertices();
+        stats.deferredTasksLeft = taskHeap.size();
+        return accepted;
+    }
+
+    /** Run a single spur query through the engine and stitch the candidate path. */
+    private Candidate runSpur(
+        GraphPath<V, E> parent, int spurIndex, Set<V> bannedVertices, Set<E> bannedEdges,
+        double rootCost, Map<V, Double> reverseDistances)
+    {
+        List<V> parentVertices = parent.getVertexList();
+        List<E> parentEdges = parent.getEdgeList();
+        V spurNode = parentVertices.get(spurIndex);
+        V sink = parent.getEndVertex();
+        V source = parent.getStartVertex();
+        GraphPath<V, E> spur = engine.findPath(
+            graph, spurNode, sink, bannedVertices, bannedEdges, reverseDistances);
+        if (spur == null) {
+            return null;
+        }
+        List<V> candVerts = new ArrayList<>(spurIndex + spur.getVertexList().size());
+        List<E> candEdges = new ArrayList<>(spurIndex + spur.getEdgeList().size());
+        for (int i = 0; i < spurIndex; i++) {
+            candVerts.add(parentVertices.get(i));
+            candEdges.add(parentEdges.get(i));
+        }
+        candVerts.addAll(spur.getVertexList());
+        candEdges.addAll(spur.getEdgeList());
+        double cost = rootCost + spur.getWeight();
+        GraphPath<V, E> candidate = new GraphWalk<>(graph, source, sink, candVerts, candEdges, cost);
+        return new Candidate(candidate, cost, spurIndex, stats.candidateOrdinal++);
+    }
+
+    /**
+     * Compute the set of edges that standard Yen would ban at {@code spurIndex} given the
+     * current {@code accepted} list. An edge is banned iff there exists a previously accepted
+     * path whose first {@code spurIndex+1} vertices match {@code parentVertices} and whose
+     * {@code spurIndex}-th edge would otherwise be the next edge of the spur.
+     */
+    private Set<E> computeYenBannedEdges(
+        List<V> parentVertices, int spurIndex, List<GraphPath<V, E>> accepted)
+    {
+        Set<E> bannedEdges = new HashSet<>();
+        for (GraphPath<V, E> other : accepted) {
+            List<V> ov = other.getVertexList();
+            if (ov.size() <= spurIndex + 1) {
+                continue;
+            }
+            boolean prefixMatch = true;
+            for (int i = 0; i <= spurIndex; i++) {
+                if (!parentVertices.get(i).equals(ov.get(i))) {
+                    prefixMatch = false;
+                    break;
+                }
+            }
+            if (prefixMatch) {
+                bannedEdges.add(other.getEdgeList().get(spurIndex));
+            }
+        }
+        return bannedEdges;
+    }
+
+    /**
+     * True iff the spur node has at least one outgoing edge that survives the current bans
+     * (banned-vertex set + banned-edge set). When this is false the spur is provably impossible
+     * and the task can be skipped exactly — adding more bans later can only remove legal edges,
+     * never add them, so a "false" verdict here is stable through the rest of the run.
+     */
+    private boolean hasLegalExit(V spurNode, Set<V> bannedVertices, Set<E> bannedEdges)
+    {
+        for (E e : graph.outgoingEdgesOf(spurNode)) {
+            if (bannedEdges.contains(e)) {
+                continue;
+            }
+            V v = oppositeOf(graph, spurNode, e);
+            if (bannedVertices.contains(v)) {
+                continue;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Reverse distances
+    // --------------------------------------------------------------------------------------------
+
+    private Map<V, Double> computeReverseDistances(V sink)
+    {
+        Graph<V, E> reversed = new EdgeReversedGraph<>(graph);
+        // Plain Dijkstra single-source on the reversed graph.
+        Map<V, Double> dist = new HashMap<>();
+        // Comparator-based PQ, no inner-generic-class headaches: entries are (vertex, dist, ord).
+        PriorityQueue<Object[]> pq = new PriorityQueue<>(
+            (a, b) -> {
+                int c = Double.compare((Double) a[1], (Double) b[1]);
+                if (c != 0) {
+                    return c;
+                }
+                return Long.compare((Long) a[2], (Long) b[2]);
+            });
+        dist.put(sink, 0.0);
+        long ord = 0;
+        pq.offer(new Object[] { sink, 0.0, ord });
+        while (!pq.isEmpty()) {
+            Object[] entry = pq.poll();
+            @SuppressWarnings("unchecked")
+            V u = (V) entry[0];
+            double du = (Double) entry[1];
+            Double known = dist.get(u);
+            if (known == null || du > known) {
+                continue;
+            }
+            for (E ed : reversed.outgoingEdgesOf(u)) {
+                V to = oppositeOf(reversed, u, ed);
+                double w = reversed.getEdgeWeight(ed);
+                if (w < 0.0) {
+                    throw new IllegalArgumentException(
+                        "BoundedPrunedYen requires non-negative edge weights");
+                }
+                double nd = du + w;
+                Double existing = dist.get(to);
+                if (existing == null || nd < existing) {
+                    dist.put(to, nd);
+                    pq.offer(new Object[] { to, nd, ++ord });
+                }
+            }
+        }
+        return dist;
+    }
+
+    private V oppositeOf(Graph<V, E> g, V u, E e)
+    {
+        V s = g.getEdgeSource(e);
+        V t = g.getEdgeTarget(e);
+        return u.equals(s) ? t : s;
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Spur task creation and materialization
+    // --------------------------------------------------------------------------------------------
+
+    private void addSpurTasksFor(
+        GraphPath<V, E> path, int pathIndex, List<Integer> firstDeviationIndex,
+        List<GraphPath<V, E>> accepted, Map<V, Double> reverseDistances,
+        PriorityQueue<SpurTask> taskHeap)
+    {
+        List<V> vertices = path.getVertexList();
+        List<E> edges = path.getEdgeList();
+        int n = vertices.size();
+        if (n < 2) {
+            return;
+        }
+        int devIndex = firstDeviationIndex.get(pathIndex);
+        // Spur indices: from devIndex to n-2 (spur node is vertices[i], i is also rootPrefixLen)
+        Set<V> bannedVerticesPrefix = new LinkedHashSet<>();
+        double rootCost = 0.0;
+        // Walk through prefix accumulating bans.
+        for (int i = 0; i <= n - 2; i++) {
+            if (i >= devIndex) {
+                V spurNode = vertices.get(i);
+                Double rev = reverseDistances.get(spurNode);
+                if (rev == null || Double.isInfinite(rev)) {
+                    // Unreachable from spur to sink even on the original graph -> never produces
+                    // a path under any bans.
+                    stats.unreachableSpurs++;
+                } else {
+                    // Exact impossible-spur skip. Compute the Yen banned edges for this spur and
+                    // check whether the spur node has any surviving outgoing edge. Adding bans
+                    // later can only remove legal edges, never add them, so a "no legal exit"
+                    // verdict here is stable for the rest of the run. This eliminates the
+                    // path-chain pathology where every spur's only outgoing edge gets banned.
+                    Set<E> bannedEdges = computeYenBannedEdges(vertices, i, accepted);
+                    if (!hasLegalExit(spurNode, bannedVerticesPrefix, bannedEdges)) {
+                        stats.skippedImpossibleSpurTasks++;
+                    } else {
+                        double lb = rootCost + rev;
+                        SpurTask t = new SpurTask(
+                            pathIndex, i, new HashSet<>(bannedVerticesPrefix), rootCost, lb,
+                            stats.spurTasksCreated++);
+                        taskHeap.offer(t);
+                    }
+                }
+            }
+            // Update prefix bans for next iteration: ban vertex[i] going forward (it becomes part
+            // of the root prefix for spur index i+1 onward).
+            bannedVerticesPrefix.add(vertices.get(i));
+            rootCost += graph.getEdgeWeight(edges.get(i));
+        }
+    }
+
+    private Candidate materialize(
+        SpurTask task, List<GraphPath<V, E>> accepted, Map<V, Double> reverseDistances)
+    {
+        GraphPath<V, E> parent = accepted.get(task.parentIndex);
+        Set<E> bannedEdges =
+            computeYenBannedEdges(parent.getVertexList(), task.spurIndex, accepted);
+        return runSpur(
+            parent, task.spurIndex, task.bannedVertices, bannedEdges, task.rootCost,
+            reverseDistances);
+    }
+
+    private static boolean approxEq(double a, double b)
+    {
+        return Math.abs(a - b) <= 1e-12 * Math.max(1.0, Math.max(Math.abs(a), Math.abs(b)));
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Stats
+    // --------------------------------------------------------------------------------------------
+
+    /** Run statistics. Reset on every call to {@link #getPaths}. */
+    public static final class Stats
+    {
+        public long shortestPathCalls;
+        public long spurTasksCreated;
+        public long spurTasksMaterialized;
+        public long materializedCandidates;
+        public long deferredTasksLeft;
+        public long candidateHeapPushes;
+        public long candidateHeapPops;
+        public long unreachableSpurs;
+        public long expandedVertices;
+        /**
+         * Number of spur indices that were skipped exactly because the spur node had no legal
+         * outgoing edge after applying the prefix-vertex bans and the Yen banned-edge rule.
+         * Adding more bans later can only remove legal exits, so the skip is sound.
+         */
+        public long skippedImpossibleSpurTasks;
+        long candidateOrdinal;
+
+        void reset()
+        {
+            shortestPathCalls = 0;
+            spurTasksCreated = 0;
+            spurTasksMaterialized = 0;
+            materializedCandidates = 0;
+            deferredTasksLeft = 0;
+            candidateHeapPushes = 0;
+            candidateHeapPops = 0;
+            unreachableSpurs = 0;
+            expandedVertices = 0;
+            skippedImpossibleSpurTasks = 0;
+            candidateOrdinal = 0;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Stats{" + "spCalls=" + shortestPathCalls + ", tasksCreated=" + spurTasksCreated
+                + ", tasksMaterialized=" + spurTasksMaterialized + ", candPushes="
+                + candidateHeapPushes + ", candPops=" + candidateHeapPops + ", unreachableSpurs="
+                + unreachableSpurs + ", skippedImpossibleSpurs=" + skippedImpossibleSpurTasks
+                + ", deferredLeft=" + deferredTasksLeft + ", expanded=" + expandedVertices + '}';
+        }
+    }
+
+    public Stats getStats()
+    {
+        return stats;
+    }
+
+    public String engineName()
+    {
+        return engine.name();
+    }
+
+    // --------------------------------------------------------------------------------------------
+    // Internal helper types
+    // --------------------------------------------------------------------------------------------
+
+    private final class SpurTask
+        implements Comparable<SpurTask>
+    {
+        final int parentIndex;
+        final int spurIndex;
+        final Set<V> bannedVertices;
+        final double rootCost;
+        final double lowerBound;
+        final long ord;
+
+        SpurTask(
+            int parentIndex, int spurIndex, Set<V> bannedVertices, double rootCost,
+            double lowerBound, long ord)
+        {
+            this.parentIndex = parentIndex;
+            this.spurIndex = spurIndex;
+            this.bannedVertices = bannedVertices;
+            this.rootCost = rootCost;
+            this.lowerBound = lowerBound;
+            this.ord = ord;
+        }
+
+        @Override
+        public int compareTo(SpurTask o)
+        {
+            int c = Double.compare(this.lowerBound, o.lowerBound);
+            if (c != 0) {
+                return c;
+            }
+            return Long.compare(this.ord, o.ord);
+        }
+    }
+
+    private final class Candidate
+        implements Comparable<Candidate>
+    {
+        final GraphPath<V, E> path;
+        final double cost;
+        final int firstDeviationIndex;
+        final long ord;
+
+        Candidate(GraphPath<V, E> path, double cost, int firstDeviationIndex, long ord)
+        {
+            this.path = path;
+            this.cost = cost;
+            this.firstDeviationIndex = firstDeviationIndex;
+            this.ord = ord;
+        }
+
+        @Override
+        public int compareTo(Candidate o)
+        {
+            int c = Double.compare(this.cost, o.cost);
+            if (c != 0) {
+                return c;
+            }
+            return Long.compare(this.ord, o.ord);
+        }
+    }
+
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DijkstraSpurEngine.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DijkstraSpurEngine.java
@@ -1,0 +1,94 @@
+/*
+ * (C) Copyright 2026-2026, by Shai Eilat and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.graph.GraphWalk;
+import org.jgrapht.graph.MaskSubgraph;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Spur shortest-path engine that delegates to JGraphT's {@link DijkstraShortestPath}. Bans are
+ * applied by wrapping the input graph in a {@link MaskSubgraph} so we do not duplicate or modify
+ * the underlying Dijkstra implementation. The {@code reverseDistancesToSink} hint is unused
+ * here; it is consumed by the bounded-pruned Yen driver itself, not by this engine.
+ *
+ * <p>
+ * Edge weights must be non-negative (a Dijkstra precondition).
+ *
+ * <p>
+ * The {@link #expandedVertices()} counter is reported as {@code 0} because
+ * {@code DijkstraShortestPath} does not expose a per-call expansion count. The metric is
+ * documented as best-effort on {@link SpurShortestPathEngine}.
+ *
+ * @param <V> graph vertex type
+ * @param <E> graph edge type
+ */
+public class DijkstraSpurEngine<V, E>
+    implements SpurShortestPathEngine<V, E>
+{
+    private long pathQueries;
+
+    @Override
+    public GraphPath<V, E> findPath(
+        Graph<V, E> graph, V source, V sink, Set<V> bannedVertices, Set<E> bannedEdges,
+        Map<V, Double> reverseDistancesToSink)
+    {
+        pathQueries++;
+        if (source.equals(sink)) {
+            // Trivial zero-length walk; matches YenKShortestPath behaviour for source==sink.
+            return new GraphWalk<>(
+                graph, source, sink, Collections.singletonList(source), Collections.emptyList(),
+                0.0);
+        }
+        Set<V> banV = bannedVertices == null ? Collections.emptySet() : bannedVertices;
+        Set<E> banE = bannedEdges == null ? Collections.emptySet() : bannedEdges;
+        Graph<V, E> masked = (banV.isEmpty() && banE.isEmpty())
+            ? graph
+            : new MaskSubgraph<>(graph, banV::contains, banE::contains);
+        return new DijkstraShortestPath<>(masked).getPath(source, sink);
+    }
+
+    @Override
+    public long expandedVertices()
+    {
+        return 0L;
+    }
+
+    @Override
+    public long pathQueries()
+    {
+        return pathQueries;
+    }
+
+    @Override
+    public void resetCounters()
+    {
+        pathQueries = 0;
+    }
+
+    @Override
+    public String name()
+    {
+        return "Dijkstra";
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/SpurShortestPathEngine.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/SpurShortestPathEngine.java
@@ -1,0 +1,95 @@
+/*
+ * (C) Copyright 2026-2026, by Shai Eilat and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Abstract subroutine for the spur shortest-path computations performed by
+ * {@link BoundedPrunedYenKShortestPath}.
+ *
+ * <p>
+ * Implementations must return an exact non-negative-weight shortest path from {@code source} to
+ * {@code sink} on the input {@code graph} after temporarily removing the supplied
+ * {@code bannedVertices} and {@code bannedEdges}. Implementations may use the optional
+ * {@code reverseDistancesToSink} hint (computed once on the original graph by the caller) for
+ * admissible heuristic / pruning purposes.
+ *
+ * <p>
+ * This is a pluggable abstraction so that different shortest-path back-ends can be benchmarked
+ * inside the same Yen variant: classical Dijkstra and A* with reverse-distance heuristic. The
+ * engine API is intentionally narrow so swapping engines does not change Yen-level behaviour.
+ *
+ * @param <V> graph vertex type
+ * @param <E> graph edge type
+ */
+public interface SpurShortestPathEngine<V, E>
+{
+    /**
+     * Compute an exact shortest path from {@code source} to {@code sink} on {@code graph} ignoring
+     * vertices in {@code bannedVertices} and edges in {@code bannedEdges}.
+     *
+     * @param graph original graph (engines should not mutate it)
+     * @param source source vertex of the spur query
+     * @param sink target vertex of the spur query
+     * @param bannedVertices vertices to ignore (must not include {@code source} or {@code sink})
+     * @param bannedEdges edges to ignore
+     * @param reverseDistancesToSink optional hint, lower-bound distances from each vertex to
+     *        {@code sink} computed on the original graph; may be {@code null} for engines that do
+     *        not need it
+     * @return the shortest path or {@code null} if no path exists in the masked graph
+     */
+    GraphPath<V, E> findPath(
+        Graph<V, E> graph, V source, V sink, Set<V> bannedVertices, Set<E> bannedEdges,
+        Map<V, Double> reverseDistancesToSink);
+
+    /**
+     * Number of vertices the engine has expanded (popped from its open set) since the last
+     * {@link #resetCounters()} call. Best-effort metric used by benchmarks; engines that do not
+     * track expansion (e.g. those delegating to a back-end without a public expansion counter)
+     * may return {@code 0}.
+     *
+     * @return number of vertices popped from the engine's open set since the last reset, or
+     *         {@code 0} when not tracked
+     */
+    long expandedVertices();
+
+    /**
+     * Number of shortest-path queries answered since the last {@link #resetCounters()} call.
+     *
+     * @return number of shortest-path queries answered since the last reset
+     */
+    long pathQueries();
+
+    /**
+     * Reset internal counters. Called by {@link BoundedPrunedYenKShortestPath} between independent
+     * runs so that counters report per-run statistics.
+     */
+    void resetCounters();
+
+    /**
+     * Symbolic name of the engine, used in benchmark reports.
+     *
+     * @return a short human-readable identifier for this engine
+     */
+    String name();
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BoundedPrunedYenKShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BoundedPrunedYenKShortestPathTest.java
@@ -1,0 +1,621 @@
+/*
+ * (C) Copyright 2026-2026, by Shai Eilat and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.Graph;
+import org.jgrapht.GraphPath;
+import org.jgrapht.Graphs;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.SimpleDirectedWeightedGraph;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Regression tests asserting that {@link BoundedPrunedYenKShortestPath} produces the same ordered
+ * sequence of path weights as {@link YenKShortestPath} on a variety of graphs.
+ */
+public class BoundedPrunedYenKShortestPathTest
+{
+    private static final double EPS = 1e-9;
+
+    @Test
+    public void testNegativeKThrows()
+    {
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        Graphs.addEdgeWithVertices(g, 1, 2, 1.0);
+        assertThrows(
+            IllegalArgumentException.class,
+            () -> new BoundedPrunedYenKShortestPath<>(g).getPaths(1, 2, -1));
+    }
+
+    @Test
+    public void testKZeroReturnsEmpty()
+    {
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        g.addVertex(1);
+        g.addVertex(2);
+        List<GraphPath<Integer, DefaultWeightedEdge>> paths =
+            new BoundedPrunedYenKShortestPath<>(g).getPaths(1, 2, 0);
+        assertEquals(0, paths.size());
+    }
+
+    @Test
+    public void testUnreachableSink()
+    {
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        g.addVertex(1);
+        g.addVertex(2);
+        List<GraphPath<Integer, DefaultWeightedEdge>> paths =
+            new BoundedPrunedYenKShortestPath<>(g).getPaths(1, 2, 5);
+        assertEquals(0, paths.size());
+    }
+
+    @Test
+    public void testSimpleDiamondMatchesStandardYen()
+    {
+        // 1 -> 2 -> 4
+        // 1 -> 3 -> 4
+        // 1 -> 4 (longer)
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int v : new int[] { 1, 2, 3, 4 }) {
+            g.addVertex(v);
+        }
+        Graphs.addEdge(g, 1, 2, 1.0);
+        Graphs.addEdge(g, 2, 4, 2.0);
+        Graphs.addEdge(g, 1, 3, 2.0);
+        Graphs.addEdge(g, 3, 4, 1.0);
+        Graphs.addEdge(g, 1, 4, 10.0);
+
+        assertSamePathWeights(g, 1, 4, 5);
+    }
+
+    @Test
+    public void testTieEqualWeights()
+    {
+        // Two equal-weight paths from 1 to 4: 1-2-4 and 1-3-4.
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int v : new int[] { 1, 2, 3, 4 }) {
+            g.addVertex(v);
+        }
+        Graphs.addEdge(g, 1, 2, 1.0);
+        Graphs.addEdge(g, 2, 4, 1.0);
+        Graphs.addEdge(g, 1, 3, 1.0);
+        Graphs.addEdge(g, 3, 4, 1.0);
+
+        assertSamePathWeights(g, 1, 4, 4);
+    }
+
+    @Test
+    public void testCyclicGraph()
+    {
+        // 1 -> 2 -> 3 -> 1 (cycle), 2 -> 3 path used
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int v : new int[] { 1, 2, 3 }) {
+            g.addVertex(v);
+        }
+        Graphs.addEdge(g, 1, 2, 1.0);
+        Graphs.addEdge(g, 2, 3, 1.0);
+        Graphs.addEdge(g, 3, 1, 1.0);
+        Graphs.addEdge(g, 1, 3, 5.0);
+
+        assertSamePathWeights(g, 1, 3, 5);
+    }
+
+    @Test
+    public void testLayeredDagSeveralK()
+    {
+        Graph<Integer, DefaultWeightedEdge> g = layeredDag(4, 4, 12345L);
+        for (int k : new int[] { 1, 2, 5, 10 }) {
+            assertSamePathWeights(g, 0, sinkOf(g), k);
+        }
+    }
+
+    @Test
+    public void testRandomDag()
+    {
+        Graph<Integer, DefaultWeightedEdge> g = randomDag(80, 320, 99L);
+        assertSamePathWeights(g, 0, 79, 20);
+    }
+
+    @Test
+    public void testGridGraph()
+    {
+        Graph<Integer, DefaultWeightedEdge> g = grid(8, 8, 7L);
+        assertSamePathWeights(g, 0, 8 * 8 - 1, 10);
+    }
+
+    @Test
+    public void testAStarEngineMatchesStandardYen()
+    {
+        Graph<Integer, DefaultWeightedEdge> g = layeredDag(5, 5, 42L);
+        BoundedPrunedYenKShortestPath<Integer, DefaultWeightedEdge> bpAStar =
+            new BoundedPrunedYenKShortestPath<>(g, new AStarSpurEngine<>());
+        YenKShortestPath<Integer, DefaultWeightedEdge> yen = new YenKShortestPath<>(g);
+        int sink = sinkOf(g);
+        List<Double> bp = weights(bpAStar.getPaths(0, sink, 15));
+        List<Double> std = weights(yen.getPaths(0, sink, 15));
+        assertEqualsWeights(std, bp, "AStar engine vs standard Yen");
+    }
+
+    @Test
+    public void testStatsNonNegative()
+    {
+        Graph<Integer, DefaultWeightedEdge> g = randomDag(100, 600, 13L);
+        BoundedPrunedYenKShortestPath<Integer, DefaultWeightedEdge> bp =
+            new BoundedPrunedYenKShortestPath<>(g);
+        bp.getPaths(0, 99, 25);
+        BoundedPrunedYenKShortestPath.Stats s = bp.getStats();
+        assertNotNull(s);
+        assertTrue(s.shortestPathCalls > 0);
+        assertTrue(s.spurTasksCreated >= 0);
+        assertTrue(s.spurTasksMaterialized <= s.spurTasksCreated);
+        assertTrue(s.candidateHeapPops >= 0);
+    }
+
+    @Test
+    public void testNonDecreasingWeights()
+    {
+        Graph<Integer, DefaultWeightedEdge> g = layeredDag(6, 4, 1L);
+        BoundedPrunedYenKShortestPath<Integer, DefaultWeightedEdge> bp =
+            new BoundedPrunedYenKShortestPath<>(g);
+        List<GraphPath<Integer, DefaultWeightedEdge>> paths = bp.getPaths(0, sinkOf(g), 30);
+        double prev = Double.NEGATIVE_INFINITY;
+        for (GraphPath<Integer, DefaultWeightedEdge> p : paths) {
+            assertTrue(p.getWeight() >= prev - EPS, "weights must be non-decreasing");
+            prev = p.getWeight();
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Edge cases
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void testKLargerThanTotalPaths()
+    {
+        // Diamond: exactly 3 simple paths from 1 to 4. Asking for 100 must return only 3.
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int v : new int[] { 1, 2, 3, 4 }) {
+            g.addVertex(v);
+        }
+        Graphs.addEdge(g, 1, 2, 1.0);
+        Graphs.addEdge(g, 2, 4, 1.0);
+        Graphs.addEdge(g, 1, 3, 2.0);
+        Graphs.addEdge(g, 3, 4, 2.0);
+        Graphs.addEdge(g, 1, 4, 10.0);
+        // Match YenKShortestPath behaviour exactly — both should terminate and return all paths.
+        assertSamePathWeights(g, 1, 4, 100);
+    }
+
+    @Test
+    public void testZeroWeightEdges()
+    {
+        // Zero weights are allowed (non-negative). Multiple zero-weight paths must all be found.
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int v : new int[] { 1, 2, 3, 4 }) {
+            g.addVertex(v);
+        }
+        Graphs.addEdge(g, 1, 2, 0.0);
+        Graphs.addEdge(g, 2, 4, 0.0);
+        Graphs.addEdge(g, 1, 3, 0.0);
+        Graphs.addEdge(g, 3, 4, 0.0);
+        Graphs.addEdge(g, 1, 4, 1.0);
+        assertSamePathWeights(g, 1, 4, 5);
+    }
+
+    @Test
+    public void testSingleEdgeGraph()
+    {
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        g.addVertex(1);
+        g.addVertex(2);
+        Graphs.addEdge(g, 1, 2, 7.5);
+        assertSamePathWeights(g, 1, 2, 5);
+    }
+
+    @Test
+    public void testSourceEqualsSink()
+    {
+        // Match YenKShortestPath behaviour for source==sink (whatever it returns).
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        g.addVertex(1);
+        g.addVertex(2);
+        Graphs.addEdge(g, 1, 2, 1.0);
+        assertSamePathWeights(g, 1, 1, 3);
+    }
+
+    @Test
+    public void testLargeKDenseDag()
+    {
+        // Dense small DAG; ask for many paths. Stress-tests the dedup and termination logic
+        // when the candidate heap empties before reaching k.
+        Graph<Integer, DefaultWeightedEdge> g = layeredDag(4, 5, 314L);
+        assertSamePathWeights(g, 0, sinkOf(g), 500);
+    }
+
+    @Test
+    public void testRejectsNegativeWeights()
+    {
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        Graphs.addEdgeWithVertices(g, 1, 2, -1.0);
+        BoundedPrunedYenKShortestPath<Integer, DefaultWeightedEdge> bp =
+            new BoundedPrunedYenKShortestPath<>(g);
+        assertThrows(IllegalArgumentException.class, () -> bp.getPaths(1, 2, 1));
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Both engines: explicit cross-check
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void testBothEnginesAgreeWithStandardYen()
+    {
+        long[] seeds = { 1L, 2L, 3L, 4L, 5L };
+        for (long seed : seeds) {
+            Graph<Integer, DefaultWeightedEdge> g = layeredDag(5, 4, seed);
+            int sink = sinkOf(g);
+            List<Double> std = weights(new YenKShortestPath<>(g).getPaths(0, sink, 12));
+            List<Double> bpDij = weights(
+                new BoundedPrunedYenKShortestPath<>(g, new DijkstraSpurEngine<>())
+                    .getPaths(0, sink, 12));
+            List<Double> bpAstar = weights(
+                new BoundedPrunedYenKShortestPath<>(g, new AStarSpurEngine<>())
+                    .getPaths(0, sink, 12));
+            assertEqualsWeights(std, bpDij, "Dijkstra engine seed=" + seed);
+            assertEqualsWeights(std, bpAstar, "AStar engine seed=" + seed);
+        }
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Fuzz tests against YenKShortestPath
+    // ---------------------------------------------------------------------------------------
+
+    /**
+     * Property-style fuzz test: generate a wide population of random DAGs with varied size and
+     * density, run both engines, and assert each returns the same ordered weight sequence as
+     * {@link YenKShortestPath}. Any divergence aborts with the failing case so it is reproducible
+     * from the seed alone.
+     */
+    @Test
+    public void testFuzzRandomDagsAgainstStandardYen()
+    {
+        Random meta = new Random(20260509L);
+        int totalCases = 40;
+        for (int caseIdx = 0; caseIdx < totalCases; caseIdx++) {
+            int n = 8 + meta.nextInt(80); // 8..87 vertices
+            int extraEdges = meta.nextInt(2 * n);
+            int k = 1 + meta.nextInt(25);
+            long seed = meta.nextLong();
+            Graph<Integer, DefaultWeightedEdge> g =
+                randomDagWithChain(n, extraEdges, seed);
+            String label = String.format(
+                "case=%d n=%d extras=%d k=%d seed=%d", caseIdx, n, extraEdges, k, seed);
+            assertSameForBothEngines(g, 0, n - 1, k, label);
+        }
+    }
+
+    /**
+     * Fuzz test with cycles: random sparse graphs that may contain cycles. Yen's algorithm
+     * returns loopless paths regardless. Asserts both engines match {@link YenKShortestPath} on
+     * each generated graph.
+     */
+    @Test
+    public void testFuzzRandomCyclicGraphsAgainstStandardYen()
+    {
+        Random meta = new Random(987654321L);
+        int totalCases = 30;
+        for (int caseIdx = 0; caseIdx < totalCases; caseIdx++) {
+            int n = 6 + meta.nextInt(40);
+            int m = n + meta.nextInt(2 * n);
+            int k = 1 + meta.nextInt(20);
+            long seed = meta.nextLong();
+            Graph<Integer, DefaultWeightedEdge> g = randomDigraph(n, m, seed);
+            int sink = n - 1;
+            if (!g.containsVertex(0) || !g.containsVertex(sink)) {
+                continue; // skip degenerate cases
+            }
+            String label = String.format(
+                "cyclic case=%d n=%d m=%d k=%d seed=%d", caseIdx, n, m, k, seed);
+            assertSameForBothEngines(g, 0, sink, k, label);
+        }
+    }
+
+    @Test
+    public void testFuzzGridsAndChainsAgainstStandardYen()
+    {
+        long[] seeds = { 11L, 22L, 33L, 44L, 55L };
+        // grids of varied shapes
+        for (long seed : seeds) {
+            for (int rows : new int[] { 3, 5, 8 }) {
+                for (int cols : new int[] { 3, 5, 8 }) {
+                    Graph<Integer, DefaultWeightedEdge> g = grid(rows, cols, seed);
+                    String label = String.format(
+                        "grid %dx%d seed=%d", rows, cols, seed);
+                    assertSameForBothEngines(g, 0, rows * cols - 1, 8, label);
+                }
+            }
+        }
+    }
+
+    /** Helper used by fuzz tests: assert both engines match standard Yen on the given graph. */
+    private static void assertSameForBothEngines(
+        Graph<Integer, DefaultWeightedEdge> g, Integer source, Integer sink, int k, String label)
+    {
+        List<Double> std = weights(new YenKShortestPath<>(g).getPaths(source, sink, k));
+        List<Double> bpDij = weights(
+            new BoundedPrunedYenKShortestPath<>(g, new DijkstraSpurEngine<>())
+                .getPaths(source, sink, k));
+        List<Double> bpAstar = weights(
+            new BoundedPrunedYenKShortestPath<>(g, new AStarSpurEngine<>())
+                .getPaths(source, sink, k));
+        assertEqualsWeights(std, bpDij, label + " [Dijkstra]");
+        assertEqualsWeights(std, bpAstar, label + " [AStar]");
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Impossible-spur skip
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    public void testImpossibleSpurSkipEliminatesPathChainTasks()
+    {
+        // On a pure path chain, every spur's only outgoing edge is banned by the Yen rule
+        // (because the only accepted path uses it). The exact impossible-spur skip must catch
+        // every one of these and create zero spur tasks. Total skipped should equal n-1.
+        int n = 100;
+        Graph<Integer, DefaultWeightedEdge> g = pathChain(n, 11L);
+        BoundedPrunedYenKShortestPath<Integer, DefaultWeightedEdge> bp =
+            new BoundedPrunedYenKShortestPath<>(g, new DijkstraSpurEngine<>());
+        bp.getPaths(0, n - 1, 5);
+        BoundedPrunedYenKShortestPath.Stats s = bp.getStats();
+        assertEquals(0L, s.spurTasksCreated, "no doomed tasks should be created on a path chain");
+        assertEquals(
+            (long) (n - 1), s.skippedImpossibleSpurTasks,
+            "every spur position must be skipped on a path chain");
+    }
+
+    @Test
+    public void testPathChainReturnsSinglePath()
+    {
+        // Single-path DAG, k > 1: must return just that one path.
+        Graph<Integer, DefaultWeightedEdge> g = pathChain(20, 99L);
+        List<GraphPath<Integer, DefaultWeightedEdge>> paths =
+            new BoundedPrunedYenKShortestPath<>(g, new DijkstraSpurEngine<>())
+                .getPaths(0, 19, 5);
+        assertEquals(1, paths.size());
+    }
+
+    /** Simple linear chain 0 -&gt; 1 -&gt; ... -&gt; n-1; helper used by the new tests above. */
+    static Graph<Integer, DefaultWeightedEdge> pathChain(int n, long seed)
+    {
+        Random rnd = new Random(seed);
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int i = 0; i < n; i++) {
+            g.addVertex(i);
+        }
+        for (int i = 0; i + 1 < n; i++) {
+            Graphs.addEdge(g, i, i + 1, 1.0 + rnd.nextInt(5));
+        }
+        return g;
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------------------
+
+    private static <V, E> void assertSamePathWeights(Graph<V, E> g, V src, V sink, int k)
+    {
+        List<Double> std = weights(new YenKShortestPath<>(g).getPaths(src, sink, k));
+        List<Double> bp =
+            weights(new BoundedPrunedYenKShortestPath<>(g).getPaths(src, sink, k));
+        assertEqualsWeights(std, bp, "standard vs bounded-pruned");
+    }
+
+    private static void assertEqualsWeights(List<Double> std, List<Double> bp, String label)
+    {
+        assertEquals(std.size(), bp.size(), label + ": path count");
+        for (int i = 0; i < std.size(); i++) {
+            assertEquals(std.get(i), bp.get(i), EPS, label + ": weight at index " + i);
+        }
+    }
+
+    private static <V, E> List<Double> weights(List<GraphPath<V, E>> paths)
+    {
+        List<Double> w = new ArrayList<>(paths.size());
+        for (GraphPath<V, E> p : paths) {
+            w.add(p.getWeight());
+        }
+        return w;
+    }
+
+    private static int sinkOf(Graph<Integer, ?> g)
+    {
+        int max = 0;
+        for (Integer v : g.vertexSet()) {
+            if (v > max) {
+                max = v;
+            }
+        }
+        return max;
+    }
+
+    /** Layered DAG with `layers` layers of `width` vertices, plus source 0 and sink (last). */
+    static Graph<Integer, DefaultWeightedEdge> layeredDag(int layers, int width, long seed)
+    {
+        Random rnd = new Random(seed);
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        int src = 0;
+        g.addVertex(src);
+        int next = 1;
+        int[][] layerVerts = new int[layers][width];
+        for (int l = 0; l < layers; l++) {
+            for (int j = 0; j < width; j++) {
+                layerVerts[l][j] = next;
+                g.addVertex(next++);
+            }
+        }
+        int sink = next;
+        g.addVertex(sink);
+        // src -> first layer
+        for (int j = 0; j < width; j++) {
+            Graphs.addEdge(g, src, layerVerts[0][j], 1.0 + rnd.nextInt(5));
+        }
+        // between layers
+        for (int l = 0; l + 1 < layers; l++) {
+            for (int j = 0; j < width; j++) {
+                for (int j2 = 0; j2 < width; j2++) {
+                    if (rnd.nextDouble() < 0.5) {
+                        Graphs.addEdge(g, layerVerts[l][j], layerVerts[l + 1][j2],
+                            1.0 + rnd.nextInt(5));
+                    }
+                }
+            }
+        }
+        // last layer -> sink
+        for (int j = 0; j < width; j++) {
+            Graphs.addEdge(g, layerVerts[layers - 1][j], sink, 1.0 + rnd.nextInt(5));
+        }
+        return g;
+    }
+
+    /**
+     * DAG with a guaranteed source-to-sink chain plus {@code extraEdges} random forward edges.
+     * Used by the fuzz tests so source 0 and sink n-1 are always connected.
+     */
+    static Graph<Integer, DefaultWeightedEdge> randomDagWithChain(int n, int extraEdges, long seed)
+    {
+        Random rnd = new Random(seed);
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int i = 0; i < n; i++) {
+            g.addVertex(i);
+        }
+        for (int i = 0; i + 1 < n; i++) {
+            Graphs.addEdge(g, i, i + 1, 1.0 + rnd.nextInt(5));
+        }
+        int placed = 0;
+        int attempts = 0;
+        while (placed < extraEdges && attempts < extraEdges * 10 + 50) {
+            attempts++;
+            int u = rnd.nextInt(n - 1);
+            int v = u + 1 + rnd.nextInt(n - 1 - u);
+            if (g.containsEdge(u, v)) {
+                continue;
+            }
+            Graphs.addEdge(g, u, v, 1.0 + rnd.nextInt(10));
+            placed++;
+        }
+        return g;
+    }
+
+    /**
+     * Random simple digraph on n vertices that may contain cycles. May leave 0 or n-1 unreachable
+     * from each other; callers should handle that. Edge weights in [1, 10).
+     */
+    static Graph<Integer, DefaultWeightedEdge> randomDigraph(int n, int m, long seed)
+    {
+        Random rnd = new Random(seed);
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int i = 0; i < n; i++) {
+            g.addVertex(i);
+        }
+        int placed = 0;
+        int attempts = 0;
+        while (placed < m && attempts < m * 10 + 50) {
+            attempts++;
+            int u = rnd.nextInt(n);
+            int v = rnd.nextInt(n);
+            if (u == v || g.containsEdge(u, v)) {
+                continue;
+            }
+            Graphs.addEdge(g, u, v, 1.0 + rnd.nextInt(9));
+            placed++;
+        }
+        return g;
+    }
+
+    /** Random DAG on n vertices 0..n-1 with edges only (u,v) where u&lt;v. */
+    static Graph<Integer, DefaultWeightedEdge> randomDag(int n, int m, long seed)
+    {
+        Random rnd = new Random(seed);
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int i = 0; i < n; i++) {
+            g.addVertex(i);
+        }
+        // chain to ensure source-to-sink reachability
+        for (int i = 0; i + 1 < n; i++) {
+            Graphs.addEdge(g, i, i + 1, 1.0 + rnd.nextInt(5));
+        }
+        int extra = Math.max(0, m - (n - 1));
+        for (int e = 0; e < extra; e++) {
+            int u = rnd.nextInt(n - 1);
+            int v = u + 1 + rnd.nextInt(n - 1 - u);
+            if (g.containsEdge(u, v)) {
+                continue;
+            }
+            Graphs.addEdge(g, u, v, 1.0 + rnd.nextInt(10));
+        }
+        return g;
+    }
+
+    static Graph<Integer, DefaultWeightedEdge> grid(int rows, int cols, long seed)
+    {
+        Random rnd = new Random(seed);
+        Graph<Integer, DefaultWeightedEdge> g =
+            new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        int n = rows * cols;
+        for (int i = 0; i < n; i++) {
+            g.addVertex(i);
+        }
+        for (int r = 0; r < rows; r++) {
+            for (int c = 0; c < cols; c++) {
+                int u = r * cols + c;
+                if (c + 1 < cols) {
+                    Graphs.addEdge(g, u, r * cols + c + 1, 1.0 + rnd.nextInt(3));
+                }
+                if (r + 1 < rows) {
+                    Graphs.addEdge(g, u, (r + 1) * cols + c, 1.0 + rnd.nextInt(3));
+                }
+            }
+        }
+        return g;
+    }
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/BoundedPrunedYenKShortestPathPerformance.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/BoundedPrunedYenKShortestPathPerformance.java
@@ -1,0 +1,154 @@
+/*
+ * (C) Copyright 2026-2026, by Shai Eilat and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.perf.shortestpath;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.shortestpath.*;
+import org.jgrapht.alg.util.*;
+import org.jgrapht.generate.*;
+import org.jgrapht.graph.*;
+import org.jgrapht.util.*;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+/**
+ * JMH benchmark comparing {@link YenKShortestPath} against
+ * {@link BoundedPrunedYenKShortestPath} with both {@link DijkstraSpurEngine} and
+ * {@link AStarSpurEngine}. Measures average time per {@code getPaths} call on randomly generated
+ * weighted directed graphs of varying density and {@code k}.
+ *
+ * <p>
+ * All variants are exact and return the same ordered sequence of path weights as
+ * {@link YenKShortestPath}; this benchmark only measures wall-clock cost.
+ *
+ * @author Shai Eilat
+ */
+@BenchmarkMode(Mode.AverageTime)
+@Fork(value = 1, warmups = 0, jvmArgs = "--illegal-access=permit")
+@Warmup(iterations = 3, time = 5)
+@Measurement(iterations = 5, time = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class BoundedPrunedYenKShortestPathPerformance
+{
+
+    private static final Random RANDOM = new Random(19L);
+
+    @Benchmark
+    public List<List<GraphPath<Integer, DefaultWeightedEdge>>> testYenKShortestPath(
+        BoundedPrunedYenState state)
+    {
+        return computeResult(new YenKShortestPath<>(state.graph), state);
+    }
+
+    @Benchmark
+    public List<List<GraphPath<Integer, DefaultWeightedEdge>>> testBoundedPrunedYenWithDijkstra(
+        BoundedPrunedYenState state)
+    {
+        return computeResult(
+            new BoundedPrunedYenKShortestPath<>(state.graph, new DijkstraSpurEngine<>()), state);
+    }
+
+    @Benchmark
+    public List<List<GraphPath<Integer, DefaultWeightedEdge>>> testBoundedPrunedYenWithAStar(
+        BoundedPrunedYenState state)
+    {
+        return computeResult(
+            new BoundedPrunedYenKShortestPath<>(state.graph, new AStarSpurEngine<>()), state);
+    }
+
+    private List<List<GraphPath<Integer, DefaultWeightedEdge>>> computeResult(
+        org.jgrapht.alg.interfaces.KShortestPathAlgorithm<Integer, DefaultWeightedEdge> algorithm,
+        BoundedPrunedYenState state)
+    {
+        List<List<GraphPath<Integer, DefaultWeightedEdge>>> result =
+            new ArrayList<>(state.numberOfQueries);
+        for (Pair<Integer, Integer> query : state.queries) {
+            int source = query.getFirst();
+            int target = query.getSecond();
+            result.add(algorithm.getPaths(source, target, state.k));
+        }
+        return result;
+    }
+
+    @State(Scope.Benchmark)
+    public static class BoundedPrunedYenState
+    {
+        @Param({ "100" })
+        int n;
+        @Param({ "0.1", "0.3" })
+        double p;
+        @Param({ "20", "100" })
+        int k;
+        @Param({ "10" })
+        int numberOfQueries;
+
+        GraphGenerator<Integer, DefaultWeightedEdge, Integer> generator;
+        SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph;
+        List<Pair<Integer, Integer>> queries;
+
+        @Setup(Level.Iteration)
+        public void generateGraph()
+        {
+            generator = new GnpRandomGraphGenerator<>(n, p);
+            graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+            graph.setVertexSupplier(SupplierUtil.createIntegerSupplier());
+            generator.generateGraph(graph);
+            makeConnected(graph);
+            addEdgeWeights(graph);
+            queries = selectQueries();
+        }
+
+        private List<Pair<Integer, Integer>> selectQueries()
+        {
+            Set<Pair<Integer, Integer>> result =
+                CollectionUtil.newHashSetWithExpectedSize(numberOfQueries);
+            Object[] vertices = graph.vertexSet().toArray();
+            while (result.size() < numberOfQueries) {
+                int sourceIndex = (int) (Math.random() * vertices.length);
+                int targetIndex = (int) (Math.random() * vertices.length);
+                while (sourceIndex == targetIndex) {
+                    targetIndex = (int) (Math.random() * vertices.length);
+                }
+                Integer source = (Integer) vertices[sourceIndex];
+                Integer target = (Integer) vertices[targetIndex];
+                result.add(Pair.of(source, target));
+            }
+            return new ArrayList<>(result);
+        }
+
+        private void makeConnected(Graph<Integer, DefaultWeightedEdge> graph)
+        {
+            Object[] vertices = graph.vertexSet().toArray();
+            for (int i = 0; i < vertices.length - 1; i++) {
+                if (!graph.containsEdge((Integer) vertices[i], (Integer) vertices[i + 1])) {
+                    graph.addEdge((Integer) vertices[i], (Integer) vertices[i + 1]);
+                }
+            }
+        }
+
+        private void addEdgeWeights(Graph<Integer, DefaultWeightedEdge> graph)
+        {
+            for (DefaultWeightedEdge edge : graph.edgeSet()) {
+                double weight = 1.0 + Math.abs(RANDOM.nextInt(1000));
+                graph.setEdgeWeight(edge, weight);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR follows the design discussed on the `jgrapht-dev` mailing list:
https://groups.google.com/g/jgrapht-dev/c/JHFs5n7dMpI

## Summary

Adds a new exact Yen-family implementation, `BoundedPrunedYenKShortestPath`, alongside the existing `YenKShortestPath`, with two separable optimisations behind a single public class:

- **Exact**, returns the same ordered path-weight sequence as `YenKShortestPath`. Regression-tested against it.
- **Default engine remains Dijkstra** (`DijkstraSpurEngine` mirrors the spur step of today's `YenKShortestPath`).
- **Optional `AStarSpurEngine`** gives large wins on dense random graphs; admissible by construction (no exactness trade-off).
- **Bounded-pruned scheduling is workload-conditional**: helps on dense / long-output workloads, can be a regression on sparse random Gnp where each spur Dijkstra is already cheap.
- **Existing `YenKShortestPath` is unchanged.**

## What is in this PR

- `org.jgrapht.alg.shortestpath.SpurShortestPathEngine` — new pluggable spur SP back-end interface (per-vertex/edge ban set + reverse-distance hint).
- `org.jgrapht.alg.shortestpath.DijkstraSpurEngine` — thin adapter delegating to `DijkstraShortestPath` via `MaskSubgraph` for ban handling.
- `org.jgrapht.alg.shortestpath.AStarSpurEngine` — thin adapter delegating to `AStarShortestPath` via `MaskSubgraph` + an `AStarAdmissibleHeuristic` built from a one-time reverse-distance precomputation. No A* / Dijkstra logic is duplicated.
- `org.jgrapht.alg.shortestpath.BoundedPrunedYenKShortestPath` — bounded-pruned Yen driver. Defers each spur as a `SpurTask` keyed by an admissible lower bound and only materialises tasks that could still beat the cheapest known candidate. Includes an exact impossible-spur skip that eliminates doomed tasks before any spur shortest-path query is issued.

## Tests

`BoundedPrunedYenKShortestPathTest` — 24 cases, JUnit 5:

- Hand-built edge cases: negative-k, k=0, unreachable sink, source==sink, zero-weight edges, single-edge graph, k larger than total paths, large-k stress, negative-weight rejection.
- Explicit cross-engine smoke (Dijkstra + A* vs `YenKShortestPath`).
- Property-style fuzz suites covering ~115 random graph configurations across random DAGs, random cyclic digraphs, and grids — every case asserts the same ordered path-weight sequence as `YenKShortestPath`. Failing cases print the seed.
- Impossible-spur skip behaviour (asserts zero spur tasks created on a path chain; n−1 tasks skipped).

Full `jgrapht-core` test suite passes locally with no regression in unrelated tests.

## Benchmark

### Primary evidence: JMH

`org.jgrapht.perf.shortestpath.BoundedPrunedYenKShortestPathPerformance`, in the same style as `KShortestPathsPerformance`. Tight measurement on Gnp random digraphs (`-f 2 -wi 2 -i 8`, Cnt=16):

| n | Yen ms | Bounded+Dij ms | Bounded+A* ms | A* speedup |
|---:|---:|---:|---:|---:|
| 100 | 29 / 150 / 53 / 241 | 36 / 204 / 72 / 384 | 7.8 / 41.9 / 18.0 / 76.2 | ~3.0–3.7× |
| 500 | 738.9 ± 91 | 1326.1 ± 206 | **67.9 ± 17.6** | **10.88×** |
| 1500 | 9845 ± 3838 | 16724 ± 3343 | **360.2 ± 73** | **27.33×** |

(n=100 cells: four (p, k) combinations from default JMH params; n=500 and n=1500 were a separate `-p` override at p=0.1, k=50.)

The Bounded+Dijkstra column is consistently a regression on Gnp random digraphs: on this workload each plain spur Dijkstra is already cheap, and the bounded-scheduling overhead does not pay back. The headline win on dense random graphs is therefore driven by the A* spur engine, not by the bounded-pruned scheduler alone.

At n=1500 the baseline has high variance across generated graph instances (~39% coefficient of variation), but the speedup remains large across forks and measurements.

### Wider scout coverage

A wider non-JMH scout suite (used during development, not part of the PR) over layered DAGs, random DAGs, grids, chains, and adversarial near-uniform-weight DAGs shows the same qualitative pattern: large wins on structured DAGs (up to ~70× on a 2000-vertex heavy DAG), small regression on sparse 4-connected grids, and a path-chain pathology that the exact impossible-spur skip resolves cleanly. Numbers from that wider suite were used to motivate the design and are recorded on the dev-list thread linked above; the JMH benchmark in this PR is the primary performance evidence going forward.

## Open questions answered on the dev list

- Public `SpurShortestPathEngine` in `org.jgrapht.alg.shortestpath` is fine; no separate `.spi` package.
- `DijkstraSpurEngine` is the conservative default.
- Existing `YenKShortestPath` is left untouched; an opt-in A* spur back-end for it can come as a follow-up.
- Benchmark lives at `jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/`, not in `jgrapht-demo`.
- References (Yen 1971, Martins & Pascoal 2003, Aljazzar & Leue 2011 K*) added to the `BoundedPrunedYenKShortestPath` Javadoc.

## Build status

- 24/24 unit tests pass.
- `mvn checkstyle:check -P checkstyle` clean.
- `mvn javadoc:aggregate` clean.