### PR TITLE
perf(shortestpath): Optimize DijkstraManyToManyShortestPaths.getPaths(V) to run one source search

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPaths.java
@@ -66,6 +66,26 @@ public class DijkstraManyToManyShortestPaths<V, E> extends BaseManyToManyShortes
 
     /**
      * {@inheritDoc}
+     *
+     * <p>
+     * In this Dijkstra-based implementation, a single {@code getPaths(source)} call runs one
+     * shortest-paths search from {@code source} that settles every reachable vertex. The
+     * inherited fallback in {@link BaseManyToManyShortestPaths} would otherwise dispatch one
+     * {@link #getPath(Object, Object)} call per vertex of the graph, each of which re-runs a
+     * fresh Dijkstra from the same source via {@link #getManyToManyPaths(Set, Set)}.
+     * </p>
+     */
+    @Override
+    public ShortestPathAlgorithm.SingleSourcePaths<V, E> getPaths(V source)
+    {
+        if (!graph.containsVertex(source)) {
+            throw new IllegalArgumentException("graph must contain the source vertex");
+        }
+        return getShortestPathsTree(graph, source, graph.vertexSet());
+    }
+
+    /**
+     * {@inheritDoc}
      */
     @Override
     public ManyToManyShortestPaths<V, E> getManyToManyPaths(Set<V> sources, Set<V> targets)

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/BaseManyToManyShortestPathsTest.java
@@ -26,6 +26,7 @@ import org.jgrapht.util.*;
 import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 /**
@@ -371,6 +372,47 @@ public abstract class BaseManyToManyShortestPathsTest
                 GraphPath<Integer, DefaultWeightedEdge> actual = paths.getPath(source, target);
                 assertEquals(expected.getWeight(), actual.getWeight(), 1e-9);
                 assertEquals(expected.getVertexList(), actual.getVertexList());
+            }
+        }
+    }
+
+    /**
+     * Asserts that the {@code SingleSourcePaths} returned by a many-to-many algorithm's
+     * {@code getPaths(V)} call is correct. {@link DijkstraShortestPath} is the certificate of
+     * correctness. Handles both reachable targets (matching weight + vertex list) and
+     * unreachable targets ({@code null} path / {@code +Inf} weight) per the
+     * {@link ShortestPathAlgorithm.SingleSourcePaths} contract.
+     *
+     * @param graph a graph
+     * @param paths single-source shortest paths object returned by the algorithm under test
+     * @param source source vertex
+     * @param targets target vertices
+     */
+    protected void assertCorrectPaths(
+        Graph<Integer, DefaultWeightedEdge> graph,
+        ShortestPathAlgorithm.SingleSourcePaths<Integer, DefaultWeightedEdge> paths,
+        Integer source, Iterable<Integer> targets)
+    {
+        assertEquals(graph, paths.getGraph());
+        assertEquals(source, paths.getSourceVertex());
+
+        ShortestPathAlgorithm.SingleSourcePaths<Integer, DefaultWeightedEdge> expectedPaths =
+            new DijkstraShortestPath<>(graph).getPaths(source);
+
+        for (Integer target : targets) {
+            String tag = " for target " + target;
+            assertEquals(expectedPaths.getWeight(target), paths.getWeight(target), 1e-9,
+                "weight mismatch" + tag);
+            GraphPath<Integer, DefaultWeightedEdge> expectedPath = expectedPaths.getPath(target);
+            GraphPath<Integer, DefaultWeightedEdge> actualPath = paths.getPath(target);
+            if (expectedPath == null) {
+                assertNull(actualPath, "expected null path" + tag);
+            } else {
+                assertNotNull(actualPath, "expected non-null path" + tag);
+                assertEquals(expectedPath.getWeight(), actualPath.getWeight(), 1e-9,
+                    "path weight mismatch" + tag);
+                assertEquals(expectedPath.getVertexList(), actualPath.getVertexList(),
+                    "vertex-list mismatch" + tag);
             }
         }
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
@@ -165,6 +165,55 @@ public class CHManyToManyShortestPathsTest extends BaseManyToManyShortestPathsTe
         super.testOnRandomGraphs(40, 5, new int[][] { { 10, 15 }, { 10, 10 }, { 15, 10 } }, 10);
     }
 
+    /**
+     * Regression test that protects CHManyToManyShortestPaths against a future accidental
+     * silent-bypass of its contraction-hierarchy preprocessing on the inherited
+     * {@link BaseManyToManyShortestPaths#getPaths(Object)} path.
+     *
+     * <p>
+     * If a future maintainer were to push the optimization recently added to
+     * {@link DijkstraManyToManyShortestPaths#getPaths(Object)} up into the abstract base class,
+     * {@code CHManyToManyShortestPaths.getPaths(source)} would silently route through plain
+     * Dijkstra over the original graph instead of the contracted hierarchy. Both produce
+     * correct paths so behavioral equivalence alone cannot detect a silent switch; this test
+     * therefore at minimum locks in correctness against a fresh oracle. Combined with the
+     * sibling spy test on {@code DefaultManyToManyShortestPaths}, it provides a tripwire on
+     * any base-class change that would alter the dispatch path.
+     * </p>
+     */
+    @Test
+    public void testGetPathsMatchesDijkstraOracle()
+    {
+        Graph<Integer, DefaultWeightedEdge> graph = getSimpleGraph();
+        ContractionHierarchy<Integer, DefaultWeightedEdge> hierarchy =
+            new ContractionHierarchyPrecomputation<>(graph, () -> new Random(SEED), executor)
+                .computeContractionHierarchy();
+
+        CHManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new CHManyToManyShortestPaths<>(hierarchy);
+        ShortestPathAlgorithm.SingleSourcePaths<Integer, DefaultWeightedEdge> paths =
+            alg.getPaths(1);
+
+        DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
+            new DijkstraShortestPath<>(graph);
+        ShortestPathAlgorithm.SingleSourcePaths<Integer, DefaultWeightedEdge> oraclePaths =
+            oracle.getPaths(1);
+
+        assertEquals(graph, paths.getGraph());
+        assertEquals(Integer.valueOf(1), paths.getSourceVertex());
+        for (Integer target : graph.vertexSet()) {
+            assertEquals(
+                oraclePaths.getWeight(target), paths.getWeight(target), 1e-9,
+                "weight mismatch for target " + target);
+            if (oraclePaths.getPath(target) != null) {
+                assertEquals(
+                    oraclePaths.getPath(target).getVertexList(),
+                    paths.getPath(target).getVertexList(),
+                    "vertex-list mismatch for target " + target);
+            }
+        }
+    }
+
     @Override
     protected ManyToManyShortestPathsAlgorithm<Integer, DefaultWeightedEdge> getAlgorithm(
         Graph<Integer, DefaultWeightedEdge> graph)

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/CHManyToManyShortestPathsTest.java
@@ -194,24 +194,7 @@ public class CHManyToManyShortestPathsTest extends BaseManyToManyShortestPathsTe
         ShortestPathAlgorithm.SingleSourcePaths<Integer, DefaultWeightedEdge> paths =
             alg.getPaths(1);
 
-        DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
-            new DijkstraShortestPath<>(graph);
-        ShortestPathAlgorithm.SingleSourcePaths<Integer, DefaultWeightedEdge> oraclePaths =
-            oracle.getPaths(1);
-
-        assertEquals(graph, paths.getGraph());
-        assertEquals(Integer.valueOf(1), paths.getSourceVertex());
-        for (Integer target : graph.vertexSet()) {
-            assertEquals(
-                oraclePaths.getWeight(target), paths.getWeight(target), 1e-9,
-                "weight mismatch for target " + target);
-            if (oraclePaths.getPath(target) != null) {
-                assertEquals(
-                    oraclePaths.getPath(target).getVertexList(),
-                    paths.getPath(target).getVertexList(),
-                    "vertex-list mismatch for target " + target);
-            }
-        }
+        assertCorrectPaths(graph, paths, 1, graph.vertexSet());
     }
 
     @Override

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DefaultManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DefaultManyToManyShortestPathsTest.java
@@ -17,7 +17,6 @@
  */
 package org.jgrapht.alg.shortestpath;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -149,13 +148,9 @@ public class DefaultManyToManyShortestPathsTest extends BaseManyToManyShortestPa
             new DefaultManyToManyShortestPaths<>(graph, spyFunction);
         SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(1);
 
-        // Sanity: the result must agree with a fresh oracle on every reachable target.
-        DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
-            new DijkstraShortestPath<>(graph);
-        for (Integer target : graph.vertexSet()) {
-            assertEquals(
-                oracle.getPathWeight(1, target), paths.getWeight(target), 1e-12);
-        }
+        // Sanity: the result must agree with a fresh oracle on every target.
+        assertCorrectPaths(graph, paths, 1, graph.vertexSet());
+
         // The whole point of this test: the user-supplied function must be reached.
         // The exact invocation count is implementation detail of the inherited base-class
         // fallback, so we only assert it is positive.

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DefaultManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DefaultManyToManyShortestPathsTest.java
@@ -17,10 +17,16 @@
  */
 package org.jgrapht.alg.shortestpath;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
+import org.jgrapht.alg.interfaces.ShortestPathAlgorithm.SingleSourcePaths;
 import org.jgrapht.graph.*;
 import org.junit.jupiter.api.*;
 
@@ -83,6 +89,81 @@ public class DefaultManyToManyShortestPathsTest extends BaseManyToManyShortestPa
     public void testOnRandomGraphs()
     {
         super.testOnRandomGraphs(30, 5, new int[][] { { 5, 10 }, { 5, 5 }, { 10, 5 } }, 10);
+    }
+
+    /**
+     * Regression test that protects DefaultManyToManyShortestPaths against an accidental
+     * silent-bypass of its user-supplied algorithm function on the inherited
+     * {@link BaseManyToManyShortestPaths#getPaths(Object)} path.
+     *
+     * <p>
+     * If a future maintainer were to push the optimization recently added to
+     * {@link DijkstraManyToManyShortestPaths#getPaths(Object)} up into the abstract base class,
+     * the user-supplied algorithm function would stop being consulted on
+     * {@code getPaths(source)} calls. This test wraps the function in a counting spy and
+     * asserts that the spy is invoked, so any such silent rerouting fails loudly here.
+     * </p>
+     */
+    @Test
+    public void testGetPathsConsultsProvidedAlgorithmFunction()
+    {
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        graph.addVertex(2);
+        graph.addVertex(3);
+        graph.setEdgeWeight(graph.addEdge(1, 2), 1.0);
+        graph.setEdgeWeight(graph.addEdge(2, 3), 1.0);
+        graph.setEdgeWeight(graph.addEdge(1, 3), 3.0);
+
+        AtomicInteger getPathInvocations = new AtomicInteger(0);
+        Function<Graph<Integer, DefaultWeightedEdge>,
+            ShortestPathAlgorithm<Integer, DefaultWeightedEdge>> spyFunction =
+                g -> new ShortestPathAlgorithm<Integer, DefaultWeightedEdge>()
+                {
+                    private final ShortestPathAlgorithm<Integer, DefaultWeightedEdge> inner =
+                        new DijkstraShortestPath<>(g);
+
+                    @Override
+                    public GraphPath<Integer, DefaultWeightedEdge> getPath(
+                        Integer source, Integer sink)
+                    {
+                        getPathInvocations.incrementAndGet();
+                        return inner.getPath(source, sink);
+                    }
+
+                    @Override
+                    public double getPathWeight(Integer source, Integer sink)
+                    {
+                        return inner.getPathWeight(source, sink);
+                    }
+
+                    @Override
+                    public SingleSourcePaths<Integer, DefaultWeightedEdge> getPaths(Integer source)
+                    {
+                        return inner.getPaths(source);
+                    }
+                };
+
+        DefaultManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new DefaultManyToManyShortestPaths<>(graph, spyFunction);
+        SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(1);
+
+        // Sanity: the result must agree with a fresh oracle on every reachable target.
+        DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
+            new DijkstraShortestPath<>(graph);
+        for (Integer target : graph.vertexSet()) {
+            assertEquals(
+                oracle.getPathWeight(1, target), paths.getWeight(target), 1e-12);
+        }
+        // The whole point of this test: the user-supplied function must be reached.
+        // The exact invocation count is implementation detail of the inherited base-class
+        // fallback, so we only assert it is positive.
+        assertTrue(
+            getPathInvocations.get() > 0,
+            "DefaultManyToManyShortestPaths.getPaths(source) must consult the user-supplied "
+                + "algorithm function; a zero invocation count indicates the function was "
+                + "silently bypassed (e.g. by a base-class shortcut).");
     }
 
     @Override

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPathsTest.java
@@ -21,6 +21,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.*;
 
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
@@ -155,6 +158,210 @@ public class DijkstraManyToManyShortestPathsTest extends BaseManyToManyShortestP
         DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
             new DijkstraManyToManyShortestPaths<>(graph);
         assertThrows(IllegalArgumentException.class, () -> alg.getPaths(42));
+    }
+
+    @Test
+    public void testGetPathsSingleVertexGraph()
+    {
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(7);
+        DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new DijkstraManyToManyShortestPaths<>(graph);
+
+        SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(7);
+        assertEquals(Integer.valueOf(7), paths.getSourceVertex());
+        assertEquals(0d, paths.getWeight(7), 0d);
+        assertNotNull(paths.getPath(7));
+        assertEquals(0, paths.getPath(7).getLength());
+    }
+
+    @Test
+    public void testGetPathsSourceHasNoOutgoingEdges()
+    {
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int v : new int[] { 1, 2, 3 }) {
+            graph.addVertex(v);
+        }
+        graph.setEdgeWeight(graph.addEdge(2, 3), 1d);
+        DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new DijkstraManyToManyShortestPaths<>(graph);
+
+        SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(1);
+        assertEquals(0d, paths.getWeight(1), 0d);
+        assertNull(paths.getPath(2));
+        assertNull(paths.getPath(3));
+        assertEquals(Double.POSITIVE_INFINITY, paths.getWeight(2), 0d);
+        assertEquals(Double.POSITIVE_INFINITY, paths.getWeight(3), 0d);
+    }
+
+    @Test
+    public void testGetPathsDisconnectedGraph()
+    {
+        // Two disjoint components: source reaches {1,2,3}, isolated component is {10,11}
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int v : new int[] { 1, 2, 3, 10, 11 }) {
+            graph.addVertex(v);
+        }
+        graph.setEdgeWeight(graph.addEdge(1, 2), 1d);
+        graph.setEdgeWeight(graph.addEdge(2, 3), 1d);
+        graph.setEdgeWeight(graph.addEdge(10, 11), 1d);
+        DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new DijkstraManyToManyShortestPaths<>(graph);
+        DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
+            new DijkstraShortestPath<>(graph);
+        SingleSourcePaths<Integer, DefaultWeightedEdge> expected = oracle.getPaths(1);
+
+        SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(1);
+        for (int target : new int[] { 1, 2, 3 }) {
+            assertEquals(expected.getWeight(target), paths.getWeight(target), 1e-12);
+            assertEquals(
+                expected.getPath(target).getVertexList(), paths.getPath(target).getVertexList());
+        }
+        assertNull(paths.getPath(10));
+        assertNull(paths.getPath(11));
+        assertEquals(Double.POSITIVE_INFINITY, paths.getWeight(10), 0d);
+        assertEquals(Double.POSITIVE_INFINITY, paths.getWeight(11), 0d);
+    }
+
+    @Test
+    public void testGetPathsCyclicGraphWithSelfLoopOnSource()
+    {
+        // Graph with cycles, including a self-loop on source. The optimized override
+        // must still return the trivial zero-length walk for source == target rather than
+        // following the self-loop. DijkstraClosestFirstIterator handles cycles correctly;
+        // this test pins that behavior.
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int v : new int[] { 1, 2, 3, 4 }) {
+            graph.addVertex(v);
+        }
+        graph.setEdgeWeight(graph.addEdge(1, 1), 5d); // self-loop on source
+        graph.setEdgeWeight(graph.addEdge(1, 2), 1d);
+        graph.setEdgeWeight(graph.addEdge(2, 3), 1d);
+        graph.setEdgeWeight(graph.addEdge(3, 2), 1d); // back-edge creating a 2↔3 cycle
+        graph.setEdgeWeight(graph.addEdge(3, 4), 1d);
+        DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new DijkstraManyToManyShortestPaths<>(graph);
+        DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
+            new DijkstraShortestPath<>(graph);
+        SingleSourcePaths<Integer, DefaultWeightedEdge> expected = oracle.getPaths(1);
+
+        SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(1);
+        for (int target : new int[] { 1, 2, 3, 4 }) {
+            assertEquals(expected.getWeight(target), paths.getWeight(target), 1e-12);
+            assertEquals(
+                expected.getPath(target).getVertexList(), paths.getPath(target).getVertexList());
+        }
+        // Source-to-source path is the zero-length walk, not the self-loop.
+        assertEquals(0d, paths.getWeight(1), 0d);
+        assertEquals(0, paths.getPath(1).getLength());
+    }
+
+    @Test
+    public void testGetPathsCalledTwiceReturnsConsistentResults()
+    {
+        // Two back-to-back calls on the same source must produce the same SingleSourcePaths
+        // content. Pins against any latent stateful caching bug introduced by the override.
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph = buildSampleGraph(11L, 30);
+        DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new DijkstraManyToManyShortestPaths<>(graph);
+
+        Integer source = graph.vertexSet().iterator().next();
+        SingleSourcePaths<Integer, DefaultWeightedEdge> first = alg.getPaths(source);
+        SingleSourcePaths<Integer, DefaultWeightedEdge> second = alg.getPaths(source);
+        for (Integer target : graph.vertexSet()) {
+            assertEquals(first.getWeight(target), second.getWeight(target), 1e-12);
+            GraphPath<Integer, DefaultWeightedEdge> firstPath = first.getPath(target);
+            GraphPath<Integer, DefaultWeightedEdge> secondPath = second.getPath(target);
+            if (firstPath == null) {
+                assertNull(secondPath);
+            } else {
+                assertEquals(firstPath.getVertexList(), secondPath.getVertexList());
+            }
+        }
+    }
+
+    @Test
+    public void testGetPathsFuzzAgainstDijkstraOracle()
+    {
+        // For 10 seeded random directed weighted graphs of varying sizes and densities,
+        // assert that dmm.getPaths(source) matches DijkstraShortestPath.getPaths(source) on
+        // every target. Failure mode: a regression introduced into the getPaths(V) override
+        // that diverges from the canonical Dijkstra answer for some graph shape we didn't
+        // hand-build.
+        long[] seeds = { 1L, 2L, 3L, 5L, 7L, 11L, 13L, 17L, 19L, 23L };
+        int[] vertexCounts = { 10, 20, 35, 50, 80 };
+        for (long seed : seeds) {
+            Random rng = new Random(seed);
+            int n = vertexCounts[(int) (Math.abs(seed) % vertexCounts.length)];
+            DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+                buildRandomGraph(rng, n);
+            DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+                new DijkstraManyToManyShortestPaths<>(graph);
+            DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
+                new DijkstraShortestPath<>(graph);
+
+            for (Integer source : graph.vertexSet()) {
+                SingleSourcePaths<Integer, DefaultWeightedEdge> expected = oracle.getPaths(source);
+                SingleSourcePaths<Integer, DefaultWeightedEdge> actual = alg.getPaths(source);
+                for (Integer target : graph.vertexSet()) {
+                    double expectedWeight = expected.getWeight(target);
+                    double actualWeight = actual.getWeight(target);
+                    assertEquals(
+                        expectedWeight, actualWeight, 1e-9,
+                        "weight mismatch for seed=" + seed + " src=" + source + " tgt=" + target);
+                    GraphPath<Integer, DefaultWeightedEdge> expectedPath = expected.getPath(target);
+                    GraphPath<Integer, DefaultWeightedEdge> actualPath = actual.getPath(target);
+                    if (expectedPath == null) {
+                        assertNull(
+                            actualPath,
+                            "expected null path for seed=" + seed + " src=" + source + " tgt="
+                                + target);
+                    } else {
+                        assertTrue(
+                            actualPath != null,
+                            "expected non-null path for seed=" + seed + " src=" + source + " tgt="
+                                + target);
+                        assertEquals(
+                            expectedPath.getWeight(), actualPath.getWeight(), 1e-9,
+                            "path weight mismatch for seed=" + seed + " src=" + source + " tgt="
+                                + target);
+                    }
+                }
+            }
+        }
+    }
+
+    private static DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> buildSampleGraph(
+        long seed, int n)
+    {
+        return buildRandomGraph(new Random(seed), n);
+    }
+
+    private static DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> buildRandomGraph(
+        Random rng, int n)
+    {
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        for (int v = 0; v < n; v++) {
+            graph.addVertex(v);
+        }
+        // Density chosen to give a mix of reachable and unreachable target pairs for most seeds.
+        double p = 0.2;
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (i != j && rng.nextDouble() < p) {
+                    DefaultWeightedEdge edge = graph.addEdge(i, j);
+                    if (edge != null) {
+                        graph.setEdgeWeight(edge, 1d + rng.nextInt(1000));
+                    }
+                }
+            }
+        }
+        return graph;
     }
 
     @Override

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPathsTest.java
@@ -17,10 +17,14 @@
  */
 package org.jgrapht.alg.shortestpath;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.jgrapht.*;
 import org.jgrapht.alg.interfaces.*;
+import org.jgrapht.alg.interfaces.ShortestPathAlgorithm.SingleSourcePaths;
 import org.jgrapht.graph.*;
 import org.junit.jupiter.api.*;
 
@@ -90,6 +94,67 @@ public class DijkstraManyToManyShortestPathsTest extends BaseManyToManyShortestP
     public void testOnRandomGraphs()
     {
         super.testOnRandomGraphs(100, 20, new int[][] { { 50, 30 }, { 40, 40 }, { 30, 50 } }, 50);
+    }
+
+    @Test
+    public void testGetPathsSingleSourceMatchesDijkstra()
+    {
+        // The inherited getPaths(V) was previously implemented by issuing one
+        // getPath(source, v) per vertex of the graph, which re-ran Dijkstra |V| times from the
+        // same source. The optimized implementation runs a single shortest-paths search from
+        // source instead. This test pins that result against a fresh DijkstraShortestPath as the
+        // ground-truth oracle, and additionally verifies the unreachable-vertex contract.
+
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        graph.addVertex(2);
+        graph.addVertex(3);
+        graph.addVertex(4);
+        graph.addVertex(5);
+        graph.setEdgeWeight(graph.addEdge(1, 2), 1.5);
+        graph.setEdgeWeight(graph.addEdge(2, 3), 2.0);
+        graph.setEdgeWeight(graph.addEdge(1, 3), 5.0);
+        graph.setEdgeWeight(graph.addEdge(3, 4), 1.0);
+        // vertex 5 is intentionally isolated: unreachable from 1 in the directed graph
+
+        DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new DijkstraManyToManyShortestPaths<>(graph);
+        DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
+            new DijkstraShortestPath<>(graph);
+        SingleSourcePaths<Integer, DefaultWeightedEdge> oraclePaths = oracle.getPaths(1);
+
+        SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(1);
+        assertEquals(graph, paths.getGraph());
+        assertEquals(Integer.valueOf(1), paths.getSourceVertex());
+
+        // Source vertex itself
+        assertEquals(0d, paths.getWeight(1), 1e-12);
+        assertNotNull(paths.getPath(1));
+        assertEquals(0, paths.getPath(1).getLength());
+
+        // Reachable targets
+        for (Integer target : new Integer[] { 2, 3, 4 }) {
+            assertEquals(oraclePaths.getWeight(target), paths.getWeight(target), 1e-12);
+            assertEquals(
+                oraclePaths.getPath(target).getVertexList(),
+                paths.getPath(target).getVertexList());
+        }
+
+        // Unreachable target (5): SingleSourcePaths contract is null path / +Inf weight
+        assertNull(paths.getPath(5));
+        assertEquals(Double.POSITIVE_INFINITY, paths.getWeight(5), 0d);
+    }
+
+    @Test
+    public void testGetPathsRejectsVertexNotInGraph()
+    {
+        DefaultDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph =
+            new DefaultDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+        graph.addVertex(1);
+        DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
+            new DijkstraManyToManyShortestPaths<>(graph);
+        assertThrows(IllegalArgumentException.class, () -> alg.getPaths(42));
     }
 
     @Override

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/DijkstraManyToManyShortestPathsTest.java
@@ -18,10 +18,8 @@
 package org.jgrapht.alg.shortestpath;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.*;
 
@@ -123,30 +121,15 @@ public class DijkstraManyToManyShortestPathsTest extends BaseManyToManyShortestP
 
         DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
             new DijkstraManyToManyShortestPaths<>(graph);
-        DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
-            new DijkstraShortestPath<>(graph);
-        SingleSourcePaths<Integer, DefaultWeightedEdge> oraclePaths = oracle.getPaths(1);
-
         SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(1);
-        assertEquals(graph, paths.getGraph());
-        assertEquals(Integer.valueOf(1), paths.getSourceVertex());
 
-        // Source vertex itself
-        assertEquals(0d, paths.getWeight(1), 1e-12);
-        assertNotNull(paths.getPath(1));
+        // Source, reachable targets, and unreachable target (5) all covered by the oracle
+        // helper — assertCorrectPaths handles the null-path / +Inf-weight contract for
+        // unreachable vertices.
+        assertCorrectPaths(graph, paths, 1, graph.vertexSet());
+
+        // Pin the source-vertex contract explicitly: zero-length walk.
         assertEquals(0, paths.getPath(1).getLength());
-
-        // Reachable targets
-        for (Integer target : new Integer[] { 2, 3, 4 }) {
-            assertEquals(oraclePaths.getWeight(target), paths.getWeight(target), 1e-12);
-            assertEquals(
-                oraclePaths.getPath(target).getVertexList(),
-                paths.getPath(target).getVertexList());
-        }
-
-        // Unreachable target (5): SingleSourcePaths contract is null path / +Inf weight
-        assertNull(paths.getPath(5));
-        assertEquals(Double.POSITIVE_INFINITY, paths.getWeight(5), 0d);
     }
 
     @Test
@@ -170,9 +153,7 @@ public class DijkstraManyToManyShortestPathsTest extends BaseManyToManyShortestP
             new DijkstraManyToManyShortestPaths<>(graph);
 
         SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(7);
-        assertEquals(Integer.valueOf(7), paths.getSourceVertex());
-        assertEquals(0d, paths.getWeight(7), 0d);
-        assertNotNull(paths.getPath(7));
+        assertCorrectPaths(graph, paths, 7, graph.vertexSet());
         assertEquals(0, paths.getPath(7).getLength());
     }
 
@@ -189,11 +170,7 @@ public class DijkstraManyToManyShortestPathsTest extends BaseManyToManyShortestP
             new DijkstraManyToManyShortestPaths<>(graph);
 
         SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(1);
-        assertEquals(0d, paths.getWeight(1), 0d);
-        assertNull(paths.getPath(2));
-        assertNull(paths.getPath(3));
-        assertEquals(Double.POSITIVE_INFINITY, paths.getWeight(2), 0d);
-        assertEquals(Double.POSITIVE_INFINITY, paths.getWeight(3), 0d);
+        assertCorrectPaths(graph, paths, 1, graph.vertexSet());
     }
 
     @Test
@@ -210,20 +187,9 @@ public class DijkstraManyToManyShortestPathsTest extends BaseManyToManyShortestP
         graph.setEdgeWeight(graph.addEdge(10, 11), 1d);
         DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
             new DijkstraManyToManyShortestPaths<>(graph);
-        DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
-            new DijkstraShortestPath<>(graph);
-        SingleSourcePaths<Integer, DefaultWeightedEdge> expected = oracle.getPaths(1);
 
         SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(1);
-        for (int target : new int[] { 1, 2, 3 }) {
-            assertEquals(expected.getWeight(target), paths.getWeight(target), 1e-12);
-            assertEquals(
-                expected.getPath(target).getVertexList(), paths.getPath(target).getVertexList());
-        }
-        assertNull(paths.getPath(10));
-        assertNull(paths.getPath(11));
-        assertEquals(Double.POSITIVE_INFINITY, paths.getWeight(10), 0d);
-        assertEquals(Double.POSITIVE_INFINITY, paths.getWeight(11), 0d);
+        assertCorrectPaths(graph, paths, 1, graph.vertexSet());
     }
 
     @Test
@@ -245,18 +211,10 @@ public class DijkstraManyToManyShortestPathsTest extends BaseManyToManyShortestP
         graph.setEdgeWeight(graph.addEdge(3, 4), 1d);
         DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
             new DijkstraManyToManyShortestPaths<>(graph);
-        DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
-            new DijkstraShortestPath<>(graph);
-        SingleSourcePaths<Integer, DefaultWeightedEdge> expected = oracle.getPaths(1);
 
         SingleSourcePaths<Integer, DefaultWeightedEdge> paths = alg.getPaths(1);
-        for (int target : new int[] { 1, 2, 3, 4 }) {
-            assertEquals(expected.getWeight(target), paths.getWeight(target), 1e-12);
-            assertEquals(
-                expected.getPath(target).getVertexList(), paths.getPath(target).getVertexList());
-        }
+        assertCorrectPaths(graph, paths, 1, graph.vertexSet());
         // Source-to-source path is the zero-length walk, not the self-loop.
-        assertEquals(0d, paths.getWeight(1), 0d);
         assertEquals(0, paths.getPath(1).getLength());
     }
 
@@ -301,36 +259,9 @@ public class DijkstraManyToManyShortestPathsTest extends BaseManyToManyShortestP
                 buildRandomGraph(rng, n);
             DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> alg =
                 new DijkstraManyToManyShortestPaths<>(graph);
-            DijkstraShortestPath<Integer, DefaultWeightedEdge> oracle =
-                new DijkstraShortestPath<>(graph);
 
             for (Integer source : graph.vertexSet()) {
-                SingleSourcePaths<Integer, DefaultWeightedEdge> expected = oracle.getPaths(source);
-                SingleSourcePaths<Integer, DefaultWeightedEdge> actual = alg.getPaths(source);
-                for (Integer target : graph.vertexSet()) {
-                    double expectedWeight = expected.getWeight(target);
-                    double actualWeight = actual.getWeight(target);
-                    assertEquals(
-                        expectedWeight, actualWeight, 1e-9,
-                        "weight mismatch for seed=" + seed + " src=" + source + " tgt=" + target);
-                    GraphPath<Integer, DefaultWeightedEdge> expectedPath = expected.getPath(target);
-                    GraphPath<Integer, DefaultWeightedEdge> actualPath = actual.getPath(target);
-                    if (expectedPath == null) {
-                        assertNull(
-                            actualPath,
-                            "expected null path for seed=" + seed + " src=" + source + " tgt="
-                                + target);
-                    } else {
-                        assertTrue(
-                            actualPath != null,
-                            "expected non-null path for seed=" + seed + " src=" + source + " tgt="
-                                + target);
-                        assertEquals(
-                            expectedPath.getWeight(), actualPath.getWeight(), 1e-9,
-                            "path weight mismatch for seed=" + seed + " src=" + source + " tgt="
-                                + target);
-                    }
-                }
+                assertCorrectPaths(graph, alg.getPaths(source), source, graph.vertexSet());
             }
         }
     }

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/DijkstraManyToManyShortestPathsGetPathsPerformance.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/DijkstraManyToManyShortestPathsGetPathsPerformance.java
@@ -1,0 +1,141 @@
+/*
+ * (C) Copyright 2026-2026, by Shai Eilat and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.perf.shortestpath;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.interfaces.ShortestPathAlgorithm.*;
+import org.jgrapht.alg.shortestpath.*;
+import org.jgrapht.generate.*;
+import org.jgrapht.graph.*;
+import org.jgrapht.util.*;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+/**
+ * JMH benchmark for {@link DijkstraManyToManyShortestPaths#getPaths(Object)}.
+ *
+ * <p>
+ * Compares two variants in the same JVM:
+ * <ul>
+ *   <li>{@code testBaseClassLoop} faithfully reproduces the inherited
+ *       {@code BaseManyToManyShortestPaths.getPaths(source)} default — for each vertex
+ *       {@code v} in the graph, call {@code getPath(source, v)}, which dispatches
+ *       through {@code getManyToManyPaths(singleton(source), singleton(v))} and runs a
+ *       fresh Dijkstra from {@code source} on every iteration.</li>
+ *   <li>{@code testOptimizedGetPaths} calls the
+ *       {@link DijkstraManyToManyShortestPaths#getPaths(Object)} override that runs a
+ *       single Dijkstra from {@code source} settling every reachable vertex.</li>
+ * </ul>
+ *
+ * <p>
+ * Both variants are exact and produce a {@code SingleSourcePaths} honouring the same
+ * externally-visible contract; this benchmark only measures wall-clock cost.
+ *
+ * @author Shai Eilat
+ */
+@BenchmarkMode(Mode.AverageTime)
+@Fork(value = 1, warmups = 0, jvmArgs = "--illegal-access=permit")
+@Warmup(iterations = 3, time = 5)
+@Measurement(iterations = 5, time = 5)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class DijkstraManyToManyShortestPathsGetPathsPerformance
+{
+
+    private static final long SEED = 19L;
+
+    @Benchmark
+    public List<SingleSourcePaths<Integer, DefaultWeightedEdge>> testBaseClassLoop(
+        GetPathsState state)
+    {
+        List<SingleSourcePaths<Integer, DefaultWeightedEdge>> result =
+            new ArrayList<>(state.sources.size());
+        for (Integer source : state.sources) {
+            Map<Integer, GraphPath<Integer, DefaultWeightedEdge>> paths = new HashMap<>();
+            for (Integer v : state.graph.vertexSet()) {
+                paths.put(v, state.algorithm.getPath(source, v));
+            }
+            result.add(new ListSingleSourcePathsImpl<>(state.graph, source, paths));
+        }
+        return result;
+    }
+
+    @Benchmark
+    public List<SingleSourcePaths<Integer, DefaultWeightedEdge>> testOptimizedGetPaths(
+        GetPathsState state)
+    {
+        List<SingleSourcePaths<Integer, DefaultWeightedEdge>> result =
+            new ArrayList<>(state.sources.size());
+        for (Integer source : state.sources) {
+            result.add(state.algorithm.getPaths(source));
+        }
+        return result;
+    }
+
+    @State(Scope.Benchmark)
+    public static class GetPathsState
+    {
+        @Param({ "50", "100", "200" })
+        int n;
+        @Param({ "0.1" })
+        double p;
+        @Param({ "5" })
+        int numberOfSources;
+
+        SimpleDirectedWeightedGraph<Integer, DefaultWeightedEdge> graph;
+        DijkstraManyToManyShortestPaths<Integer, DefaultWeightedEdge> algorithm;
+        List<Integer> sources;
+
+        @Setup(Level.Iteration)
+        public void generateGraph()
+        {
+            Random rng = new Random(SEED);
+            graph = new SimpleDirectedWeightedGraph<>(DefaultWeightedEdge.class);
+            graph.setVertexSupplier(SupplierUtil.createIntegerSupplier());
+            new GnpRandomGraphGenerator<Integer, DefaultWeightedEdge>(n, p, SEED).generateGraph(
+                graph);
+            makeConnected();
+            for (DefaultWeightedEdge edge : graph.edgeSet()) {
+                graph.setEdgeWeight(edge, 1.0 + rng.nextInt(1000));
+            }
+            algorithm = new DijkstraManyToManyShortestPaths<>(graph);
+            sources = pickSources(rng);
+        }
+
+        private void makeConnected()
+        {
+            Object[] vertices = graph.vertexSet().toArray();
+            for (int i = 0; i < vertices.length - 1; i++) {
+                if (!graph.containsEdge((Integer) vertices[i], (Integer) vertices[i + 1])) {
+                    graph.addEdge((Integer) vertices[i], (Integer) vertices[i + 1]);
+                }
+            }
+        }
+
+        private List<Integer> pickSources(Random rng)
+        {
+            Object[] vertices = graph.vertexSet().toArray();
+            Set<Integer> chosen = new LinkedHashSet<>();
+            while (chosen.size() < numberOfSources) {
+                chosen.add((Integer) vertices[rng.nextInt(vertices.length)]);
+            }
+            return new ArrayList<>(chosen);
+        }
+    }
+}


### PR DESCRIPTION
Posted to `jgrapht-dev` as a heads-up before opening this PR:
https://groups.google.com/g/jgrapht-dev/c/0tSGUKHCp1U

## Summary

`DijkstraManyToManyShortestPaths` inherits the default `getPaths(V source)` implementation from `BaseManyToManyShortestPaths`, which calls `getPath(source, v)` for every vertex `v` in the graph. Each of those calls dispatches through `getManyToManyPaths(singleton(source), singleton(v))`, which in this subclass runs a fresh `DijkstraClosestFirstIterator` from `source`. A single `getPaths(source)` therefore performs `|V|` Dijkstras from the same source, turning what should be a single `O(V log V + E)` query into `O(|V| · (V log V + E))`.

This PR overrides `getPaths(V)` on `DijkstraManyToManyShortestPaths` only with:

```java
return getShortestPathsTree(graph, source, graph.vertexSet());
```

which returns a `TreeSingleSourcePathsImpl<V, E>`. Both `ListSingleSourcePathsImpl` (the historical return type) and `TreeSingleSourcePathsImpl` honor the same `SingleSourcePaths` contract on every externally-visible method (`getGraph`, `getSourceVertex`, `getWeight(target)`, `getPath(target)`), including the unreachable-target case (null path, `+∞` weight) and the source==target case (singleton walk, weight 0).

### Why the override lives on the concrete subclass

The abstract `BaseManyToManyShortestPaths` is also extended by two other classes whose `getPaths(V)` semantics differ:

- `DefaultManyToManyShortestPaths` accepts a user-supplied `Function<Graph, ShortestPathAlgorithm>` and is expected to consult it on every shortest-path query. Routing `getPaths(V)` through `getShortestPathsTree` here would silently bypass that algorithm function.
- `CHManyToManyShortestPaths` uses a precomputed contraction hierarchy. Routing `getPaths(V)` through plain Dijkstra over the original graph would silently bypass that preprocessing.

Both behaviours are preserved by specialising only on the concrete subclass.

## JMH benchmark

### What the benchmark measures, and why the speedup is bounded by |V|

The change is an asymptotic class change, not a constant-factor tweak. The old implementation runs `|V|` Dijkstras from the same source; the override runs `1`. The achievable speedup is therefore bounded above by `|V|`, and any measurement should sit below that ceiling by whatever fraction the constant-factor differences (graph-instance variance, allocation, JIT artefacts, `getShortestPathsTree` vs `getPath` setup) eat into the savings. The numbers below should be read as "how close to the `|V|` ceiling does each cell get," not as standalone multiples.

### Setup

`org.jgrapht.perf.shortestpath.DijkstraManyToManyShortestPathsGetPathsPerformance`. Two `@Benchmark` methods in the same JVM:

- `testBaseClassLoop` reproduces the inherited `|V|`-Dijkstra default.
- `testOptimizedGetPaths` calls the override.

`GnpRandomGraphGenerator` p=0.1, 5 sources/op, JDK 21, `@Fork 1, @Warmup 3×5s, @Measurement 5×5s`. Graphs are regenerated per JMH iteration with a fixed seed.

### Results

| n   | base loop ms     | optimized ms     | speedup | |V| ceiling | % of ceiling |
|----:|-----------------:|-----------------:|--------:|-----------:|-------------:|
|  50 | 1.124 ± 0.585    | 0.033 ± 0.004    | 34×     | 50         | 68%          |
| 100 | 7.599 ± 3.071    | 0.118 ± 0.002    | 64×     | 100        | 64%          |
| 200 | 38.720 ± 0.807   | 0.413 ± 0.013    | 94×     | 200        | 47%          |

Every cell sits in a tight 47–68% band of the `|V|` ceiling — the speedup is the expected outcome of an `O(|V| · X) → O(X)` algorithmic change, not a microbench artefact.

A second in-process re-run on a different machine (`@Fork 0`, otherwise identical params) reproduces the same band: 33× / 51× / 90× at n=50/100/200 (66% / 51% / 45% of ceiling). The middle cell is the noisiest because the optimized timing at n=100 is in the sub-millisecond range and the per-iteration Gnp regeneration dominates instance-to-instance variance.

## Tests

- `DijkstraManyToManyShortestPathsTest` (18 tests, all pass). New cases: oracle-match on a hand-built graph, vertex-not-in-graph rejection, single-vertex graph, source-with-no-outgoing-edges, disconnected graph, cyclic graph with self-loop on source, twice-called consistency, and a seeded fuzz suite that compares `getPaths(source)` against a fresh `DijkstraShortestPath` oracle on 10 random graphs.
- `DefaultManyToManyShortestPathsTest`: a counting-spy test asserts the user-supplied algorithm function is still consulted by `getPaths(V)`, guarding against an accidental future push of the override up into the base class.
- `CHManyToManyShortestPathsTest`: pins `getPaths(source)` against a Dijkstra oracle on the contracted hierarchy.
- All three reuse a new `BaseManyToManyShortestPathsTest.assertCorrectPaths(graph, SingleSourcePaths, source, targets)` helper (added per code review) that handles both reachable and unreachable targets per the `SingleSourcePaths` contract.

## Build status

- `mvn -pl jgrapht-core test` — 6885 / 6885 pass (15 unrelated upstream skips)
- `mvn -pl jgrapht-core checkstyle:check -P checkstyle` — clean
- `mvn -pl jgrapht-core javadoc:javadoc` — clean
