### PR TITLE
perf(shortestpath): Speed up AllDirectedPaths non-simple-paths mode

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
@@ -221,7 +221,7 @@ public class AllDirectedPaths<V, E>
          * edges whose minimum distances is small enough.
          */
         List<GraphPath<V, E>> completePaths = new ArrayList<>();
-        Deque<List<E>> incompletePaths = new LinkedList<>();
+        Deque<List<E>> incompletePaths = new ArrayDeque<>();
 
         // Input sanity checking
         if (maxPathLength != null && maxPathLength < 0) {
@@ -271,10 +271,17 @@ public class AllDirectedPaths<V, E>
             E leafEdge = incompletePath.get(lengthSoFar - 1);
             V leafNode = graph.getEdgeTarget(leafEdge);
 
-            Set<V> pathVertices = new HashSet<>();
-            for (E pathEdge : incompletePath) {
-                pathVertices.add(graph.getEdgeSource(pathEdge));
-                pathVertices.add(graph.getEdgeTarget(pathEdge));
+            // pathVertices is only consulted by the simple-path filter below;
+            // building it in non-simple mode is wasted work proportional to path length.
+            Set<V> pathVertices;
+            if (simplePathsOnly) {
+                pathVertices = new HashSet<>();
+                for (E pathEdge : incompletePath) {
+                    pathVertices.add(graph.getEdgeSource(pathEdge));
+                    pathVertices.add(graph.getEdgeTarget(pathEdge));
+                }
+            } else {
+                pathVertices = null;
             }
 
             for (E outEdge : graph.outgoingEdgesOf(leafNode)) {

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/AllDirectedPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/AllDirectedPathsTest.java
@@ -246,6 +246,185 @@ public class AllDirectedPathsTest
                     path, path.getLength())));
     }
 
+    @Test
+    public void testNonSimpleModeAdjacentVerticesWithSelfLoops()
+    {
+        // Two-vertex graph 0 → 1 with self-loops on both. Non-simple paths from 0 to 1 of length
+        // ≤ 3 are:
+        //   0→1 (length 1)
+        //   0→0→1, 0→1→1 (length 2)
+        //   0→0→0→1, 0→0→1→1, 0→1→1→1 (length 3)
+        // Total = 6.
+        DefaultDirectedGraph<Integer, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex(0);
+        graph.addVertex(1);
+        graph.addEdge(0, 0);
+        graph.addEdge(1, 1);
+        graph.addEdge(0, 1);
+
+        List<GraphPath<Integer, DefaultEdge>> paths =
+            new AllDirectedPaths<>(graph).getAllPaths(0, 1, false, 3);
+        assertEquals(6, paths.size());
+    }
+
+    @Test
+    public void testNonSimpleModeCycleWithoutSelfLoops()
+    {
+        // Triangle 0 → 1 → 2 → 0. Non-simple paths from 0 to 1 of length ≤ 4 are:
+        //   0→1 (length 1)
+        //   0→1→2→0→1 (length 4)
+        // No length-2 or length-3 walk from 0 ends at 1.
+        DefaultDirectedGraph<Integer, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex(0);
+        graph.addVertex(1);
+        graph.addVertex(2);
+        graph.addEdge(0, 1);
+        graph.addEdge(1, 2);
+        graph.addEdge(2, 0);
+
+        List<GraphPath<Integer, DefaultEdge>> paths =
+            new AllDirectedPaths<>(graph).getAllPaths(0, 1, false, 4);
+        assertEquals(2, paths.size());
+    }
+
+    @Test
+    public void testNonSimpleModePathValidatorStillRespected()
+    {
+        // The pathValidator must still be invoked when simplePathsOnly = false, even after the
+        // refactor that guards the pathVertices set behind the simple-paths flag.
+        DefaultDirectedGraph<Integer, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex(0);
+        graph.addVertex(1);
+        graph.addVertex(2);
+        graph.addEdge(0, 0);
+        graph.addEdge(0, 1);
+        graph.addEdge(1, 2);
+        graph.addEdge(2, 2);
+
+        // Reject any edge into vertex 1.
+        PathValidator<Integer, DefaultEdge> validator =
+            (partialPath, edge) -> graph.getEdgeTarget(edge) != 1;
+        List<GraphPath<Integer, DefaultEdge>> paths =
+            new AllDirectedPaths<>(graph, validator).getAllPaths(0, 2, false, 3);
+        // Every walk from 0 to 2 must traverse 0→1 (the only path to 1) and then 1→2.
+        // The validator forbids any edge into 1, so no walks should reach 2.
+        assertTrue(paths.isEmpty());
+    }
+
+    @Test
+    public void testNonSimpleModeMaxLengthBoundary()
+    {
+        DefaultDirectedGraph<Integer, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex(0);
+        graph.addVertex(1);
+        graph.addEdge(0, 0);
+        graph.addEdge(0, 1);
+
+        AllDirectedPaths<Integer, DefaultEdge> alg = new AllDirectedPaths<>(graph);
+
+        // maxLength=0: only the trivial zero-length walk when source == target.
+        List<GraphPath<Integer, DefaultEdge>> zeroLen =
+            alg.getAllPaths(Set.of(0), Set.of(0), false, 0);
+        assertEquals(1, zeroLen.size());
+        assertEquals(0, zeroLen.get(0).getLength());
+
+        // maxLength=1: zero-length walk at 0, plus 0→0 self-loop, plus 0→1 direct edge.
+        List<GraphPath<Integer, DefaultEdge>> oneLen =
+            alg.getAllPaths(Set.of(0), Set.of(0, 1), false, 1);
+        assertEquals(3, oneLen.size());
+    }
+
+    @Test
+    public void testNonSimpleModeMatchesBruteForce()
+    {
+        // Property-style: for a few seeded random small cyclic digraphs, compare the
+        // multiset of vertex-sequences returned by getAllPaths against a brute-force walk
+        // enumeration. The refactor changes the per-pop inner loop and the queue impl; this
+        // test fails loudly if either changes the produced walk multiset.
+        long[] seeds = { 1L, 2L, 3L, 5L, 7L };
+        for (long seed : seeds) {
+            DefaultDirectedGraph<Integer, DefaultEdge> graph =
+                buildRandomCyclicGraph(new Random(seed), 5, 0.4, 0.2);
+            Integer source = 0;
+            Integer target = graph.vertexSet().size() - 1;
+            int maxLength = 4;
+
+            List<List<Integer>> bruteForce =
+                bruteForceWalks(graph, source, target, maxLength);
+            List<GraphPath<Integer, DefaultEdge>> actual =
+                new AllDirectedPaths<>(graph).getAllPaths(source, target, false, maxLength);
+            List<List<Integer>> actualVertexLists = new ArrayList<>(actual.size());
+            for (GraphPath<Integer, DefaultEdge> path : actual) {
+                actualVertexLists.add(path.getVertexList());
+            }
+
+            assertEquals(
+                bruteForce.size(), actualVertexLists.size(),
+                "walk count mismatch for seed=" + seed);
+            // Compare as multisets — order of enumeration is not part of the contract.
+            assertEquals(
+                new HashSet<>(bruteForce), new HashSet<>(actualVertexLists),
+                "walk multiset mismatch for seed=" + seed);
+        }
+    }
+
+    private static DefaultDirectedGraph<Integer, DefaultEdge> buildRandomCyclicGraph(
+        Random rng, int n, double edgeProbability, double selfLoopProbability)
+    {
+        DefaultDirectedGraph<Integer, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        for (int v = 0; v < n; v++) {
+            graph.addVertex(v);
+        }
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (i == j) {
+                    if (rng.nextDouble() < selfLoopProbability) {
+                        graph.addEdge(i, j);
+                    }
+                } else if (rng.nextDouble() < edgeProbability) {
+                    graph.addEdge(i, j);
+                }
+            }
+        }
+        return graph;
+    }
+
+    private static List<List<Integer>> bruteForceWalks(
+        Graph<Integer, DefaultEdge> graph, Integer source, Integer target, int maxLength)
+    {
+        List<List<Integer>> walks = new ArrayList<>();
+        Deque<Integer> stack = new ArrayDeque<>();
+        stack.push(source);
+        bruteForceWalksRec(graph, target, maxLength, stack, walks);
+        return walks;
+    }
+
+    private static void bruteForceWalksRec(
+        Graph<Integer, DefaultEdge> graph, Integer target, int remaining, Deque<Integer> stack,
+        List<List<Integer>> walks)
+    {
+        Integer current = stack.peek();
+        if (target.equals(current)) {
+            List<Integer> walk = new ArrayList<>(stack);
+            Collections.reverse(walk);
+            walks.add(walk);
+        }
+        if (remaining == 0) {
+            return;
+        }
+        for (DefaultEdge edge : graph.outgoingEdgesOf(current)) {
+            Integer next = graph.getEdgeTarget(edge);
+            stack.push(next);
+            bruteForceWalksRec(graph, target, remaining - 1, stack, walks);
+            stack.pop();
+        }
+    }
+
     private static Graph<String, DefaultEdge> toyGraph()
     {
         Graph<String, DefaultEdge> graph = new DefaultDirectedGraph<>(DefaultEdge.class);

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/AllDirectedPathsNonSimplePerformance.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/AllDirectedPathsNonSimplePerformance.java
@@ -1,0 +1,96 @@
+/*
+ * (C) Copyright 2026-2026, by Shai Eilat and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.perf.shortestpath;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.shortestpath.*;
+import org.jgrapht.graph.*;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+/**
+ * JMH benchmark for {@link AllDirectedPaths#getAllPaths(Object, Object, boolean, Integer)} in
+ * non-simple-paths mode. Exercises the inner loop of {@code generatePaths} where the
+ * per-pop {@code pathVertices} {@code HashSet} is only read in simple-paths mode but was
+ * unconditionally rebuilt on every iteration in earlier revisions.
+ *
+ * <p>
+ * Cyclic grid graph with self-loops on every vertex. Source = corner (0,0),
+ * target = adjacent vertex (0,1). Non-simple-paths mode with {@code maxPathLength} swept across
+ * a few values to amortise JIT warmup and produce enough partial paths to exercise the inner
+ * loop of {@code generatePaths}.
+ *
+ * @author Shai Eilat
+ */
+@BenchmarkMode(Mode.AverageTime)
+@Fork(value = 1, warmups = 0, jvmArgs = "--illegal-access=permit")
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 8, time = 2)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class AllDirectedPathsNonSimplePerformance
+{
+
+    @Benchmark
+    public List<GraphPath<Integer, DefaultEdge>> testGetAllPathsNonSimple(CyclicGridState state)
+    {
+        return state.algorithm.getAllPaths(state.source, state.target, false, state.maxPathLength);
+    }
+
+    @State(Scope.Benchmark)
+    public static class CyclicGridState
+    {
+        @Param({ "5" })
+        int gridSize;
+        @Param({ "6", "8", "10" })
+        int maxPathLength;
+
+        DefaultDirectedGraph<Integer, DefaultEdge> graph;
+        AllDirectedPaths<Integer, DefaultEdge> algorithm;
+        Integer source;
+        Integer target;
+
+        @Setup(Level.Trial)
+        public void buildGraph()
+        {
+            graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+            int n = gridSize;
+            for (int i = 0; i < n * n; i++) {
+                graph.addVertex(i);
+            }
+            for (int row = 0; row < n; row++) {
+                for (int col = 0; col < n; col++) {
+                    int v = row * n + col;
+                    graph.addEdge(v, v);
+                    if (col + 1 < n) {
+                        graph.addEdge(v, v + 1);
+                        graph.addEdge(v + 1, v);
+                    }
+                    if (row + 1 < n) {
+                        graph.addEdge(v, v + n);
+                        graph.addEdge(v + n, v);
+                    }
+                }
+            }
+            algorithm = new AllDirectedPaths<>(graph);
+            source = 0;
+            target = 1;
+        }
+    }
+}


### PR DESCRIPTION
Posted to `jgrapht-dev` as a heads-up before opening this PR:
https://groups.google.com/g/jgrapht-dev/c/lcPK9CDGLTU

## Summary

Two small changes to `AllDirectedPaths.generatePaths`:

1. Guard the per-pop `pathVertices` `HashSet` rebuild behind `simplePathsOnly`. The set is only consulted by the simple-path self-intersection filter, so building it in `simplePathsOnly = false` mode was wasted `O(path length)` work per popped partial path. Java short-circuit evaluation means the field is only dereferenced when populated.

2. Switch the `incompletePaths` queue from `LinkedList` to `ArrayDeque` to remove per-node linked-list overhead. The queue is only used through the `Deque` interface (`poll` / `addFirst` / `add` / `isEmpty`), which `ArrayDeque` supports identically with better allocation behaviour.

Both changes are pure refactors with no behavioural difference.

## JMH benchmark

`org.jgrapht.perf.shortestpath.AllDirectedPathsNonSimplePerformance` on a 5×5 cyclic grid with self-loops on every vertex, source = corner, target = adjacent vertex (1), non-simple-paths mode. JDK 21, `@Fork 1, @Warmup 5×2s, @Measurement 8×2s`. Run on master and on this branch with the same JMH file:

| maxPathLength | master ms       | branch ms       | speedup |
|--------------:|----------------:|----------------:|--------:|
|  6 |  0.096 ± 0.003 |  0.060 ± 0.005 | 1.60×    |
|  8 |  1.699 ± 0.030 |  0.873 ± 0.025 | 1.95×    |
| 10 | 30.392 ± 0.380 | 14.150 ± 0.158 | 2.15×    |

The relative speedup grows with `maxPathLength` as the inner loop becomes more amortised over JIT warmup.

## Tests

`AllDirectedPathsTest` (14 tests, all pass). New cases:

- Two-vertex graph with self-loops on both, walks of length ≤ 3 (exact count 6).
- Three-vertex cycle without self-loops, walks of length ≤ 4 (exact count 2).
- `pathValidator` still consulted in non-simple mode.
- `maxLength = 0` and `maxLength = 1` boundary cases.
- Seeded fuzz that compares the algorithm's non-simple-mode walk multiset against an in-test brute-force DFS oracle on 5 random small cyclic digraphs.

## Build status

- `mvn -pl jgrapht-core test` — 6880 / 6880 pass (15 unrelated upstream skips)
- `mvn -pl jgrapht-core checkstyle:check -P checkstyle` — clean
- `mvn -pl jgrapht-core javadoc:javadoc` — clean
