### PR TITLE
Optimize AllDirectedPaths preprocessing with forward pruning

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/AllDirectedPaths.java
@@ -26,6 +26,17 @@ import java.util.*;
  * A Dijkstra-like algorithm to find all paths between two sets of nodes in a directed graph, with
  * options to search only simple paths and to limit the path length.
  *
+ * <p>
+ * The algorithm runs in two phases. Preprocessing decorates each edge with the minimum number of
+ * edges still needed to reach a target. Enumeration then walks the decorated edges from the source
+ * set, using the decoration to abandon any partial path that cannot complete within the budget. By
+ * default a forward BFS from the source set is also run as part of preprocessing, so that edges
+ * whose source endpoint is not reachable from any requested source within the budget are dropped
+ * from the decoration up front. This can substantially reduce preprocessing cost on graphs where a
+ * non-trivial fraction of the target-reachable subgraph is not reachable from the sources. See
+ * {@link #setForwardPruning(boolean)} for how to disable it.
+ * </p>
+ *
  * @param <V> the graph vertex type
  * @param <E> the graph edge type
  *
@@ -40,6 +51,16 @@ public class AllDirectedPaths<V, E>
      * this means that all paths are valid.
      */
     private final PathValidator<V, E> pathValidator;
+
+    /**
+     * Whether to apply the forward-pruning preprocessing step. When {@code true} (the default), a
+     * forward BFS from the source set is run before the backward edge-decoration sweep and edges
+     * that cannot lie on any source-to-target walk within the budget are dropped. When
+     * {@code false}, the historical backward-only preprocessing behaviour is used.
+     *
+     * @see #setForwardPruning(boolean)
+     */
+    private boolean forwardPruning = true;
 
     /**
      * Create a new instance.
@@ -67,6 +88,44 @@ public class AllDirectedPaths<V, E>
     {
         this.graph = GraphTests.requireDirected(graph);
         this.pathValidator = pathValidator;
+    }
+
+    /**
+     * Configure whether the preprocessing step applies the forward-pruning optimisation.
+     *
+     * <p>
+     * When forward pruning is enabled (the default), {@link #getAllPaths} first runs a forward
+     * BFS from the source set and uses the result to drop edges whose source endpoint is not
+     * reachable from any source within the bound, or whose forward-plus-backward length exceeds
+     * the bound. The prune is exact &mdash; it never drops an edge that could lie on a feasible
+     * source-to-target walk &mdash; and can be a large win when a substantial fraction of the
+     * graph is backward-reachable from the targets but not forward-reachable from the sources.
+     * On graphs where the prune never fires (e.g. small dense strongly-connected digraphs), the
+     * optimisation adds the cost of one extra {@code O(V + E)} BFS per {@code getAllPaths}
+     * call.
+     * </p>
+     *
+     * <p>
+     * Setting forward pruning to {@code false} recovers the historical preprocessing behaviour
+     * exactly &mdash; useful when the cost of the extra BFS is known to dominate.
+     * </p>
+     *
+     * @param forwardPruning whether to apply the forward-pruning preprocessing step
+     */
+    public void setForwardPruning(boolean forwardPruning)
+    {
+        this.forwardPruning = forwardPruning;
+    }
+
+    /**
+     * Whether the preprocessing step currently applies the forward-pruning optimisation.
+     *
+     * @return {@code true} if forward pruning is enabled
+     * @see #setForwardPruning(boolean)
+     */
+    public boolean isForwardPruning()
+    {
+        return forwardPruning;
     }
 
     /**
@@ -116,9 +175,14 @@ public class AllDirectedPaths<V, E>
             return Collections.emptyList();
         }
 
-        // Decorate the edges with the minimum path lengths through them
-        Map<E, Integer> edgeMinDistancesFromTargets =
-            edgeMinDistancesBackwards(targetVertices, maxPathLength);
+        // Decorate the edges with the minimum path lengths through them. When forward pruning
+        // is enabled (the default), first compute forward distances from the source set and use
+        // them to drop edges that cannot lie on any feasible source -> target walk within the
+        // budget. When disabled, behave identically to the historical backward-only sweep.
+        Map<V, Integer> vertexMinDistancesFromSources = forwardPruning
+            ? vertexMinDistancesForwards(sourceVertices, maxPathLength) : null;
+        Map<E, Integer> edgeMinDistancesFromTargets = edgeMinDistancesBackwards(
+            targetVertices, vertexMinDistancesFromSources, maxPathLength);
 
         // Generate all the paths
 
@@ -128,16 +192,38 @@ public class AllDirectedPaths<V, E>
     }
 
     /**
-     * Compute the minimum number of edges in a path to the targets through each edge, so long as it
-     * is not greater than a bound.
+     * Compute the minimum number of edges in a walk to the targets through each edge, so long as
+     * it is not greater than a bound and the edge can lie on at least one source -&gt; target walk
+     * of length at most {@code maxPathLength} (this includes every simple path of length at most
+     * {@code maxPathLength}, since every simple path is also a walk).
+     *
+     * <p>
+     * When {@code vertexMinDistancesFromSources} is non-{@code null} the sandwich condition is
+     * enforced: an edge {@code (u, v)} is retained only when {@code u} is forward-reachable from
+     * some source and {@code dF(u) + (1 + dB(v)) <= maxPathLength} (when bounded), where
+     * {@code dF(u)} is the forward BFS distance from the source set to {@code u} and
+     * {@code 1 + dB(v)} is the backward BFS distance to a target through this edge. Edges that
+     * fail the sandwich cannot appear on any feasible source -&gt; target walk and would therefore
+     * never be traversed by the forward enumeration in {@link #generatePaths} in either
+     * {@code simplePathsOnly = true} or {@code simplePathsOnly = false} mode. When
+     * {@code vertexMinDistancesFromSources} is {@code null}, the historical backward-only sweep
+     * is performed.
+     * </p>
      *
      * @param targetVertices the target vertices
+     * @param vertexMinDistancesFromSources forward BFS distances from the source set, computed
+     *        with the same {@code maxPathLength} bound; vertices not in the map are not
+     *        forward-reachable within that bound. May be {@code null} to disable the sandwich
+     *        prune.
      * @param maxPathLength maximum number of edges to allow in a path (if null, all edges will be
      *        considered, which may be expensive)
      *
-     * @return the minimum number of edges in a path from each edge to the targets, encoded in a Map
+     * @return the minimum number of edges in a path from each edge to the targets, encoded in a
+     *         Map
      */
-    private Map<E, Integer> edgeMinDistancesBackwards(Set<V> targetVertices, Integer maxPathLength)
+    private Map<E, Integer> edgeMinDistancesBackwards(
+        Set<V> targetVertices, Map<V, Integer> vertexMinDistancesFromSources,
+        Integer maxPathLength)
     {
         /*
          * We walk backwards through the network from the target vertices, marking edges and
@@ -157,8 +243,14 @@ public class AllDirectedPaths<V, E>
             }
         }
 
-        // Bootstrap the process with the target vertices
+        // Bootstrap the process with the target vertices. When the sandwich prune is enabled,
+        // skip targets that no source can reach within the budget.
         for (V target : targetVertices) {
+            if (vertexMinDistancesFromSources != null
+                && !vertexMinDistancesFromSources.containsKey(target))
+            {
+                continue;
+            }
             vertexMinDistances.put(target, 0);
             verticesToProcess.add(target);
         }
@@ -172,6 +264,27 @@ public class AllDirectedPaths<V, E>
             // Check whether the incoming edges of this node are correctly
             // decorated
             for (E edge : graph.incomingEdgesOf(vertex)) {
+                V edgeSource = graph.getEdgeSource(edge);
+
+                // Sandwich prune: drop edges whose source side is not reachable from the
+                // source set, or whose total forward + backward length already exceeds the
+                // budget. Skipped entirely when the prune is disabled. The bound comparison is
+                // written as (forwardOfSource > maxPathLength - childDistance) rather than the
+                // addition form to avoid integer overflow at extreme maxPathLength values; the
+                // BFS bounds guarantee childDistance <= maxPathLength when maxPathLength is set,
+                // so the right-hand side is non-negative.
+                if (vertexMinDistancesFromSources != null) {
+                    Integer forwardOfSource = vertexMinDistancesFromSources.get(edgeSource);
+                    if (forwardOfSource == null) {
+                        continue;
+                    }
+                    if (maxPathLength != null
+                        && forwardOfSource > maxPathLength - childDistance)
+                    {
+                        continue;
+                    }
+                }
+
                 // Mark the edge if needed
                 if (!edgeMinDistances.containsKey(edge)
                     || (edgeMinDistances.get(edge) > childDistance))
@@ -180,7 +293,6 @@ public class AllDirectedPaths<V, E>
                 }
 
                 // Mark the edge's source vertex if needed
-                V edgeSource = graph.getEdgeSource(edge);
                 if (!vertexMinDistances.containsKey(edgeSource)
                     || (vertexMinDistances.get(edgeSource) > childDistance))
                 {
@@ -195,6 +307,51 @@ public class AllDirectedPaths<V, E>
 
         assert verticesToProcess.isEmpty();
         return edgeMinDistances;
+    }
+
+    /**
+     * Compute the minimum number of edges in a forward BFS from the source vertices, capped at
+     * {@code maxPathLength} when given. Used together with
+     * {@link #edgeMinDistancesBackwards(Set, Map, Integer)} to apply sandwich-style pruning of the
+     * edge decoration map.
+     *
+     * @param sourceVertices the source vertices
+     * @param maxPathLength maximum number of forward edges to expand (if null, the BFS is
+     *        unrestricted)
+     *
+     * @return for every vertex reachable from {@code sourceVertices} within {@code maxPathLength}
+     *         edges, its minimum forward distance from the source set
+     */
+    private Map<V, Integer> vertexMinDistancesForwards(
+        Set<V> sourceVertices, Integer maxPathLength)
+    {
+        Map<V, Integer> vertexMinDistances = new HashMap<>();
+        Queue<V> verticesToProcess = new ArrayDeque<>();
+
+        for (V source : sourceVertices) {
+            if (!vertexMinDistances.containsKey(source)) {
+                vertexMinDistances.put(source, 0);
+                verticesToProcess.add(source);
+            }
+        }
+
+        for (V vertex; (vertex = verticesToProcess.poll()) != null;) {
+            int currentDistance = vertexMinDistances.get(vertex);
+            if (maxPathLength != null && currentDistance >= maxPathLength) {
+                continue;
+            }
+            int childDistance = currentDistance + 1;
+
+            for (E edge : graph.outgoingEdgesOf(vertex)) {
+                V child = graph.getEdgeTarget(edge);
+                if (!vertexMinDistances.containsKey(child)) {
+                    vertexMinDistances.put(child, childDistance);
+                    verticesToProcess.add(child);
+                }
+            }
+        }
+
+        return vertexMinDistances;
     }
 
     /**

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/AllDirectedPathsTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/AllDirectedPathsTest.java
@@ -223,6 +223,49 @@ public class AllDirectedPathsTest
     }
 
     @Test
+    public void testTargetReachableButSourceUnreachableBranchIsIgnored()
+    {
+        // Sandwich-prune sanity check: when forward pruning is enabled (the default), a
+        // vertex that can reach the target but is not reachable from any source must not
+        // appear on any returned path. With forward pruning disabled, the algorithm still
+        // returns the same path set (since the unreachable branch is not actually reachable
+        // forward); forward pruning only affects preprocessing cost, not the produced path
+        // set.
+        DefaultDirectedGraph<String, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("S");
+        graph.addVertex("A");
+        graph.addVertex("T");
+        graph.addEdge("S", "A");
+        graph.addEdge("A", "T");
+
+        // Dead source-side branch: U and V can reach T (U -> T) but no edge from S
+        // ever leads into U or V.
+        graph.addVertex("U");
+        graph.addVertex("V");
+        graph.addEdge("U", "T");
+        graph.addEdge("V", "U");
+
+        // Default behaviour now applies forward pruning; explicitly construct a non-pruning
+        // instance so the same test covers both code paths.
+        AllDirectedPaths<String, DefaultEdge> prunedAlg = new AllDirectedPaths<>(graph);
+        AllDirectedPaths<String, DefaultEdge> unprunedAlg = new AllDirectedPaths<>(graph);
+        unprunedAlg.setForwardPruning(false);
+
+        for (AllDirectedPaths<String, DefaultEdge> alg : Arrays.asList(prunedAlg, unprunedAlg)) {
+            List<GraphPath<String, DefaultEdge>> simplePaths = alg.getAllPaths("S", "T", true, 5);
+            assertEquals(1, simplePaths.size());
+            assertEquals(Arrays.asList("S", "A", "T"), simplePaths.get(0).getVertexList());
+
+            List<GraphPath<String, DefaultEdge>> nonSimplePaths = alg.getAllPaths(
+                Collections.singleton("S"), Collections.singleton("T"), false, 5);
+            assertEquals(1, nonSimplePaths.size());
+            assertEquals(
+                Arrays.asList("S", "A", "T"), nonSimplePaths.get(0).getVertexList());
+        }
+    }
+
+    @Test
     public void testZeroLengthPaths()
     {
         // Verify fix for https://github.com/jgrapht/jgrapht/issues/640.
@@ -372,6 +415,158 @@ public class AllDirectedPathsTest
         }
     }
 
+    @Test
+    public void testMultipleSourcesPartialGarden()
+    {
+        // Two sources {S1, S2}; S1 reaches T via S1→A→T, S2 is isolated. A separate
+        // source-disconnected garden vertex U → T should be pruned for both sources when
+        // sandwich-prune mode is enabled, and produces the same final path set when
+        // disabled.
+        DefaultDirectedGraph<String, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        for (String v : new String[] { "S1", "S2", "A", "T", "U" }) {
+            graph.addVertex(v);
+        }
+        graph.addEdge("S1", "A");
+        graph.addEdge("A", "T");
+        graph.addEdge("U", "T");
+
+        for (boolean forwardPruning : new boolean[] { false, true }) {
+            AllDirectedPaths<String, DefaultEdge> alg = new AllDirectedPaths<>(graph);
+            alg.setForwardPruning(forwardPruning);
+            List<GraphPath<String, DefaultEdge>> paths =
+                alg.getAllPaths(Set.of("S1", "S2"), Set.of("T"), true, 5);
+            assertEquals(1, paths.size(), "forwardPruning=" + forwardPruning);
+            assertEquals(Arrays.asList("S1", "A", "T"), paths.get(0).getVertexList());
+        }
+    }
+
+    @Test
+    public void testUnboundedSimplePathsWithUnreachableGarden()
+    {
+        // simplePathsOnly=true with maxPathLength=null. Both modes must produce the same
+        // final path set; the prune only affects preprocessing.
+        DefaultDirectedGraph<String, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        for (String v : new String[] { "S", "A", "T", "U", "V" }) {
+            graph.addVertex(v);
+        }
+        graph.addEdge("S", "A");
+        graph.addEdge("A", "T");
+        graph.addEdge("U", "T");
+        graph.addEdge("V", "U");
+
+        for (boolean forwardPruning : new boolean[] { false, true }) {
+            AllDirectedPaths<String, DefaultEdge> alg = new AllDirectedPaths<>(graph);
+            alg.setForwardPruning(forwardPruning);
+            List<GraphPath<String, DefaultEdge>> paths =
+                alg.getAllPaths(Set.of("S"), Set.of("T"), true, null);
+            assertEquals(1, paths.size(), "forwardPruning=" + forwardPruning);
+            assertEquals(Arrays.asList("S", "A", "T"), paths.get(0).getVertexList());
+        }
+    }
+
+    @Test
+    public void testSourceEqualsTargetInDisconnectedGraph()
+    {
+        // S is both source and target. A second disconnected vertex U has an edge into S
+        // (so S is backward-reachable from U) but U is not forward-reachable from S. The
+        // trivial zero-length walk at S must still be produced under both modes.
+        DefaultDirectedGraph<String, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        graph.addVertex("S");
+        graph.addVertex("U");
+        graph.addEdge("U", "S");
+
+        for (boolean forwardPruning : new boolean[] { false, true }) {
+            AllDirectedPaths<String, DefaultEdge> alg = new AllDirectedPaths<>(graph);
+            alg.setForwardPruning(forwardPruning);
+            List<GraphPath<String, DefaultEdge>> paths =
+                alg.getAllPaths(Set.of("S"), Set.of("S"), true, 5);
+            assertEquals(1, paths.size(), "forwardPruning=" + forwardPruning);
+            assertEquals(0, paths.get(0).getLength());
+        }
+    }
+
+    @Test
+    public void testDenseStronglyConnectedLossCase()
+    {
+        // Loss case shape: small dense strongly-connected digraph where every vertex is
+        // both forward-reachable from source and backward-reachable from target. Forward
+        // pruning cannot drop anything here. Tests that enabling it does not change the
+        // result on this shape — bounded overhead is OK; wrong answers are not.
+        int n = 6;
+        DefaultDirectedGraph<Integer, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        for (int v = 0; v < n; v++) {
+            graph.addVertex(v);
+        }
+        for (int i = 0; i < n; i++) {
+            for (int j = 0; j < n; j++) {
+                if (i != j) {
+                    graph.addEdge(i, j);
+                }
+            }
+        }
+        int maxLength = 3;
+        List<List<Integer>> expected = bruteForceSimplePaths(graph, 0, n - 1, maxLength);
+
+        for (boolean forwardPruning : new boolean[] { false, true }) {
+            AllDirectedPaths<Integer, DefaultEdge> alg = new AllDirectedPaths<>(graph);
+            alg.setForwardPruning(forwardPruning);
+            List<GraphPath<Integer, DefaultEdge>> actual =
+                alg.getAllPaths(0, n - 1, true, maxLength);
+            assertEquals(
+                new HashSet<>(expected), vertexListsAsSet(actual),
+                "forwardPruning=" + forwardPruning);
+        }
+    }
+
+    @Test
+    public void testFuzzAgainstBruteForce()
+    {
+        // For 8 seeded random small directed graphs, compare the path set returned by
+        // AllDirectedPaths against a brute-force enumeration in both prune modes. The two
+        // modes must always produce the same path set as each other and as the brute-force
+        // oracle. DefaultDirectedGraph has no parallel edges, so set semantics (rather
+        // than multiset) are sufficient to detect any divergence. Mixes:
+        //   - simple vs non-simple mode
+        //   - reachable source-disconnected garden vertices and partial reachability
+        //   - small bounded maxLength so the brute force terminates fast
+        long[] seeds = { 1L, 2L, 3L, 5L, 7L, 11L, 13L, 17L };
+        for (long seed : seeds) {
+            Random rng = new Random(seed);
+            DefaultDirectedGraph<Integer, DefaultEdge> graph =
+                buildRandomDigraphWithIsolatedPocket(rng, 4, 4, 0.4);
+            Integer source = 0;
+            Integer target = 3;
+            int maxLength = 4;
+
+            Set<List<Integer>> expectedSimple =
+                new HashSet<>(bruteForceSimplePaths(graph, source, target, maxLength));
+            Set<List<Integer>> expectedNonSimple =
+                new HashSet<>(bruteForceWalks(graph, source, target, maxLength));
+
+            for (boolean forwardPruning : new boolean[] { false, true }) {
+                AllDirectedPaths<Integer, DefaultEdge> alg = new AllDirectedPaths<>(graph);
+                alg.setForwardPruning(forwardPruning);
+                Set<List<Integer>> actualSimple = vertexListsAsSet(
+                    alg.getAllPaths(source, target, true, maxLength));
+                assertEquals(
+                    expectedSimple, actualSimple,
+                    "simple-mode path set mismatch seed=" + seed
+                        + " forwardPruning=" + forwardPruning);
+
+                Set<List<Integer>> actualNonSimple = vertexListsAsSet(
+                    alg.getAllPaths(source, target, false, maxLength));
+                assertEquals(
+                    expectedNonSimple, actualNonSimple,
+                    "non-simple-mode path set mismatch seed=" + seed
+                        + " forwardPruning=" + forwardPruning);
+            }
+        }
+    }
+
     private static DefaultDirectedGraph<Integer, DefaultEdge> buildRandomCyclicGraph(
         Random rng, int n, double edgeProbability, double selfLoopProbability)
     {
@@ -392,6 +587,90 @@ public class AllDirectedPathsTest
             }
         }
         return graph;
+    }
+
+    private static DefaultDirectedGraph<Integer, DefaultEdge> buildRandomDigraphWithIsolatedPocket(
+        Random rng, int mainSize, int pocketSize, double edgeProbability)
+    {
+        // mainSize vertices labeled 0..mainSize-1 form the main connected component.
+        // pocketSize vertices labeled mainSize..mainSize+pocketSize-1 are a separate pocket
+        // with edges into vertex (mainSize-1) but no edges from the main component to the
+        // pocket — i.e. source-unreachable but target-reachable. Exercises the sandwich prune.
+        DefaultDirectedGraph<Integer, DefaultEdge> graph =
+            new DefaultDirectedGraph<>(DefaultEdge.class);
+        for (int v = 0; v < mainSize + pocketSize; v++) {
+            graph.addVertex(v);
+        }
+        for (int i = 0; i < mainSize; i++) {
+            for (int j = 0; j < mainSize; j++) {
+                if (i != j && rng.nextDouble() < edgeProbability) {
+                    graph.addEdge(i, j);
+                }
+            }
+        }
+        // Guarantee at least one path 0 → ... → mainSize-1 exists by adding a chain edge.
+        for (int i = 0; i + 1 < mainSize; i++) {
+            if (graph.getEdge(i, i + 1) == null) {
+                graph.addEdge(i, i + 1);
+            }
+        }
+        for (int p = 0; p < pocketSize; p++) {
+            int pocketVertex = mainSize + p;
+            graph.addEdge(pocketVertex, mainSize - 1);
+            // intra-pocket edges (do not connect back to main)
+            for (int q = 0; q < pocketSize; q++) {
+                int otherPocketVertex = mainSize + q;
+                if (p != q && rng.nextDouble() < edgeProbability) {
+                    graph.addEdge(pocketVertex, otherPocketVertex);
+                }
+            }
+        }
+        return graph;
+    }
+
+    private static Set<List<Integer>> vertexListsAsSet(List<GraphPath<Integer, DefaultEdge>> paths)
+    {
+        Set<List<Integer>> result = new HashSet<>(paths.size());
+        for (GraphPath<Integer, DefaultEdge> path : paths) {
+            result.add(path.getVertexList());
+        }
+        return result;
+    }
+
+    private static List<List<Integer>> bruteForceSimplePaths(
+        Graph<Integer, DefaultEdge> graph, Integer source, Integer target, int maxLength)
+    {
+        List<List<Integer>> paths = new ArrayList<>();
+        List<Integer> current = new ArrayList<>();
+        current.add(source);
+        Set<Integer> visited = new HashSet<>();
+        visited.add(source);
+        bruteForceSimplePathsRec(graph, target, maxLength, current, visited, paths);
+        return paths;
+    }
+
+    private static void bruteForceSimplePathsRec(
+        Graph<Integer, DefaultEdge> graph, Integer target, int remaining, List<Integer> current,
+        Set<Integer> visited, List<List<Integer>> paths)
+    {
+        Integer head = current.get(current.size() - 1);
+        if (target.equals(head)) {
+            paths.add(new ArrayList<>(current));
+        }
+        if (remaining == 0) {
+            return;
+        }
+        for (DefaultEdge edge : graph.outgoingEdgesOf(head)) {
+            Integer next = graph.getEdgeTarget(edge);
+            if (visited.contains(next)) {
+                continue;
+            }
+            current.add(next);
+            visited.add(next);
+            bruteForceSimplePathsRec(graph, target, remaining - 1, current, visited, paths);
+            current.remove(current.size() - 1);
+            visited.remove(next);
+        }
     }
 
     private static List<List<Integer>> bruteForceWalks(

--- a/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/AllDirectedPathsSandwichPrunePerformance.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/perf/shortestpath/AllDirectedPathsSandwichPrunePerformance.java
@@ -1,0 +1,144 @@
+/*
+ * (C) Copyright 2026-2026, by Shai Eilat and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.perf.shortestpath;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.shortestpath.*;
+import org.jgrapht.graph.*;
+import org.openjdk.jmh.annotations.*;
+
+import java.util.*;
+import java.util.concurrent.*;
+
+/**
+ * JMH benchmark for {@link AllDirectedPaths} preprocessing on workloads that target the
+ * forward-pruning step in {@code edgeMinDistancesBackwards}.
+ *
+ * <p>
+ * Two cell families, each parameterised over {@code forwardPruning} so the cost of the
+ * optimisation is directly comparable to the historical preprocessing path in the same JVM:
+ * <ul>
+ *   <li><b>Win case ({@code testWinCase}).</b> Forward chain of {@code chainLen} vertices
+ *       {@code 0 → 1 → … → chainLen-1 = T} plus a {@code gardenSize}-vertex
+ *       source-disconnected garden whose every vertex has an edge into {@code T}. Simple-paths
+ *       mode, {@code maxPathLength = chainLen + 5}. The garden is reachable backwards from
+ *       {@code T} but no garden vertex is reachable forwards from the source, so when forward
+ *       pruning is off the backward sweep marks every garden vertex.</li>
+ *   <li><b>Loss case ({@code testLossCase}).</b> Small dense strongly-connected digraph where
+ *       {@code F = B = V}, so the forward BFS is pure overhead and the prune never drops
+ *       anything. Bounds the regression cost when forward pruning is enabled on a graph it
+ *       cannot help.</li>
+ * </ul>
+ *
+ * @author Shai Eilat
+ */
+@BenchmarkMode(Mode.AverageTime)
+@Fork(value = 1, warmups = 0)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 8, time = 2)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class AllDirectedPathsSandwichPrunePerformance
+{
+
+    @Benchmark
+    public List<GraphPath<Integer, DefaultEdge>> testWinCase(WinState state)
+    {
+        return state.algorithm.getAllPaths(state.source, state.target, true, state.maxPathLength);
+    }
+
+    @Benchmark
+    public List<GraphPath<Integer, DefaultEdge>> testLossCase(LossState state)
+    {
+        return state.algorithm.getAllPaths(state.source, state.target, true, state.maxPathLength);
+    }
+
+    @State(Scope.Benchmark)
+    public static class WinState
+    {
+        @Param({ "500", "1000", "2000" })
+        int gardenSize;
+        @Param({ "20" })
+        int chainLen;
+        @Param({ "false", "true" })
+        boolean forwardPruning;
+
+        DefaultDirectedGraph<Integer, DefaultEdge> graph;
+        AllDirectedPaths<Integer, DefaultEdge> algorithm;
+        Integer source;
+        Integer target;
+        int maxPathLength;
+
+        @Setup(Level.Trial)
+        public void buildGraph()
+        {
+            graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+            for (int i = 0; i < chainLen + gardenSize; i++) {
+                graph.addVertex(i);
+            }
+            for (int i = 0; i < chainLen - 1; i++) {
+                graph.addEdge(i, i + 1);
+            }
+            int targetVertex = chainLen - 1;
+            for (int g = 0; g < gardenSize; g++) {
+                int gardenVertex = chainLen + g;
+                graph.addEdge(gardenVertex, targetVertex);
+            }
+            algorithm = new AllDirectedPaths<>(graph);
+            algorithm.setForwardPruning(forwardPruning);
+            source = 0;
+            target = targetVertex;
+            maxPathLength = chainLen + 5;
+        }
+    }
+
+    @State(Scope.Benchmark)
+    public static class LossState
+    {
+        @Param({ "20" })
+        int n;
+        @Param({ "3" })
+        int maxPathLength;
+        @Param({ "false", "true" })
+        boolean forwardPruning;
+
+        DefaultDirectedGraph<Integer, DefaultEdge> graph;
+        AllDirectedPaths<Integer, DefaultEdge> algorithm;
+        Integer source;
+        Integer target;
+
+        @Setup(Level.Trial)
+        public void buildGraph()
+        {
+            graph = new DefaultDirectedGraph<>(DefaultEdge.class);
+            for (int i = 0; i < n; i++) {
+                graph.addVertex(i);
+            }
+            for (int i = 0; i < n; i++) {
+                for (int j = 0; j < n; j++) {
+                    if (i != j) {
+                        graph.addEdge(i, j);
+                    }
+                }
+            }
+            algorithm = new AllDirectedPaths<>(graph);
+            algorithm.setForwardPruning(forwardPruning);
+            source = 0;
+            target = n - 1;
+        }
+    }
+}


### PR DESCRIPTION
This PR optimizes `AllDirectedPaths` preprocessing by adding a forward
reachability pass from the source set before the existing backward
edge-decoration sweep.

The current implementation decorates every edge that can reach a target
backwards, even if that edge's source is not reachable from any requested
source. In graphs with source-disconnected target regions, this spends
preprocessing time on edges that enumeration can never visit.

The new preprocessing keeps only edges satisfying the safe sandwich
condition:

    dF(u) + 1 + dB(v) <= maxPathLength

where `dF(u)` is the forward BFS distance from the source set to `u`, and
`dB(v)` is the backward distance from `v` to a target.

The optimization is enabled by default. `setForwardPruning(false)` restores
the historical backward-only preprocessing behaviour. The returned path set
is unchanged.

Discussion: https://groups.google.com/g/jgrapht-dev/c/fhhJk9FVFoo

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)
