### PR TITLE
Add label-correcting and epsilon-approximation multi-objective shortest path algorithms

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/EpsilonApproximationMultiObjectiveShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/EpsilonApproximationMultiObjectiveShortestPath.java
@@ -1,0 +1,295 @@
+/*
+ * (C) Copyright 2017-2026, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.*;
+import org.jgrapht.graph.*;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+/**
+ * An epsilon-approximation algorithm for the multi-objective shortest paths problem.
+ *
+ * <p>
+ * The algorithm follows a label-correcting relaxation process and keeps a set of non-dominated
+ * labels for each vertex. In addition, labels which are sufficiently close according to the epsilon
+ * tolerance are discarded in order to reduce the number of stored labels.
+ *
+ * <p>
+ * All objective values must be non-negative.
+ *
+ * @author Mario Fuentes Jimenez
+ *
+ * @param <V> the vertex type
+ * @param <E> the edge type
+ */
+public class EpsilonApproximationMultiObjectiveShortestPath<V, E>
+    extends BaseMultiObjectiveShortestPathAlgorithm<V, E>
+{
+    // the edge weight function
+    private final Function<E, double[]> edgeWeightFunction;
+    // the number of objectives
+    private final int objectives;
+    // the approximation tolerance
+    private final double epsilon;
+    // final labels for each node
+    private final Map<V, LinkedList<Label>> nodeLabels;
+    // labels waiting to be expanded
+    private final Queue<Label> queue;
+
+    /**
+     * Create a new shortest path algorithm
+     *
+     * @param graph the input graph
+     * @param edgeWeightFunction the edge weight function
+     * @param epsilon the approximation tolerance
+     */
+    public EpsilonApproximationMultiObjectiveShortestPath(
+        Graph<V, E> graph, Function<E, double[]> edgeWeightFunction, double epsilon)
+    {
+        super(graph);
+        this.edgeWeightFunction =
+            Objects.requireNonNull(edgeWeightFunction, "Function cannot be null");
+        if (Double.compare(epsilon, 0d) < 0) {
+            throw new IllegalArgumentException("Epsilon must be non-negative");
+        }
+        this.objectives = validateEdgeWeightFunction(edgeWeightFunction);
+        this.epsilon = epsilon;
+        this.nodeLabels = new HashMap<>();
+        this.queue = new ArrayDeque<>();
+    }
+
+    @Override
+    public List<GraphPath<V, E>> getPaths(V source, V sink)
+    {
+        return this.getPaths(source).getPaths(sink);
+    }
+
+    @Override
+    public MultiObjectiveSingleSourcePaths<V, E> getPaths(V source)
+    {
+        if (!graph.containsVertex(source)) {
+            throw new IllegalArgumentException(
+                BaseMultiObjectiveShortestPathAlgorithm.GRAPH_MUST_CONTAIN_THE_SOURCE_VERTEX);
+        }
+
+        if (graph.vertexSet().isEmpty() || graph.edgeSet().isEmpty()) {
+            return new ListMultiObjectiveSingleSourcePathsImpl<>(
+                graph, source, Collections.emptyMap());
+        }
+
+        if (nodeLabels.isEmpty()) {
+            runAlgorithm(source);
+        }
+
+        Map<V, List<GraphPath<V, E>>> paths = buildPaths(source);
+        return new ListMultiObjectiveSingleSourcePathsImpl<>(graph, source, paths);
+    }
+
+    /**
+     * Execute the main algorithm
+     */
+    private void runAlgorithm(V source)
+    {
+        Label sourceLabel = new Label(source, new double[objectives], null, null);
+        for (V v : graph.vertexSet()) {
+            nodeLabels.put(v, new LinkedList<>());
+        }
+        nodeLabels.get(source).add(sourceLabel);
+        queue.add(sourceLabel);
+
+        while (!queue.isEmpty()) {
+            Label curLabel = queue.poll();
+            V v = curLabel.node;
+            for (E e : graph.outgoingEdgesOf(v)) {
+                V u = Graphs.getOppositeVertex(graph, e, v);
+                Label newLabel =
+                    new Label(u, sum(curLabel.value, edgeWeightFunction.apply(e)), curLabel, e);
+
+                boolean isDominated = false;
+                boolean isClose = false;
+                LinkedList<Label> uLabels = nodeLabels.get(u);
+                ListIterator<Label> it = uLabels.listIterator();
+                while (it.hasNext()) {
+                    Label oldLabel = it.next();
+                    if (dominates(oldLabel.value, newLabel.value)) {
+                        isDominated = true;
+                        break;
+                    }
+                    if (close(oldLabel.value, newLabel.value, epsilon)) {
+                        isClose = true;
+                        break;
+                    }
+                    if (dominates(newLabel.value, oldLabel.value)) {
+                        it.remove();
+                    }
+                }
+                if (!isDominated && !isClose) {
+                    uLabels.add(newLabel);
+                    queue.add(newLabel);
+                }
+            }
+        }
+    }
+
+    /**
+     * Build the actual paths from the final labels of each node.
+     *
+     * @param source the source vertex
+     * @return the paths
+     */
+    private Map<V, List<GraphPath<V, E>>> buildPaths(V source)
+    {
+        Map<V, List<GraphPath<V, E>>> paths = new HashMap<>();
+        for (V sink : graph.vertexSet()) {
+            if (sink.equals(source)) {
+                paths.put(sink, List.of(createEmptyPath(source, sink)));
+            } else {
+                paths.put(sink, nodeLabels.get(sink).stream().map(l -> {
+                    double weight = 0d;
+                    LinkedList<E> edgeList = new LinkedList<>();
+                    Label cur = l;
+                    while (cur != null && cur.fromPrevious != null) {
+                        weight += graph.getEdgeWeight(cur.fromPrevious);
+                        edgeList.push(cur.fromPrevious);
+                        cur = cur.previous;
+                    }
+                    return new GraphWalk<>(graph, source, sink, edgeList, weight);
+                }).collect(Collectors.toList()));
+            }
+        }
+        return paths;
+    }
+
+    /**
+     * Compute the sum of two vectors
+     *
+     * @param a the first vector
+     * @param b the second vector
+     * @return the sum
+     */
+    private static double[] sum(double[] a, double b[])
+    {
+        int d = a.length;
+        double[] res = new double[d];
+        for (int i = 0; i < d; i++) {
+            res[i] = a[i] + b[i];
+        }
+        return res;
+    }
+
+    /**
+     * Return whether a vector dominates another.
+     *
+     * @param a the first vector
+     * @param b the second vector
+     * @return true if the first vector dominates the second
+     */
+    private static boolean dominates(double[] a, double[] b)
+    {
+        boolean strict = false;
+        int d = a.length;
+        for (int i = 0; i < d; i++) {
+            if (a[i] > b[i]) {
+                return false;
+            }
+            if (a[i] < b[i]) {
+                strict = true;
+            }
+        }
+        return strict;
+    }
+
+    /**
+     * Return whether two vectors are close according to the epsilon tolerance.
+     *
+     * @param a the first vector
+     * @param b the second vector
+     * @param epsilon the approximation tolerance
+     * @return true if the vectors are close
+     */
+    private static boolean close(double[] a, double[] b, double epsilon)
+    {
+        int d = a.length;
+        for (int i = 0; i < d; i++) {
+            double tolerance = Math.abs(a[i]) * epsilon;
+            if (Math.abs(a[i] - b[i]) > tolerance) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Check the validity of the edge weight function
+     *
+     * @param edgeWeightFunction the edge weight function
+     * @return the number of dimensions
+     */
+    private int validateEdgeWeightFunction(Function<E, double[]> edgeWeightFunction)
+    {
+        int dim = 0;
+        for (E e : graph.edgeSet()) {
+            double[] f = edgeWeightFunction.apply(e);
+            if (f == null) {
+                throw new IllegalArgumentException("Invalid edge weight function");
+            }
+            if (dim == 0) {
+                dim = f.length;
+            } else {
+                if (dim != f.length) {
+                    throw new IllegalArgumentException("Invalid edge weight function");
+                }
+            }
+            for (int i = 0; i < dim; i++) {
+                if (Double.compare(f[i], 0d) < 0) {
+                    throw new IllegalArgumentException("Edge weight must be non-negative");
+                }
+            }
+        }
+        return dim;
+    }
+
+    /**
+     * A node label.
+     */
+    private class Label
+    {
+        public V node;
+        public double[] value;
+        public Label previous;
+        public E fromPrevious;
+
+        public Label(V node, double[] value, Label previous, E fromPrevious)
+        {
+            this.node = node;
+            this.value = value;
+            this.previous = previous;
+            this.fromPrevious = fromPrevious;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Label [node=" + node + ", value=" + Arrays.toString(value) + ", fromPrevious="
+                + fromPrevious + "]";
+        }
+    }
+}

--- a/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/LabelCorrectingMultiObjectiveShortestPath.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/shortestpath/LabelCorrectingMultiObjectiveShortestPath.java
@@ -1,0 +1,271 @@
+/*
+ * (C) Copyright 2017-2026, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.*;
+import org.jgrapht.graph.*;
+
+import java.util.*;
+import java.util.function.*;
+import java.util.stream.*;
+
+/**
+ * A label-correcting algorithm for the multi-objective shortest paths problem.
+ *
+ * <p>
+ * The algorithm is a multiple objective extension of the Bellman-Ford relaxation process. It
+ * maintains a set of non-dominated labels for each vertex and iteratively propagates labels through
+ * outgoing edges. A newly generated label is discarded if it is dominated by an existing label at the
+ * same vertex. Existing labels dominated by the new label are removed.
+ *
+ * <p>
+ * All objective values must be non-negative.
+ *
+ * @author Mario Fuentes Jimenez
+ *
+ * @param <V> the vertex type
+ * @param <E> the edge type
+ */
+public class LabelCorrectingMultiObjectiveShortestPath<V, E>
+    extends BaseMultiObjectiveShortestPathAlgorithm<V, E>
+{
+    // the edge weight function
+    private final Function<E, double[]> edgeWeightFunction;
+    // the number of objectives
+    private final int objectives;
+    // final labels for each node
+    private final Map<V, LinkedList<Label>> nodeLabels;
+    // labels waiting to be expanded
+    private final Queue<Label> queue;
+
+    /**
+     * Create a new shortest path algorithm.
+     *
+     * @param graph the input graph
+     * @param edgeWeightFunction the edge weight function
+     */
+    public LabelCorrectingMultiObjectiveShortestPath(
+        Graph<V, E> graph, Function<E, double[]> edgeWeightFunction)
+    {
+        super(graph);
+        this.edgeWeightFunction =
+            Objects.requireNonNull(edgeWeightFunction, "Function cannot be null");
+        this.objectives = validateEdgeWeightFunction(edgeWeightFunction);
+        this.nodeLabels = new HashMap<>();
+        this.queue = new ArrayDeque<>();
+    }
+
+    @Override
+    public List<GraphPath<V, E>> getPaths(V source, V sink)
+    {
+        return this.getPaths(source).getPaths(sink);
+    }
+
+    @Override
+    public MultiObjectiveSingleSourcePaths<V, E> getPaths(V source)
+    {
+        if (!graph.containsVertex(source)) {
+            throw new IllegalArgumentException(
+                BaseMultiObjectiveShortestPathAlgorithm.GRAPH_MUST_CONTAIN_THE_SOURCE_VERTEX);
+        }
+
+        if (graph.vertexSet().isEmpty() || graph.edgeSet().isEmpty()) {
+            return new ListMultiObjectiveSingleSourcePathsImpl<>(
+                graph, source, Collections.emptyMap());
+        }
+
+        if (nodeLabels.isEmpty()) {
+            runAlgorithm(source);
+        }
+
+        Map<V, List<GraphPath<V, E>>> paths = buildPaths(source);
+        return new ListMultiObjectiveSingleSourcePathsImpl<>(graph, source, paths);
+    }
+
+    /**
+     * Execute the main algorithm.
+     *
+     * @param source the source vertex
+     */
+    private void runAlgorithm(V source)
+    {
+        Label sourceLabel = new Label(source, new double[objectives], null, null);
+
+        for (V v : graph.vertexSet()) {
+            nodeLabels.put(v, new LinkedList<>());
+        }
+
+        nodeLabels.get(source).add(sourceLabel);
+        queue.add(sourceLabel);
+
+        while (!queue.isEmpty()) {
+            Label curLabel = queue.poll();
+            V v = curLabel.node;
+
+            for (E e : graph.outgoingEdgesOf(v)) {
+                V u = Graphs.getOppositeVertex(graph, e, v);
+                Label newLabel =
+                    new Label(u, sum(curLabel.value, edgeWeightFunction.apply(e)), curLabel, e);
+
+                boolean isDominated = false;
+                LinkedList<Label> uLabels = nodeLabels.get(u);
+                ListIterator<Label> it = uLabels.listIterator();
+
+                while (it.hasNext()) {
+                    Label oldLabel = it.next();
+                    if (dominates(oldLabel.value, newLabel.value)) {
+                        isDominated = true;
+                        break;
+                    }
+                    if (dominates(newLabel.value, oldLabel.value)) {
+                        it.remove();
+                    }
+                }
+
+                if (!isDominated) {
+                    uLabels.add(newLabel);
+                    queue.add(newLabel);
+                }
+            }
+        }
+    }
+
+    /**
+     * Build the actual paths from the final labels of each node.
+     *
+     * @param source the source vertex
+     * @return the paths
+     */
+    private Map<V, List<GraphPath<V, E>>> buildPaths(V source)
+    {
+        Map<V, List<GraphPath<V, E>>> paths = new HashMap<>();
+        for (V sink : graph.vertexSet()) {
+            if (sink.equals(source)) {
+                paths.put(sink, List.of(createEmptyPath(source, sink)));
+            } else {
+                paths.put(sink, nodeLabels.get(sink).stream().map(l -> {
+                    double weight = 0d;
+                    LinkedList<E> edgeList = new LinkedList<>();
+                    Label cur = l;
+                    while (cur != null && cur.fromPrevious != null) {
+                        weight += graph.getEdgeWeight(cur.fromPrevious);
+                        edgeList.push(cur.fromPrevious);
+                        cur = cur.previous;
+                    }
+                    return new GraphWalk<>(graph, source, sink, edgeList, weight);
+                }).collect(Collectors.toList()));
+            }
+        }
+        return paths;
+    }
+
+    /**
+     * Compute the sum of two vectors.
+     *
+     * @param a the first vector
+     * @param b the second vector
+     * @return the sum
+     */
+    private static double[] sum(double[] a, double b[])
+    {
+        int d = a.length;
+        double[] res = new double[d];
+        for (int i = 0; i < d; i++) {
+            res[i] = a[i] + b[i];
+        }
+        return res;
+    }
+
+    /**
+     * Return whether a vector dominates another.
+     *
+     * @param a the first vector
+     * @param b the second vector
+     * @return true if the first vector dominates the second
+     */
+    private static boolean dominates(double[] a, double[] b)
+    {
+        boolean strict = false;
+        int d = a.length;
+        for (int i = 0; i < d; i++) {
+            if (a[i] > b[i]) {
+                return false;
+            }
+            if (a[i] < b[i]) {
+                strict = true;
+            }
+        }
+        return strict;
+    }
+
+    /**
+     * Check the validity of the edge weight function.
+     *
+     * @param edgeWeightFunction the edge weight function
+     * @return the number of dimensions
+     */
+    private int validateEdgeWeightFunction(Function<E, double[]> edgeWeightFunction)
+    {
+        int dim = 0;
+        for (E e : graph.edgeSet()) {
+            double[] f = edgeWeightFunction.apply(e);
+            if (f == null) {
+                throw new IllegalArgumentException("Invalid edge weight function");
+            }
+            if (dim == 0) {
+                dim = f.length;
+            } else {
+                if (dim != f.length) {
+                    throw new IllegalArgumentException("Invalid edge weight function");
+                }
+            }
+            for (int i = 0; i < dim; i++) {
+                if (Double.compare(f[i], 0d) < 0) {
+                    throw new IllegalArgumentException("Edge weight must be non-negative");
+                }
+            }
+        }
+        return dim;
+    }
+
+    /**
+     * A node label.
+     */
+    private class Label
+    {
+        public V node;
+        public double[] value;
+        public Label previous;
+        public E fromPrevious;
+
+        public Label(V node, double[] value, Label previous, E fromPrevious)
+        {
+            this.node = node;
+            this.value = value;
+            this.previous = previous;
+            this.fromPrevious = fromPrevious;
+        }
+
+        @Override
+        public String toString()
+        {
+            return "Label [node=" + node + ", value=" + Arrays.toString(value) + ", fromPrevious="
+                + fromPrevious + "]";
+        }
+    }
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/EpsilonApproximationMultiObjectiveShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/EpsilonApproximationMultiObjectiveShortestPathTest.java
@@ -1,0 +1,159 @@
+/*
+ * (C) Copyright 2017-2026, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import org.jgrapht.*;
+import org.jgrapht.alg.interfaces.MultiObjectiveShortestPathAlgorithm.*;
+import org.jgrapht.graph.*;
+import org.junit.jupiter.api.*;
+
+import java.util.*;
+import java.util.stream.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test {@link EpsilonApproximationMultiObjectiveShortestPath}.
+ *
+ * @author Mario Fuentes Jimenez
+ */
+public class EpsilonApproximationMultiObjectiveShortestPathTest
+{
+
+    @Test
+    public void testGraphDirected()
+    {
+        DirectedPseudograph<Integer, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex(1);
+        g.addVertex(2);
+        g.addVertex(3);
+
+        DefaultEdge e12 = g.addEdge(1, 2);
+        DefaultEdge e13 = g.addEdge(1, 3);
+        DefaultEdge e32 = g.addEdge(3, 2);
+
+        DefaultEdgeFunction<DefaultEdge, double[]> f =
+            new DefaultEdgeFunction<>(new double[] { 0.0, 0.0 });
+
+        f.set(e12, new double[] { 5.0, 2.0 });
+        f.set(e13, new double[] { 2.0, 8.0 });
+        f.set(e32, new double[] { 1.0, 4.0 });
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> paths =
+            new EpsilonApproximationMultiObjectiveShortestPath<>(g, f, 0.0).getPaths(1);
+
+        List<GraphPath<Integer, DefaultEdge>> paths12 = paths.getPaths(2);
+        assertEquals(2, paths12.size());
+    }
+
+    @Test
+    public void testApproximation()
+    {
+        DirectedPseudograph<Integer, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex(1);
+        g.addVertex(2);
+        g.addVertex(3);
+
+        DefaultEdge e12 = g.addEdge(1, 2);
+        DefaultEdge e13 = g.addEdge(1, 3);
+        DefaultEdge e32 = g.addEdge(3, 2);
+
+        DefaultEdgeFunction<DefaultEdge, double[]> f =
+            new DefaultEdgeFunction<>(new double[] { 0.0, 0.0 });
+
+        f.set(e12, new double[] { 10.0, 10.0 });
+        f.set(e13, new double[] { 10.5, 9.8 });
+        f.set(e32, new double[] { 0.0, 0.0 });
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> paths =
+            new EpsilonApproximationMultiObjectiveShortestPath<>(g, f, 0.10).getPaths(1);
+
+        List<GraphPath<Integer, DefaultEdge>> paths12 = paths.getPaths(2);
+        assertEquals(1, paths12.size());
+    }
+
+    @Test
+    public void testNoPaths()
+    {
+        DirectedPseudograph<Integer, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex(1);
+        g.addVertex(2);
+
+        DefaultEdgeFunction<DefaultEdge, double[]> f =
+            new DefaultEdgeFunction<>(new double[] { 0.0, 0.0 });
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> paths1 =
+            new EpsilonApproximationMultiObjectiveShortestPath<>(g, f, 0.10).getPaths(1);
+
+        List<GraphPath<Integer, DefaultEdge>> paths11 = paths1.getPaths(1);
+        assertEquals(1, paths11.size());
+        List<GraphPath<Integer, DefaultEdge>> paths12 = paths1.getPaths(2);
+        assertEquals(0, paths12.size());
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> paths2 =
+            new EpsilonApproximationMultiObjectiveShortestPath<>(g, f, 0.10).getPaths(2);
+
+        List<GraphPath<Integer, DefaultEdge>> paths21 = paths2.getPaths(1);
+        assertEquals(0, paths21.size());
+        List<GraphPath<Integer, DefaultEdge>> paths22 = paths2.getPaths(2);
+        assertEquals(1, paths22.size());
+    }
+
+    @Test
+    public void testCompareWithMartinShortestPath()
+    {
+        DirectedPseudograph<Integer, DefaultEdge> g =
+            new DirectedPseudograph<>(DefaultEdge.class);
+
+        IntStream.range(1, 6).forEach(g::addVertex);
+        DefaultEdge e12 = g.addEdge(1, 2);
+        DefaultEdge e13 = g.addEdge(1, 3);
+        DefaultEdge e14 = g.addEdge(1, 4);
+        DefaultEdge e24 = g.addEdge(2, 4);
+        DefaultEdge e25 = g.addEdge(2, 5);
+        DefaultEdge e34 = g.addEdge(3, 4);
+        DefaultEdge e35 = g.addEdge(3, 5);
+        DefaultEdge e45 = g.addEdge(4, 5);
+
+        DefaultEdgeFunction<DefaultEdge, double[]> f =
+            new DefaultEdgeFunction<>(new double[] { 0.0, 0.0 });
+
+        f.set(e12, new double[] { 1.0, 5.0 });
+        f.set(e13, new double[] { 4.0, 2.0 });
+        f.set(e14, new double[] { 4.0, 4.0 });
+        f.set(e24, new double[] { 1.0, 2.0 });
+        f.set(e25, new double[] { 2.0, 5.0 });
+        f.set(e34, new double[] { 2.0, 3.0 });
+        f.set(e35, new double[] { 6.0, 1.0 });
+        f.set(e45, new double[] { 3.0, 3.0 });
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> martinPaths =
+            new MartinShortestPath<>(g, f).getPaths(1);
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> epsilonPaths =
+            new EpsilonApproximationMultiObjectiveShortestPath<>(g, f, 0.0).getPaths(1);
+
+        for (int i = 1; i <= 5; i++) {
+            assertEquals(martinPaths.getPaths(i).size(), epsilonPaths.getPaths(i).size());
+        }
+    }
+
+}

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/LabelCorrectingMultiObjectiveShortestPathTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/shortestpath/LabelCorrectingMultiObjectiveShortestPathTest.java
@@ -1,0 +1,160 @@
+/*
+ * (C) Copyright 2017-2026, by Dimitrios Michail and Contributors.
+ *
+ * JGraphT : a free Java graph-theory library
+ *
+ * See the CONTRIBUTORS.md file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0, or the
+ * GNU Lesser General Public License v2.1 or later
+ * which is available at
+ * http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR LGPL-2.1-or-later
+ */
+package org.jgrapht.alg.shortestpath;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.interfaces.MultiObjectiveShortestPathAlgorithm.MultiObjectiveSingleSourcePaths;
+import org.jgrapht.graph.DefaultEdge;
+import org.jgrapht.graph.DefaultEdgeFunction;
+import org.jgrapht.graph.DirectedPseudograph;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test {@link LabelCorrectingMultiObjectiveShortestPath}.
+ *
+ * @author Mario Fuentes Jimenez
+ */
+public class LabelCorrectingMultiObjectiveShortestPathTest
+{
+
+    @Test
+    public void testGraphDirected()
+    {
+        DirectedPseudograph<Integer, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex(1);
+        g.addVertex(2);
+        g.addVertex(3);
+
+        DefaultEdge e12 = g.addEdge(1, 2);
+        DefaultEdge e13 = g.addEdge(1, 3);
+        DefaultEdge e32 = g.addEdge(3, 2);
+
+        DefaultEdgeFunction<DefaultEdge, double[]> f =
+            new DefaultEdgeFunction<>(new double[] { 0.0, 0.0 });
+
+        f.set(e12, new double[] { 5.0, 2.0 });
+        f.set(e13, new double[] { 2.0, 8.0 });
+        f.set(e32, new double[] { 1.0, 4.0 });
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> paths =
+            new LabelCorrectingMultiObjectiveShortestPath<>(g, f).getPaths(1);
+
+        List<GraphPath<Integer, DefaultEdge>> paths12 = paths.getPaths(2);
+        assertEquals(2, paths12.size());
+    }
+
+    @Test
+    public void testDominatedPaths()
+    {
+        DirectedPseudograph<Integer, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex(1);
+        g.addVertex(2);
+        g.addVertex(3);
+
+        DefaultEdge e12 = g.addEdge(1, 2);
+        DefaultEdge e13 = g.addEdge(1, 3);
+        DefaultEdge e32 = g.addEdge(3, 2);
+
+        DefaultEdgeFunction<DefaultEdge, double[]> f =
+            new DefaultEdgeFunction<>(new double[] { 0.0, 0.0 });
+
+        f.set(e12, new double[] { 3.0, 3.0 });
+        f.set(e13, new double[] { 5.0, 5.0 });
+        f.set(e32, new double[] { 5.0, 5.0 });
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> paths =
+            new LabelCorrectingMultiObjectiveShortestPath<>(g, f).getPaths(1);
+
+        List<GraphPath<Integer, DefaultEdge>> paths12 = paths.getPaths(2);
+        assertEquals(1, paths12.size());
+    }
+
+    @Test
+    public void testNoPaths()
+    {
+        DirectedPseudograph<Integer, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        g.addVertex(1);
+        g.addVertex(2);
+
+        DefaultEdgeFunction<DefaultEdge, double[]> f =
+            new DefaultEdgeFunction<>(new double[] { 0.0, 0.0 });
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> paths1 =
+            new LabelCorrectingMultiObjectiveShortestPath<>(g, f).getPaths(1);
+
+        List<GraphPath<Integer, DefaultEdge>> paths11 = paths1.getPaths(1);
+        assertEquals(1, paths11.size());
+        List<GraphPath<Integer, DefaultEdge>> paths12 = paths1.getPaths(2);
+        assertEquals(0, paths12.size());
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> paths2 =
+            new LabelCorrectingMultiObjectiveShortestPath<>(g, f).getPaths(2);
+
+        List<GraphPath<Integer, DefaultEdge>> paths21 = paths2.getPaths(1);
+        assertEquals(0, paths21.size());
+        List<GraphPath<Integer, DefaultEdge>> paths22 = paths2.getPaths(2);
+        assertEquals(1, paths22.size());
+    }
+
+    @Test
+    public void testCompareWithMartinShortestPath()
+    {
+        DirectedPseudograph<Integer, DefaultEdge> g = new DirectedPseudograph<>(DefaultEdge.class);
+
+        IntStream.range(1, 6).forEach(g::addVertex);
+        DefaultEdge e12 = g.addEdge(1, 2);
+        DefaultEdge e13 = g.addEdge(1, 3);
+        DefaultEdge e14 = g.addEdge(1, 4);
+        DefaultEdge e24 = g.addEdge(2, 4);
+        DefaultEdge e25 = g.addEdge(2, 5);
+        DefaultEdge e34 = g.addEdge(3, 4);
+        DefaultEdge e35 = g.addEdge(3, 5);
+        DefaultEdge e45 = g.addEdge(4, 5);
+
+        DefaultEdgeFunction<DefaultEdge, double[]> f =
+            new DefaultEdgeFunction<>(new double[] { 0.0, 0.0 });
+
+            f.set(e12, new double[] { 1.0, 5.0 });
+            f.set(e13, new double[] { 4.0, 2.0 });
+            f.set(e14, new double[] { 4.0, 4.0 });
+            f.set(e24, new double[] { 1.0, 2.0 });
+            f.set(e25, new double[] { 2.0, 5.0 });
+            f.set(e34, new double[] { 2.0, 3.0 });
+            f.set(e35, new double[] { 6.0, 1.0 });
+            f.set(e45, new double[] { 3.0, 3.0 });
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> martinPaths =
+            new MartinShortestPath<>(g, f).getPaths(1);
+
+        MultiObjectiveSingleSourcePaths<Integer, DefaultEdge> labelCorrectingPaths =
+            new LabelCorrectingMultiObjectiveShortestPath<>(g, f).getPaths(1);
+
+        for (int i = 1; i <= 5; i++) {
+            assertEquals(martinPaths.getPaths(i).size(), labelCorrectingPaths.getPaths(i).size());
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request introduces two new algorithms for the multi-objective shortest path problem:

- LabelCorrectingMultiObjectiveShortestPath
- EpsilonApproximationMultiObjectiveShortestPath

The implementation follows the design patterns already used in JGraphT, particularly MartinShortestPath.

Main characteristics:

** Computes Pareto-optimal paths using a label-correcting strategy.
** Includes an epsilon-approximation variant that reduces the number of stored labels by merging sufficiently similar labels.
**Includes unit tests for correctness, no-path scenarios, approximation behaviour, and comparison against MartinShortestPath.

This implementation was developed as part of an academic project based on multi-objective shortest path algorithms and adapted to follow JGraphT coding conventions and architecture.
