### PR TITLE
Add `UnionFind.contains()` method

### DIFF
--- a/jgrapht-core/src/main/java/org/jgrapht/alg/util/UnionFind.java
+++ b/jgrapht-core/src/main/java/org/jgrapht/alg/util/UnionFind.java
@@ -61,7 +61,7 @@ public class UnionFind<T>
      */
     public void addElement(T element)
     {
-        if (parentMap.containsKey(element))
+        if (contains(element))
             throw new IllegalArgumentException(
                 "element is already contained in UnionFind: " + element);
         parentMap.put(element, element);
@@ -86,6 +86,16 @@ public class UnionFind<T>
     }
 
     /**
+     * Returns true if the given value is an element in this UnionFind data structure.
+     *
+     * @param element a value that might be in this
+     * @return true if this contains the given value
+    */
+    public boolean contains(final T element) {
+        return parentMap.containsKey(element);
+    }
+
+    /**
      * Returns the representative element of the set that element is in.
      *
      * @param element The element to find.
@@ -94,7 +104,7 @@ public class UnionFind<T>
      */
     public T find(final T element)
     {
-        if (!parentMap.containsKey(element)) {
+        if (!contains(element)) {
             throw new IllegalArgumentException(
                 "element is not contained in this UnionFind data structure: " + element);
         }
@@ -129,7 +139,7 @@ public class UnionFind<T>
      */
     public void union(T element1, T element2)
     {
-        if (!parentMap.containsKey(element1) || !parentMap.containsKey(element2)) {
+        if (!contains(element1) || !contains(element2)) {
             throw new IllegalArgumentException("elements must be contained in given set");
         }
 

--- a/jgrapht-core/src/test/java/org/jgrapht/alg/util/UnionFindTest.java
+++ b/jgrapht-core/src/test/java/org/jgrapht/alg/util/UnionFindTest.java
@@ -51,6 +51,10 @@ public class UnionFindTest
         assertEquals(5, uf.numberOfSets());
         testIdentical(strs, sets, uf);
 
+        assertTrue(uf.contains("aaa"));
+        assertTrue(uf.contains("eee"));
+        assertFalse(uf.contains("fff"));
+
         uf.union(strs[0], strs[1]);
         assertEquals(4, uf.numberOfSets());
         union(sets, strs[0], strs[1]);


### PR DESCRIPTION
This pull request adds method `UnionFind.contains()`.

I didn't add myself to the `@author` list because I'm not sure this small contribution rises to that level.

----

- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/Become-a-Contributor>
- [x] I read and understood <https://github.com/jgrapht/jgrapht/wiki/How-to-make-your-first-%28code%29-contribution>
- [x] I added [unit tests](https://github.com/jgrapht/jgrapht/wiki/Unit-testing)
- [x] I added [documentation](https://github.com/jgrapht/jgrapht/wiki/How-to-write-documentation)
- [x] I followed the [Coding and Style Conventions](https://github.com/jgrapht/jgrapht/wiki/Coding-and-Style-Conventions)
- [x] I **have not** modified `HISTORY.md` or `CONTRIBUTORS.md`
- [x] I ensured that [the git commit message is a good one](https://github.com/joelparkerhenderson/git_commit_message)

